### PR TITLE
[feat] Core read endpoints with in-memory adapters

### DIFF
--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -7,4 +7,10 @@ module.exports = {
     '^.+\\.tsx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.json' }],
   },
   transformIgnorePatterns: ['/node_modules/'],
+  moduleNameMapper: {
+    // @src/core is a pre-existing path alias inside @lifting-logbook/core sources.
+    // Map it so jest can resolve transitive imports when a test loads core.
+    '^@src/core$': '<rootDir>/../../packages/core/src/index.ts',
+    '^@src/core/(.*)$': '<rootDir>/../../packages/core/src/$1',
+  },
 };

--- a/apps/api/src/adapters/in-memory/cycle-dashboard.adapter.ts
+++ b/apps/api/src/adapters/in-memory/cycle-dashboard.adapter.ts
@@ -1,0 +1,25 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { CycleDashboard } from '@lifting-logbook/core';
+import { ICycleDashboardRepository } from '../../ports/ICycleDashboardRepository';
+import { SEED_PROGRAM, seedCycleDashboard } from './fixtures';
+
+@Injectable()
+export class InMemoryCycleDashboardRepository
+  implements ICycleDashboardRepository
+{
+  private dashboards = new Map<string, CycleDashboard>([
+    [SEED_PROGRAM, seedCycleDashboard()],
+  ]);
+
+  async getCycleDashboard(program: string): Promise<CycleDashboard> {
+    const dashboard = this.dashboards.get(program);
+    if (!dashboard) {
+      throw new NotFoundException(`Program '${program}' not found`);
+    }
+    return dashboard;
+  }
+
+  async saveCycleDashboard(dashboard: CycleDashboard): Promise<void> {
+    this.dashboards.set(dashboard.program, dashboard);
+  }
+}

--- a/apps/api/src/adapters/in-memory/cycle-dashboard.adapter.ts
+++ b/apps/api/src/adapters/in-memory/cycle-dashboard.adapter.ts
@@ -1,6 +1,7 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { CycleDashboard } from '@lifting-logbook/core';
 import { ICycleDashboardRepository } from '../../ports/ICycleDashboardRepository';
+import { ProgramNotFoundError } from '../../ports/errors';
 import { SEED_PROGRAM, seedCycleDashboard } from './fixtures';
 
 @Injectable()
@@ -14,7 +15,7 @@ export class InMemoryCycleDashboardRepository
   async getCycleDashboard(program: string): Promise<CycleDashboard> {
     const dashboard = this.dashboards.get(program);
     if (!dashboard) {
-      throw new NotFoundException(`Program '${program}' not found`);
+      throw new ProgramNotFoundError(program);
     }
     return dashboard;
   }

--- a/apps/api/src/adapters/in-memory/fixtures.ts
+++ b/apps/api/src/adapters/in-memory/fixtures.ts
@@ -1,0 +1,94 @@
+import {
+  CycleDashboard,
+  LiftRecord,
+  LiftingProgramSpec,
+  TrainingMax,
+  Weekday,
+} from '@lifting-logbook/core';
+
+/**
+ * Seed data for the in-memory adapters used in v0.2 to wire the API end-to-end
+ * before real persistence (Google Sheets adapters + auth) lands. One program,
+ * one cycle, enough records to render the "today's workout" UI path.
+ */
+
+export const SEED_PROGRAM = '5-3-1';
+
+export const seedCycleDashboard = (): CycleDashboard => ({
+  program: SEED_PROGRAM,
+  cycleUnit: 'week',
+  cycleNum: 1,
+  cycleDate: new Date('2026-04-20T00:00:00.000Z'),
+  sheetName: '',
+  cycleStartWeekday: Weekday.Monday,
+});
+
+export const seedTrainingMaxes = (): TrainingMax[] => [
+  { lift: 'Squat', weight: 315, dateUpdated: new Date('2026-04-20T00:00:00.000Z') },
+  { lift: 'Bench Press', weight: 225, dateUpdated: new Date('2026-04-20T00:00:00.000Z') },
+  { lift: 'Deadlift', weight: 405, dateUpdated: new Date('2026-04-20T00:00:00.000Z') },
+  { lift: 'Overhead Press', weight: 145, dateUpdated: new Date('2026-04-20T00:00:00.000Z') },
+];
+
+export const seedLiftRecords = (): LiftRecord[] => [
+  {
+    program: SEED_PROGRAM,
+    cycleNum: 1,
+    workoutNum: 1,
+    date: new Date('2026-04-20T00:00:00.000Z'),
+    lift: 'Squat',
+    setNum: 1,
+    weight: 205,
+    reps: 5,
+    notes: '',
+  },
+  {
+    program: SEED_PROGRAM,
+    cycleNum: 1,
+    workoutNum: 1,
+    date: new Date('2026-04-20T00:00:00.000Z'),
+    lift: 'Squat',
+    setNum: 2,
+    weight: 235,
+    reps: 5,
+    notes: '',
+  },
+  {
+    program: SEED_PROGRAM,
+    cycleNum: 1,
+    workoutNum: 1,
+    date: new Date('2026-04-20T00:00:00.000Z'),
+    lift: 'Squat',
+    setNum: 3,
+    weight: 265,
+    reps: 5,
+    notes: 'AMRAP',
+  },
+];
+
+export const seedProgramSpec = (): LiftingProgramSpec[] => [
+  {
+    offset: 0,
+    lift: 'Squat',
+    increment: 5,
+    order: 1,
+    sets: 3,
+    reps: 5,
+    amrap: true,
+    warmUpPct: '0.4,0.5,0.6',
+    wtDecrementPct: 0.1,
+    activation: 'compound',
+  },
+  {
+    offset: 0,
+    lift: 'Bench Press',
+    increment: 5,
+    order: 2,
+    sets: 3,
+    reps: 5,
+    amrap: true,
+    warmUpPct: '0.4,0.5,0.6',
+    wtDecrementPct: 0.1,
+    activation: 'compound',
+  },
+];

