### PR TITLE
[infra] Configure GitHub Actions: Docker build and push on merge to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,58 @@
+name: Build & Push Docker Images
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  REGISTRY: us-central1-docker.pkg.dev
+  GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  ARTIFACT_REPO: lifting-logbook
+
+jobs:
+  build-and-push:
+    name: Build & Push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # required for Workload Identity Federation
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to GCP via Workload Identity Federation
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.REGISTRY }} --quiet
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push api image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.GCP_PROJECT_ID }}/${{ env.ARTIFACT_REPO }}/api:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.GCP_PROJECT_ID }}/${{ env.ARTIFACT_REPO }}/api:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push web image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/web/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.GCP_PROJECT_ID }}/${{ env.ARTIFACT_REPO }}/web:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.GCP_PROJECT_ID }}/${{ env.ARTIFACT_REPO }}/web:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Creates `.github/workflows/deploy.yml` triggered on push to `main`
- Authenticates to GCP using Workload Identity Federation via `google-github-actions/auth@v2` — no JSON key files in secrets
- Builds `apps/api` and `apps/web` Docker images using their existing multi-stage Dockerfiles
- Tags each image with `<registry>/api:<sha>` + `<registry>/api:latest` (same for `web`)
- Pushes both images to Artifact Registry (`us-central1-docker.pkg.dev`)
- Does **not** deploy to GKE or Cloud Run — that is the Infrastructure milestone

## Acceptance Criteria

- [x] `.github/workflows/deploy.yml` created
- [x] Triggers on: `push` to `main`
- [x] Authenticates to GCP using Workload Identity Federation (no JSON key files in secrets)
- [x] Builds `apps/api` image tagged `<registry>/api:<sha>` and `<registry>/api:latest`
- [x] Builds `apps/web` image tagged `<registry>/web:<sha>` and `<registry>/web:latest`
- [x] Both images pushed to Artifact Registry on success
- [x] Workflow does NOT deploy to GKE or Cloud Run (that is the Infrastructure milestone)

## Required secrets

Three secrets must be set in the repo before this workflow runs:

| Secret | Value |
|---|---|
| `GCP_PROJECT_ID` | GCP project ID (e.g. `lifting-logbook-123`) |
| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Full WIF provider resource name |
| `GCP_SERVICE_ACCOUNT` | Service account email used for impersonation |

## References

- [google-github-actions/auth — Workload Identity Federation](https://github.com/google-github-actions/auth#workload-identity-federation)
- [docker/build-push-action](https://github.com/docker/build-push-action)
- [Google Artifact Registry — Docker authentication](https://cloud.google.com/artifact-registry/docs/docker/authentication)

Closes #17