### PR TITLE
[docs] Create architecture diagrams

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -148,6 +148,19 @@ monorepo/
 
 ---
 
+## Architecture Diagrams
+
+Visual representations of the system are in [`docs/diagrams/`](diagrams/):
+
+| Diagram | What it shows |
+|---------|--------------|
+| [Hexagonal Architecture](diagrams/hexagonal-architecture.md) | `packages/core` at the center, port interfaces, and adapter implementations |
+| [Package Dependencies](diagrams/package-dependencies.md) | Compile-time dependency graph across all monorepo packages and apps |
+| [Deployment Topology](diagrams/deployment-topology.md) | GKE Autopilot vs. Cloud Run traffic split, shared infrastructure, CI/CD |
+| [Data Flow](diagrams/data-flow.md) | Request path: client → transport → domain service → repository adapter → data store |
+
+---
+
 ## Product Requirements
 
 See [PRD.md](PRD.md) for the lightweight product requirements document: user personas,

--- a/docs/diagrams/data-flow.md
+++ b/docs/diagrams/data-flow.md
@@ -1,0 +1,39 @@
+# Data Flow — Request Path
+
+A single request from a client through the full stack: transport authentication,
+per-user adapter resolution, domain logic execution, and persistence.
+
+```mermaid
+sequenceDiagram
+    participant Client as Client<br/>(web / mobile)
+    participant Transport as Transport Layer<br/>(REST Controller or GraphQL Resolver)
+    participant Auth as IAuthProvider<br/>(Clerk Adapter)
+    participant Factory as IRepositoryFactory
+    participant Service as Domain Service<br/>(packages/core)
+    participant Repo as IWorkoutRepository<br/>(Sheets or Postgres Adapter)
+    participant Store as Data Store<br/>(Google Sheets / PostgreSQL)
+
+    Client->>Transport: HTTP request + JWT
+    Transport->>Auth: verify(jwt)
+    Auth-->>Transport: AuthUser (user_id · adapter_type)
+    Transport->>Factory: forUser(authUser)
+    Note right of Factory: Reads user_data_source<br/>Returns correct adapter<br/>(cached ~5 min TTL)
+    Factory-->>Transport: RepositoryBundle
+    Transport->>Service: execute(input, repositoryBundle)
+    Service->>Repo: read / write domain objects
+    Repo->>Store: API call (Sheets) or SQL query (Postgres)
+    Store-->>Repo: raw data
+    Repo-->>Service: domain objects
+    Service-->>Transport: result
+    Transport-->>Client: HTTP response (JSON)
+```
+
+**Key points:**
+- The transport layer never contains business logic — it authenticates, resolves adapters, and delegates.
+- The domain service (`packages/core`) is unaware of which adapter is in use; it interacts only with port interfaces.
+- Adapter selection is per-user, per-request, enabling different users to be on different data stores simultaneously (Sheets vs. Postgres).
+- REST and GraphQL share the same service call path — only the transport wrapper differs.
+
+**See also:** [ADR-003: Per-User Data Store Configuration](../adr/ADR-003-per-user-data-store-config.md) ·
+[ADR-004: Multi-Data-Store Adapter Strategy](../adr/ADR-004-multi-data-store-adapters.md) ·
+[ADR-006: Dual Transport Layer](../adr/ADR-006-rest-and-graphql-dual-transport.md)

