### PR TITLE
[chore] Scaffold apps/api — NestJS with Fastify adapter

### DIFF
--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/*.spec.ts'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.json' }],
+  },
+  transformIgnorePatterns: ['/node_modules/'],
+};

--- a/apps/api/nest-cli.json
+++ b/apps/api/nest-cli.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/nest-cli",
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src",
+  "entryFile": "main"
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,10 +7,23 @@
     "dev": "nest start --watch",
     "start": "node dist/main.js",
     "lint": "eslint src",
-    "test": "jest --passWithNoTests"
+    "test": "jest"
   },
   "dependencies": {
     "@lifting-logbook/core": "*",
-    "@lifting-logbook/types": "*"
+    "@lifting-logbook/types": "*",
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-fastify": "^10.0.0",
+    "fastify": "^4.0.0",
+    "reflect-metadata": "^0.2.0",
+    "rxjs": "^7.8.0"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "@nestjs/schematics": "^10.0.0",
+    "@nestjs/testing": "^10.0.0",
+    "ts-node": "^10.9.0",
+    "tsconfig-paths": "^4.2.0"
   }
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { HealthModule } from './health/health.module';
+
+@Module({
+  imports: [HealthModule],
+})
+export class AppModule {}

--- a/apps/api/src/health/health.controller.spec.ts
+++ b/apps/api/src/health/health.controller.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HealthController } from './health.controller';
+
+describe('HealthController', () => {
+  let controller: HealthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+    }).compile();
+
+    controller = module.get<HealthController>(HealthController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('GET /health returns status ok with an ISO timestamp', () => {
+    const result = controller.health();
+
+    expect(result.status).toBe('ok');
+    expect(typeof result.timestamp).toBe('string');
+    expect(new Date(result.timestamp).toISOString()).toBe(result.timestamp);
+  });
+});

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller()
+export class HealthController {
+  @Get('health')
+  health(): { status: string; timestamp: string } {
+    return { status: 'ok', timestamp: new Date().toISOString() };
+  }
+}

--- a/apps/api/src/health/health.module.ts
+++ b/apps/api/src/health/health.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { HealthController } from './health.controller';
+
+@Module({
+  controllers: [HealthController],
+})
+export class HealthModule {}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,0 +1,14 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create<NestFastifyApplication>(
+    AppModule,
+    new FastifyAdapter(),
+  );
+  await app.listen(3000, '0.0.0.0');
+}
+
+bootstrap();

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "**/*.spec.ts"]
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Expands the `apps/api` stub (created in #4) into a full NestJS scaffold with Fastify adapter
- Adds `GET /health` endpoint returning `{ status: 'ok', timestamp: <ISO-8601> }` — the only endpoint at this milestone
- All config files in place: `nest-cli.json`, `tsconfig.json`, `tsconfig.build.json`, `jest.config.js`

## Acceptance Criteria

- [x] `apps/api/src/main.ts` bootstraps with `FastifyAdapter`, binds `0.0.0.0:3000`
- [x] `GET /health` returns `{ status: 'ok', timestamp: <ISO string> }`
- [x] `tsconfig.build.json` excludes `**/*.spec.ts` — dist is clean
- [x] `nest-cli.json` has `sourceRoot: "src"` and `entryFile: "main"`
- [x] `turbo run test --filter=@lifting-logbook/api` passes (2/2 specs green)
- [x] `nest build` succeeds — `dist/main.js` present for Dockerfile runner stage

## Notes

Replaces auto-closed #47 (base branch deleted on merge of #46). Head branch and commits are unchanged.

## Test plan

- `npm install` from repo root
- `npx turbo run test --filter=@lifting-logbook/api` — expect 2 passing specs
- `npx turbo run build --filter=@lifting-logbook/api` — expect `apps/api/dist/main.js` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)