### PR TITLE
[feat] Define data repository port interfaces

### DIFF
--- a/apps/api/src/ports/ICycleDashboardRepository.ts
+++ b/apps/api/src/ports/ICycleDashboardRepository.ts
@@ -1,0 +1,7 @@
+import { CycleDashboard } from '@lifting-logbook/core';
+
+export interface ICycleDashboardRepository {
+  getCycleDashboard(program: string): Promise<CycleDashboard>;
+
+  saveCycleDashboard(dashboard: CycleDashboard): Promise<void>;
+}

--- a/apps/api/src/ports/ILiftRecordRepository.ts
+++ b/apps/api/src/ports/ILiftRecordRepository.ts
@@ -1,0 +1,7 @@
+import { LiftRecord } from '@lifting-logbook/core';
+
+export interface ILiftRecordRepository {
+  getLiftRecords(program: string, cycleNum: number): Promise<LiftRecord[]>;
+
+  appendLiftRecords(program: string, records: LiftRecord[]): Promise<void>;
+}

--- a/apps/api/src/ports/ILiftingProgramSpecRepository.ts
+++ b/apps/api/src/ports/ILiftingProgramSpecRepository.ts
@@ -1,0 +1,5 @@
+import { LiftingProgramSpec } from '@lifting-logbook/core';
+
+export interface ILiftingProgramSpecRepository {
+  getProgramSpec(program: string): Promise<LiftingProgramSpec[]>;
+}

--- a/apps/api/src/ports/ITrainingMaxRepository.ts
+++ b/apps/api/src/ports/ITrainingMaxRepository.ts
@@ -1,0 +1,7 @@
+import { TrainingMax } from '@lifting-logbook/core';
+
+export interface ITrainingMaxRepository {
+  getTrainingMaxes(program: string): Promise<TrainingMax[]>;
+
+  saveTrainingMaxes(program: string, maxes: TrainingMax[]): Promise<void>;
+}

--- a/apps/api/src/ports/IWorkoutRepository.ts
+++ b/apps/api/src/ports/IWorkoutRepository.ts
@@ -1,0 +1,16 @@
+import { LiftRecord } from '@lifting-logbook/core';
+
+export interface IWorkoutRepository {
+  getWorkout(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+  ): Promise<LiftRecord[]>;
+
+  saveWorkout(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+    records: LiftRecord[],
+  ): Promise<void>;
+}

--- a/apps/api/src/ports/index.ts
+++ b/apps/api/src/ports/index.ts
@@ -1,0 +1,5 @@
+export * from './ICycleDashboardRepository';
+export * from './ILiftingProgramSpecRepository';
+export * from './ILiftRecordRepository';
+export * from './ITrainingMaxRepository';
+export * from './IWorkoutRepository';

--- a/apps/api/src/ports/ports.compile-test.ts
+++ b/apps/api/src/ports/ports.compile-test.ts
@@ -1,0 +1,74 @@
+/**
+ * Compile-time contract tests for port interfaces.
+ *
+ * Each test assigns a mock object literal directly to the interface type.
+ * If the mock is missing a required method or uses an incompatible signature,
+ * the TypeScript compiler will error here — no runtime needed.
+ */
+import { CycleDashboard, LiftRecord, LiftingProgramSpec, TrainingMax } from '@lifting-logbook/core';
+import { ICycleDashboardRepository } from './ICycleDashboardRepository';
+import { ILiftingProgramSpecRepository } from './ILiftingProgramSpecRepository';
+import { ILiftRecordRepository } from './ILiftRecordRepository';
+import { ITrainingMaxRepository } from './ITrainingMaxRepository';
+import { IWorkoutRepository } from './IWorkoutRepository';
+
+// ---------------------------------------------------------------------------
+// ICycleDashboardRepository
+// ---------------------------------------------------------------------------
+
+const _cycleDashboardRepo: ICycleDashboardRepository = {
+  getCycleDashboard: (): Promise<CycleDashboard> =>
+    Promise.resolve({} as CycleDashboard),
+  saveCycleDashboard: (): Promise<void> =>
+    Promise.resolve(),
+};
+
+// ---------------------------------------------------------------------------
+// ILiftingProgramSpecRepository
+// ---------------------------------------------------------------------------
+
+const _programSpecRepo: ILiftingProgramSpecRepository = {
+  getProgramSpec: (): Promise<LiftingProgramSpec[]> =>
+    Promise.resolve([]),
+};
+
+// ---------------------------------------------------------------------------
+// ILiftRecordRepository
+// ---------------------------------------------------------------------------
+
+const _liftRecordRepo: ILiftRecordRepository = {
+  getLiftRecords: (): Promise<LiftRecord[]> =>
+    Promise.resolve([]),
+  appendLiftRecords: (): Promise<void> =>
+    Promise.resolve(),
+};
+
+// ---------------------------------------------------------------------------
+// ITrainingMaxRepository
+// ---------------------------------------------------------------------------
+
+const _trainingMaxRepo: ITrainingMaxRepository = {
+  getTrainingMaxes: (): Promise<TrainingMax[]> =>
+    Promise.resolve([]),
+  saveTrainingMaxes: (): Promise<void> =>
+    Promise.resolve(),
+};
+
+// ---------------------------------------------------------------------------
+// IWorkoutRepository
+// ---------------------------------------------------------------------------
+
+const _workoutRepo: IWorkoutRepository = {
+  getWorkout: (): Promise<LiftRecord[]> =>
+    Promise.resolve([]),
+  saveWorkout: (): Promise<void> =>
+    Promise.resolve(),
+};
+
+// Suppress "declared but never read" errors — these variables exist solely
+// to trigger structural type checking at compile time.
+void _cycleDashboardRepo;
+void _programSpecRepo;
+void _liftRecordRepo;
+void _trainingMaxRepo;
+void _workoutRepo;


### PR DESCRIPTION
## Summary

- Adds five repository port interfaces in `apps/api/src/ports/` per ADR-002 (Ports and Adapters)
- All interfaces import domain model types from `@lifting-logbook/core` — no infrastructure dependencies
- Barrel export via `apps/api/src/ports/index.ts`
- Compile-time contract tests (`ports.compile-test.ts`) assign mock objects to each interface type, catching signature mismatches at build time

## Interfaces

| Interface | Methods |
|---|---|
| `ICycleDashboardRepository` | `getCycleDashboard`, `saveCycleDashboard` |
| `ILiftingProgramSpecRepository` | `getProgramSpec` |
| `ILiftRecordRepository` | `getLiftRecords`, `appendLiftRecords` |
| `ITrainingMaxRepository` | `getTrainingMaxes`, `saveTrainingMaxes` |
| `IWorkoutRepository` | `getWorkout`, `saveWorkout` |

## Acceptance Criteria

- [x] All five interfaces defined in `apps/api/src/ports/`
- [x] Each interface has a corresponding compile-time test
- [x] All interfaces exported from `apps/api/src/ports/index.ts`
- [x] TypeScript compiles without error across the monorepo

## Test plan

- `npx tsc --noEmit` in `apps/api` — passes clean
- `npm run build` (turbo) — `@lifting-logbook/api`, `@lifting-logbook/core`, `@lifting-logbook/types` all succeed; `@lifting-logbook/web` fails on pre-existing missing `next` binary (unrelated)
- `npm run lint` (turbo) — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)