--- a/docs/diagrams/deployment-topology.md
+++ b/docs/diagrams/deployment-topology.md
@@ -1,0 +1,69 @@
+# Deployment Topology
+
+GKE Autopilot is the primary deployment target. Cloud Run runs the same container image
+as a secondary target for A/B infrastructure comparison. A Cloud Load Balancer splits
+traffic between them. Shared infrastructure (VPC, Cloud SQL, Artifact Registry) is
+provisioned by Terraform and consumed by both targets.
+
+```mermaid
+graph TB
+    Client["Client\n(Browser / Mobile App)"]
+
+    subgraph cicd["CI/CD"]
+        GHA["GitHub Actions\n(build · test · push · deploy)"]
+    end
+
+    subgraph gcp["Google Cloud Platform"]
+        AR["Artifact Registry\n(Docker images)"]
+        LB["Cloud Load Balancer\n(URL map · traffic split)"]
+
+        subgraph shared["Shared Infrastructure · Terraform"]
+            VPC["VPC"]
+            SQL["Cloud SQL\n(PostgreSQL)"]
+        end
+
+        subgraph gke["GKE Autopilot · primary (90%)"]
+            API_K8s["api · Deployment\n2–10 pods · HPA\nHelm managed"]
+            Web_K8s["web · Deployment\nHelm managed"]
+        end
+
+        subgraph cloudrun["Cloud Run · comparison (10%)"]
+            API_CR["api · Service\n(scale-to-zero)"]
+            Web_CR["web · Service\n(scale-to-zero)"]
+        end
+    end
+
+    subgraph external["External Services"]
+        Clerk["Clerk\n(Auth)"]
+        SheetsAPI["Google Sheets API\n(per-user data store)"]
+        Firebase["Firebase Analytics"]
+    end
+
+    Client --> LB
+    LB -->|"90%"| API_K8s
+    LB -->|"10%"| API_CR
+    LB --> Web_K8s
+    LB --> Web_CR
+    GHA --> AR
+    AR --> API_K8s
+    AR --> API_CR
+    AR --> Web_K8s
+    AR --> Web_CR
+    API_K8s --> SQL
+    API_CR --> SQL
+    API_K8s --> Clerk
+    API_CR --> Clerk
+    API_K8s --> SheetsAPI
+    API_CR --> SheetsAPI
+    API_K8s --> Firebase
+    API_CR --> Firebase
+    VPC --- SQL
+    VPC --- API_K8s
+    VPC --- API_CR
+```
+
+**Traffic split** is adjusted via Terraform without redeployment. Initial ratio: 90% GKE / 10%
+Cloud Run. Metrics captured for comparison: request latency (p50/p95/p99), cold start
+frequency, cost per request, and scale-out time under load.
+
+**See also:** [ADR-009: Infrastructure — GKE Autopilot Primary, Cloud Run Comparison](../adr/ADR-009-infrastructure-kubernetes-cloud-run.md)

--- a/docs/diagrams/hexagonal-architecture.md
+++ b/docs/diagrams/hexagonal-architecture.md
@@ -1,0 +1,57 @@
+# Hexagonal Architecture (Ports and Adapters)
+
+`packages/core` contains pure domain logic with zero infrastructure dependencies. All
+external concerns — data storage, authentication, transport — are accessed through port
+interfaces and implemented as swappable adapters.
+
+**Dependency rule:** source-code dependencies point inward. Transport and adapters depend
+on ports and core. Core depends on nothing outside itself.
+
+Solid arrows = call / depend on. Dashed arrows = implements.
+
+```mermaid
+graph TB
+    subgraph clients["Clients"]
+        Web["apps/web\n(Next.js)"]
+        Mobile["apps/mobile\n(Expo)"]
+    end
+
+    subgraph transport["Transport · apps/api/src/transport"]
+        REST["REST Controllers\n/api/rest/v1/"]
+        GQL["GraphQL Resolvers\n/api/graphql"]
+    end
+
+    subgraph domain["Domain · packages/core"]
+        Services["Domain Services\n(RPT logic · progression math)"]
+        Models["Models / Parsers"]
+    end
+
+    subgraph ports["Port Interfaces · apps/api/src/ports"]
+        IAuth["IAuthProvider"]
+        IFactory["IRepositoryFactory"]
+        IRepos["IWorkoutRepository\nITrainingMaxRepository\nILiftRecordRepository · …"]
+    end
+
+    subgraph adapters["Adapters · apps/api/src/adapters"]
+        Clerk["Clerk\nAuth Adapter"]
+        Sheets["Google Sheets\nRepository Adapters"]
+        PG["PostgreSQL\nRepository Adapters"]
+    end
+
+    Web -->|HTTP| REST
+    Web -->|HTTP| GQL
+    Mobile -->|HTTP| REST
+    Mobile -->|HTTP| GQL
+    REST --> Services
+    GQL --> Services
+    Services --> IAuth
+    Services --> IFactory
+    IFactory --> IRepos
+    Clerk -.->|implements| IAuth
+    Sheets -.->|implements| IRepos
+    PG -.->|implements| IRepos
+```
+
+**See also:** [ADR-002: Hexagonal Architecture](../adr/ADR-002-ports-and-adapters.md) ·
+[ADR-003: Per-User Data Store Configuration](../adr/ADR-003-per-user-data-store-config.md) ·
+[ADR-006: Dual Transport Layer](../adr/ADR-006-rest-and-graphql-dual-transport.md)

