### PR TITLE
[feat] Define IRepositoryFactory interface and RepositoryBundle type

### DIFF
--- a/apps/api/src/ports/factory.ts
+++ b/apps/api/src/ports/factory.ts
@@ -1,0 +1,18 @@
+import { AuthUser } from './auth';
+import { ICycleDashboardRepository } from './ICycleDashboardRepository';
+import { ILiftingProgramSpecRepository } from './ILiftingProgramSpecRepository';
+import { ILiftRecordRepository } from './ILiftRecordRepository';
+import { ITrainingMaxRepository } from './ITrainingMaxRepository';
+import { IWorkoutRepository } from './IWorkoutRepository';
+
+export interface RepositoryBundle {
+  cycleDashboard: ICycleDashboardRepository;
+  liftingProgramSpec: ILiftingProgramSpecRepository;
+  liftRecord: ILiftRecordRepository;
+  trainingMax: ITrainingMaxRepository;
+  workout: IWorkoutRepository;
+}
+
+export interface IRepositoryFactory {
+  forUser(user: AuthUser): Promise<RepositoryBundle>;
+}

--- a/apps/api/src/ports/index.ts
+++ b/apps/api/src/ports/index.ts
@@ -1,4 +1,5 @@
 export * from './auth';
+export * from './factory';
 export * from './ICycleDashboardRepository';
 export * from './ILiftingProgramSpecRepository';
 export * from './ILiftRecordRepository';

--- a/apps/api/src/ports/ports.compile-test.ts
+++ b/apps/api/src/ports/ports.compile-test.ts
@@ -7,6 +7,7 @@
  */
 import { CycleDashboard, LiftRecord, LiftingProgramSpec, TrainingMax } from '@lifting-logbook/core';
 import { AuthUser, IAuthProvider } from './auth';
+import { IRepositoryFactory, RepositoryBundle } from './factory';
 import { ICycleDashboardRepository } from './ICycleDashboardRepository';
 import { ILiftingProgramSpecRepository } from './ILiftingProgramSpecRepository';
 import { ILiftRecordRepository } from './ILiftRecordRepository';
@@ -75,6 +76,22 @@ const _workoutRepo: IWorkoutRepository = {
     Promise.resolve(),
 };
 
+// ---------------------------------------------------------------------------
+// IRepositoryFactory
+// ---------------------------------------------------------------------------
+
+const _repositoryBundle: RepositoryBundle = {
+  cycleDashboard: _cycleDashboardRepo,
+  liftingProgramSpec: _programSpecRepo,
+  liftRecord: _liftRecordRepo,
+  trainingMax: _trainingMaxRepo,
+  workout: _workoutRepo,
+};
+
+const _repositoryFactory: IRepositoryFactory = {
+  forUser: (): Promise<RepositoryBundle> => Promise.resolve(_repositoryBundle),
+};
+
 // Suppress "declared but never read" errors — these variables exist solely
 // to trigger structural type checking at compile time.
 void _authProvider;
@@ -83,3 +100,5 @@ void _programSpecRepo;
 void _liftRecordRepo;
 void _trainingMaxRepo;
 void _workoutRepo;
+void _repositoryBundle;
+void _repositoryFactory;


### PR DESCRIPTION
## Summary
- Defines `RepositoryBundle` type containing all five data repository interfaces (`cycleDashboard`, `liftingProgramSpec`, `liftRecord`, `trainingMax`, `workout`)
- Defines `IRepositoryFactory` interface: `{ forUser(user: AuthUser): Promise<RepositoryBundle> }`
- Both defined in `apps/api/src/ports/factory.ts` and exported from `apps/api/src/ports/index.ts`
- Compile-time contract test added to `ports.compile-test.ts`

## Acceptance Criteria
- [x] `RepositoryBundle` type defined, containing all five data repository interfaces
- [x] `IRepositoryFactory` interface defined: `{ forUser(user: AuthUser): Promise<RepositoryBundle> }`
- [x] Both defined in `apps/api/src/ports/factory.ts`
- [x] Both exported from `apps/api/src/ports/index.ts`
- [x] Compile-time test verifying the type relationships
- [x] TypeScript compiles without error

Closes #13