### PR TITLE
[feat] Define IAuthProvider interface and AuthUser type

### DIFF
--- a/apps/api/src/ports/auth.ts
+++ b/apps/api/src/ports/auth.ts
@@ -1,0 +1,10 @@
+export interface AuthUser {
+  id: string;
+  email: string;
+  provider: string;
+  displayName?: string;
+}
+
+export interface IAuthProvider {
+  verifyToken(token: string): Promise<AuthUser>;
+}

--- a/apps/api/src/ports/index.ts
+++ b/apps/api/src/ports/index.ts
@@ -1,3 +1,4 @@
+export * from './auth';
 export * from './ICycleDashboardRepository';
 export * from './ILiftingProgramSpecRepository';
 export * from './ILiftRecordRepository';

--- a/apps/api/src/ports/ports.compile-test.ts
+++ b/apps/api/src/ports/ports.compile-test.ts
@@ -6,11 +6,21 @@
  * the TypeScript compiler will error here — no runtime needed.
  */
 import { CycleDashboard, LiftRecord, LiftingProgramSpec, TrainingMax } from '@lifting-logbook/core';
+import { AuthUser, IAuthProvider } from './auth';
 import { ICycleDashboardRepository } from './ICycleDashboardRepository';
 import { ILiftingProgramSpecRepository } from './ILiftingProgramSpecRepository';
 import { ILiftRecordRepository } from './ILiftRecordRepository';
 import { ITrainingMaxRepository } from './ITrainingMaxRepository';
 import { IWorkoutRepository } from './IWorkoutRepository';
+
+// ---------------------------------------------------------------------------
+// IAuthProvider
+// ---------------------------------------------------------------------------
+
+const _authProvider: IAuthProvider = {
+  verifyToken: (): Promise<AuthUser> =>
+    Promise.resolve({ id: '1', email: 'test@example.com', provider: 'clerk' }),
+};
 
 // ---------------------------------------------------------------------------
 // ICycleDashboardRepository
@@ -67,6 +77,7 @@ const _workoutRepo: IWorkoutRepository = {
 
 // Suppress "declared but never read" errors — these variables exist solely
 // to trigger structural type checking at compile time.
+void _authProvider;
 void _cycleDashboardRepo;
 void _programSpecRepo;
 void _liftRecordRepo;


### PR DESCRIPTION
## Summary
- Defines `AuthUser` type with `id`, `email`, `provider`, and optional `displayName` fields
- Defines `IAuthProvider` interface with `verifyToken(token: string): Promise<AuthUser>`
- Both defined in `apps/api/src/ports/auth.ts` and exported from `apps/api/src/ports/index.ts`
- Compile-time test verifying structural type compatibility

## Acceptance Criteria
- [x] `AuthUser` type defined with required fields (`id`, `email`, `provider`) and optional `displayName`
- [x] `IAuthProvider` interface defined: `{ verifyToken(token: string): Promise<AuthUser> }`
- [x] Both defined in `apps/api/src/ports/auth.ts`
- [x] Both exported from `apps/api/src/ports/index.ts`
- [x] Compile-time test verifying the type relationships
- [x] TypeScript compiles without error

Closes #12