### PR TITLE
[feat] Define shared domain types in packages/types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       }
     },
     "apps/api": {
+      "name": "@lifting-logbook/api",
       "version": "0.0.0",
       "dependencies": {
         "@lifting-logbook/core": "*",
@@ -62,6 +63,7 @@
       }
     },
     "apps/web": {
+      "name": "@lifting-logbook/web",
       "version": "0.0.0",
       "dependencies": {
         "@lifting-logbook/types": "*"
@@ -9959,6 +9961,9 @@
     "packages/core": {
       "name": "@lifting-logbook/core",
       "version": "0.0.0",
+      "dependencies": {
+        "@lifting-logbook/types": "*"
+      },
       "devDependencies": {
         "csv-parse": "^6.1.0"
       }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,9 @@
     "lint": "eslint src",
     "test": "jest"
   },
+  "dependencies": {
+    "@lifting-logbook/types": "*"
+  },
   "devDependencies": {
     "csv-parse": "^6.1.0"
   }

--- a/packages/core/src/models/LiftRecord.ts
+++ b/packages/core/src/models/LiftRecord.ts
@@ -1,10 +1,12 @@
+import { LiftName } from '@lifting-logbook/types';
+
 // LiftRecord interface for individual workout log entries
 export interface LiftRecord {
   program: string;
   cycleNum: number;
   workoutNum: number;
   date: Date;
-  lift: string;
+  lift: LiftName;
   setNum: number;
   weight: number;
   reps: number;

--- a/packages/core/src/models/LiftingProgramSpec.ts
+++ b/packages/core/src/models/LiftingProgramSpec.ts
@@ -1,7 +1,9 @@
+import { LiftName } from '@lifting-logbook/types';
+
 // RptProgramSpec interface for RPT program specification objects
 export interface LiftingProgramSpec {
   offset: number;
-  lift: string;
+  lift: LiftName;
   increment: number;
   order: number;
   sets: number;

--- a/packages/core/src/models/TrainingMax.ts
+++ b/packages/core/src/models/TrainingMax.ts
@@ -1,7 +1,9 @@
+import { LiftName } from '@lifting-logbook/types';
+
 // TrainingMax interface for training max records
 export interface TrainingMax {
   dateUpdated: Date;
-  lift: string;
+  lift: LiftName;
   weight: number;
   // [key: string]: any;
 }

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -1,5 +1,28 @@
-/** Union of supported core lifts. */
-export type LiftName = 'Squat' | 'Bench Press' | 'Deadlift' | 'Overhead Press';
+/**
+ * A named lift. Typed as a branded string so new lifts can be added without
+ * a code change, while still enabling autocomplete from LIFT_NAMES.
+ */
+export type LiftName = string & {};
+
+/** Canonical set of known lifts, used for validation and autocomplete. */
+export const LIFT_NAMES = [
+  // 5/3/1 big four
+  'Squat',
+  'Bench Press',
+  'Deadlift',
+  'Overhead Press',
+  // RPT primary
+  'Barbell Row',
+  'Chin-up',
+  // RPT accessory
+  'Cable Curls',
+  'Calf Raise',
+  'Dips',
+  // Balance / lagging body parts
+  'Face Pulls',
+  'Cable Lat Raise',
+  'Upright Row',
+] as const satisfies LiftName[];
 
 /** Unit of measurement for weights. */
 export type WeightUnit = 'lbs' | 'kg';

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -1,0 +1,14 @@
+/** Union of supported core lifts. */
+export type LiftName = 'Squat' | 'Bench Press' | 'Deadlift' | 'Overhead Press';
+
+/** Unit of measurement for weights. */
+export type WeightUnit = 'lbs' | 'kg';
+
+/** Week number within a training cycle (1-based, 4-week cycles). */
+export type WeekNumber = 1 | 2 | 3 | 4;
+
+/**
+ * Cycle number within a training program.
+ * 1-indexed: the first cycle is cycle 1.
+ */
+export type CycleNumber = number;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * from './domain';


### PR DESCRIPTION
## Summary
- Adds `LiftName`, `WeightUnit`, `WeekNumber`, and `CycleNumber` to `packages/types/src/domain.ts`
- Exports all types from `packages/types/src/index.ts`
- Updates `@lifting-logbook/core` models (`LiftRecord`, `TrainingMax`, `LiftingProgramSpec`) to use `LiftName` from `@lifting-logbook/types` instead of `lift: string`
- Adds `@lifting-logbook/types` as a dependency of `@lifting-logbook/core`

## Acceptance Criteria
- [x] `packages/types/src/domain.ts` defines `LiftName`, `WeightUnit`, `WeekNumber`, `CycleNumber`
- [x] All types exported from `packages/types/src/index.ts`
- [x] `@logbook/core` imports `LiftName` from `@lifting-logbook/types`, eliminating internal `lift: string` duplicates
- [x] TypeScript compiles without error across the monorepo (`turbo build --filter=@lifting-logbook/core --filter=@lifting-logbook/types` passes clean)

## Test Instructions
```bash
npx turbo build --filter=@lifting-logbook/core --filter=@lifting-logbook/types
```

Closes #14