--- a/docs/diagrams/package-dependencies.md
+++ b/docs/diagrams/package-dependencies.md
@@ -1,0 +1,32 @@
+# Monorepo Package Dependency Graph
+
+Arrows indicate compile-time dependencies (`package.json` workspace references).
+`packages/core` and `packages/types` have no local dependencies — they are the
+foundation the rest of the monorepo builds on.
+
+```mermaid
+graph TB
+    subgraph packages["packages/"]
+        Core["packages/core\npure domain logic\n(services · models · parsers)"]
+        Types["packages/types\nshared TypeScript interfaces\n& API contracts"]
+    end
+
+    subgraph apps["apps/"]
+        API["apps/api\nNestJS + Fastify\n(primary API server)"]
+        APILegacy["apps/api-legacy\nExpress\n(legacy comparison)"]
+        Web["apps/web\nNext.js App Router"]
+        Mobile["apps/mobile\nExpo (React Native)"]
+    end
+
+    API --> Core
+    API --> Types
+    APILegacy --> Core
+    APILegacy --> Types
+    Web --> Types
+    Mobile --> Types
+```
+
+`apps/web` and `apps/mobile` depend on `packages/types` for shared API contracts
+(request/response shapes) but not on `packages/core` — domain logic runs server-side only.
+
+**See also:** [ADR-001: Monorepo Structure with Turborepo](../adr/ADR-001-monorepo-structure.md)


### PR DESCRIPTION
## Summary

- Adds `docs/diagrams/` with four Mermaid diagrams covering the system's structural views
- Updates `docs/README.md` with a new Architecture Diagrams section and index table

## Diagrams

| File | What it shows |
|------|--------------|
| `hexagonal-architecture.md` | `packages/core` at center, port interfaces, adapter implementations (solid = calls/depends, dashed = implements) |
| `package-dependencies.md` | Compile-time workspace dependency graph: core and types have no local deps; api and api-legacy depend on both; web and mobile depend on types only |
| `deployment-topology.md` | GKE Autopilot (90%) / Cloud Run (10%) traffic split via Cloud Load Balancer; shared Terraform-managed infra; GitHub Actions CI/CD push to Artifact Registry |
| `data-flow.md` | Sequence diagram: JWT auth → per-user adapter resolution (IRepositoryFactory) → domain service call → repository adapter → data store |

## Acceptance Criteria

- [x] Hexagonal architecture diagram — shows `packages/core` at the center, port interfaces, and adapter implementations in apps/api
- [x] Monorepo package dependency graph — shows relationships between packages/core, packages/types, apps/api, apps/api-legacy, apps/web, apps/mobile
- [x] Deployment topology diagram — GKE Autopilot vs. Cloud Run paths, shared infra (VPC, load balancer, DNS)
- [x] Data flow diagram — request path from client → transport → use case → repository adapter → data store
- [x] Diagrams stored in `docs/diagrams/` and referenced from `docs/README.md`
- [x] Format: Mermaid (renders natively in GitHub)

Closes #23