### PR TITLE
[fix] Serialize amrap as "TRUE"/"FALSE" string in mapLiftingProgramSpec

### DIFF
--- a/packages/core/src/utils/mapper/mapLiftingProgramSpec.ts
+++ b/packages/core/src/utils/mapper/mapLiftingProgramSpec.ts
@@ -9,9 +9,14 @@ export function mapLiftingProgramSpec(specs: LiftingProgramSpec[]): SpreadsheetC
   return [
     headers,
     ...specs.map((spec) =>
-      headers.map(
-        (header) => spec[LIFTING_PROGRAM_SPEC_HEADER_MAP[header]!.key as keyof LiftingProgramSpec] as SpreadsheetCell,
-      ),
+      headers.map((header) => {
+        const { key, type } = LIFTING_PROGRAM_SPEC_HEADER_MAP[header]!;
+        const value = spec[key as keyof LiftingProgramSpec];
+        if (type === "boolean|string" && typeof value === "boolean") {
+          return value ? "TRUE" : "FALSE";
+        }
+        return value as SpreadsheetCell;
+      }),
     ),
   ];
 }

--- a/packages/core/tests/core/utils/mapper/mapLiftingProgramSpec.test.ts
+++ b/packages/core/tests/core/utils/mapper/mapLiftingProgramSpec.test.ts
@@ -2,62 +2,47 @@ import {
   LIFTING_PROGRAM_SPEC_HEADER_MAP,
   LiftingProgramSpec,
   mapLiftingProgramSpec,
+  parseLiftingProgramSpec,
 } from "@src/core";
+
+const specs: LiftingProgramSpec[] = [
+  {
+    offset: 0,
+    lift: "Squat",
+    increment: 5,
+    order: 1,
+    sets: 3,
+    reps: 5,
+    amrap: true,
+    warmUpPct: "40,50,60",
+    wtDecrementPct: 0,
+    activation: "None",
+  },
+  {
+    offset: 0,
+    lift: "Bench",
+    increment: 2.5,
+    order: 2,
+    sets: 3,
+    reps: 5,
+    amrap: false,
+    warmUpPct: "40,50,60",
+    wtDecrementPct: 0,
+    activation: "None",
+  },
+];
 
 describe("mapLiftingProgramSpec", () => {
   it("should map LiftingProgramSpec[] to 2D array with all columns and headers", () => {
     const headers = Object.keys(LIFTING_PROGRAM_SPEC_HEADER_MAP);
-    const specs: LiftingProgramSpec[] = [
-      {
-        offset: 0,
-        lift: "Squat",
-        increment: 5,
-        order: 1,
-        sets: 3,
-        reps: 5,
-        amrap: true,
-        warmUpPct: "40,50,60",
-        wtDecrementPct: 0,
-        activation: "None",
-      },
-      {
-        offset: 0,
-        lift: "Bench",
-        increment: 2.5,
-        order: 2,
-        sets: 3,
-        reps: 5,
-        amrap: false,
-        warmUpPct: "40,50,60",
-        wtDecrementPct: 0,
-        activation: "None",
-      },
-    ];
     const result = mapLiftingProgramSpec(specs);
     expect(result[0]).toEqual(headers);
-    expect(result[1]).toEqual([
-      0,
-      "Squat",
-      5,
-      1,
-      3,
-      5,
-      true,
-      "40,50,60",
-      0,
-      "None",
-    ]);
-    expect(result[2]).toEqual([
-      0,
-      "Bench",
-      2.5,
-      2,
-      3,
-      5,
-      false,
-      "40,50,60",
-      0,
-      "None",
-    ]);
+    expect(result[1]).toEqual([0, "Squat", 5, 1, 3, 5, "TRUE", "40,50,60", 0, "None"]);
+    expect(result[2]).toEqual([0, "Bench", 2.5, 2, 3, 5, "FALSE", "40,50,60", 0, "None"]);
+  });
+
+  it("round-trips through parseLiftingProgramSpec preserving amrap as boolean", () => {
+    const roundTripped = parseLiftingProgramSpec(mapLiftingProgramSpec(specs));
+    expect(roundTripped).toEqual(specs);
   });
 });

--- a/packages/core/tests/core/utils/mapper/mapLiftingProgramSpec.test.ts
+++ b/packages/core/tests/core/utils/mapper/mapLiftingProgramSpec.test.ts
@@ -41,7 +41,7 @@ describe("mapLiftingProgramSpec", () => {
     expect(result[2]).toEqual([0, "Bench", 2.5, 2, 3, 5, "FALSE", "40,50,60", 0, "None"]);
   });
 
-  it("round-trips through parseLiftingProgramSpec preserving amrap as boolean", () => {
+  it("maps amrap boolean to string so parseLiftingProgramSpec can round-trip it", () => {
     const roundTripped = parseLiftingProgramSpec(mapLiftingProgramSpec(specs));
     expect(roundTripped).toEqual(specs);
   });


### PR DESCRIPTION
## Summary

- `mapLiftingProgramSpec` was writing `amrap` as a raw boolean (`true`/`false`) while `parseLiftingProgramSpec` expects `"TRUE"`/`"FALSE"` strings, breaking the parse → map → write round-trip
- Fixed by checking the header map `type` field and converting `boolean|string` fields before returning
- Now type-visible because PR #77 replaced `any[][]` with `SpreadsheetCell[][]`

## Acceptance Criteria

- [x] `mapLiftingProgramSpec` converts `boolean` cell values to `"TRUE"`/`"FALSE"` strings before returning
- [x] Round-trip test added: `parseLiftingProgramSpec(mapLiftingProgramSpec(specs))` returns specs equal to the input

## Test plan

- [ ] Run `packages/core` tests: `npx jest --testPathPatterns="mapLiftingProgramSpec|parseLiftingProgramSpec"`
- [ ] Verify 3 tests pass (1 existing mapper test updated, 1 new round-trip, 1 existing parser test)

Closes #79