### PR TITLE
[feat] Lift library and exercise tagging

### DIFF
--- a/packages/core/src/catalog/index.ts
+++ b/packages/core/src/catalog/index.ts
@@ -1,0 +1,3 @@
+export * from './lifts';
+export * from './resolve';
+export * from './slotMaps';

--- a/packages/core/src/catalog/lifts.ts
+++ b/packages/core/src/catalog/lifts.ts
@@ -1,0 +1,58 @@
+import { Lift } from '@lifting-logbook/types';
+
+/**
+ * Curated seed catalog of common barbell, dumbbell, and bodyweight movements.
+ * Each entry carries classification (compound | accessory) and one or more
+ * movement pattern tags.
+ *
+ * Tags combine to express a pattern:
+ *   push + vertical   = overhead press pattern
+ *   push + horizontal = bench press / dip pattern
+ *   pull + vertical   = chin-up / lat pulldown pattern
+ *   pull + horizontal = row pattern
+ *   hinge             = hip hinge pattern (deadlift, RDL)
+ *   carry             = loaded carry pattern
+ *
+ * Squats are represented as compound lifts with no movement tags — the squat
+ * pattern does not map to any of the above axes.
+ */
+export const LIFT_CATALOG: Lift[] = [
+  // --- Squat pattern ---
+  { id: 'back-squat',    name: 'Back Squat',    classification: 'compound',  movementTags: [] },
+  { id: 'front-squat',   name: 'Front Squat',   classification: 'compound',  movementTags: [] },
+  { id: 'goblet-squat',  name: 'Goblet Squat',  classification: 'accessory', movementTags: [] },
+
+  // --- Hip hinge pattern ---
+  { id: 'deadlift',           name: 'Deadlift',                 classification: 'compound',  movementTags: ['hinge'] },
+  { id: 'romanian-deadlift',  name: 'Romanian Deadlift',        classification: 'compound',  movementTags: ['hinge'] },
+  { id: 'hip-thrust',         name: 'Hip Thrust',               classification: 'accessory', movementTags: ['hinge'] },
+  { id: 'kb-swing',           name: 'Kettlebell Swing',         classification: 'accessory', movementTags: ['hinge'] },
+
+  // --- Vertical push pattern ---
+  { id: 'overhead-press',  name: 'Overhead Press',  classification: 'compound',  movementTags: ['push', 'vertical'] },
+  { id: 'push-press',      name: 'Push Press',      classification: 'compound',  movementTags: ['push', 'vertical'] },
+
+  // --- Horizontal push pattern ---
+  { id: 'bench-press',         name: 'Bench Press',         classification: 'compound',  movementTags: ['push', 'horizontal'] },
+  { id: 'incline-bench-press', name: 'Incline Bench Press', classification: 'compound',  movementTags: ['push', 'horizontal'] },
+  { id: 'dip',                 name: 'Dip',                 classification: 'compound',  movementTags: ['push', 'horizontal'] },
+
+  // --- Vertical pull pattern ---
+  { id: 'chin-up',       name: 'Chin-up',       classification: 'compound',  movementTags: ['pull', 'vertical'] },
+  { id: 'pull-up',       name: 'Pull-up',        classification: 'compound',  movementTags: ['pull', 'vertical'] },
+  { id: 'lat-pulldown',  name: 'Lat Pulldown',   classification: 'accessory', movementTags: ['pull', 'vertical'] },
+
+  // --- Horizontal pull pattern ---
+  { id: 'barbell-row',  name: 'Barbell Row',   classification: 'compound',  movementTags: ['pull', 'horizontal'] },
+  { id: 'db-row',       name: 'Dumbbell Row',  classification: 'accessory', movementTags: ['pull', 'horizontal'] },
+  { id: 'upright-row',  name: 'Upright Row',   classification: 'accessory', movementTags: ['pull', 'horizontal'] },
+  { id: 'face-pull',    name: 'Face Pull',      classification: 'accessory', movementTags: ['pull', 'horizontal'] },
+
+  // --- Carry pattern ---
+  { id: 'farmers-carry',  name: "Farmer's Carry",  classification: 'compound',  movementTags: ['carry'] },
+
+  // --- Common accessories ---
+  { id: 'cable-curl',    name: 'Cable Curl',    classification: 'accessory', movementTags: ['pull'] },
+  { id: 'lateral-raise', name: 'Lateral Raise', classification: 'accessory', movementTags: ['push', 'vertical'] },
+  { id: 'calf-raise',    name: 'Calf Raise',    classification: 'accessory', movementTags: [] },
+];