--- a/apps/api/src/adapters/in-memory/lift-record.adapter.ts
+++ b/apps/api/src/adapters/in-memory/lift-record.adapter.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { LiftRecord } from '@lifting-logbook/core';
+import { ILiftRecordRepository } from '../../ports/ILiftRecordRepository';
+import { SEED_PROGRAM, seedLiftRecords } from './fixtures';
+
+@Injectable()
+export class InMemoryLiftRecordRepository implements ILiftRecordRepository {
+  private recordsByProgram = new Map<string, LiftRecord[]>([
+    [SEED_PROGRAM, seedLiftRecords()],
+  ]);
+
+  async getLiftRecords(program: string, cycleNum: number): Promise<LiftRecord[]> {
+    const records = this.recordsByProgram.get(program) ?? [];
+    return records.filter((r) => r.cycleNum === cycleNum);
+  }
+
+  async appendLiftRecords(program: string, records: LiftRecord[]): Promise<void> {
+    const existing = this.recordsByProgram.get(program) ?? [];
+    this.recordsByProgram.set(program, [...existing, ...records]);
+  }
+}

--- a/apps/api/src/adapters/in-memory/lifting-program-spec.adapter.ts
+++ b/apps/api/src/adapters/in-memory/lifting-program-spec.adapter.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { LiftingProgramSpec } from '@lifting-logbook/core';
+import { ILiftingProgramSpecRepository } from '../../ports/ILiftingProgramSpecRepository';
+import { SEED_PROGRAM, seedProgramSpec } from './fixtures';
+
+@Injectable()
+export class InMemoryLiftingProgramSpecRepository
+  implements ILiftingProgramSpecRepository
+{
+  private specByProgram = new Map<string, LiftingProgramSpec[]>([
+    [SEED_PROGRAM, seedProgramSpec()],
+  ]);
+
+  async getProgramSpec(program: string): Promise<LiftingProgramSpec[]> {
+    return this.specByProgram.get(program) ?? [];
+  }
+}

--- a/apps/api/src/adapters/in-memory/training-max.adapter.ts
+++ b/apps/api/src/adapters/in-memory/training-max.adapter.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { TrainingMax } from '@lifting-logbook/core';
+import { ITrainingMaxRepository } from '../../ports/ITrainingMaxRepository';
+import { SEED_PROGRAM, seedTrainingMaxes } from './fixtures';
+
+@Injectable()
+export class InMemoryTrainingMaxRepository implements ITrainingMaxRepository {
+  private maxesByProgram = new Map<string, TrainingMax[]>([
+    [SEED_PROGRAM, seedTrainingMaxes()],
+  ]);
+
+  async getTrainingMaxes(program: string): Promise<TrainingMax[]> {
+    return this.maxesByProgram.get(program) ?? [];
+  }
+
+  async saveTrainingMaxes(program: string, maxes: TrainingMax[]): Promise<void> {
+    this.maxesByProgram.set(program, maxes);
+  }
+}

--- a/apps/api/src/adapters/in-memory/workout.adapter.ts
+++ b/apps/api/src/adapters/in-memory/workout.adapter.ts
@@ -1,0 +1,40 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { LiftRecord } from '@lifting-logbook/core';
+import { IWorkoutRepository } from '../../ports/IWorkoutRepository';
+import { SEED_PROGRAM, seedLiftRecords } from './fixtures';
+
+const workoutKey = (program: string, cycleNum: number, workoutNum: number) =>
+  `${program}::${cycleNum}::${workoutNum}`;
+
+@Injectable()
+export class InMemoryWorkoutRepository implements IWorkoutRepository {
+  private workouts = new Map<string, LiftRecord[]>();
+
+  constructor() {
+    const seed = seedLiftRecords();
+    this.workouts.set(workoutKey(SEED_PROGRAM, 1, 1), seed);
+  }
+
+  async getWorkout(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+  ): Promise<LiftRecord[]> {
+    const records = this.workouts.get(workoutKey(program, cycleNum, workoutNum));
+    if (!records) {
+      throw new NotFoundException(
+        `Workout ${workoutNum} for program '${program}' cycle ${cycleNum} not found`,
+      );
+    }
+    return records;
+  }
+
+  async saveWorkout(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+    records: LiftRecord[],
+  ): Promise<void> {
+    this.workouts.set(workoutKey(program, cycleNum, workoutNum), records);
+  }
+}

--- a/apps/api/src/adapters/in-memory/workout.adapter.ts
+++ b/apps/api/src/adapters/in-memory/workout.adapter.ts
@@ -1,6 +1,7 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { LiftRecord } from '@lifting-logbook/core';
 import { IWorkoutRepository } from '../../ports/IWorkoutRepository';
+import { WorkoutNotFoundError } from '../../ports/errors';
 import { SEED_PROGRAM, seedLiftRecords } from './fixtures';
 
 const workoutKey = (program: string, cycleNum: number, workoutNum: number) =>
@@ -22,9 +23,7 @@ export class InMemoryWorkoutRepository implements IWorkoutRepository {
   ): Promise<LiftRecord[]> {
     const records = this.workouts.get(workoutKey(program, cycleNum, workoutNum));
     if (!records) {
-      throw new NotFoundException(
-        `Workout ${workoutNum} for program '${program}' cycle ${cycleNum} not found`,
-      );
+      throw new WorkoutNotFoundError(program, cycleNum, workoutNum);
     }
     return records;
   }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,7 +1,8 @@
 import { Module } from '@nestjs/common';
 import { HealthModule } from './health/health.module';
+import { ProgramsModule } from './programs/programs.module';
 
 @Module({
-  imports: [HealthModule],
+  imports: [HealthModule, ProgramsModule],
 })
 export class AppModule {}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -2,12 +2,14 @@ import 'reflect-metadata';
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import { AppModule } from './app.module';
+import { DomainNotFoundFilter } from './programs/not-found.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(
     AppModule,
     new FastifyAdapter(),
   );
+  app.useGlobalFilters(new DomainNotFoundFilter());
   await app.listen(3000, '0.0.0.0');
 }
 

