### PR TITLE
[chore] Add Claude Code hook-config and gitignore settings.local.json

### DIFF
--- a/.claude/hook-config.json
+++ b/.claude/hook-config.json
@@ -1,0 +1,20 @@
+{
+  "repo": "brownm09/lifting-logbook",
+  "project_number": "2",
+  "project_owner": "brownm09",
+  "project_node_id": "PVT_kwHOAjEKvM4BTuEF",
+  "epic_field_id": "PVTSSF_lAHOAjEKvM4BTuEFzhA7GEs",
+  "epic_options": {
+    "Monorepo Scaffolding":         "974b67c1",
+    "Package & App Scaffolding":    "26d27ab2",
+    "Port Interfaces":              "9196ffd9",
+    "Shared Types":                 "42bf8843",
+    "CI/CD Foundation":             "23133b3a",
+    "Architecture & Documentation": "656e470c"
+  },
+  "milestones": [
+    "v0.1 — Foundation",
+    "v0.2 — Core API",
+    "v0.3 — Client Applications"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dist/
 
 # GAS / clasp (retained from source repo — remove when GAS migration is complete)
 .clasptoken*
+
+# Claude Code local overrides (machine-specific permissions, not for team sharing)
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Opts lifting-logbook into the global `PostToolUse` hook (`~/.claude/scripts/post-tool-use.py`) by providing `.claude/hook-config.json` with project-specific IDs. The global hook reads this file from `cwd` at runtime and skips silently if absent, so the hook works across any project that provides one.

Also gitignores `.claude/settings.local.json` so machine-specific permission overrides are never accidentally committed.

## Global hook tracking

Primary issue: brownm09/engineering-journal#6

## Acceptance Criteria

- [x] `.claude/hook-config.json` present with repo, project number, owner, node ID, Epic field ID, Epic options, and milestones
- [x] `.claude/settings.local.json` added to `.gitignore`
- [ ] Global hook script exists at `~/.claude/scripts/post-tool-use.py` (out of band — not committed to this repo)
- [ ] `~/.claude/settings.json` updated to register the hook (out of band)

## Test

Create a test issue with `gh issue create` and confirm the hook fires, adds the item to project #2, and emits the Epic/milestone reminder via stderr.