### PR TITLE
[chore] Restore no-explicit-any in packages/core legacy directories

### DIFF
--- a/packages/core/eslint.config.js
+++ b/packages/core/eslint.config.js
@@ -99,14 +99,4 @@ module.exports = [
       }],
     },
   },
-  // TODO(#52): Remove once GAS-era code is re-typed under issue #52.
-  // These directories were migrated from the Google Apps Script codebase and use
-  // `any` for spreadsheet data structures (mixed-type row arrays). Proper types
-  // require a dedicated cleanup pass; suppress here to keep CI green in the interim.
-  {
-    files: ['src/models/**/*.ts', 'src/services/**/*.ts', 'src/utils/**/*.ts'],
-    rules: {
-      '@typescript-eslint/no-explicit-any': 'off',
-    },
-  },
 ];

--- a/packages/core/src/models/CycleDashboard.ts
+++ b/packages/core/src/models/CycleDashboard.ts
@@ -16,5 +16,4 @@ export interface CycleDashboard {
   cycleDate: Date;
   sheetName: string;
   cycleStartWeekday: Weekday;
-  [key: string]: any;
 }

--- a/packages/core/src/models/LiftingProgramSpec.ts
+++ b/packages/core/src/models/LiftingProgramSpec.ts
@@ -12,5 +12,4 @@ export interface LiftingProgramSpec {
   warmUpPct: string;
   wtDecrementPct: number;
   activation: string;
-  [key: string]: any;
 }

--- a/packages/core/src/models/SpreadsheetCell.ts
+++ b/packages/core/src/models/SpreadsheetCell.ts
@@ -1,0 +1,2 @@
+/** A single cell value from a spreadsheet grid (Google Sheets / CSV). */
+export type SpreadsheetCell = string | number | boolean | Date | null;

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -1,5 +1,6 @@
 export * from "./CycleDashboard";
 export * from "./LiftingProgramSpec";
 export * from "./LiftRecord";
+export * from "./SpreadsheetCell";
 export * from "./TrainingMax";
 export * from "./UpdateCycleOverrides";

--- a/packages/core/src/services/workout/calculateLiftWeights.ts
+++ b/packages/core/src/services/workout/calculateLiftWeights.ts
@@ -9,6 +9,7 @@ import {
   PROG_SPEC_WARMUP_PCTS,
   PROG_SPEC_WORK_PCTS,
   SET_HEADER,
+  SpreadsheetCell,
   SPEC_WEIGHT_HEADER,
 } from "@src/core";
 