--- a/apps/api/src/ports/errors.ts
+++ b/apps/api/src/ports/errors.ts
@@ -1,0 +1,26 @@
+/**
+ * Framework-agnostic errors raised by port adapters. Controllers (or an
+ * exception filter) translate these to HTTP responses so that adapters stay
+ * free of `@nestjs/common` imports and can be reused by non-HTTP callers
+ * (queue workers, CLI tools, alternate transports).
+ */
+
+export class ProgramNotFoundError extends Error {
+  constructor(public readonly program: string) {
+    super(`Program '${program}' not found`);
+    this.name = 'ProgramNotFoundError';
+  }
+}
+
+export class WorkoutNotFoundError extends Error {
+  constructor(
+    public readonly program: string,
+    public readonly cycleNum: number,
+    public readonly workoutNum: number,
+  ) {
+    super(
+      `Workout ${workoutNum} for program '${program}' cycle ${cycleNum} not found`,
+    );
+    this.name = 'WorkoutNotFoundError';
+  }
+}

--- a/apps/api/src/ports/index.ts
+++ b/apps/api/src/ports/index.ts
@@ -1,5 +1,6 @@
 export * from './auth';
 export * from './factory';
+export * from './tokens';
 export * from './ICycleDashboardRepository';
 export * from './ILiftingProgramSpecRepository';
 export * from './ILiftRecordRepository';

--- a/apps/api/src/ports/index.ts
+++ b/apps/api/src/ports/index.ts
@@ -1,4 +1,5 @@
 export * from './auth';
+export * from './errors';
 export * from './factory';
 export * from './tokens';
 export * from './ICycleDashboardRepository';

--- a/apps/api/src/ports/tokens.ts
+++ b/apps/api/src/ports/tokens.ts
@@ -1,0 +1,7 @@
+export const CYCLE_DASHBOARD_REPOSITORY = Symbol('ICycleDashboardRepository');
+export const WORKOUT_REPOSITORY = Symbol('IWorkoutRepository');
+export const TRAINING_MAX_REPOSITORY = Symbol('ITrainingMaxRepository');
+export const LIFT_RECORD_REPOSITORY = Symbol('ILiftRecordRepository');
+export const LIFTING_PROGRAM_SPEC_REPOSITORY = Symbol(
+  'ILiftingProgramSpecRepository',
+);

--- a/apps/api/src/programs/cycle-dashboard.controller.spec.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.spec.ts
@@ -1,0 +1,43 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Weekday } from '@lifting-logbook/core';
+import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
+import { CYCLE_DASHBOARD_REPOSITORY } from '../ports/tokens';
+import { CycleDashboardController } from './cycle-dashboard.controller';
+
+describe('CycleDashboardController', () => {
+  let controller: CycleDashboardController;
+  let repo: jest.Mocked<ICycleDashboardRepository>;
+
+  beforeEach(async () => {
+    repo = {
+      getCycleDashboard: jest.fn(),
+      saveCycleDashboard: jest.fn(),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CycleDashboardController],
+      providers: [{ provide: CYCLE_DASHBOARD_REPOSITORY, useValue: repo }],
+    }).compile();
+    controller = module.get(CycleDashboardController);
+  });
+
+  it('GET /programs/:program/cycles/current returns mapped dashboard', async () => {
+    repo.getCycleDashboard.mockResolvedValue({
+      program: '5-3-1',
+      cycleUnit: 'week',
+      cycleNum: 2,
+      cycleDate: new Date('2026-04-20T00:00:00.000Z'),
+      sheetName: '',
+      cycleStartWeekday: Weekday.Monday,
+    });
+
+    const result = await controller.getCurrentCycle('5-3-1');
+
+    expect(repo.getCycleDashboard).toHaveBeenCalledWith('5-3-1');
+    expect(result).toEqual({
+      program: '5-3-1',
+      cycleNum: 2,
+      cycleStartDate: '2026-04-20',
+      weeks: [],
+    });
+  });
+});

--- a/apps/api/src/programs/cycle-dashboard.controller.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Inject, Param } from '@nestjs/common';
+import { CycleDashboardResponse } from '@lifting-logbook/types';
+import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
+import { CYCLE_DASHBOARD_REPOSITORY } from '../ports/tokens';
+import { toCycleDashboardResponse } from './mappers';
+
+@Controller('programs/:program')
+export class CycleDashboardController {
+  constructor(
+    @Inject(CYCLE_DASHBOARD_REPOSITORY)
+    private readonly cycleDashboardRepo: ICycleDashboardRepository,
+  ) {}
+
+  @Get('cycles/current')
+  async getCurrentCycle(
+    @Param('program') program: string,
+  ): Promise<CycleDashboardResponse> {
+    const dashboard = await this.cycleDashboardRepo.getCycleDashboard(program);
+    return toCycleDashboardResponse(dashboard);
+  }
+}

--- a/apps/api/src/programs/lift-records.controller.spec.ts
+++ b/apps/api/src/programs/lift-records.controller.spec.ts
@@ -1,0 +1,65 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Weekday } from '@lifting-logbook/core';
+import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
+import { ILiftRecordRepository } from '../ports/ILiftRecordRepository';
+import {
+  CYCLE_DASHBOARD_REPOSITORY,
+  LIFT_RECORD_REPOSITORY,
+} from '../ports/tokens';
+import { LiftRecordsController } from './lift-records.controller';
+
+describe('LiftRecordsController', () => {
+  let controller: LiftRecordsController;
+  let liftRecordRepo: jest.Mocked<ILiftRecordRepository>;
+  let dashboardRepo: jest.Mocked<ICycleDashboardRepository>;
+
+  beforeEach(async () => {
+    liftRecordRepo = {
+      getLiftRecords: jest.fn(),
+      appendLiftRecords: jest.fn(),
+    };
+    dashboardRepo = {
+      getCycleDashboard: jest.fn(),
+      saveCycleDashboard: jest.fn(),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LiftRecordsController],
+      providers: [
+        { provide: LIFT_RECORD_REPOSITORY, useValue: liftRecordRepo },
+        { provide: CYCLE_DASHBOARD_REPOSITORY, useValue: dashboardRepo },
+      ],
+    }).compile();
+    controller = module.get(LiftRecordsController);
+  });
+
+  it('fetches lift records scoped to current cycle', async () => {
+    dashboardRepo.getCycleDashboard.mockResolvedValue({
+      program: '5-3-1',
+      cycleUnit: 'week',
+      cycleNum: 4,
+      cycleDate: new Date('2026-04-20T00:00:00.000Z'),
+      sheetName: '',
+      cycleStartWeekday: Weekday.Monday,
+    });
+    liftRecordRepo.getLiftRecords.mockResolvedValue([
+      {
+        program: '5-3-1',
+        cycleNum: 4,
+        workoutNum: 1,
+        date: new Date('2026-04-20T00:00:00.000Z'),
+        lift: 'Bench Press',
+        setNum: 1,
+        weight: 180,
+        reps: 5,
+        notes: '',
+      },
+    ]);
+
+    const result = await controller.getLiftRecords('5-3-1');
+
+    expect(liftRecordRepo.getLiftRecords).toHaveBeenCalledWith('5-3-1', 4);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.lift).toBe('Bench Press');
+    expect(result[0]?.date).toBe('2026-04-20');
+  });
+});

