### PR TITLE
[docs] Add source references to all ADRs

### DIFF
--- a/docs/adr-references.md
+++ b/docs/adr-references.md
@@ -1,0 +1,146 @@
+# ADR Reference Index
+
+Consolidated list of all external sources cited across the Architecture Decision Records.
+Each entry links back to the ADR where it is discussed and provides a brief description of why the source is relevant.
+
+---
+
+## Architectural Patterns
+
+| Source | Cited In | Relevance |
+|---|---|---|
+| [Alistair Cockburn — Hexagonal Architecture (2005)](https://alistair.cockburn.us/hexagonal-architecture/) | [ADR-002](adr/ADR-002-ports-and-adapters.md) | Origin of the Ports and Adapters pattern; the port/adapter vocabulary and dependency rule used throughout the codebase come from here. |
+| [Robert C. Martin — The Clean Architecture (2012)](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html) | [ADR-002](adr/ADR-002-ports-and-adapters.md) | Generalises the dependency inversion principle into the "dependency rule": source-code dependencies must point inward toward higher-level policy. |
+| [Martin Fowler — Inversion of Control Containers and the Dependency Injection Pattern](https://martinfowler.com/articles/injection.html) | [ADR-002](adr/ADR-002-ports-and-adapters.md), [ADR-011](adr/ADR-011-api-server-nestjs-and-express.md) | Background on constructor injection and IoC containers; directly relevant to how NestJS wires adapters to ports. |
+
+---
+
+## Monorepo Tooling
+
+| Source | Cited In | Relevance |
+|---|---|---|
+| [Turborepo — Getting Started](https://turbo.build/repo/docs) | [ADR-001](adr/ADR-001-monorepo-structure.md) | Official Turborepo docs; covers caching model, pipeline configuration, and workspace setup. |
+| [Turborepo — `turbo prune`](https://turbo.build/repo/docs/reference/prune) | [ADR-001](adr/ADR-001-monorepo-structure.md) | Pruning the monorepo for Docker builds; the approach used to scope `COPY` in each app's Dockerfile. |
+| [npm Workspaces](https://docs.npmjs.com/cli/v10/using-npm/workspaces) | [ADR-001](adr/ADR-001-monorepo-structure.md) | The npm workspace protocol enabling `"@logbook/core": "*"` inter-package references. |
+| [Nx — Getting Started](https://nx.dev/getting-started/intro) | [ADR-001](adr/ADR-001-monorepo-structure.md) | Primary alternative to Turborepo; ruled out as over-configured for this scale. |
+
+---
+
+## API Server
+
+| Source | Cited In | Relevance |
+|---|---|---|
+| [NestJS — Documentation](https://docs.nestjs.com) | [ADR-006](adr/ADR-006-rest-and-graphql-dual-transport.md), [ADR-011](adr/ADR-011-api-server-nestjs-and-express.md) | Official NestJS docs; covers modules, providers, controllers, guards, interceptors, and exception filters. |
+| [NestJS — Dependency Injection](https://docs.nestjs.com/fundamentals/dependency-injection) | [ADR-011](adr/ADR-011-api-server-nestjs-and-express.md) | The DI container mechanics (`@Injectable`, `@Inject`) that replace Express's manual wiring. |
+| [NestJS — Performance (Fastify adapter)](https://docs.nestjs.com/techniques/performance) | [ADR-011](adr/ADR-011-api-server-nestjs-and-express.md) | Documents the `FastifyAdapter`; explains the platform-agnostic adapter API and how to swap from the default Express adapter. |
+| [NestJS — GraphQL (Code First)](https://docs.nestjs.com/graphql/quick-start) | [ADR-006](adr/ADR-006-rest-and-graphql-dual-transport.md), [ADR-011](adr/ADR-011-api-server-nestjs-and-express.md) | Code-first approach using TypeScript decorators to generate the GraphQL SDL alongside REST controllers in the same module. |
+| [Fastify — Documentation](https://fastify.dev/docs/latest/) | [ADR-011](adr/ADR-011-api-server-nestjs-and-express.md) | The underlying HTTP framework; covers request/response lifecycle, plugins, and schema-based validation. |
+| [Fastify — Benchmarks](https://fastify.dev/benchmarks/) | [ADR-011](adr/ADR-011-api-server-nestjs-and-express.md) | Benchmark data supporting the ~2× throughput advantage over Express cited in the Rationale. |
+| [Express.js — Routing](https://expressjs.com/en/guide/routing.html) | [ADR-011](adr/ADR-011-api-server-nestjs-and-express.md) | The manual routing approach (`app.get()`) used in the legacy `apps/api-legacy` implementation. |
+
+---
+
+## Transport Layer (REST + GraphQL)
+
+| Source | Cited In | Relevance |
+|---|---|---|
+| [GraphQL Specification (October 2021)](https://spec.graphql.org/October2021/) | [ADR-006](adr/ADR-006-rest-and-graphql-dual-transport.md) | Normative language and type system specification for GraphQL. |
+| [graphql/dataloader](https://github.com/graphql/dataloader) | [ADR-006](adr/ADR-006-rest-and-graphql-dual-transport.md) | The batching and caching utility for solving the N+1 problem in nested GraphQL resolvers. |
+| [Apollo Client — Documentation](https://www.apollographql.com/docs/react/) | [ADR-006](adr/ADR-006-rest-and-graphql-dual-transport.md) | GraphQL client library referenced in the REST vs. GraphQL caching comparison. |
+
+---
+
+## Authentication
+
+| Source | Cited In | Relevance |
+|---|---|---|
+| [RFC 6749 — OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749) | [ADR-005](adr/ADR-005-authentication-strategy.md) | Core OAuth 2.0 specification; defines the authorisation code flow used by Clerk and Auth0. |
+| [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html) | [ADR-005](adr/ADR-005-authentication-strategy.md) | OIDC identity layer on top of OAuth 2.0; defines the ID token, `sub` claim, and UserInfo endpoint. |
+| [RFC 7636 — PKCE](https://datatracker.ietf.org/doc/html/rfc7636) | [ADR-005](adr/ADR-005-authentication-strategy.md) | Proof Key for Code Exchange; prevents authorisation code interception in mobile and SPA flows. |
+| [OASIS SAML 2.0 Core Specification](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf) | [ADR-005](adr/ADR-005-authentication-strategy.md) | Enterprise SSO standard referenced in Future Considerations for B2B extension scenarios. |
+| [Clerk — Documentation](https://clerk.com/docs) | [ADR-005](adr/ADR-005-authentication-strategy.md) | Official Clerk docs; covers Next.js SDK, JWT verification, and organisation/session management. |
+| [Clerk — Next.js SDK](https://clerk.com/docs/references/nextjs/overview) | [ADR-007](adr/ADR-007-nextjs-app-router-web-frontend.md) | The `@clerk/nextjs` middleware-based auth integration for the App Router. |
+| [Auth0 — Documentation](https://auth0.com/docs) | [ADR-005](adr/ADR-005-authentication-strategy.md) | Official Auth0 docs; the primary alternative to Clerk. |
+
+---
+
+## Web Frontend
+
+| Source | Cited In | Relevance |
+|---|---|---|
+| [Next.js — App Router Documentation](https://nextjs.org/docs/app) | [ADR-007](adr/ADR-007-nextjs-app-router-web-frontend.md) | Official App Router docs; covers Server Components, Client Components, routing, layouts, and Suspense streaming. |
+| [React — Server Components](https://react.dev/reference/rsc/server-components) | [ADR-007](adr/ADR-007-nextjs-app-router-web-frontend.md) | React core team reference for RSC; the model the App Router is built on. |
+| [Next.js — Loading UI and Streaming](https://nextjs.org/docs/app/building-your-application/routing/loading-ui-and-streaming) | [ADR-007](adr/ADR-007-nextjs-app-router-web-frontend.md) | How Suspense boundaries and `loading.tsx` enable progressive rendering of data-heavy pages. |
+| [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/) | [ADR-007](adr/ADR-007-nextjs-app-router-web-frontend.md) | The testing approach for Client Components cited in the Consequences section. |
+
+---
+
+## Data Layer
+
+| Source | Cited In | Relevance |
+|---|---|---|
+| [Google Sheets API v4 — Reference](https://developers.google.com/sheets/api/reference/rest) | [ADR-004](adr/ADR-004-multi-data-store-adapters.md) | The API used by the Sheets adapter; documents range notation, batch operations, and value rendering modes. |
+| [Google Sheets API — Usage Limits](https://developers.google.com/sheets/api/limits) | [ADR-004](adr/ADR-004-multi-data-store-adapters.md) | The 100 requests/100 seconds per-user quota cited in the Consequences section. |
+| [googleapis npm package](https://www.npmjs.com/package/googleapis) | [ADR-004](adr/ADR-004-multi-data-store-adapters.md) | The Node.js client library wrapping the Sheets API. |
+| [Prisma ORM — Getting Started](https://www.prisma.io/docs/getting-started) | [ADR-004](adr/ADR-004-multi-data-store-adapters.md) | The ORM for the Postgres adapter; provides schema definition, type-safe query building, and migrations. |
+| [Prisma Migrate](https://www.prisma.io/docs/orm/prisma-migrate/getting-started) | [ADR-004](adr/ADR-004-multi-data-store-adapters.md) | The migration system for evolving the Postgres schema. |
+| [Prisma Client — Middleware](https://www.prisma.io/docs/orm/prisma-client/client-extensions/middleware) | [ADR-003](adr/ADR-003-per-user-data-store-config.md) | How Prisma middleware injects `app.current_user_id` before each query to enforce per-user scoping. |
+| [PostgreSQL — JSON Types (JSONB)](https://www.postgresql.org/docs/current/datatype-json.html) | [ADR-003](adr/ADR-003-per-user-data-store-config.md) | The `JSONB` column type used for `adapter_config`; covers indexing, operators, and storage behaviour. |
+| [PostgreSQL — Row Security Policies](https://www.postgresql.org/docs/current/ddl-rowsecurity.html) | [ADR-010](adr/ADR-010-multi-tenancy-data-isolation.md) | The RLS feature used for database-level isolation; `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` and `CREATE POLICY` syntax. |
+| [PostgreSQL — Schemas](https://www.postgresql.org/docs/current/ddl-schemas.html) | [ADR-010](adr/ADR-010-multi-tenancy-data-isolation.md) | The schema-per-tenant alternative to shared-schema; covers `CREATE SCHEMA` and `search_path`. |
+| [PgBouncer — Usage](https://www.pgbouncer.org/usage.html) | [ADR-010](adr/ADR-010-multi-tenancy-data-isolation.md) | Connection pooler cited in the schema-per-tenant alternative discussion (`search_path` management). |
+
+---
+
+## Infrastructure
+
+| Source | Cited In | Relevance |
+|---|---|---|
+| [GKE Autopilot — Overview](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview) | [ADR-009](adr/ADR-009-infrastructure-kubernetes-cloud-run.md) | Documents the Autopilot node management model, pod-based billing, and resource constraints. |
+| [Google Cloud Run — Overview](https://cloud.google.com/run/docs/overview/what-is-cloud-run) | [ADR-009](adr/ADR-009-infrastructure-kubernetes-cloud-run.md) | Documents scale-to-zero behaviour, cold start characteristics, and request-based billing. |
+| [Terraform — Documentation](https://developer.hashicorp.com/terraform/docs) | [ADR-009](adr/ADR-009-infrastructure-kubernetes-cloud-run.md) | IaC tool used to provision GKE, Cloud Run, VPC, and load balancer resources. |
+| [Helm — Documentation](https://helm.sh/docs/) | [ADR-009](adr/ADR-009-infrastructure-kubernetes-cloud-run.md) | Kubernetes package manager for `charts/api` and `charts/web`; covers chart structure, values files, and `helm upgrade`. |
+| [Kubernetes — Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) | [ADR-009](adr/ADR-009-infrastructure-kubernetes-cloud-run.md) | The HPA configuration shown in the Decision section (`minReplicas: 2`, `maxReplicas: 10`, CPU target 70%). |
+| [Google Cloud Load Balancing — HTTPS](https://cloud.google.com/load-balancing/docs/https) | [ADR-009](adr/ADR-009-infrastructure-kubernetes-cloud-run.md) | The load balancer used for 90/10 traffic splitting between GKE and Cloud Run. |
+| [Google Artifact Registry — Overview](https://cloud.google.com/artifact-registry/docs/overview) | [ADR-009](adr/ADR-009-infrastructure-kubernetes-cloud-run.md) | Container registry where Docker images are pushed by CI/CD. |
+| [k6 — Load Testing Documentation](https://grafana.com/docs/k6/latest/) | [ADR-009](adr/ADR-009-infrastructure-kubernetes-cloud-run.md) | Load testing tool used for the scale-out time metric in the A/B infrastructure comparison. |
+| [Google Cloud KMS — Envelope Encryption](https://cloud.google.com/kms/docs/envelope-encryption) | [ADR-003](adr/ADR-003-per-user-data-store-config.md) | Encryption strategy for the `adapter_config` column, which stores sensitive Sheets credentials. |
+
+---
+
+## Mobile
+
+| Source | Cited In | Relevance |
+|---|---|---|
+| [React Native — Getting Started](https://reactnative.dev/docs/getting-started) | [ADR-008](adr/ADR-008-mobile-strategy.md) | Official React Native documentation. |
+| [Expo — Documentation](https://docs.expo.dev) | [ADR-008](adr/ADR-008-mobile-strategy.md) | Expo managed workflow used in Phase 1; covers project structure, native modules, and OTA updates. |
+| [Expo EAS Build](https://docs.expo.dev/build/introduction/) | [ADR-008](adr/ADR-008-mobile-strategy.md) | Cloud build service producing Android APKs without a local native toolchain. |
+| [React Navigation — Getting Started](https://reactnavigation.org/docs/getting-started) | [ADR-008](adr/ADR-008-mobile-strategy.md) | Navigation library used in the React Native client. |
+| [Jetpack Compose — Documentation](https://developer.android.com/develop/ui/compose/documentation) | [ADR-008](adr/ADR-008-mobile-strategy.md) | Native Android UI framework used in the Kotlin (Phase 2) client. |
+| [Kotlin — Documentation](https://kotlinlang.org/docs/home.html) | [ADR-008](adr/ADR-008-mobile-strategy.md) | Official Kotlin language reference. |
+| [Google Play — Manage Tracks](https://support.google.com/googleplay/android-developer/answer/9844487) | [ADR-008](adr/ADR-008-mobile-strategy.md) | How internal, closed testing, and production tracks work; the mechanism for deploying Phase 1 and Phase 2 builds simultaneously. |
+
+---
+
+## Analytics and A/B Testing
+
+| Source | Cited In | Relevance |
+|---|---|---|
+| [Firebase Analytics — Overview](https://firebase.google.com/docs/analytics) | [ADR-012](adr/ADR-012-analytics-and-ab-testing.md) | Official Firebase Analytics docs; covers event logging, user properties, and audience segmentation. |
+| [React Native Firebase — Analytics](https://rnfirebase.io/analytics/usage) | [ADR-012](adr/ADR-012-analytics-and-ab-testing.md) | The `@react-native-firebase/analytics` SDK used in the React Native client. |
+| [Firebase Analytics for Android](https://firebase.google.com/docs/analytics/get-started?platform=android) | [ADR-012](adr/ADR-012-analytics-and-ab-testing.md) | The `com.google.firebase:firebase-analytics` SDK used in the Kotlin client. |
+| [Firebase Crashlytics](https://firebase.google.com/docs/crashlytics) | [ADR-012](adr/ADR-012-analytics-and-ab-testing.md) | Crash reporting SDK used in both clients; crash-free session rate is a primary A/B comparison metric. |
+| [Firebase Performance Monitoring](https://firebase.google.com/docs/perf-mon) | [ADR-012](adr/ADR-012-analytics-and-ab-testing.md) | Screen render time and app startup time SDK cited in the A/B metrics table. |
+| [Firebase — BigQuery Export](https://firebase.google.com/docs/projects/bigquery-export) | [ADR-012](adr/ADR-012-analytics-and-ab-testing.md) | How Firebase Analytics data is streamed to BigQuery for deeper analysis. |
+| [Optimizely Feature Experimentation — Welcome](https://docs.developers.optimizely.com/feature-experimentation/docs/welcome) | [ADR-012](adr/ADR-012-analytics-and-ab-testing.md) | Official Optimizely docs; covers experiment configuration, variation assignment, and event tracking. |
+| [Optimizely — JavaScript (React) SDK](https://docs.developers.optimizely.com/feature-experimentation/docs/javascript-react-sdk) | [ADR-012](adr/ADR-012-analytics-and-ab-testing.md) | The `@optimizely/react-sdk` used in the React Native client. |
+| [Optimizely — Android SDK](https://docs.developers.optimizely.com/feature-experimentation/docs/android-sdk) | [ADR-012](adr/ADR-012-analytics-and-ab-testing.md) | The `com.optimizely.sdk:android-sdk` used in the Kotlin client. |
+
+---
+
+## Compliance
+
+| Source | Cited In | Relevance |
+|---|---|---|
+| [GDPR — Article 17: Right to Erasure](https://gdpr-info.eu/art-17-gdpr/) | [ADR-010](adr/ADR-010-multi-tenancy-data-isolation.md) | The regulatory requirement driving the erasure complexity comparison between shared-schema and schema-per-tenant strategies. |
+| [HHS — HIPAA Security Rule](https://www.hhs.gov/hipaa/for-professionals/security/index.html) | [ADR-010](adr/ADR-010-multi-tenancy-data-isolation.md) | US healthcare data protection regulation discussed in the HIPAA section; relevant if the application is extended to clinical contexts. |

--- a/docs/adr/ADR-001-monorepo-structure.md
+++ b/docs/adr/ADR-001-monorepo-structure.md
@@ -74,3 +74,12 @@ cross-package changes harder.
 
 **Single flat package:** Simplest structure, but loses the clean separation between domain logic
 and infrastructure adapters that is central to the architectural goals of this project.
+
+---
+
+## References
+
+- [Turborepo — Getting Started](https://turbo.build/repo/docs) — Official Turborepo documentation; covers caching model, pipeline configuration, and workspace setup.
+- [Turborepo — `turbo prune`](https://turbo.build/repo/docs/reference/prune) — Pruning the monorepo to a minimal subgraph for Docker builds; referenced in the Consequences section.
+- [npm Workspaces](https://docs.npmjs.com/cli/v10/using-npm/workspaces) — The npm workspace protocol used for inter-package references (`"@logbook/core": "*"`).
+- [Nx — Getting Started](https://nx.dev/getting-started/intro) — The primary alternative considered; more opinionated and better suited to larger package counts.

--- a/docs/adr/ADR-002-ports-and-adapters.md
+++ b/docs/adr/ADR-002-ports-and-adapters.md
@@ -79,3 +79,11 @@ persistence technology. Less suited to the multi-adapter goal of this project.
 
 **No formal pattern (ad hoc separation):** The current GAS version's approach. Works at small
 scale but does not provide the enforcement or discoverability needed as the system grows.
+
+---
+
+## References
+
+- [Alistair Cockburn — Hexagonal Architecture (2005)](https://alistair.cockburn.us/hexagonal-architecture/) — The original article coining the Ports and Adapters pattern. The dependency rule and the port/adapter vocabulary used in this ADR come directly from here.
+- [Robert C. Martin — The Clean Architecture (2012)](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html) — Generalises the dependency inversion principle into the "dependency rule": source-code dependencies must point inward, toward higher-level policy.
+- [Martin Fowler — Inversion of Control Containers and the Dependency Injection Pattern](https://martinfowler.com/articles/injection.html) — Background on constructor injection and the IoC container patterns used by NestJS to wire adapters to ports.

--- a/docs/adr/ADR-003-per-user-data-store-config.md
+++ b/docs/adr/ADR-003-per-user-data-store-config.md
@@ -88,3 +88,11 @@ onboard Sheets users without immediate data migration is a functional requiremen
 Adds a third-party dependency for what is essentially a data routing decision. Overkill at this
 stage, though a feature flag layer could be added on top of this approach later for canary
 migrations.
+
+---
+
+## References
+
+- [PostgreSQL — JSON Types (JSONB)](https://www.postgresql.org/docs/current/datatype-json.html) — Documents the `JSONB` column type used for `adapter_config`; covers indexing, operators, and storage behaviour.
+- [Google Cloud KMS — Envelope Encryption](https://cloud.google.com/kms/docs/envelope-encryption) — The encryption strategy recommended for the `adapter_config` column, which stores sensitive Sheets OAuth tokens and service account credentials.
+- [Prisma Client — Middleware](https://www.prisma.io/docs/orm/prisma-client/client-extensions/middleware) — How Prisma middleware is used to enforce the per-user cache lookup and inject `app.current_user_id` before each query.

--- a/docs/adr/ADR-004-multi-data-store-adapters.md
+++ b/docs/adr/ADR-004-multi-data-store-adapters.md
@@ -100,3 +100,13 @@ portfolio signal for a director of engineering role.
 
 **Prisma for both Sheets and Postgres:** Not feasible — Prisma is a relational database ORM and
 has no Sheets adapter.
+
+---
+
+## References
+
+- [Google Sheets API v4 — Reference](https://developers.google.com/sheets/api/reference/rest) — The API used by the Sheets adapter for reads and writes; documents range notation, batch operations, and value rendering modes.
+- [Google Sheets API — Usage Limits](https://developers.google.com/sheets/api/limits) — Documents the 100 requests/100 seconds per-user quota cited in the Consequences section.
+- [googleapis npm package](https://www.npmjs.com/package/googleapis) — The Node.js client library wrapping the Sheets API.
+- [Prisma ORM — Getting Started](https://www.prisma.io/docs/getting-started) — The ORM used for the Postgres adapter; provides schema definition, type-safe query building, and migrations.
+- [Prisma Migrate](https://www.prisma.io/docs/orm/prisma-migrate/getting-started) — The migration system used for evolving the Postgres schema.

--- a/docs/adr/ADR-005-authentication-strategy.md
+++ b/docs/adr/ADR-005-authentication-strategy.md
@@ -94,3 +94,14 @@ For applications handling PHI (Protected Health Information) under HIPAA, the au
 provide a signed Business Associate Agreement (BAA). Auth0 (on Enterprise plan) and Clerk (on
 Enterprise plan) both offer BAAs. Custom OAuth implementations would need to be certified
 independently, which is significantly more expensive.
+
+---
+
+## References
+
+- [RFC 6749 — The OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749) — The IETF specification for OAuth 2.0; defines the authorisation code, implicit, client credentials, and resource owner password flows.
+- [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html) — The OIDC identity layer on top of OAuth 2.0; defines the ID token, `sub` claim, and UserInfo endpoint used by Clerk and Auth0.
+- [RFC 7636 — Proof Key for Code Exchange (PKCE)](https://datatracker.ietf.org/doc/html/rfc7636) — The PKCE extension that prevents authorisation code interception attacks; referenced in the Rationale section.
+- [OASIS SAML 2.0 Core Specification](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf) — The enterprise SSO standard cited in the Future Considerations section.
+- [Clerk — Documentation](https://clerk.com/docs) — Official Clerk developer docs; covers Next.js SDK, JWT verification, and organisation/session management.
+- [Auth0 — Documentation](https://auth0.com/docs) — Official Auth0 developer docs; the primary alternative to Clerk.

--- a/docs/adr/ADR-006-rest-and-graphql-dual-transport.md
+++ b/docs/adr/ADR-006-rest-and-graphql-dual-transport.md
@@ -107,3 +107,13 @@ what a REST migration looks like (the Express/NestJS legacy comparison serves a 
 
 **gRPC:** Relevant for internal service-to-service communication in microservice architectures.
 Not appropriate here — this is a client-facing API for web and mobile clients that expect HTTP.
+
+---
+
+## References
+
+- [GraphQL Specification (October 2021)](https://spec.graphql.org/October2021/) — The normative GraphQL language and type system specification.
+- [NestJS — GraphQL Quick Start](https://docs.nestjs.com/graphql/quick-start) — Documents the code-first approach using `@nestjs/graphql` and TypeScript decorators to generate the SDL.
+- [graphql/dataloader](https://github.com/graphql/dataloader) — The batching and caching utility for solving the N+1 problem in nested GraphQL resolvers; referenced in the Consequences section.
+- [Apollo Client — Documentation](https://www.apollographql.com/docs/react/) — The GraphQL client library referenced for client-side caching; cited in the REST vs. GraphQL caching comparison.
+- [NestJS — Controllers (REST)](https://docs.nestjs.com/controllers) — NestJS REST controller documentation using `@Get`, `@Post`, and related decorators.

--- a/docs/adr/ADR-007-nextjs-app-router-web-frontend.md
+++ b/docs/adr/ADR-007-nextjs-app-router-web-frontend.md
@@ -75,3 +75,13 @@ choice, but smaller ecosystem than Next.js. Ruled out on portfolio visibility gr
 
 **Vue or Svelte:** Viable frontend frameworks. Ruled out because the codebase is TypeScript-
 native and the team (and portfolio) is React-focused.
+
+---
+
+## References
+
+- [Next.js — App Router Documentation](https://nextjs.org/docs/app) — Official App Router docs; covers Server Components, Client Components, routing, layouts, and Suspense streaming.
+- [React — Server Components](https://react.dev/reference/rsc/server-components) — The React core team's reference documentation for React Server Components, the model the App Router is built on.
+- [Next.js — Loading UI and Streaming](https://nextjs.org/docs/app/building-your-application/routing/loading-ui-and-streaming) — How Suspense boundaries and `loading.tsx` enable progressive rendering; cited in the Rationale section.
+- [Clerk — Next.js SDK](https://clerk.com/docs/references/nextjs/overview) — The `@clerk/nextjs` SDK providing middleware-based authentication for the App Router.
+- [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/) — The testing approach for Client Components cited in the Consequences section.

--- a/docs/adr/ADR-008-mobile-strategy.md
+++ b/docs/adr/ADR-008-mobile-strategy.md
@@ -99,3 +99,15 @@ the TypeScript/Kotlin stack being built. Ruled out on ecosystem consistency grou
 
 **iOS:** Not currently a target platform. Could be added in a future phase using either React
 Native (minimal additional work) or Swift/SwiftUI (a separate native implementation).
+
+---
+
+## References
+
+- [React Native — Getting Started](https://reactnative.dev/docs/getting-started) — Official React Native documentation.
+- [Expo — Documentation](https://docs.expo.dev) — The Expo managed workflow used in Phase 1; covers project structure, native modules, and OTA updates.
+- [Expo EAS Build](https://docs.expo.dev/build/introduction/) — The cloud build service used to produce Android APKs without a local native toolchain.
+- [React Navigation — Getting Started](https://reactnavigation.org/docs/getting-started) — The navigation library used in the React Native client.
+- [Jetpack Compose — Documentation](https://developer.android.com/develop/ui/compose/documentation) — The native Android UI framework used in the Kotlin (Phase 2) client.
+- [Kotlin — Documentation](https://kotlinlang.org/docs/home.html) — Official Kotlin language reference.
+- [Google Play — Manage Tracks](https://support.google.com/googleplay/android-developer/answer/9844487) — How internal, closed testing, and production tracks work; the mechanism for deploying Phase 1 and Phase 2 builds simultaneously.

--- a/docs/adr/ADR-009-infrastructure-kubernetes-cloud-run.md
+++ b/docs/adr/ADR-009-infrastructure-kubernetes-cloud-run.md
@@ -175,3 +175,16 @@ of engineering role targeting enterprise environments.
 (circuit breaking, mTLS, richer A/B splitting). Appropriate for a microservice architecture.
 Ruled out as premature — the application is a monolith at this stage and Istio's operational
 cost is not justified.
+
+---
+
+## References
+
+- [GKE Autopilot — Overview](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview) — Documents the Autopilot node management model, pod-based billing, and resource constraints cited in the Rationale and cost estimate sections.
+- [Google Cloud Run — Overview](https://cloud.google.com/run/docs/overview/what-is-cloud-run) — Documents scale-to-zero behaviour, cold start characteristics, and request-based billing; all cited in the comparison rationale.
+- [Terraform — Documentation](https://developer.hashicorp.com/terraform/docs) — The IaC tool used to provision GKE, Cloud Run, VPC, and load balancer resources.
+- [Helm — Documentation](https://helm.sh/docs/) — The Kubernetes package manager used for `charts/api` and `charts/web`; covers chart structure, values files, and `helm upgrade`.
+- [Kubernetes — Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) — The HPA configuration shown in the Decision section (`minReplicas: 2`, `maxReplicas: 10`, CPU target 70%).
+- [Google Cloud Load Balancing — HTTPS Load Balancer](https://cloud.google.com/load-balancing/docs/https) — The load balancer used for traffic splitting between GKE and Cloud Run.
+- [Google Artifact Registry — Overview](https://cloud.google.com/artifact-registry/docs/overview) — The container registry where Docker images are pushed by CI/CD.
+- [k6 — Load Testing Documentation](https://grafana.com/docs/k6/latest/) — The load testing tool used for the scale-out time metric in the A/B comparison table.

--- a/docs/adr/ADR-010-multi-tenancy-data-isolation.md
+++ b/docs/adr/ADR-010-multi-tenancy-data-isolation.md
@@ -137,3 +137,13 @@ erasure is a hard requirement.
 expensive: each tenant requires a Cloud SQL instance (~$7–15/month minimum), making this
 prohibitively costly for a consumer product. Appropriate only for B2B SaaS with enterprise
 pricing that absorbs the infrastructure cost, or for HIPAA/regulated data.
+
+---
+
+## References
+
+- [PostgreSQL — Row Security Policies](https://www.postgresql.org/docs/current/ddl-rowsecurity.html) — The RLS feature used for database-level isolation; documents `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` and `CREATE POLICY` syntax.
+- [PostgreSQL — Schemas](https://www.postgresql.org/docs/current/ddl-schemas.html) — The schema-per-tenant alternative; covers `CREATE SCHEMA`, `search_path`, and namespace isolation.
+- [GDPR — Article 17: Right to Erasure](https://gdpr-info.eu/art-17-gdpr/) — The regulatory requirement analysed in the Compliance Analysis section; the difference in erasure complexity between shared-schema and schema-per-tenant is documented relative to this article.
+- [HHS — HIPAA Security Rule](https://www.hhs.gov/hipaa/for-professionals/security/index.html) — The US healthcare data protection regulation discussed in the HIPAA section; relevant if the application is extended to clinical contexts.
+- [PgBouncer — Usage](https://www.pgbouncer.org/usage.html) — The connection pooler cited in the schema-per-tenant alternative discussion (`search_path` management requirement).

--- a/docs/adr/ADR-011-api-server-nestjs-and-express.md
+++ b/docs/adr/ADR-011-api-server-nestjs-and-express.md
@@ -146,3 +146,15 @@ enterprise adoption. Ruled out on portfolio visibility grounds.
 choice. Excellent DX but not REST or GraphQL — using it would undermine the goal of comparing
 those two paradigms empirically ([ADR-006](ADR-006-rest-and-graphql-dual-transport.md)). Ruled
 out for this project.
+
+---
+
+## References
+
+- [NestJS — Documentation](https://docs.nestjs.com) — Official NestJS docs; covers modules, providers, controllers, guards, interceptors, and exception filters.
+- [NestJS — Dependency Injection](https://docs.nestjs.com/fundamentals/dependency-injection) — The DI container mechanics (`@Injectable`, `@Inject`, module providers) that replace Express's manual wiring.
+- [NestJS — Performance (Fastify)](https://docs.nestjs.com/techniques/performance) — Documents the `FastifyAdapter` used instead of the default Express adapter; explains the platform-agnostic adapter API.
+- [NestJS — GraphQL (Code First)](https://docs.nestjs.com/graphql/quick-start) — The code-first approach using TypeScript decorators to generate the SDL; used alongside REST controllers in the same module.
+- [Fastify — Documentation](https://fastify.dev/docs/latest/) — The underlying HTTP framework; covers request/response lifecycle, plugins, and schema-based validation.
+- [Fastify — Benchmarks](https://fastify.dev/benchmarks/) — Benchmark data supporting the ~2× throughput advantage over Express cited in the Rationale section.
+- [Express.js — Routing](https://expressjs.com/en/guide/routing.html) — The manual routing approach (`app.get()`) used in the legacy `apps/api-legacy` implementation.

--- a/docs/adr/ADR-012-analytics-and-ab-testing.md
+++ b/docs/adr/ADR-012-analytics-and-ab-testing.md
@@ -172,3 +172,17 @@ Cloud Messaging) reduces the number of SDK dependencies.
 **Custom analytics:** Logging events to the backend API and building analytics in BigQuery.
 Maximum flexibility, zero vendor dependency. Significantly more engineering effort. Ruled out
 for this project — the goal is demonstrated analytics integration, not a custom analytics stack.
+
+---
+
+## References
+
+- [Firebase Analytics — Overview](https://firebase.google.com/docs/analytics) — Official Firebase Analytics documentation; covers event logging, user properties, and audience segmentation.
+- [React Native Firebase — Analytics](https://rnfirebase.io/analytics/usage) — The `@react-native-firebase/analytics` SDK used in the React Native (Phase 1) client.
+- [Firebase Analytics for Android](https://firebase.google.com/docs/analytics/get-started?platform=android) — The `com.google.firebase:firebase-analytics` SDK used in the Kotlin (Phase 2) client.
+- [Firebase Crashlytics](https://firebase.google.com/docs/crashlytics) — The crash reporting SDK used in both clients; crash-free session rate is a primary A/B comparison metric.
+- [Firebase Performance Monitoring](https://firebase.google.com/docs/perf-mon) — The screen render time and app startup time SDK cited in the metrics table.
+- [Optimizely Feature Experimentation — Welcome](https://docs.developers.optimizely.com/feature-experimentation/docs/welcome) — Official Optimizely Feature Experimentation docs; covers experiment configuration, variation assignment, and event tracking.
+- [Optimizely — JavaScript (React) SDK](https://docs.developers.optimizely.com/feature-experimentation/docs/javascript-react-sdk) — The `@optimizely/react-sdk` used in the React Native client.
+- [Optimizely — Android SDK](https://docs.developers.optimizely.com/feature-experimentation/docs/android-sdk) — The `com.optimizely.sdk:android-sdk` used in the Kotlin client.
+- [Firebase — BigQuery Export](https://firebase.google.com/docs/projects/bigquery-export) — How Firebase Analytics data is streamed to BigQuery for deeper analysis; recommended in the Consequences section.


### PR DESCRIPTION
## Summary

Adds a `## References` section to each of the 12 ADRs and a new consolidated `docs/adr-references.md` index.

Each ADR reference section links to the canonical source for every technology, specification, or pattern cited in that document — covering official docs (NestJS, Next.js, Prisma, Firebase, etc.), IETF/OASIS/W3C specifications (OAuth 2.0, OIDC, PKCE, SAML 2.0, GraphQL), foundational writings (Cockburn's Hexagonal Architecture, Uncle Bob's Clean Architecture, Fowler's DI article), and regulatory sources (GDPR Article 17, HIPAA).

`docs/adr-references.md` groups all sources by domain for easy lookup:
- Architectural Patterns
- Monorepo Tooling
- API Server
- Transport Layer (REST + GraphQL)
- Authentication
- Web Frontend
- Data Layer
- Infrastructure
- Mobile
- Analytics and A/B Testing
- Compliance

## Acceptance Criteria

- [x] Each ADR has a `## References` section with links and relevance descriptions
- [x] `docs/adr-references.md` exists as a consolidated, domain-grouped index with back-links to each ADR

## Test Instructions

Open any ADR in `docs/adr/` and verify the `## References` section appears at the bottom. Open `docs/adr-references.md` and verify links are grouped by domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)