@@ -20,11 +21,11 @@ import {
  * @returns Updated 2D array with lift dates synchronized.
  */
 export function calculateLiftWeights(
-  data: any[][],
+  data: SpreadsheetCell[][],
   programSpecs: LiftingProgramSpec[],
   editedCellRow: number,
   editedCellCol: number,
-): any[][] {
+): SpreadsheetCell[][] {
   const workoutMetaHeaderRowIdx = data.findIndex((row) =>
     row.includes(LIFT_DATE_HEADER),
   );
@@ -50,7 +51,7 @@ export function calculateLiftWeights(
     (spec) => spec.lift === editedLiftName,
   );
   const editedOffset = currLiftSpec?.offset;
-  const currLiftTm = editedLiftData[metaWeightIdx];
+  const currLiftTm = editedLiftData[metaWeightIdx] as number;
   const currLiftIncrement = currLiftSpec?.increment || 1;
 
   // If edited column is not the "Reps" column, return empty array
@@ -61,7 +62,7 @@ export function calculateLiftWeights(
     throw new Error("Edited row is not in the metadata section.");
 
   console.log(
-    `Edited lift: ${editedLiftName}, Weight: ${currLiftTm}, Offset: ${editedOffset}.`,
+    `Edited lift: ${String(editedLiftName)}, Weight: ${currLiftTm}, Offset: ${editedOffset}.`,
   );
 
   const progSpecWarmPcts: number[] = PROG_SPEC_WARMUP_PCTS(

--- a/packages/core/src/services/workout/createGridV2.ts
+++ b/packages/core/src/services/workout/createGridV2.ts
@@ -3,6 +3,7 @@ import {
   LIFT_PLAN_HEADERS,
   LIFT_SPEC_HEADERS,
   LiftingProgramSpec,
+  SpreadsheetCell,
   TrainingMax,
   WORKOUT_SHEET_HEADERS,
 } from "@src/core";
@@ -14,27 +15,27 @@ import { generateLiftSpec } from "./generateLiftSpec";
  * @param {CycleDashboard} cycleDashboard
  * @param {LiftingProgramSpec[]} progSpecData
  * @param {TrainingMax[]} tmData
- * @returns {any[][]}
+ * @returns {SpreadsheetCell[][]}
  */
 
 export function createGridV2(
   cycleDashboard: CycleDashboard,
   progSpecData: LiftingProgramSpec[],
   tmData: TrainingMax[],
-) {
+): SpreadsheetCell[][] {
   console.log(
     `Creating grid with ${progSpecData.length} lift specs and ${tmData.length} training maxes starting from ${cycleDashboard.cycleDate.toISOString()}.`,
   );
 
-  const resultGrid: any[][] = [];
+  const resultGrid: SpreadsheetCell[][] = [];
 
   resultGrid.push(WORKOUT_SHEET_HEADERS);
   resultGrid[0]![1] = cycleDashboard.program;
   resultGrid[0]![3] = cycleDashboard.cycleNum;
   // resultGrid[0][5] = cycleDashboard.weight;
-  const progSpecGrid: any[][] = [];
+  const progSpecGrid: SpreadsheetCell[][] = [];
   progSpecGrid.push(LIFT_SPEC_HEADERS);
-  const workoutGrid: any[][] = [];
+  const workoutGrid: SpreadsheetCell[][] = [];
   workoutGrid.push(LIFT_PLAN_HEADERS);
 
   // console.log(`Program spec data: \n\t${progSpecData.join('\n\t')}`)

--- a/packages/core/src/services/workout/extractLiftRecords.ts
+++ b/packages/core/src/services/workout/extractLiftRecords.ts
@@ -1,12 +1,12 @@
-import { LiftRecord, LiftRecordRequiredKeys, REPS_HEADER } from "@src/core";
+import { LiftRecord, LiftRecordRequiredKeys, REPS_HEADER, SpreadsheetCell } from "@src/core";
 
 /**
  * Extract lift records from a 2D grid of data.
- * @param {any[][]} data
+ * @param {SpreadsheetCell[][]} data
  * @returns {LiftRecord[]}
  */
 
-export function extractLiftRecords(data: any[][]): LiftRecord[] {
+export function extractLiftRecords(data: SpreadsheetCell[][]): LiftRecord[] {
   if (!data || data.length < 2) return [];
   // Extract program and cycle from the first few rows (look for 'Program' and 'Cycle' headers)
   let program: string | undefined = undefined;
@@ -15,10 +15,10 @@ export function extractLiftRecords(data: any[][]): LiftRecord[] {
     const row = data[i];
     if (Array.isArray(row)) {
       for (let j = 0; j < row.length; j++) {
-        if (typeof row[j] === "string" && row[j].trim() === "Program") {
+        if (typeof row[j] === "string" && (row[j] as string).trim() === "Program") {
           program = row[j + 1] !== undefined ? String(row[j + 1]) : undefined;
         }
-        if (typeof row[j] === "string" && row[j].trim() === "Cycle") {
+        if (typeof row[j] === "string" && (row[j] as string).trim() === "Cycle") {
           const val = row[j + 1];
           if (val !== undefined && val !== "") {
             const num = Number(val);
@@ -52,7 +52,7 @@ export function extractLiftRecords(data: any[][]): LiftRecord[] {
     for (const idx of requiredIdxs) {
       if (row[idx] === undefined || row[idx] === "") {
         throw new Error(
-          `Missing required field '${headers[idx]}' at row ${headerIdx + i + 1}, column ${idx + 1}`,
+          `Missing required field '${String(headers[idx])}' at row ${headerIdx + i + 1}, column ${idx + 1}`,
         );
       }
     }
@@ -79,47 +79,47 @@ export function extractLiftRecords(data: any[][]): LiftRecord[] {
       dateToWorkoutNum.set(dateStr, workoutNum);
     }
     // Map row to LiftRecord
-    const rec: any = {};
+    const rec: Record<string, unknown> = {};
     for (let j = 0; j < headers.length; j++) {
       const key = headers[j];
       const value = row[j];
       switch (key) {
-        case "Set":
-          const currSetMatch = value.match(/Set\s*(\d+)/i);
+        case "Set": {
+          const currSetMatch = (value as string).match(/Set\s*(\d+)/i);
           if (currSetMatch) {
-            rec.setNum = Number(currSetMatch[1]);
+            rec["setNum"] = Number(currSetMatch[1]);
           } else {
             throw new Error(
-              `Invalid Set string format at row ${headerIdx + i + 1}: ${value}`,
+              `Invalid Set string format at row ${headerIdx + i + 1}: ${String(value)}`,
             );
           }
           break;
+        }
         case "Weight":
         case "Reps":
-          rec[key.trim().toLowerCase()] = Number(value);
+          rec[(key as string).trim().toLowerCase()] = Number(value);
           break;
         default:
           if (
             !LiftRecordRequiredKeys.includes(
-              key.toLowerCase().trim() as keyof LiftRecord,
+              String(key).toLowerCase().trim() as keyof LiftRecord,
             )
           ) {
             throw new Error(
-              `Unexpected column header '${key}' at row ${headerIdx + 1}, column ${j + 1}.`,
+              `Unexpected column header '${String(key)}' at row ${headerIdx + 1}, column ${j + 1}.`,
             );
           }
-          rec[key.trim().toLowerCase()] = value;
+          rec[String(key).trim().toLowerCase()] = value;
           break;
       }
-      // rec[`${LIFT_RECORD_HEADER_MAP[key]}`] = value;
     }
     // Add required program and cycleNum
-    rec.program = program;
-    rec.cycleNum = cycleNum;
-    rec.workoutNum = workoutNum;
+    rec["program"] = program;
+    rec["cycleNum"] = cycleNum;
+    rec["workoutNum"] = workoutNum;
 
     // Validate all LiftRecord keys (including notes)
-    const recTyped = rec as LiftRecord;
+    const recTyped = rec as unknown as LiftRecord;
     const missingKeys = LiftRecordRequiredKeys.filter(
       (key) => recTyped[key] === undefined || recTyped[key] === null,
     );

--- a/packages/core/src/services/workout/findWorkoutRowsToHideOnEdit.ts
+++ b/packages/core/src/services/workout/findWorkoutRowsToHideOnEdit.ts
@@ -1,4 +1,5 @@
 import { REPS_HEADER } from "@src/core/constants";
+import { SpreadsheetCell } from "@src/core";
 
 /**
  * Given the sheet data and the edited row,
@@ -11,7 +12,7 @@ import { REPS_HEADER } from "@src/core/constants";
  * @returns array of 1-based row numbers to hide
  */
 export function findWorkoutRowsToHideOnEdit(
-  workoutData: any[][],
+  workoutData: SpreadsheetCell[][],
   editedRow: number,
   editedCol: number,
 ): number[] {

--- a/packages/core/src/services/workout/generateLiftPlan.ts
+++ b/packages/core/src/services/workout/generateLiftPlan.ts
@@ -4,22 +4,22 @@ import {
   PROG_SPEC_WORK_PCTS,
   WARMUP_BASE_REPS,
 } from "@src/core/constants";
-import { LiftingProgramSpec, TrainingMax } from "@src/core/models";
+import { LiftingProgramSpec, SpreadsheetCell, TrainingMax } from "@src/core/models";
 
 /**
  * Creates a lift plan from a training max and program spec.
  * @param {TrainingMax} tm
  * @param {LiftingProgramSpec} ps
  * @param {Date} startDate
- * @return {any[]}
+ * @return {SpreadsheetCell[][]}
  */
 
 export function generateLiftPlan(
   tm: TrainingMax,
   ps: LiftingProgramSpec,
   _startDate: Date,
-) {
-  const workoutGrid: any[][] = [];
+): SpreadsheetCell[][] {
+  const workoutGrid: SpreadsheetCell[][] = [];
   const progSpecLiftName = ps.lift;
   const progSpecNumSets = ps.sets;
   const progSpecIncrement = ps.increment;

--- a/packages/core/src/services/workout/generateLiftSpec.ts
+++ b/packages/core/src/services/workout/generateLiftSpec.ts
@@ -3,6 +3,7 @@ import {
   CORE_LIFT_HEADER,
   LIFT_SPEC_HEADERS,
   LiftingProgramSpec,
+  SpreadsheetCell,
   TrainingMax,
 } from "@src/core";
 
@@ -11,20 +12,20 @@ import {
  * @param {TrainingMax} tm
  * @param {LiftingProgramSpec} ps
  * @param {Date} startDate
- * @return {any[]}
+ * @return {SpreadsheetCell[]}
  */
 
 export function generateLiftSpec(
   tm: TrainingMax,
   ps: LiftingProgramSpec,
   startDate: Date,
-) {
+): SpreadsheetCell[] {
   // console.log(`Offset for ${ps.lift}: ${ps.offset}`);
   const liftDate = addDaysLocal(startDate, ps.offset);
   // console.log(`Original start date: ${formatDateYYYYMMDD(startDate)}; offset date: ${formatDateYYYYMMDD(liftDate)}`);
 
   // Build a mapping from header to value
-  const specMap: Record<string, any> = {
+  const specMap: Record<string, SpreadsheetCell> = {
     [CORE_LIFT_HEADER]: ps.lift,
     Scheme: `${ps.sets} × ${ps.reps}`,
     "Inc. Amt.": ps.increment,
@@ -34,5 +35,5 @@ export function generateLiftSpec(
   };
 
   // Return values in the order of LIFT_SPEC_HEADERS
-  return LIFT_SPEC_HEADERS.map((header) => specMap[header]);
+  return LIFT_SPEC_HEADERS.map((header) => specMap[header] ?? null);
 }

--- a/packages/core/src/services/workout/updateLiftDates.ts
+++ b/packages/core/src/services/workout/updateLiftDates.ts
@@ -5,6 +5,7 @@ import {
   LIFT_HEADER,
   LiftingProgramSpec,
   NOTES_HEADER,
+  SpreadsheetCell,
 } from "@src/core";
 
 /**
@@ -15,11 +16,11 @@ import {
  * @returns Updated 2D array with lift dates synchronized.
  */
 export function updateLiftDates(
-  data: any[][],
+  data: SpreadsheetCell[][],
   programSpecs: LiftingProgramSpec[],
   editedCellRow: number,
   editedCellCol: number,
-): any[][] {
+): SpreadsheetCell[][] {
   const workoutMetaHeaderRowIdx = data.findIndex((row) =>
     row.includes(LIFT_DATE_HEADER),
   );
@@ -40,7 +41,7 @@ export function updateLiftDates(
   if (!editedLiftData)
     throw new Error(`No data row at index ${editedCellRow}.`);
   const editedLiftName = editedLiftData[coreLiftIdx];
-  const editedLiftDate = editedLiftData[liftDateIdx];
+  const editedLiftDate = editedLiftData[liftDateIdx] as string | number | Date;
   const editedOffset = programSpecs.find(
     (spec) => spec.lift === editedLiftName,
   )?.offset;
@@ -53,7 +54,7 @@ export function updateLiftDates(
     throw new Error("Edited row is not in the metadata section.");
 
   console.log(
-    `Edited lift: ${editedLiftName}, Date: ${editedLiftDate}, Offset: ${editedOffset}.`,
+    `Edited lift: ${String(editedLiftName)}, Date: ${String(editedLiftDate)}, Offset: ${editedOffset}.`,
   );
   // Find all lifts with the same offset (including the edited lift)
   const otherLiftsWithSameOffset = programSpecs
@@ -71,7 +72,7 @@ export function updateLiftDates(
     if (rowIdx === -1) throw new Error(`Meta row for lift ${liftName} not found.`);
     const metaRow = data[rowIdx]!;
     console.log(
-      `Updating lift ${liftName} at row ${rowIdx} from ${metaRow[liftDateIdx]} to date ${editedLiftDate}.`,
+      `Updating lift ${liftName} at row ${rowIdx} from ${String(metaRow[liftDateIdx])} to date ${String(editedLiftDate)}.`,
     );
     metaRow[liftDateIdx] = new Date(editedLiftDate);
   });
@@ -81,7 +82,7 @@ export function updateLiftDates(
       .filter((row) => row[entryLiftIdx] === liftName)
       .forEach((row) => {
         console.log(
-          `Updating entry for lift ${liftName} from ${row[entryDateIdx]} to date ${editedLiftDate}.`,
+          `Updating entry for lift ${String(liftName)} from ${String(row[entryDateIdx])} to date ${String(editedLiftDate)}.`,
         );
         row[entryDateIdx] = new Date(editedLiftDate);
       });

--- a/packages/core/src/utils/mapper/mapCycleDashboard.ts
+++ b/packages/core/src/utils/mapper/mapCycleDashboard.ts
@@ -1,4 +1,4 @@
-import { CycleDashboard } from "@src/core";
+import { CycleDashboard, SpreadsheetCell } from "@src/core";
 import {
   CYCLE_DATE_KEY,
   CYCLE_NUM_KEY,
@@ -12,7 +12,7 @@ import {
  * @param {CycleDashboard} obj
  * @returns {any[][]} 2D array with [key, value] pairs
  */
-export function mapCycleDashboard(obj: CycleDashboard): any[][] {
+export function mapCycleDashboard(obj: CycleDashboard): SpreadsheetCell[][] {
   return [
     ["Key", "Value"],
     [PROGRAM_KEY, obj.program],

--- a/packages/core/src/utils/mapper/mapLiftRecords.ts
+++ b/packages/core/src/utils/mapper/mapLiftRecords.ts
@@ -1,10 +1,10 @@
-import { LIFT_RECORD_HEADER_MAP, LiftRecord } from "@src/core";
+import { LIFT_RECORD_HEADER_MAP, LiftRecord, SpreadsheetCell } from "@src/core";
 /**
  * Converts an array of LiftRecord objects to a 2D array (for writing to a sheet)
  * @param {LiftRecord[]} records
- * @returns {any[][]} 2D array with headers in row 0
+ * @returns {SpreadsheetCell[][]} 2D array with headers in row 0
  */
-export function mapLiftRecords(records: LiftRecord[]): any[][] {
+export function mapLiftRecords(records: LiftRecord[]): SpreadsheetCell[][] {
   const headers = Object.keys(LIFT_RECORD_HEADER_MAP);
   return [
     headers,

--- a/packages/core/src/utils/mapper/mapLiftingProgramSpec.ts
+++ b/packages/core/src/utils/mapper/mapLiftingProgramSpec.ts
@@ -1,16 +1,16 @@
-import { LIFTING_PROGRAM_SPEC_HEADER_MAP, LiftingProgramSpec } from "@src/core";
+import { LIFTING_PROGRAM_SPEC_HEADER_MAP, LiftingProgramSpec, SpreadsheetCell } from "@src/core";
 /**
  * Converts an array of LiftingProgramSpec objects to a 2D array (for writing to a sheet)
  * @param {LiftingProgramSpec[]} specs
- * @returns {any[][]} 2D array with headers in row 0
+ * @returns {SpreadsheetCell[][]} 2D array with headers in row 0
  */
-export function mapLiftingProgramSpec(specs: LiftingProgramSpec[]): any[][] {
+export function mapLiftingProgramSpec(specs: LiftingProgramSpec[]): SpreadsheetCell[][] {
   const headers = Object.keys(LIFTING_PROGRAM_SPEC_HEADER_MAP);
   return [
     headers,
     ...specs.map((spec) =>
       headers.map(
-        (header) => spec[LIFTING_PROGRAM_SPEC_HEADER_MAP[header]!.key],
+        (header) => spec[LIFTING_PROGRAM_SPEC_HEADER_MAP[header]!.key as keyof LiftingProgramSpec] as SpreadsheetCell,
       ),
     ),
   ];

--- a/packages/core/src/utils/mapper/mapTrainingMaxes.ts
+++ b/packages/core/src/utils/mapper/mapTrainingMaxes.ts
@@ -1,10 +1,10 @@
-import { TRAINING_MAX_HEADER_MAP, TrainingMax } from "@src/core";
+import { TRAINING_MAX_HEADER_MAP, TrainingMax, SpreadsheetCell } from "@src/core";
 /**
  * Converts an array of TrainingMax objects to a 2D array (for writing to a sheet)
  * @param {TrainingMax[]} maxes
- * @returns {any[][]} 2D array with headers in row 0
+ * @returns {SpreadsheetCell[][]} 2D array with headers in row 0
  */
-export function mapTrainingMaxes(maxes: TrainingMax[]): any[][] {
+export function mapTrainingMaxes(maxes: TrainingMax[]): SpreadsheetCell[][] {
   const headers = Object.keys(TRAINING_MAX_HEADER_MAP);
   return [
     headers,

--- a/packages/core/src/utils/parser/parseCycleDashboard.ts
+++ b/packages/core/src/utils/parser/parseCycleDashboard.ts
@@ -1,4 +1,4 @@
-import { CycleDashboard, Weekday } from "@src/core";
+import { CycleDashboard, SpreadsheetCell, Weekday } from "@src/core";
 import {
   CYCLE_DATE_KEY,
   CYCLE_NUM_KEY,
@@ -10,24 +10,24 @@ import {
 
 /**
  * Parses a 2D array (from CSV or sheet) into a CycleDashboard object.
- * @param {any[][]} data - 2D array with headers in column 0 and values in column 1
+ * @param {SpreadsheetCell[][]} data - 2D array with headers in column 0 and values in column 1
  * @returns {CycleDashboard}
  */
 function toTitleCase(str: string): string {
   return str.toLowerCase().replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
-export function parseCycleDashboard(data: any[][]): CycleDashboard {
-  const map: Record<string, string> = {};
+export function parseCycleDashboard(data: SpreadsheetCell[][]): CycleDashboard {
+  const map: Record<string, SpreadsheetCell | undefined> = {};
   data.forEach(([key, value]) => {
-    map[key] = value;
+    map[String(key)] = value;
   });
   return {
-    program: map[PROGRAM_KEY] ?? "",
-    cycleUnit: map[CYCLE_UNIT_KEY] ?? "",
+    program: String(map[PROGRAM_KEY] ?? ""),
+    cycleUnit: String(map[CYCLE_UNIT_KEY] ?? ""),
     cycleNum: Number(map[CYCLE_NUM_KEY]),
-    cycleDate: new Date(map[CYCLE_DATE_KEY] ?? ""),
-    sheetName: map[SHEET_NAME_KEY] ?? "",
-    cycleStartWeekday: toTitleCase(map[CYCLE_START_WEEKDAY_KEY] ?? "") as Weekday,
+    cycleDate: new Date(String(map[CYCLE_DATE_KEY] ?? "")),
+    sheetName: String(map[SHEET_NAME_KEY] ?? ""),
+    cycleStartWeekday: toTitleCase(String(map[CYCLE_START_WEEKDAY_KEY] ?? "")) as Weekday,
   };
 }

--- a/packages/core/src/utils/parser/parseLiftRecords.ts
+++ b/packages/core/src/utils/parser/parseLiftRecords.ts
@@ -1,28 +1,28 @@
-import { LIFT_RECORD_HEADER_MAP, LiftRecord } from "@src/core";
+import { LIFT_RECORD_HEADER_MAP, LiftRecord, SpreadsheetCell } from "@src/core";
 import { tableToObjects } from "./tableToObjects";
 
 /**
  * Converts a 2D array to an array of LiftRecord objects.
- * @param {any[][]} data
+ * @param {SpreadsheetCell[][]} data
  * @returns {LiftRecord[]}
  */
 
-export function parseLiftRecords(data: any[][]): LiftRecord[] {
+export function parseLiftRecords(data: SpreadsheetCell[][]): LiftRecord[] {
   const headerMap = LIFT_RECORD_HEADER_MAP;
   const rawObjects = tableToObjects(data, undefined);
   return rawObjects.map((obj) => {
-    const result: any = {};
+    const result: Record<string, unknown> = {};
     for (const header in headerMap) {
       const { key, type } = headerMap[header]!;
-      let value = obj[header];
+      let value: unknown = obj[header];
       if (type === "number") {
         value = Number(value);
       }
       if (key === "date") {
-        value = new Date(value);
+        value = new Date(String(value ?? ""));
       }
       result[key] = value;
     }
-    return result as LiftRecord;
+    return result as unknown as LiftRecord;
   });
 }

--- a/packages/core/src/utils/parser/parseLiftingProgramSpec.ts
+++ b/packages/core/src/utils/parser/parseLiftingProgramSpec.ts
@@ -1,22 +1,22 @@
-import { LIFTING_PROGRAM_SPEC_HEADER_MAP, LiftingProgramSpec } from "@src/core";
+import { LIFTING_PROGRAM_SPEC_HEADER_MAP, LiftingProgramSpec, SpreadsheetCell } from "@src/core";
 import { tableToObjects } from "./tableToObjects";
 
 /**
  * Converts a 2D array to an array of LiftingProgramSpec objects.
- * @param {any[][]} data
+ * @param {SpreadsheetCell[][]} data
  * @returns {LiftingProgramSpec[]}
  */
 
-export function parseLiftingProgramSpec(data: any[][]): LiftingProgramSpec[] {
+export function parseLiftingProgramSpec(data: SpreadsheetCell[][]): LiftingProgramSpec[] {
   // Use header map from constants
   const headerMap = LIFTING_PROGRAM_SPEC_HEADER_MAP;
   // Convert using tableToObjects, then cast/convert types
   const rawObjects = tableToObjects(data, undefined);
   const parsed = rawObjects.map((obj) => {
-    const result: any = {};
+    const result: Record<string, unknown> = {};
     for (const header in headerMap) {
       const { key, type } = headerMap[header]!;
-      let value = obj[header];
+      let value: unknown = obj[header];
       if (type === "number") {
         value = Number(value);
       } else if (type === "boolean|string") {
@@ -26,7 +26,7 @@ export function parseLiftingProgramSpec(data: any[][]): LiftingProgramSpec[] {
       }
       result[key] = value;
     }
-    return result as LiftingProgramSpec;
+    return result as unknown as LiftingProgramSpec;
   });
 
   // Sort by offset, then order

--- a/packages/core/src/utils/parser/parseTrainingMaxes.ts
+++ b/packages/core/src/utils/parser/parseTrainingMaxes.ts
@@ -1,48 +1,48 @@
-import { TRAINING_MAX_HEADER_MAP, TrainingMax } from "@src/core";
+import { TRAINING_MAX_HEADER_MAP, TrainingMax, SpreadsheetCell } from "@src/core";
 import { tableToObjects } from "./tableToObjects";
 
 /**
  * Example: parseTrainingMaxes(sheet.getDataRange().getValues())
- * @param {any[][]} data
+ * @param {SpreadsheetCell[][]} data
  * @returns {TrainingMax[]}
  */
 
-export function parseTrainingMaxes(data: any[][]): TrainingMax[] {
+export function parseTrainingMaxes(data: SpreadsheetCell[][]): TrainingMax[] {
   const headerMap = TRAINING_MAX_HEADER_MAP;
   const rawObjects = tableToObjects(data, undefined);
   // console.log(`Raw training max objects: ${JSON.stringify(rawObjects)}.`);
   return rawObjects.map((obj) => {
-    const result: any = {};
+    const result: Record<string, unknown> = {};
     for (const header in headerMap) {
       const { key, type } = headerMap[header]!;
-      let value = obj[header];
+      let value: unknown = obj[header];
       if (type === "number") {
         value = Number(value);
       }
       if (key === "dateUpdated") {
-        value = new Date(value);
+        value = new Date(String(value ?? ""));
       }
       result[key] = value;
     }
     // console.log(`Parsed training max object: ${JSON.stringify(result)}.`);
     const isDateValid =
-      result.dateUpdated instanceof Date &&
-      !isNaN(result.dateUpdated.getTime());
+      result["dateUpdated"] instanceof Date &&
+      !isNaN((result["dateUpdated"] as Date).getTime());
     const isWeightValid =
-      typeof result.weight === "number" && !isNaN(result.weight);
+      typeof result["weight"] === "number" && !isNaN(result["weight"] as number);
     const isLiftValid =
-      typeof result.lift === "string" && result.lift.length > 0;
+      typeof result["lift"] === "string" && (result["lift"] as string).length > 0;
     if (!isLiftValid) {
       throw new Error(
-        `Invalid lift value: ${result.lift} (${JSON.stringify(result)})`,
+        `Invalid lift value: ${String(result["lift"])} (${JSON.stringify(result)})`,
       );
     }
     if (!isWeightValid) {
-      throw new Error(`Invalid weight value: ${result.weight}`);
+      throw new Error(`Invalid weight value: ${String(result["weight"])}`);
     }
     if (!isDateValid) {
-      throw new Error(`Invalid dateUpdated value: ${result.dateUpdated}`);
+      throw new Error(`Invalid dateUpdated value: ${String(result["dateUpdated"])}`);
     }
-    return result as TrainingMax;
+    return result as unknown as TrainingMax;
   });
 }

--- a/packages/core/src/utils/parser/tableToObjects.ts
+++ b/packages/core/src/utils/parser/tableToObjects.ts
@@ -1,18 +1,20 @@
+import { SpreadsheetCell } from "@src/core";
+
 /**
  * Converts a 2D array (as from Sheet.getDataRange().getValues() or parsed CSV) to an array of objects using the first row as headers.
- * @param {any[][]} data - 2D array with first row as headers
- * @returns {Record<string, any>[]}
+ * @param {SpreadsheetCell[][]} data - 2D array with first row as headers
+ * @returns {Record<string, SpreadsheetCell | undefined>[]}
  */
 
-export function tableToObjects<T = Record<string, any>>(
-  data: any[][],
+export function tableToObjects<T = Record<string, SpreadsheetCell | undefined>>(
+  data: SpreadsheetCell[][],
   headerMap?: Record<string, string>,
 ): T[] {
   if (!data || data.length < 2) return [];
-  const headers = data[0]!.map((h: any) => String(h));
+  const headers = data[0]!.map((h) => String(h));
   // console.log(`Headers: ${JSON.stringify(headers)}`);
   return data.slice(1).map((row) => {
-    const obj: Record<string, any> = {};
+    const obj: Record<string, SpreadsheetCell | undefined> = {};
     headers.forEach((header, i) => {
       const key = headerMap && headerMap[header] ? headerMap[header] : header;
       obj[key] = row[i];

--- a/packages/core/tests/core/services/workout/generateLiftPlan.test.ts
+++ b/packages/core/tests/core/services/workout/generateLiftPlan.test.ts
@@ -19,13 +19,13 @@ describe("generateLiftPlan", () => {
     expect(Array.isArray(plan)).toBe(true);
     expect(plan.length).toBe(6); // 3 warm-up + 3 work sets
     // Check first warm-up set
-    const warmup = plan.find((row) => row[2] && row[2].startsWith("Warm-up"));
+    const warmup = plan.find((row) => typeof row[2] === "string" && row[2].startsWith("Warm-up"));
     expect(warmup).toBeDefined();
     expect(warmup![1]).toBe("Bench P.");
     expect(warmup![2]).toMatch(/Warm-up \d+/);
     expect(warmup![4]).toBe(5);
     // Check first work set
-    const workset = plan.find((row) => row[2] && row[2].startsWith("Set"));
+    const workset = plan.find((row) => typeof row[2] === "string" && row[2].startsWith("Set"));
     expect(workset).toBeDefined();
     expect(workset![1]).toBe("Bench P.");
     expect(workset![2]).toMatch(/Set \d+/);


### PR DESCRIPTION
## Summary

- Introduced `SpreadsheetCell = string | number | boolean | Date | null` as the canonical type for 2D spreadsheet grid values, replacing all `any[][]` usages across services, parsers, and mappers
- Removed `[key: string]: any` index signatures from `CycleDashboard` and `LiftingProgramSpec`
- Replaced `const result: any = {}` intermediate objects in parsers with `Record<string, unknown>` + double-cast to the target interface
- Removed the directory-level `@typescript-eslint/no-explicit-any: off` override block from `packages/core/eslint.config.js`

## Acceptance Criteria

- [x] All `any` types in `packages/core/src/models/**`, `src/services/**`, and `src/utils/**` replaced with proper types
- [x] Directory-level `@typescript-eslint/no-explicit-any: off` override removed from `packages/core/eslint.config.js`
- [x] `turbo run lint` passes with the rule re-enabled

## Test plan

- `turbo run build --filter=@lifting-logbook/core` — passes clean
- `turbo run lint --filter=@lifting-logbook/core` — passes clean
- `turbo run test --filter=@lifting-logbook/core` — 20/20 suites, 64/64 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)