--- a/apps/api/src/programs/lift-records.controller.ts
+++ b/apps/api/src/programs/lift-records.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, Inject, Param } from '@nestjs/common';
+import { LiftRecordResponse } from '@lifting-logbook/types';
+import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
+import { ILiftRecordRepository } from '../ports/ILiftRecordRepository';
+import {
+  CYCLE_DASHBOARD_REPOSITORY,
+  LIFT_RECORD_REPOSITORY,
+} from '../ports/tokens';
+import { toLiftRecordResponse } from './mappers';
+
+@Controller('programs/:program')
+export class LiftRecordsController {
+  constructor(
+    @Inject(LIFT_RECORD_REPOSITORY)
+    private readonly liftRecordRepo: ILiftRecordRepository,
+    @Inject(CYCLE_DASHBOARD_REPOSITORY)
+    private readonly cycleDashboardRepo: ICycleDashboardRepository,
+  ) {}
+
+  @Get('lift-records')
+  async getLiftRecords(
+    @Param('program') program: string,
+  ): Promise<LiftRecordResponse[]> {
+    const dashboard = await this.cycleDashboardRepo.getCycleDashboard(program);
+    const records = await this.liftRecordRepo.getLiftRecords(
+      program,
+      dashboard.cycleNum,
+    );
+    return records.map(toLiftRecordResponse);
+  }
+}

--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -1,0 +1,103 @@
+import {
+  CycleDashboard,
+  LiftRecord,
+  LiftingProgramSpec,
+  TrainingMax,
+} from '@lifting-logbook/core';
+import {
+  CycleDashboardResponse,
+  LiftRecordResponse,
+  LiftingProgramSpecResponse,
+  SetResponse,
+  TrainingMaxResponse,
+  WeekNumber,
+  WorkoutLiftResponse,
+  WorkoutResponse,
+} from '@lifting-logbook/types';
+
+const isoDate = (d: Date): string => d.toISOString().slice(0, 10);
+
+export const toTrainingMaxResponse = (m: TrainingMax): TrainingMaxResponse => ({
+  lift: m.lift,
+  weight: m.weight,
+  unit: 'lbs',
+  dateUpdated: isoDate(m.dateUpdated),
+});
+
+export const toLiftRecordResponse = (
+  r: LiftRecord,
+  index: number,
+): LiftRecordResponse => ({
+  id: `${r.program}-${r.cycleNum}-${r.workoutNum}-${r.lift}-${r.setNum}-${index}`,
+  program: r.program,
+  cycleNum: r.cycleNum,
+  workoutNum: r.workoutNum,
+  date: isoDate(r.date),
+  lift: r.lift,
+  setNum: r.setNum,
+  weight: r.weight,
+  reps: r.reps,
+  notes: r.notes,
+});
+
+export const toLiftingProgramSpecResponse = (
+  s: LiftingProgramSpec,
+): LiftingProgramSpecResponse => ({
+  lift: s.lift,
+  order: s.order,
+  offset: s.offset,
+  increment: s.increment,
+  sets: s.sets,
+  reps: s.reps,
+  amrap: typeof s.amrap === 'boolean' ? s.amrap : s.amrap === 'TRUE',
+  warmUpPct: s.warmUpPct,
+  wtDecrementPct: s.wtDecrementPct,
+  activation: s.activation,
+});
+
+/**
+ * Maps a CycleDashboard to a CycleDashboardResponse.
+ * Per-week summary composition (workout dates, completion status) requires
+ * combining the dashboard with workouts and lift records — that belongs in a
+ * core use case, not the mapper. Returns weeks=[] until that lands.
+ */
+export const toCycleDashboardResponse = (
+  d: CycleDashboard,
+): CycleDashboardResponse => ({
+  program: d.program,
+  cycleNum: d.cycleNum,
+  cycleStartDate: isoDate(d.cycleDate),
+  weeks: [],
+});
+
+/**
+ * Groups a workout's lift records into the WorkoutResponse shape.
+ * Week is derived assuming 2 workouts per training week — sufficient for the
+ * in-memory v0.2 wiring; real adapters should source week from the program
+ * spec or dashboard.
+ */
+export const toWorkoutResponse = (
+  program: string,
+  cycleNum: number,
+  workoutNum: number,
+  records: LiftRecord[],
+): WorkoutResponse => {
+  const liftMap = new Map<string, SetResponse[]>();
+  for (const r of records) {
+    const set: SetResponse = {
+      setNum: r.setNum,
+      weight: r.weight,
+      reps: r.reps,
+      amrap: r.notes.toUpperCase().includes('AMRAP'),
+    };
+    const sets = liftMap.get(r.lift);
+    if (sets) sets.push(set);
+    else liftMap.set(r.lift, [set]);
+  }
+  const lifts: WorkoutLiftResponse[] = Array.from(liftMap.entries()).map(
+    ([lift, sets]) => ({ lift, sets }),
+  );
+  const week = (Math.min(4, Math.max(1, Math.ceil(workoutNum / 2))) as WeekNumber);
+  const date = records[0] ? isoDate(records[0].date) : isoDate(new Date());
+  return { program, cycleNum, workoutNum, week, date, lifts };
+};

--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -15,6 +15,9 @@ import {
   WorkoutResponse,
 } from '@lifting-logbook/types';
 
