### PR TITLE
[docs] Add ROADMAP.md and docs/proposals/ convention

### DIFF
--- a/.claude/hook-config.json
+++ b/.claude/hook-config.json
@@ -1,0 +1,20 @@
+{
+  "repo": "brownm09/lifting-logbook",
+  "project_number": "2",
+  "project_owner": "brownm09",
+  "project_node_id": "PVT_kwHOAjEKvM4BTuEF",
+  "epic_field_id": "PVTSSF_lAHOAjEKvM4BTuEFzhA7GEs",
+  "epic_options": {
+    "Monorepo Scaffolding":         "974b67c1",
+    "Package & App Scaffolding":    "26d27ab2",
+    "Port Interfaces":              "9196ffd9",
+    "Shared Types":                 "42bf8843",
+    "CI/CD Foundation":             "23133b3a",
+    "Architecture & Documentation": "656e470c"
+  },
+  "milestones": [
+    "v0.1 — Foundation",
+    "v0.2 — Core API",
+    "v0.3 — Client Applications"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dist/
 
 # GAS / clasp (retained from source repo — remove when GAS migration is complete)
 .clasptoken*
+
+# Claude Code local overrides (machine-specific permissions, not for team sharing)
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,34 @@ Before writing a `gh` or other CLI automation script:
 
 ---
 
+## Proposals and Roadmap
+
+### /propose workflow
+
+Run `/propose <one-line idea>` from the repo root to introduce a new feature or change.
+The skill handles the full flow: clarifying questions → proposal doc → GitHub issue → ROADMAP entry → PR.
+
+Do not create `docs/proposals/` files or ROADMAP entries manually unless `/propose` is
+unavailable. The skill ensures the issue, epic, and milestone are assigned consistently.
+
+### docs/proposals/ convention
+
+- Files live at `docs/proposals/YYYY-MM-DD-<slug>.md`
+- The master template is at `dev-env/claude/templates/proposal.md` — do not duplicate it here
+- Statuses: `draft` → `accepted` → `shipped` | `declined`
+- Update the `**Status:**` field in the proposal file when status changes
+- Update the linked issue's milestone or labels to match if scope changes
+
+### ROADMAP.md maintenance
+
+- `ROADMAP.md` at the repo root is the editorial view; it is **not** a GitHub mirror
+- `/propose` appends rows to the correct milestone's **Proposals** table automatically
+- Update the **Active Work** tables manually when: an item starts, completes, or moves milestones
+- Material milestone-scope changes (dropping or moving items) require a PR with an explicit
+  explanation — same bar as material changes to `docs/PRD.md`
+
+---
+
 ## Coding Standards
 
 App-level coding standards are in `docs/standards/`. Each file is a self-contained rule with

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,87 @@
+# Lifting Logbook — Roadmap
+
+Lifting Logbook is a personal strength training tracker replacing a Google Apps Script /
+Google Sheets implementation with a cloud-native web and mobile product. See [`docs/PRD.md`](docs/PRD.md)
+for the full product definition.
+
+**This is a human-curated editorial view.** It does not auto-sync from GitHub. New features
+are proposed via `/propose`, which creates the proposal doc, the GitHub issue, and the entry
+below. Status is updated manually as work progresses.
+
+---
+
+## v0.1 — Foundation `[Current]`
+
+Monorepo scaffolding, port interfaces, shared types, and CI/CD. The goal is a working
+skeleton where every app and package is wired together and the core hexagonal architecture
+is codified.
+
+### Active Work
+
+| Work stream | Description | Issues |
+|---|---|---|
+| App scaffolding | Scaffold `apps/web` (Next.js App Router) and `apps/mobile` (Expo) | [#9](https://github.com/brownm09/lifting-logbook/issues/9), [#10](https://github.com/brownm09/lifting-logbook/issues/10) |
+| Port interfaces | Define `IAuthProvider`, data repository ports, and `IRepositoryFactory` | [#11](https://github.com/brownm09/lifting-logbook/issues/11), [#12](https://github.com/brownm09/lifting-logbook/issues/12), [#13](https://github.com/brownm09/lifting-logbook/issues/13) |
+| Shared types | Domain types and API contract types in `packages/types` | [#14](https://github.com/brownm09/lifting-logbook/issues/14), [#15](https://github.com/brownm09/lifting-logbook/issues/15) |
+| CI/CD foundation | Lint and test on PR; Docker build and push on merge to main | [#16](https://github.com/brownm09/lifting-logbook/issues/16), [#17](https://github.com/brownm09/lifting-logbook/issues/17) |
+| Process infrastructure | ROADMAP and `docs/proposals/` convention | [#58](https://github.com/brownm09/lifting-logbook/issues/58) |
+
+### Proposals
+
+| Proposal | Description | Issue |
+|---|---|---|
+| *(none yet)* | | |
+
+---
+
+## v0.2 — Core API `[Next]`
+
+A working REST + GraphQL API backed by real adapters. Core module quality gates enforced.
+Architecture decisions for data access and security documented.
+
+### Active Work
+
+| Work stream | Description | Issues |
+|---|---|---|
+| Core module cleanup | Enable strict TypeScript; remove GAS Logger dependency | [#51](https://github.com/brownm09/lifting-logbook/issues/51), [#52](https://github.com/brownm09/lifting-logbook/issues/52) |
+| Architecture documentation | ADR-014 credential encryption; cache invalidation strategy; ADR-015 GraphQL DataLoader; Express legacy archival policy | [#38](https://github.com/brownm09/lifting-logbook/issues/38), [#39](https://github.com/brownm09/lifting-logbook/issues/39), [#40](https://github.com/brownm09/lifting-logbook/issues/40), [#42](https://github.com/brownm09/lifting-logbook/issues/42) |
+| Cycle planning — design | ADR-016: LLM integration, tool schema, and adapter boundary for the cycle planning agent | [#55](https://github.com/brownm09/lifting-logbook/issues/55) |
+
+### Proposals
+
+| Proposal | Description | Issue |
+|---|---|---|
+| *(none yet)* | | |
+
+---
+
+## v0.3 — Client Applications `[Later]`
+
+Web and mobile clients functional end-to-end. Key user-facing features implemented.
+
+### Active Work
+
+| Work stream | Description | Issues |
+|---|---|---|
+| Bodyweight exercise tracking | Track body weight; calculate added weight for exercises like weighted chin-ups and dips (J4 from PRD) | [#29](https://github.com/brownm09/lifting-logbook/issues/29) |
+| Cycle planning — implementation | LLM-powered training cycle recommendations, using design from ADR-016 | [#54](https://github.com/brownm09/lifting-logbook/issues/54) |
+| Mobile dependency wiring | Add `@logbook/types` workspace dependency to `apps/mobile` | [#50](https://github.com/brownm09/lifting-logbook/issues/50) |
+| A/B comparison documentation | Define exit criteria and CI event taxonomy enforcement for Express/NestJS comparison | [#41](https://github.com/brownm09/lifting-logbook/issues/41) |
+
+### Proposals
+
+| Proposal | Description | Issue |
+|---|---|---|
+| *(none yet)* | | |
+
+---
+
+## Maintenance
+
+- **Adding an item:** run `/propose <idea>` — it creates the proposal doc, the GitHub issue,
+  and the entry in the appropriate milestone section above.
+- **Updating status:** edit this file directly when work starts, completes, or is deferred.
+  No special workflow required for status changes.
+- **Milestone scope changes:** material changes (moving items between milestones, dropping
+  items) follow the same PR process as `docs/PRD.md` material changes — explicit statement
+  of what changed and why.

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,27 @@
+# docs/proposals/
+
+Lightweight feature proposal documents for Lifting Logbook.
+
+## How proposals are created
+
+Run `/propose <one-line idea>` from the repo root. The skill will:
+
+1. Ask a few clarifying questions
+2. Draft a proposal doc using the master template
+3. Write the file here as `YYYY-MM-DD-<slug>.md`
+4. Create the linked GitHub issue (with project, milestone, and epic assignment)
+5. Add the item to `ROADMAP.md` under the chosen milestone
+6. Open a PR
+
+**Master template:** [`dev-env/claude/templates/proposal.md`](https://github.com/brownm09/dev-env/blob/main/claude/templates/proposal.md)
+
+This directory holds output files only. The template lives in `dev-env`.
+
+## Proposal lifecycle
+
+| Status | Meaning |
+|---|---|
+| `draft` | Written; not yet reviewed or committed to |
+| `accepted` | Approved; linked issue is active or scheduled |
+| `shipped` | Implemented and merged |
+| `declined` | Explicitly ruled out; file kept for reference |


### PR DESCRIPTION
## Summary

- Add `ROADMAP.md` at the repo root: human-curated, milestone-grouped editorial view populated from existing open issues
- Add `docs/proposals/README.md`: marks the directory as output-only; template lives in `dev-env`
- Update `CLAUDE.md`: document `/propose` workflow, `docs/proposals/` format, and ROADMAP maintenance rules

## Changes

- `ROADMAP.md` — v0.1 / v0.2 / v0.3 sections with Active Work tables (from current open issues) and empty Proposals tables (filled by `/propose`)
- `docs/proposals/README.md` — proposal lifecycle, link to master template in `dev-env`
- `CLAUDE.md` — new `## Proposals and Roadmap` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)