--- a/packages/core/src/catalog/lifts.ts
+++ b/packages/core/src/catalog/lifts.ts
@@ -10,17 +10,15 @@ import { Lift } from '@lifting-logbook/types';
  *   push + horizontal = bench press / dip pattern
  *   pull + vertical   = chin-up / lat pulldown pattern
  *   pull + horizontal = row pattern
+ *   squat             = knee-dominant squat pattern
  *   hinge             = hip hinge pattern (deadlift, RDL)
  *   carry             = loaded carry pattern
- *
- * Squats are represented as compound lifts with no movement tags — the squat
- * pattern does not map to any of the above axes.
  */
-export const LIFT_CATALOG: Lift[] = [
+export const LIFT_CATALOG: readonly Lift[] = [
   // --- Squat pattern ---
-  { id: 'back-squat',    name: 'Back Squat',    classification: 'compound',  movementTags: [] },
-  { id: 'front-squat',   name: 'Front Squat',   classification: 'compound',  movementTags: [] },
-  { id: 'goblet-squat',  name: 'Goblet Squat',  classification: 'accessory', movementTags: [] },
+  { id: 'back-squat',    name: 'Back Squat',    classification: 'compound',  movementTags: ['squat'] },
+  { id: 'front-squat',   name: 'Front Squat',   classification: 'compound',  movementTags: ['squat'] },
+  { id: 'goblet-squat',  name: 'Goblet Squat',  classification: 'accessory', movementTags: ['squat'] },
 
   // --- Hip hinge pattern ---
   { id: 'deadlift',           name: 'Deadlift',                 classification: 'compound',  movementTags: ['hinge'] },

--- a/packages/core/src/catalog/resolve.ts
+++ b/packages/core/src/catalog/resolve.ts
@@ -1,0 +1,26 @@
+import { Lift } from '@lifting-logbook/types';
+
+/**
+ * Resolves a slot name to a Lift from the catalog.
+ *
+ * @param slotName  - The exercise slot name (e.g., the `lift` field from LiftingProgramSpec).
+ * @param slotMap   - A mapping from slot name → catalog Lift id.
+ * @param catalog   - The Lift catalog to search.
+ * @returns The matching Lift.
+ * @throws  If the slot name is not in slotMap or the resolved id is not in the catalog.
+ */
+export function resolveLift(
+  slotName: string,
+  slotMap: Record<string, string>,
+  catalog: Lift[],
+): Lift {
+  const liftId = slotMap[slotName];
+  if (liftId === undefined) {
+    throw new Error(`Unknown exercise slot: "${slotName}". Add it to the slot map.`);
+  }
+  const lift = catalog.find((l) => l.id === liftId);
+  if (!lift) {
+    throw new Error(`Lift id "${liftId}" not found in catalog.`);
+  }
+  return lift;
+}

--- a/packages/core/src/catalog/resolve.ts
+++ b/packages/core/src/catalog/resolve.ts
@@ -11,8 +11,8 @@ import { Lift } from '@lifting-logbook/types';
  */
 export function resolveLift(
   slotName: string,
-  slotMap: Record<string, string>,
-  catalog: Lift[],
+  slotMap: Readonly<Record<string, string>>,
+  catalog: readonly Lift[],
 ): Lift {
   const liftId = slotMap[slotName];
   if (liftId === undefined) {

--- a/packages/core/src/catalog/slotMaps.ts
+++ b/packages/core/src/catalog/slotMaps.ts
@@ -1,0 +1,36 @@
+/**
+ * Pre-built exercise slot maps for the built-in program templates.
+ *
+ * A slot map translates the `lift` field from LiftingProgramSpec (which may be
+ * an abbreviated or program-specific name) to a canonical catalog Lift id.
+ * Existing call sites require no changes — pass DEFAULT_SLOT_MAP to resolveLift.
+ */
+
+/**
+ * Covers all slot names used by the 5/3/1 and RPT program templates,
+ * including both canonical names (from LIFT_NAMES) and CSV-abbreviated forms.
+ */
+export const DEFAULT_SLOT_MAP: Record<string, string> = {
+  // Canonical names shared by 5/3/1 and LIFT_NAMES
+  'Squat':           'back-squat',
+  'Bench Press':     'bench-press',
+  'Deadlift':        'deadlift',
+  'Overhead Press':  'overhead-press',
+  'Barbell Row':     'barbell-row',
+  'Chin-up':         'chin-up',
+  'Cable Curls':     'cable-curl',
+  'Calf Raise':      'calf-raise',
+  'Dips':            'dip',
+  'Face Pulls':      'face-pull',
+  'Cable Lat Raise': 'lateral-raise',
+  'Upright Row':     'upright-row',
+
+  // RPT CSV-abbreviated slot names (where they differ from canonical)
+  'Bench P.':    'bench-press',
+  'BB Row':      'barbell-row',
+  'Dip':         'dip',
+  'OH Press':    'overhead-press',
+  'OH Press-HV': 'overhead-press',
+  'CBL Curls':   'cable-curl',
+  'C. Lat Raise': 'lateral-raise',
+};

--- a/packages/core/src/catalog/slotMaps.ts
+++ b/packages/core/src/catalog/slotMaps.ts
@@ -10,7 +10,7 @@
  * Covers all slot names used by the 5/3/1 and RPT program templates,
  * including both canonical names (from LIFT_NAMES) and CSV-abbreviated forms.
  */
-export const DEFAULT_SLOT_MAP: Record<string, string> = {
+export const DEFAULT_SLOT_MAP: Readonly<Record<string, string>> = {
   // Canonical names shared by 5/3/1 and LIFT_NAMES
   'Squat':           'back-squat',
   'Bench Press':     'bench-press',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from './catalog';
 export * from './constants';
 export * from './models';
 export * from './services';

--- a/packages/core/tests/core/catalog/liftCatalog.test.ts
+++ b/packages/core/tests/core/catalog/liftCatalog.test.ts
@@ -14,7 +14,7 @@ describe("LIFT_CATALOG", () => {
   });
 
   it("all movementTags are valid values", () => {
-    const validTags = new Set(['push', 'pull', 'vertical', 'horizontal', 'hinge', 'carry']);
+    const validTags = new Set(['push', 'pull', 'vertical', 'horizontal', 'hinge', 'carry', 'squat']);
     for (const lift of LIFT_CATALOG) {
       for (const tag of lift.movementTags) {
         expect(validTags.has(tag)).toBe(true);
@@ -77,10 +77,7 @@ describe("LIFT_CATALOG", () => {
 
   describe("covers major movement patterns", () => {
     it("has at least one squat-pattern lift", () => {
-      const squatLifts = LIFT_CATALOG.filter((l) =>
-        l.id.includes('squat') || l.id.includes('goblet'),
-      );
-      expect(squatLifts.length).toBeGreaterThanOrEqual(1);
+      expect(LIFT_CATALOG.some((l) => l.movementTags.includes('squat'))).toBe(true);
     });
 
     it("has at least one hinge-pattern lift", () => {
@@ -138,14 +135,25 @@ describe("resolveLift", () => {
     expect(lift.name).toBe('Bench Press');
   });
 
-  it("resolves all RPT CSV slot names without error", () => {
-    const rptSlots = [
-      'Bench P.', 'BB Row', 'Calf Raise', 'C. Lat Raise', 'OH Press-HV',
-      'Squat', 'Chin-up', 'Dip', 'Upright Row',
-      'Deadlift', 'OH Press', 'CBL Curls', 'Face Pulls',
+  it("resolves abbreviated RPT slot names to the correct catalog ids", () => {
+    const cases: [string, string][] = [
+      ['Bench P.',    'bench-press'],
+      ['BB Row',      'barbell-row'],
+      ['C. Lat Raise','lateral-raise'],
+      ['OH Press',    'overhead-press'],
+      ['OH Press-HV', 'overhead-press'],
+      ['CBL Curls',   'cable-curl'],
+      ['Dip',         'dip'],
     ];
-    for (const slot of rptSlots) {
-      expect(() => resolveLift(slot, DEFAULT_SLOT_MAP, LIFT_CATALOG)).not.toThrow();
+    for (const [slot, expectedId] of cases) {
+      expect(resolveLift(slot, DEFAULT_SLOT_MAP, LIFT_CATALOG).id).toBe(expectedId);
+    }
+  });
+
+  it("every DEFAULT_SLOT_MAP value is a valid catalog id", () => {
+    const catalogIds = new Set(LIFT_CATALOG.map((l) => l.id));
+    for (const [slot, liftId] of Object.entries(DEFAULT_SLOT_MAP)) {
+      expect(catalogIds.has(liftId)).toBe(true);
     }
   });
 

--- a/packages/core/tests/core/catalog/liftCatalog.test.ts
+++ b/packages/core/tests/core/catalog/liftCatalog.test.ts
@@ -1,0 +1,171 @@
+import { DEFAULT_SLOT_MAP, LIFT_CATALOG, resolveLift } from "@src/core";
+
+describe("LIFT_CATALOG", () => {
+  it("contains at least 20 lifts", () => {
+    expect(LIFT_CATALOG.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it("all lifts have a non-empty id, name, and valid classification", () => {
+    for (const lift of LIFT_CATALOG) {
+      expect(lift.id).toBeTruthy();
+      expect(lift.name).toBeTruthy();
+      expect(['compound', 'accessory']).toContain(lift.classification);
+    }
+  });
+
+  it("all movementTags are valid values", () => {
+    const validTags = new Set(['push', 'pull', 'vertical', 'horizontal', 'hinge', 'carry']);
+    for (const lift of LIFT_CATALOG) {
+      for (const tag of lift.movementTags) {
+        expect(validTags.has(tag)).toBe(true);
+      }
+    }
+  });
+
+  it("all lift ids are unique", () => {
+    const ids = LIFT_CATALOG.map((l) => l.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  describe("classification and tags — spot checks", () => {
+    it("deadlift is compound with hinge tag", () => {
+      const lift = LIFT_CATALOG.find((l) => l.id === 'deadlift')!;
+      expect(lift.classification).toBe('compound');
+      expect(lift.movementTags).toContain('hinge');
+    });
+
+    it("bench-press is compound with push and horizontal tags", () => {
+      const lift = LIFT_CATALOG.find((l) => l.id === 'bench-press')!;
+      expect(lift.classification).toBe('compound');
+      expect(lift.movementTags).toContain('push');
+      expect(lift.movementTags).toContain('horizontal');
+    });
+
+    it("overhead-press is compound with push and vertical tags", () => {
+      const lift = LIFT_CATALOG.find((l) => l.id === 'overhead-press')!;
+      expect(lift.classification).toBe('compound');
+      expect(lift.movementTags).toContain('push');
+      expect(lift.movementTags).toContain('vertical');
+    });
+
+    it("chin-up is compound with pull and vertical tags", () => {
+      const lift = LIFT_CATALOG.find((l) => l.id === 'chin-up')!;
+      expect(lift.classification).toBe('compound');
+      expect(lift.movementTags).toContain('pull');
+      expect(lift.movementTags).toContain('vertical');
+    });
+
+    it("barbell-row is compound with pull and horizontal tags", () => {
+      const lift = LIFT_CATALOG.find((l) => l.id === 'barbell-row')!;
+      expect(lift.classification).toBe('compound');
+      expect(lift.movementTags).toContain('pull');
+      expect(lift.movementTags).toContain('horizontal');
+    });
+
+    it("cable-curl is accessory with pull tag", () => {
+      const lift = LIFT_CATALOG.find((l) => l.id === 'cable-curl')!;
+      expect(lift.classification).toBe('accessory');
+      expect(lift.movementTags).toContain('pull');
+    });
+
+    it("farmers-carry is compound with carry tag", () => {
+      const lift = LIFT_CATALOG.find((l) => l.id === 'farmers-carry')!;
+      expect(lift.classification).toBe('compound');
+      expect(lift.movementTags).toContain('carry');
+    });
+  });
+
+  describe("covers major movement patterns", () => {
+    it("has at least one squat-pattern lift", () => {
+      const squatLifts = LIFT_CATALOG.filter((l) =>
+        l.id.includes('squat') || l.id.includes('goblet'),
+      );
+      expect(squatLifts.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("has at least one hinge-pattern lift", () => {
+      expect(LIFT_CATALOG.some((l) => l.movementTags.includes('hinge'))).toBe(true);
+    });
+
+    it("has at least one carry-pattern lift", () => {
+      expect(LIFT_CATALOG.some((l) => l.movementTags.includes('carry'))).toBe(true);
+    });
+
+    it("has at least one vertical push lift", () => {
+      expect(
+        LIFT_CATALOG.some(
+          (l) => l.movementTags.includes('push') && l.movementTags.includes('vertical'),
+        ),
+      ).toBe(true);
+    });
+
+    it("has at least one vertical pull lift", () => {
+      expect(
+        LIFT_CATALOG.some(
+          (l) => l.movementTags.includes('pull') && l.movementTags.includes('vertical'),
+        ),
+      ).toBe(true);
+    });
+
+    it("has at least one horizontal push lift", () => {
+      expect(
+        LIFT_CATALOG.some(
+          (l) => l.movementTags.includes('push') && l.movementTags.includes('horizontal'),
+        ),
+      ).toBe(true);
+    });
+
+    it("has at least one horizontal pull lift", () => {
+      expect(
+        LIFT_CATALOG.some(
+          (l) => l.movementTags.includes('pull') && l.movementTags.includes('horizontal'),
+        ),
+      ).toBe(true);
+    });
+  });
+});
+
+describe("resolveLift", () => {
+  it("resolves a canonical slot name to the correct catalog lift", () => {
+    const lift = resolveLift('Deadlift', DEFAULT_SLOT_MAP, LIFT_CATALOG);
+    expect(lift.id).toBe('deadlift');
+    expect(lift.name).toBe('Deadlift');
+  });
+
+  it("resolves an RPT-abbreviated slot name to the correct catalog lift", () => {
+    const lift = resolveLift('Bench P.', DEFAULT_SLOT_MAP, LIFT_CATALOG);
+    expect(lift.id).toBe('bench-press');
+    expect(lift.name).toBe('Bench Press');
+  });
+
+  it("resolves all RPT CSV slot names without error", () => {
+    const rptSlots = [
+      'Bench P.', 'BB Row', 'Calf Raise', 'C. Lat Raise', 'OH Press-HV',
+      'Squat', 'Chin-up', 'Dip', 'Upright Row',
+      'Deadlift', 'OH Press', 'CBL Curls', 'Face Pulls',
+    ];
+    for (const slot of rptSlots) {
+      expect(() => resolveLift(slot, DEFAULT_SLOT_MAP, LIFT_CATALOG)).not.toThrow();
+    }
+  });
+
+  it("resolves all 5/3/1 canonical slot names without error", () => {
+    const fiveThreeOneSlots = ['Squat', 'Bench Press', 'Deadlift', 'Overhead Press'];
+    for (const slot of fiveThreeOneSlots) {
+      expect(() => resolveLift(slot, DEFAULT_SLOT_MAP, LIFT_CATALOG)).not.toThrow();
+    }
+  });
+
+  it("throws when slot name is not in the slot map", () => {
+    expect(() => resolveLift('Unknown Exercise', DEFAULT_SLOT_MAP, LIFT_CATALOG)).toThrow(
+      /Unknown exercise slot/,
+    );
+  });
+
+  it("throws when resolved lift id is not in the catalog", () => {
+    const badMap: Record<string, string> = { 'Squat': 'nonexistent-id' };
+    expect(() => resolveLift('Squat', badMap, LIFT_CATALOG)).toThrow(
+      /not found in catalog/,
+    );
+  });
+});

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -5,7 +5,7 @@ export type LiftClassification = 'compound' | 'accessory';
  * Movement pattern tags used to classify a lift.
  * Tags combine to describe a pattern — e.g., push + vertical = overhead press pattern.
  */
-export type MovementTag = 'push' | 'pull' | 'vertical' | 'horizontal' | 'hinge' | 'carry';
+export type MovementTag = 'push' | 'pull' | 'vertical' | 'horizontal' | 'hinge' | 'carry' | 'squat';
 
 /** A first-class exercise domain object. */
 export interface Lift {

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -1,3 +1,20 @@
+/** Classification of a lift by primary training role. */
+export type LiftClassification = 'compound' | 'accessory';
+
+/**
+ * Movement pattern tags used to classify a lift.
+ * Tags combine to describe a pattern — e.g., push + vertical = overhead press pattern.
+ */
+export type MovementTag = 'push' | 'pull' | 'vertical' | 'horizontal' | 'hinge' | 'carry';
+
+/** A first-class exercise domain object. */
+export interface Lift {
+  id: string;
+  name: string;
+  classification: LiftClassification;
+  movementTags: MovementTag[];
+}
+
 /**
  * A named lift. Typed as a branded string so new lifts can be added without
  * a code change, while still enabling autocomplete from LIFT_NAMES.


### PR DESCRIPTION
## Summary

- Adds a `Lift` interface to `packages/types` with `id`, `name`, `classification` (`compound | accessory`), and `movementTags` (`push | pull | vertical | horizontal | hinge | carry`)
- Exports a 23-entry seed catalog from `packages/core` covering all major movement patterns (squat, hinge, vertical/horizontal push and pull, carry, common accessories)
- Provides `resolveLift(slotName, slotMap, catalog)` and `DEFAULT_SLOT_MAP` that pre-wires all existing 5/3/1 and RPT slot names to catalog ids — no changes to existing call sites

## Acceptance Criteria

- [x] `packages/types` exports a `Lift` interface with `id`, `name`, `classification`, and `movementTags`
- [x] `packages/core` exports a seeded catalog of ≥ 20 lifts covering squat, hinge, vertical push, vertical pull, horizontal push, horizontal pull, carry, and common accessories
- [x] Program configuration accepts exercise slot → `Lift` id mappings; existing 5/3/1 and RPT slot names resolve via `DEFAULT_SLOT_MAP` without changes to call sites
- [x] Unit tests cover: classification and tags for catalog entries; slot resolution with a valid catalog lift; slot resolution errors for unknown slot and unknown lift id
- [x] `packages/types` and `packages/core` strict TypeScript compilation passes with no errors

## Test plan

- `npm run test --workspace=packages/core` → 91 tests pass (21 suites), including 24 new catalog tests
- `npx tsc --build packages/types packages/core` → clean

Closes #64