+// All API date fields are emitted as `YYYY-MM-DD` in UTC. Domain `Date`
+// values must be stored as UTC midnight; adapters parsing external sources
+// (e.g. Sheets) are responsible for normalizing before the mapper runs.
 const isoDate = (d: Date): string => d.toISOString().slice(0, 10);
 
 export const toTrainingMaxResponse = (m: TrainingMax): TrainingMaxResponse => ({
@@ -24,11 +27,8 @@ export const toTrainingMaxResponse = (m: TrainingMax): TrainingMaxResponse => ({
   dateUpdated: isoDate(m.dateUpdated),
 });
 
-export const toLiftRecordResponse = (
-  r: LiftRecord,
-  index: number,
-): LiftRecordResponse => ({
-  id: `${r.program}-${r.cycleNum}-${r.workoutNum}-${r.lift}-${r.setNum}-${index}`,
+export const toLiftRecordResponse = (r: LiftRecord): LiftRecordResponse => ({
+  id: `${r.program}-${r.cycleNum}-${r.workoutNum}-${r.lift}-${r.setNum}`,
   program: r.program,
   cycleNum: r.cycleNum,
   workoutNum: r.workoutNum,
@@ -70,11 +70,18 @@ export const toCycleDashboardResponse = (
   weeks: [],
 });
 
+// Largest workoutNum whose derived week still fits in WeekNumber (1..4)
+// assuming 2 workouts per training week. Real programs vary — when that
+// becomes relevant, source week from the program spec instead of deriving.
+export const MAX_WORKOUT_NUM = 8 as const;
+
+export const isValidWorkoutNum = (n: number): boolean =>
+  Number.isInteger(n) && n >= 1 && n <= MAX_WORKOUT_NUM;
+
 /**
  * Groups a workout's lift records into the WorkoutResponse shape.
- * Week is derived assuming 2 workouts per training week — sufficient for the
- * in-memory v0.2 wiring; real adapters should source week from the program
- * spec or dashboard.
+ * Assumes 2 workouts per training week; caller must validate `workoutNum`
+ * with `isValidWorkoutNum` before invoking.
  */
 export const toWorkoutResponse = (
   program: string,
@@ -97,7 +104,7 @@ export const toWorkoutResponse = (
   const lifts: WorkoutLiftResponse[] = Array.from(liftMap.entries()).map(
     ([lift, sets]) => ({ lift, sets }),
   );
-  const week = (Math.min(4, Math.max(1, Math.ceil(workoutNum / 2))) as WeekNumber);
+  const week = Math.ceil(workoutNum / 2) as WeekNumber;
   const date = records[0] ? isoDate(records[0].date) : isoDate(new Date());
   return { program, cycleNum, workoutNum, week, date, lifts };
 };

--- a/apps/api/src/programs/not-found.filter.ts
+++ b/apps/api/src/programs/not-found.filter.ts
@@ -1,0 +1,30 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpStatus,
+} from '@nestjs/common';
+import { FastifyReply } from 'fastify';
+import {
+  ProgramNotFoundError,
+  WorkoutNotFoundError,
+} from '../ports/errors';
+
+type DomainNotFound = ProgramNotFoundError | WorkoutNotFoundError;
+
+/**
+ * Translates framework-agnostic domain "not found" errors raised by port
+ * adapters into HTTP 404 responses. Keeps adapters free of `@nestjs/common`
+ * HTTP dependencies so they can be reused by non-HTTP callers.
+ */
+@Catch(ProgramNotFoundError, WorkoutNotFoundError)
+export class DomainNotFoundFilter implements ExceptionFilter {
+  catch(err: DomainNotFound, host: ArgumentsHost): void {
+    const res = host.switchToHttp().getResponse<FastifyReply>();
+    res.status(HttpStatus.NOT_FOUND).send({
+      statusCode: HttpStatus.NOT_FOUND,
+      message: err.message,
+      error: 'Not Found',
+    });
+  }
+}

--- a/apps/api/src/programs/program-spec.controller.spec.ts
+++ b/apps/api/src/programs/program-spec.controller.spec.ts
@@ -1,0 +1,42 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
+import { LIFTING_PROGRAM_SPEC_REPOSITORY } from '../ports/tokens';
+import { ProgramSpecController } from './program-spec.controller';
+
+describe('ProgramSpecController', () => {
+  let controller: ProgramSpecController;
+  let repo: jest.Mocked<ILiftingProgramSpecRepository>;
+
+  beforeEach(async () => {
+    repo = { getProgramSpec: jest.fn() };
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProgramSpecController],
+      providers: [{ provide: LIFTING_PROGRAM_SPEC_REPOSITORY, useValue: repo }],
+    }).compile();
+    controller = module.get(ProgramSpecController);
+  });
+
+  it('returns mapped program spec with normalized amrap boolean', async () => {
+    repo.getProgramSpec.mockResolvedValue([
+      {
+        offset: 0,
+        lift: 'Squat',
+        increment: 5,
+        order: 1,
+        sets: 3,
+        reps: 5,
+        amrap: 'TRUE',
+        warmUpPct: '0.4,0.5,0.6',
+        wtDecrementPct: 0.1,
+        activation: 'compound',
+      },
+    ]);
+
+    const result = await controller.getProgramSpec('5-3-1');
+
+    expect(repo.getProgramSpec).toHaveBeenCalledWith('5-3-1');
+    expect(result).toHaveLength(1);
+    expect(result[0]?.amrap).toBe(true);
+    expect(result[0]?.lift).toBe('Squat');
+  });
+});

--- a/apps/api/src/programs/program-spec.controller.ts
+++ b/apps/api/src/programs/program-spec.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Inject, Param } from '@nestjs/common';
+import { LiftingProgramSpecResponse } from '@lifting-logbook/types';
+import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
+import { LIFTING_PROGRAM_SPEC_REPOSITORY } from '../ports/tokens';
+import { toLiftingProgramSpecResponse } from './mappers';
+
+@Controller('programs/:program')
+export class ProgramSpecController {
+  constructor(
+    @Inject(LIFTING_PROGRAM_SPEC_REPOSITORY)
+    private readonly programSpecRepo: ILiftingProgramSpecRepository,
+  ) {}
+
+  @Get('spec')
+  async getProgramSpec(
+    @Param('program') program: string,
+  ): Promise<LiftingProgramSpecResponse[]> {
+    const spec = await this.programSpecRepo.getProgramSpec(program);
+    return spec.map(toLiftingProgramSpecResponse);
+  }
+}

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -1,0 +1,71 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import { AppModule } from '../app.module';
+import { SEED_PROGRAM } from '../adapters/in-memory/fixtures';
+
+describe('Programs HTTP (e2e, in-memory adapters)', () => {
+  let app: NestFastifyApplication;
+
+  beforeAll(async () => {
+    app = await NestFactory.create<NestFastifyApplication>(
+      AppModule,
+      new FastifyAdapter(),
+      { logger: false },
+    );
+    await app.init();
+    await app.getHttpAdapter().getInstance().ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const get = (url: string) =>
+    app.getHttpAdapter().getInstance().inject({ method: 'GET', url });
+
+  it('GET /programs/:program/cycles/current returns the seeded cycle', async () => {
+    const res = await get(`/programs/${SEED_PROGRAM}/cycles/current`);
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.program).toBe(SEED_PROGRAM);
+    expect(body.cycleNum).toBe(1);
+    expect(body.cycleStartDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('GET /programs/:program/workouts/:workoutNum returns grouped lifts', async () => {
+    const res = await get(`/programs/${SEED_PROGRAM}/workouts/1`);
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.workoutNum).toBe(1);
+    expect(body.lifts.length).toBeGreaterThan(0);
+  });
+
+  it('GET /programs/:program/training-maxes returns the seeded maxes', async () => {
+    const res = await get(`/programs/${SEED_PROGRAM}/training-maxes`);
+    expect(res.statusCode).toBe(200);
+    expect(res.json().length).toBeGreaterThan(0);
+  });
+
+  it('GET /programs/:program/lift-records returns records for current cycle', async () => {
+    const res = await get(`/programs/${SEED_PROGRAM}/lift-records`);
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.every((r: { cycleNum: number }) => r.cycleNum === 1)).toBe(true);
+  });
+
+  it('GET /programs/:program/spec returns the seeded program spec', async () => {
+    const res = await get(`/programs/${SEED_PROGRAM}/spec`);
+    expect(res.statusCode).toBe(200);
+    expect(res.json().length).toBeGreaterThan(0);
+  });
+
+  it('GET unknown program returns 404', async () => {
+    const res = await get('/programs/does-not-exist/cycles/current');
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/platform-fastify';
 import { AppModule } from '../app.module';
 import { SEED_PROGRAM } from '../adapters/in-memory/fixtures';
+import { DomainNotFoundFilter } from './not-found.filter';
 
 describe('Programs HTTP (e2e, in-memory adapters)', () => {
   let app: NestFastifyApplication;
@@ -16,6 +17,7 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
       new FastifyAdapter(),
       { logger: false },
     );
+    app.useGlobalFilters(new DomainNotFoundFilter());
     await app.init();
     await app.getHttpAdapter().getInstance().ready();
   });
@@ -67,5 +69,16 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
   it('GET unknown program returns 404', async () => {
     const res = await get('/programs/does-not-exist/cycles/current');
     expect(res.statusCode).toBe(404);
+  });
+
+  // Forcing function for the Scope decision in ProgramsModule. Today adapters
+  // are Nest singletons holding mutable Map state — fine while single-tenant,
+  // but swapping `useClass` for a per-user Sheets adapter without setting
+  // `scope: Scope.REQUEST` (or a per-user factory) will leak one user's data
+  // into another's request. Unskip when auth lands.
+  it.skip('isolates adapter state per request (enable when auth lands)', () => {
+    // Expected setup: request A writes via authenticated user X, request B
+    // reads as user Y; B must not observe A's write. Requires per-request
+    // adapter instances.
   });
 });

--- a/apps/api/src/programs/programs.module.ts
+++ b/apps/api/src/programs/programs.module.ts
@@ -19,8 +19,10 @@ import { WorkoutsController } from './workouts.controller';
 
 /**
  * Wires controllers to in-memory adapters via port tokens. Adapters are
- * provider-singletons; replace with real Sheets adapters + per-user factory
- * when auth lands (see follow-up issue).
+ * provider-singletons; replace with real Sheets adapters + `Scope.REQUEST`
+ * (or a per-user factory) when auth lands. The skipped test
+ * `isolates adapter state per request` in `programs.e2e.spec.ts` is the
+ * forcing function for that wiring decision.
  */
 @Module({
   controllers: [

--- a/apps/api/src/programs/programs.module.ts
+++ b/apps/api/src/programs/programs.module.ts
@@ -1,0 +1,50 @@
+import { Module } from '@nestjs/common';
+import { InMemoryCycleDashboardRepository } from '../adapters/in-memory/cycle-dashboard.adapter';
+import { InMemoryLiftRecordRepository } from '../adapters/in-memory/lift-record.adapter';
+import { InMemoryLiftingProgramSpecRepository } from '../adapters/in-memory/lifting-program-spec.adapter';
+import { InMemoryTrainingMaxRepository } from '../adapters/in-memory/training-max.adapter';
+import { InMemoryWorkoutRepository } from '../adapters/in-memory/workout.adapter';
+import {
+  CYCLE_DASHBOARD_REPOSITORY,
+  LIFT_RECORD_REPOSITORY,
+  LIFTING_PROGRAM_SPEC_REPOSITORY,
+  TRAINING_MAX_REPOSITORY,
+  WORKOUT_REPOSITORY,
+} from '../ports/tokens';
+import { CycleDashboardController } from './cycle-dashboard.controller';
+import { LiftRecordsController } from './lift-records.controller';
+import { ProgramSpecController } from './program-spec.controller';
+import { TrainingMaxesController } from './training-maxes.controller';
+import { WorkoutsController } from './workouts.controller';
+
+/**
+ * Wires controllers to in-memory adapters via port tokens. Adapters are
+ * provider-singletons; replace with real Sheets adapters + per-user factory
+ * when auth lands (see follow-up issue).
+ */
+@Module({
+  controllers: [
+    CycleDashboardController,
+    WorkoutsController,
+    TrainingMaxesController,
+    LiftRecordsController,
+    ProgramSpecController,
+  ],
+  providers: [
+    {
+      provide: CYCLE_DASHBOARD_REPOSITORY,
+      useClass: InMemoryCycleDashboardRepository,
+    },
+    { provide: WORKOUT_REPOSITORY, useClass: InMemoryWorkoutRepository },
+    {
+      provide: TRAINING_MAX_REPOSITORY,
+      useClass: InMemoryTrainingMaxRepository,
+    },
+    { provide: LIFT_RECORD_REPOSITORY, useClass: InMemoryLiftRecordRepository },
+    {
+      provide: LIFTING_PROGRAM_SPEC_REPOSITORY,
+      useClass: InMemoryLiftingProgramSpecRepository,
+    },
+  ],
+})
+export class ProgramsModule {}

--- a/apps/api/src/programs/training-maxes.controller.spec.ts
+++ b/apps/api/src/programs/training-maxes.controller.spec.ts
@@ -1,0 +1,35 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ITrainingMaxRepository } from '../ports/ITrainingMaxRepository';
+import { TRAINING_MAX_REPOSITORY } from '../ports/tokens';
+import { TrainingMaxesController } from './training-maxes.controller';
+
+describe('TrainingMaxesController', () => {
+  let controller: TrainingMaxesController;
+  let repo: jest.Mocked<ITrainingMaxRepository>;
+
+  beforeEach(async () => {
+    repo = { getTrainingMaxes: jest.fn(), saveTrainingMaxes: jest.fn() };
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TrainingMaxesController],
+      providers: [{ provide: TRAINING_MAX_REPOSITORY, useValue: repo }],
+    }).compile();
+    controller = module.get(TrainingMaxesController);
+  });
+
+  it('returns mapped training maxes with unit and ISO date', async () => {
+    repo.getTrainingMaxes.mockResolvedValue([
+      {
+        lift: 'Squat',
+        weight: 315,
+        dateUpdated: new Date('2026-04-20T00:00:00.000Z'),
+      },
+    ]);
+
+    const result = await controller.getTrainingMaxes('5-3-1');
+
+    expect(repo.getTrainingMaxes).toHaveBeenCalledWith('5-3-1');
+    expect(result).toEqual([
+      { lift: 'Squat', weight: 315, unit: 'lbs', dateUpdated: '2026-04-20' },
+    ]);
+  });
+});

--- a/apps/api/src/programs/training-maxes.controller.ts
+++ b/apps/api/src/programs/training-maxes.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Inject, Param } from '@nestjs/common';
+import { TrainingMaxResponse } from '@lifting-logbook/types';
+import { ITrainingMaxRepository } from '../ports/ITrainingMaxRepository';
+import { TRAINING_MAX_REPOSITORY } from '../ports/tokens';
+import { toTrainingMaxResponse } from './mappers';
+
+@Controller('programs/:program')
+export class TrainingMaxesController {
+  constructor(
+    @Inject(TRAINING_MAX_REPOSITORY)
+    private readonly trainingMaxRepo: ITrainingMaxRepository,
+  ) {}
+
+  @Get('training-maxes')
+  async getTrainingMaxes(
+    @Param('program') program: string,
+  ): Promise<TrainingMaxResponse[]> {
+    const maxes = await this.trainingMaxRepo.getTrainingMaxes(program);
+    return maxes.map(toTrainingMaxResponse);
+  }
+}

--- a/apps/api/src/programs/workouts.controller.spec.ts
+++ b/apps/api/src/programs/workouts.controller.spec.ts
@@ -1,0 +1,85 @@
+import { BadRequestException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Weekday } from '@lifting-logbook/core';
+import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
+import { IWorkoutRepository } from '../ports/IWorkoutRepository';
+import {
+  CYCLE_DASHBOARD_REPOSITORY,
+  WORKOUT_REPOSITORY,
+} from '../ports/tokens';
+import { WorkoutsController } from './workouts.controller';
+
+describe('WorkoutsController', () => {
+  let controller: WorkoutsController;
+  let workoutRepo: jest.Mocked<IWorkoutRepository>;
+  let dashboardRepo: jest.Mocked<ICycleDashboardRepository>;
+
+  beforeEach(async () => {
+    workoutRepo = { getWorkout: jest.fn(), saveWorkout: jest.fn() };
+    dashboardRepo = {
+      getCycleDashboard: jest.fn(),
+      saveCycleDashboard: jest.fn(),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WorkoutsController],
+      providers: [
+        { provide: WORKOUT_REPOSITORY, useValue: workoutRepo },
+        { provide: CYCLE_DASHBOARD_REPOSITORY, useValue: dashboardRepo },
+      ],
+    }).compile();
+    controller = module.get(WorkoutsController);
+  });
+
+  it('groups records by lift, derives week, and looks up current cycle', async () => {
+    dashboardRepo.getCycleDashboard.mockResolvedValue({
+      program: '5-3-1',
+      cycleUnit: 'week',
+      cycleNum: 3,
+      cycleDate: new Date('2026-04-20T00:00:00.000Z'),
+      sheetName: '',
+      cycleStartWeekday: Weekday.Monday,
+    });
+    workoutRepo.getWorkout.mockResolvedValue([
+      {
+        program: '5-3-1',
+        cycleNum: 3,
+        workoutNum: 1,
+        date: new Date('2026-04-20T00:00:00.000Z'),
+        lift: 'Squat',
+        setNum: 1,
+        weight: 200,
+        reps: 5,
+        notes: '',
+      },
+      {
+        program: '5-3-1',
+        cycleNum: 3,
+        workoutNum: 1,
+        date: new Date('2026-04-20T00:00:00.000Z'),
+        lift: 'Squat',
+        setNum: 2,
+        weight: 220,
+        reps: 5,
+        notes: 'AMRAP',
+      },
+    ]);
+
+    const result = await controller.getWorkout('5-3-1', '1');
+
+    expect(workoutRepo.getWorkout).toHaveBeenCalledWith('5-3-1', 3, 1);
+    expect(result.cycleNum).toBe(3);
+    expect(result.week).toBe(1);
+    expect(result.lifts).toHaveLength(1);
+    expect(result.lifts[0]?.lift).toBe('Squat');
+    expect(result.lifts[0]?.sets).toEqual([
+      { setNum: 1, weight: 200, reps: 5, amrap: false },
+      { setNum: 2, weight: 220, reps: 5, amrap: true },
+    ]);
+  });
+
+  it('rejects non-numeric workoutNum', async () => {
+    await expect(controller.getWorkout('5-3-1', 'abc')).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+});

--- a/apps/api/src/programs/workouts.controller.ts
+++ b/apps/api/src/programs/workouts.controller.ts
@@ -1,0 +1,43 @@
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  Inject,
+  Param,
+} from '@nestjs/common';
+import { WorkoutResponse } from '@lifting-logbook/types';
+import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
+import { IWorkoutRepository } from '../ports/IWorkoutRepository';
+import {
+  CYCLE_DASHBOARD_REPOSITORY,
+  WORKOUT_REPOSITORY,
+} from '../ports/tokens';
+import { toWorkoutResponse } from './mappers';
+
+@Controller('programs/:program')
+export class WorkoutsController {
+  constructor(
+    @Inject(WORKOUT_REPOSITORY)
+    private readonly workoutRepo: IWorkoutRepository,
+    @Inject(CYCLE_DASHBOARD_REPOSITORY)
+    private readonly cycleDashboardRepo: ICycleDashboardRepository,
+  ) {}
+
+  @Get('workouts/:workoutNum')
+  async getWorkout(
+    @Param('program') program: string,
+    @Param('workoutNum') workoutNumParam: string,
+  ): Promise<WorkoutResponse> {
+    const workoutNum = Number.parseInt(workoutNumParam, 10);
+    if (!Number.isInteger(workoutNum) || workoutNum < 1) {
+      throw new BadRequestException('workoutNum must be a positive integer');
+    }
+    const dashboard = await this.cycleDashboardRepo.getCycleDashboard(program);
+    const records = await this.workoutRepo.getWorkout(
+      program,
+      dashboard.cycleNum,
+      workoutNum,
+    );
+    return toWorkoutResponse(program, dashboard.cycleNum, workoutNum, records);
+  }
+}

--- a/apps/api/src/programs/workouts.controller.ts
+++ b/apps/api/src/programs/workouts.controller.ts
@@ -12,7 +12,11 @@ import {
   CYCLE_DASHBOARD_REPOSITORY,
   WORKOUT_REPOSITORY,
 } from '../ports/tokens';
-import { toWorkoutResponse } from './mappers';
+import {
+  MAX_WORKOUT_NUM,
+  isValidWorkoutNum,
+  toWorkoutResponse,
+} from './mappers';
 
 @Controller('programs/:program')
 export class WorkoutsController {
@@ -29,8 +33,10 @@ export class WorkoutsController {
     @Param('workoutNum') workoutNumParam: string,
   ): Promise<WorkoutResponse> {
     const workoutNum = Number.parseInt(workoutNumParam, 10);
-    if (!Number.isInteger(workoutNum) || workoutNum < 1) {
-      throw new BadRequestException('workoutNum must be a positive integer');
+    if (!isValidWorkoutNum(workoutNum)) {
+      throw new BadRequestException(
+        `workoutNum must be an integer in [1, ${MAX_WORKOUT_NUM}]`,
+      );
     }
     const dashboard = await this.cycleDashboardRepo.getCycleDashboard(program);
     const records = await this.workoutRepo.getWorkout(

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
+    "isolatedModules": true,
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16289,6 +16289,126 @@
     "packages/types": {
       "name": "@lifting-logbook/types",
       "version": "0.0.0"
+    },
+    "apps/web/node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
+      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
+      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
+      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
+      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
+      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
+      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
+      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
+      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -98,3 +98,21 @@ export interface CycleDashboardResponse {
   cycleStartDate: string; // ISO 8601 date string
   weeks: CycleWeekSummary[];
 }
+
+// ---------------------------------------------------------------------------
+// Lifting Program Spec
+// ---------------------------------------------------------------------------
+
+/** Per-lift specification within a lifting program (e.g., 5/3/1). */
+export interface LiftingProgramSpecResponse {
+  lift: LiftName;
+  order: number;
+  offset: number;
+  increment: number;
+  sets: number;
+  reps: number;
+  amrap: boolean;
+  warmUpPct: string;
+  wtDecrementPct: number;
+  activation: string;
+}


### PR DESCRIPTION
## Summary

- Implements the five GET endpoints under `/programs/:program` (`cycles/current`, `workouts/:workoutNum`, `training-maxes`, `lift-records`, `spec`) wired through port-token DI to in-memory adapters.
- Seeds in-memory adapters with one cycle of fixture data — sufficient to render the J1/J2 "today's workout" UI path end-to-end. Real Google Sheets adapters and per-user auth land in a follow-up alongside `IRepositoryFactory` wiring.
- Adds `LiftingProgramSpecResponse` to `@lifting-logbook/types` (referenced by the issue but missing).

## Scope decision

The original AC asked for Google Sheets adapter implementations. The legacy `src/api/repositories/` adapters use Google Apps Script's `SpreadsheetApp` global and won't run in Node — building real adapters would require adding `googleapis`, OAuth credentials, per-user spreadsheet ID storage, and an auth provider, none of which exist yet. That's pulled out into a follow-up so this PR can stay focused on the API surface, controller wiring, and DI seam (which is what unblocks #84 and the first web client iteration).

## Acceptance criteria

- [x] All five endpoints implemented in `apps/api`
- [x] Each endpoint backed by its corresponding port interface — controllers `@Inject` port tokens, no direct adapter imports
- [ ] Google Sheets adapter implementations — **deferred to follow-up** (in-memory adapters used instead; see scope decision)
- [x] Unit tests for each controller (port mocks)
- [x] Integration test exercising all five endpoints + a 404 path through Fastify (`programs.e2e.spec.ts`)

## Test plan

- [ ] `cd apps/api && npm test` — all 14 tests pass
- [ ] `npm run build` from repo root — full Turbo build succeeds
- [ ] Hit each endpoint locally against `npm run dev --workspace @lifting-logbook/api` and verify the JSON shape matches the contracts in `packages/types/src/api.ts`

## Follow-ups (separate issues)

- Real Google Sheets adapters + `IRepositoryFactory.forUser` wiring + auth provider
- `CycleDashboardResponse.weeks[]` composition (currently empty — needs a core use case combining dashboard + workouts + records)
- Remove the `@src/core` path alias inside `packages/core` so the workaround in `apps/api/jest.config.js` and `tsconfig.json` (`isolatedModules`) can be dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)