### PR TITLE
[feat] Cycle generation write endpoints

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,8 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-fastify": "^10.0.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.15.1",
     "fastify": "^4.0.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.0"

--- a/apps/api/src/adapters/in-memory/fixtures.ts
+++ b/apps/api/src/adapters/in-memory/fixtures.ts
@@ -24,10 +24,10 @@ export const seedCycleDashboard = (): CycleDashboard => ({
 });
 
 export const seedTrainingMaxes = (): TrainingMax[] => [
-  { lift: 'Squat', weight: 315, dateUpdated: new Date('2026-04-20T00:00:00.000Z') },
-  { lift: 'Bench Press', weight: 225, dateUpdated: new Date('2026-04-20T00:00:00.000Z') },
-  { lift: 'Deadlift', weight: 405, dateUpdated: new Date('2026-04-20T00:00:00.000Z') },
-  { lift: 'Overhead Press', weight: 145, dateUpdated: new Date('2026-04-20T00:00:00.000Z') },
+  { lift: 'Squat', weight: 315, dateUpdated: new Date('2026-04-13T00:00:00.000Z') },
+  { lift: 'Bench Press', weight: 225, dateUpdated: new Date('2026-04-13T00:00:00.000Z') },
+  { lift: 'Deadlift', weight: 405, dateUpdated: new Date('2026-04-13T00:00:00.000Z') },
+  { lift: 'Overhead Press', weight: 145, dateUpdated: new Date('2026-04-13T00:00:00.000Z') },
 ];
 
 export const seedLiftRecords = (): LiftRecord[] => [

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import { AppModule } from './app.module';
 import { DomainNotFoundFilter } from './programs/not-found.filter';
@@ -10,6 +11,7 @@ async function bootstrap() {
     new FastifyAdapter(),
   );
   app.useGlobalFilters(new DomainNotFoundFilter());
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
   await app.listen(3000, '0.0.0.0');
 }
 

--- a/apps/api/src/programs/cycle-generation.controller.spec.ts
+++ b/apps/api/src/programs/cycle-generation.controller.spec.ts
@@ -1,0 +1,91 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Weekday } from '@lifting-logbook/core';
+import { CycleGenerationController } from './cycle-generation.controller';
+import { CycleGenerationService } from './cycle-generation.service';
+
+const PROGRAM = '5-3-1';
+
+const stubCycleDashboard = () => ({
+  program: PROGRAM,
+  cycleUnit: 'week' as const,
+  cycleNum: 2,
+  cycleDate: new Date('2026-04-27T00:00:00.000Z'),
+  sheetName: '5-3-1_Cycle_2_20260427',
+  cycleStartWeekday: Weekday.Monday,
+});
+
+describe('CycleGenerationController', () => {
+  let controller: CycleGenerationController;
+  let service: jest.Mocked<Pick<CycleGenerationService, 'startNewCycle' | 'recalculateMaxes'>>;
+
+  beforeEach(async () => {
+    service = {
+      startNewCycle: jest.fn(),
+      recalculateMaxes: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CycleGenerationController],
+      providers: [{ provide: CycleGenerationService, useValue: service }],
+    }).compile();
+
+    controller = module.get(CycleGenerationController);
+  });
+
+  describe('startNewCycle', () => {
+    it('calls service with program and dto, returns mapped response', async () => {
+      service.startNewCycle.mockResolvedValue(stubCycleDashboard());
+
+      const result = await controller.startNewCycle(PROGRAM, {});
+
+      expect(service.startNewCycle).toHaveBeenCalledWith(PROGRAM, {});
+      expect(result).toEqual({
+        program: PROGRAM,
+        cycleNum: 2,
+        cycleStartDate: '2026-04-27',
+        weeks: [],
+      });
+    });
+
+    it('passes fromCycleNum and cycleDate through to service', async () => {
+      service.startNewCycle.mockResolvedValue(stubCycleDashboard());
+
+      await controller.startNewCycle(PROGRAM, {
+        fromCycleNum: 1,
+        cycleDate: '2026-05-01',
+      });
+
+      expect(service.startNewCycle).toHaveBeenCalledWith(PROGRAM, {
+        fromCycleNum: 1,
+        cycleDate: '2026-05-01',
+      });
+    });
+
+    it('propagates service errors (e.g. 404 from unknown program)', async () => {
+      service.startNewCycle.mockRejectedValue(new Error('Program not found'));
+
+      await expect(controller.startNewCycle('unknown', {})).rejects.toThrow(
+        'Program not found',
+      );
+    });
+  });
+
+  describe('recalculateMaxes', () => {
+    it('calls service with program and returns mapped maxes', async () => {
+      service.recalculateMaxes.mockResolvedValue([
+        {
+          lift: 'Squat',
+          weight: 270,
+          dateUpdated: new Date('2026-04-27T00:00:00.000Z'),
+        },
+      ]);
+
+      const result = await controller.recalculateMaxes(PROGRAM);
+
+      expect(service.recalculateMaxes).toHaveBeenCalledWith(PROGRAM);
+      expect(result).toEqual([
+        { lift: 'Squat', weight: 270, unit: 'lbs', dateUpdated: '2026-04-27' },
+      ]);
+    });
+  });
+});

--- a/apps/api/src/programs/cycle-generation.controller.ts
+++ b/apps/api/src/programs/cycle-generation.controller.ts
@@ -1,10 +1,11 @@
-import { Controller, HttpCode, HttpStatus, Param, Post } from '@nestjs/common';
+import { Body, Controller, HttpCode, HttpStatus, Param, Post } from '@nestjs/common';
 import {
   CycleDashboardResponse,
   TrainingMaxResponse,
 } from '@lifting-logbook/types';
 import { toCycleDashboardResponse, toTrainingMaxResponse } from './mappers';
 import { CycleGenerationService } from './cycle-generation.service';
+import { StartNewCycleDto } from './start-new-cycle.dto';
 
 @Controller('programs/:program')
 export class CycleGenerationController {
@@ -16,15 +17,18 @@ export class CycleGenerationController {
    * POST /programs/:program/cycles
    *
    * Starts a new cycle: advances the cycle counter, updates training maxes
-   * from the current cycle's lift records, and persists both. Returns the
+   * from the source cycle's lift records, and persists both. Returns the
    * new cycle dashboard.
+   *
+   * Optional body: `{ fromCycleNum?: number, cycleDate?: string }` — see
+   * StartNewCycleDto for semantics.
    */
   @Post('cycles')
-  @HttpCode(HttpStatus.CREATED)
   async startNewCycle(
     @Param('program') program: string,
+    @Body() dto: StartNewCycleDto = {},
   ): Promise<CycleDashboardResponse> {
-    const newCycle = await this.cycleGenerationService.startNewCycle(program);
+    const newCycle = await this.cycleGenerationService.startNewCycle(program, dto);
     return toCycleDashboardResponse(newCycle);
   }
 

--- a/apps/api/src/programs/cycle-generation.controller.ts
+++ b/apps/api/src/programs/cycle-generation.controller.ts
@@ -5,6 +5,7 @@ import {
 } from '@lifting-logbook/types';
 import { toCycleDashboardResponse, toTrainingMaxResponse } from './mappers';
 import { CycleGenerationService } from './cycle-generation.service';
+import { ParseProgramPipe } from './program.pipe';
 import { StartNewCycleDto } from './start-new-cycle.dto';
 
 @Controller('programs/:program')
@@ -25,8 +26,8 @@ export class CycleGenerationController {
    */
   @Post('cycles')
   async startNewCycle(
-    @Param('program') program: string,
-    @Body() dto: StartNewCycleDto = {},
+    @Param('program', ParseProgramPipe) program: string,
+    @Body() dto: StartNewCycleDto,
   ): Promise<CycleDashboardResponse> {
     const newCycle = await this.cycleGenerationService.startNewCycle(program, dto);
     return toCycleDashboardResponse(newCycle);
@@ -41,7 +42,7 @@ export class CycleGenerationController {
   @Post('training-maxes/recalculate')
   @HttpCode(HttpStatus.OK)
   async recalculateMaxes(
-    @Param('program') program: string,
+    @Param('program', ParseProgramPipe) program: string,
   ): Promise<TrainingMaxResponse[]> {
     const maxes = await this.cycleGenerationService.recalculateMaxes(program);
     return maxes.map(toTrainingMaxResponse);

--- a/apps/api/src/programs/cycle-generation.controller.ts
+++ b/apps/api/src/programs/cycle-generation.controller.ts
@@ -1,0 +1,45 @@
+import { Controller, HttpCode, HttpStatus, Param, Post } from '@nestjs/common';
+import {
+  CycleDashboardResponse,
+  TrainingMaxResponse,
+} from '@lifting-logbook/types';
+import { toCycleDashboardResponse, toTrainingMaxResponse } from './mappers';
+import { CycleGenerationService } from './cycle-generation.service';
+
+@Controller('programs/:program')
+export class CycleGenerationController {
+  constructor(
+    private readonly cycleGenerationService: CycleGenerationService,
+  ) {}
+
+  /**
+   * POST /programs/:program/cycles
+   *
+   * Starts a new cycle: advances the cycle counter, updates training maxes
+   * from the current cycle's lift records, and persists both. Returns the
+   * new cycle dashboard.
+   */
+  @Post('cycles')
+  @HttpCode(HttpStatus.CREATED)
+  async startNewCycle(
+    @Param('program') program: string,
+  ): Promise<CycleDashboardResponse> {
+    const newCycle = await this.cycleGenerationService.startNewCycle(program);
+    return toCycleDashboardResponse(newCycle);
+  }
+
+  /**
+   * POST /programs/:program/training-maxes/recalculate
+   *
+   * Re-runs training max calculation against the current cycle's lift records
+   * without advancing the cycle. Returns the updated training maxes.
+   */
+  @Post('training-maxes/recalculate')
+  @HttpCode(HttpStatus.OK)
+  async recalculateMaxes(
+    @Param('program') program: string,
+  ): Promise<TrainingMaxResponse[]> {
+    const maxes = await this.cycleGenerationService.recalculateMaxes(program);
+    return maxes.map(toTrainingMaxResponse);
+  }
+}

--- a/apps/api/src/programs/cycle-generation.service.spec.ts
+++ b/apps/api/src/programs/cycle-generation.service.spec.ts
@@ -1,0 +1,198 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Weekday } from '@lifting-logbook/core';
+import {
+  ICycleDashboardRepository,
+  ILiftRecordRepository,
+  ILiftingProgramSpecRepository,
+  ITrainingMaxRepository,
+  CYCLE_DASHBOARD_REPOSITORY,
+  LIFT_RECORD_REPOSITORY,
+  LIFTING_PROGRAM_SPEC_REPOSITORY,
+  TRAINING_MAX_REPOSITORY,
+} from '../ports';
+import { CycleGenerationService } from './cycle-generation.service';
+
+const PROGRAM = '5-3-1';
+
+const stubDashboard = () => ({
+  program: PROGRAM,
+  cycleUnit: 'week' as const,
+  cycleNum: 1,
+  cycleDate: new Date('2026-04-20T00:00:00.000Z'),
+  sheetName: '',
+  cycleStartWeekday: Weekday.Monday,
+});
+
+const stubProgramSpec = () => [
+  {
+    lift: 'Squat',
+    order: 1,
+    offset: 0,
+    increment: 5,
+    sets: 3,
+    reps: 5,
+    amrap: true,
+    warmUpPct: '0.4,0.5,0.6',
+    wtDecrementPct: 0.1,
+    activation: 'compound',
+  },
+];
+
+const stubTrainingMaxes = () => [
+  {
+    lift: 'Squat',
+    weight: 315,
+    dateUpdated: new Date('2026-04-18T00:00:00.000Z'),
+  },
+];
+
+const stubLiftRecords = () => [
+  {
+    program: PROGRAM,
+    cycleNum: 1,
+    workoutNum: 1,
+    date: new Date('2026-04-20T00:00:00.000Z'),
+    lift: 'Squat',
+    setNum: 1,
+    weight: 265,
+    reps: 5,
+    notes: '',
+  },
+];
+
+describe('CycleGenerationService', () => {
+  let service: CycleGenerationService;
+  let cycleDashboardRepo: jest.Mocked<ICycleDashboardRepository>;
+  let programSpecRepo: jest.Mocked<ILiftingProgramSpecRepository>;
+  let trainingMaxRepo: jest.Mocked<ITrainingMaxRepository>;
+  let liftRecordRepo: jest.Mocked<ILiftRecordRepository>;
+
+  beforeEach(async () => {
+    cycleDashboardRepo = {
+      getCycleDashboard: jest.fn(),
+      saveCycleDashboard: jest.fn().mockResolvedValue(undefined),
+    };
+    programSpecRepo = {
+      getProgramSpec: jest.fn(),
+    };
+    trainingMaxRepo = {
+      getTrainingMaxes: jest.fn(),
+      saveTrainingMaxes: jest.fn().mockResolvedValue(undefined),
+    };
+    liftRecordRepo = {
+      getLiftRecords: jest.fn(),
+      appendLiftRecords: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CycleGenerationService,
+        { provide: CYCLE_DASHBOARD_REPOSITORY, useValue: cycleDashboardRepo },
+        {
+          provide: LIFTING_PROGRAM_SPEC_REPOSITORY,
+          useValue: programSpecRepo,
+        },
+        { provide: TRAINING_MAX_REPOSITORY, useValue: trainingMaxRepo },
+        { provide: LIFT_RECORD_REPOSITORY, useValue: liftRecordRepo },
+      ],
+    }).compile();
+
+    service = module.get(CycleGenerationService);
+  });
+
+  describe('startNewCycle', () => {
+    it('fetches current state, runs updateCycle + updateMaxes, and persists both', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockResolvedValue(stubDashboard());
+      programSpecRepo.getProgramSpec.mockResolvedValue(stubProgramSpec());
+      trainingMaxRepo.getTrainingMaxes.mockResolvedValue(stubTrainingMaxes());
+      liftRecordRepo.getLiftRecords.mockResolvedValue(stubLiftRecords());
+
+      const result = await service.startNewCycle(PROGRAM);
+
+      // Cycle number must advance by 1
+      expect(result.cycleNum).toBe(2);
+      expect(result.program).toBe(PROGRAM);
+
+      // Dashboard saved with the new cycle
+      expect(cycleDashboardRepo.saveCycleDashboard).toHaveBeenCalledWith(
+        expect.objectContaining({ cycleNum: 2 }),
+      );
+
+      // Training maxes saved — Squat record has reps >= spec and date after current max
+      expect(trainingMaxRepo.saveTrainingMaxes).toHaveBeenCalledWith(
+        PROGRAM,
+        expect.arrayContaining([
+          expect.objectContaining({ lift: 'Squat', weight: 270 }), // 265 + 5 increment
+        ]),
+      );
+    });
+
+    it('fetches lift records for the current cycle number', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockResolvedValue(stubDashboard());
+      programSpecRepo.getProgramSpec.mockResolvedValue(stubProgramSpec());
+      trainingMaxRepo.getTrainingMaxes.mockResolvedValue(stubTrainingMaxes());
+      liftRecordRepo.getLiftRecords.mockResolvedValue([]);
+
+      await service.startNewCycle(PROGRAM);
+
+      expect(liftRecordRepo.getLiftRecords).toHaveBeenCalledWith(PROGRAM, 1);
+    });
+
+    it('propagates ProgramNotFoundError from getCycleDashboard', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockRejectedValue(
+        new Error('Program not found'),
+      );
+
+      await expect(service.startNewCycle('unknown')).rejects.toThrow(
+        'Program not found',
+      );
+    });
+  });
+
+  describe('recalculateMaxes', () => {
+    it('re-runs updateMaxes against current cycle records and persists', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockResolvedValue(stubDashboard());
+      programSpecRepo.getProgramSpec.mockResolvedValue(stubProgramSpec());
+      trainingMaxRepo.getTrainingMaxes.mockResolvedValue(stubTrainingMaxes());
+      liftRecordRepo.getLiftRecords.mockResolvedValue(stubLiftRecords());
+
+      const result = await service.recalculateMaxes(PROGRAM);
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ lift: 'Squat', weight: 270 }),
+        ]),
+      );
+      expect(trainingMaxRepo.saveTrainingMaxes).toHaveBeenCalledWith(
+        PROGRAM,
+        result,
+      );
+    });
+
+    it('does not call saveCycleDashboard', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockResolvedValue(stubDashboard());
+      programSpecRepo.getProgramSpec.mockResolvedValue(stubProgramSpec());
+      trainingMaxRepo.getTrainingMaxes.mockResolvedValue(stubTrainingMaxes());
+      liftRecordRepo.getLiftRecords.mockResolvedValue([]);
+
+      await service.recalculateMaxes(PROGRAM);
+
+      expect(cycleDashboardRepo.saveCycleDashboard).not.toHaveBeenCalled();
+    });
+
+    it('returns unchanged maxes when there are no lift records', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockResolvedValue(stubDashboard());
+      programSpecRepo.getProgramSpec.mockResolvedValue(stubProgramSpec());
+      trainingMaxRepo.getTrainingMaxes.mockResolvedValue(stubTrainingMaxes());
+      liftRecordRepo.getLiftRecords.mockResolvedValue([]);
+
+      const result = await service.recalculateMaxes(PROGRAM);
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ lift: 'Squat', weight: 315 }),
+        ]),
+      );
+    });
+  });
+});

--- a/apps/api/src/programs/cycle-generation.service.spec.ts
+++ b/apps/api/src/programs/cycle-generation.service.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Weekday } from '@lifting-logbook/core';
 import {
@@ -146,6 +147,41 @@ describe('CycleGenerationService', () => {
       await expect(service.startNewCycle('unknown')).rejects.toThrow(
         'Program not found',
       );
+    });
+
+    it('fetches records for fromCycleNum when provided and advances from that cycle', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockResolvedValue(stubDashboard()); // cycleNum: 1
+      programSpecRepo.getProgramSpec.mockResolvedValue(stubProgramSpec());
+      trainingMaxRepo.getTrainingMaxes.mockResolvedValue(stubTrainingMaxes());
+      liftRecordRepo.getLiftRecords.mockResolvedValue(stubLiftRecords());
+
+      const result = await service.startNewCycle(PROGRAM, { fromCycleNum: 3 });
+
+      expect(liftRecordRepo.getLiftRecords).toHaveBeenCalledWith(PROGRAM, 3);
+      // Advances from cycle 3 → 4, not from current dashboard cycle 1 → 2
+      expect(result.cycleNum).toBe(4);
+    });
+
+    it('throws BadRequestException when fromCycleNum has no records', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockResolvedValue(stubDashboard());
+      programSpecRepo.getProgramSpec.mockResolvedValue(stubProgramSpec());
+      trainingMaxRepo.getTrainingMaxes.mockResolvedValue(stubTrainingMaxes());
+      liftRecordRepo.getLiftRecords.mockResolvedValue([]);
+
+      await expect(
+        service.startNewCycle(PROGRAM, { fromCycleNum: 5 }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('pins cycleDate when cycleDate override is provided', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockResolvedValue(stubDashboard());
+      programSpecRepo.getProgramSpec.mockResolvedValue(stubProgramSpec());
+      trainingMaxRepo.getTrainingMaxes.mockResolvedValue(stubTrainingMaxes());
+      liftRecordRepo.getLiftRecords.mockResolvedValue(stubLiftRecords());
+
+      const result = await service.startNewCycle(PROGRAM, { cycleDate: '2026-06-01' });
+
+      expect(result.cycleDate).toEqual(new Date('2026-06-01T00:00:00.000Z'));
     });
   });
 

--- a/apps/api/src/programs/cycle-generation.service.ts
+++ b/apps/api/src/programs/cycle-generation.service.ts
@@ -1,0 +1,73 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  CycleDashboard,
+  TrainingMax,
+  updateCycle,
+  updateMaxes,
+} from '@lifting-logbook/core';
+import {
+  ICycleDashboardRepository,
+  ILiftRecordRepository,
+  ILiftingProgramSpecRepository,
+  ITrainingMaxRepository,
+  CYCLE_DASHBOARD_REPOSITORY,
+  LIFT_RECORD_REPOSITORY,
+  LIFTING_PROGRAM_SPEC_REPOSITORY,
+  TRAINING_MAX_REPOSITORY,
+} from '../ports';
+
+@Injectable()
+export class CycleGenerationService {
+  constructor(
+    @Inject(CYCLE_DASHBOARD_REPOSITORY)
+    private readonly cycleDashboardRepo: ICycleDashboardRepository,
+    @Inject(LIFTING_PROGRAM_SPEC_REPOSITORY)
+    private readonly programSpecRepo: ILiftingProgramSpecRepository,
+    @Inject(TRAINING_MAX_REPOSITORY)
+    private readonly trainingMaxRepo: ITrainingMaxRepository,
+    @Inject(LIFT_RECORD_REPOSITORY)
+    private readonly liftRecordRepo: ILiftRecordRepository,
+  ) {}
+
+  /**
+   * Advances the current cycle: computes the next cycle header, updates
+   * training maxes from the current cycle's lift records, and persists both.
+   * Returns the new `CycleDashboard`.
+   */
+  async startNewCycle(program: string): Promise<CycleDashboard> {
+    const dashboard = await this.cycleDashboardRepo.getCycleDashboard(program);
+    const [programSpec, trainingMaxes, liftRecords] = await Promise.all([
+      this.programSpecRepo.getProgramSpec(program),
+      this.trainingMaxRepo.getTrainingMaxes(program),
+      this.liftRecordRepo.getLiftRecords(program, dashboard.cycleNum),
+    ]);
+
+    const newCycle = updateCycle(dashboard);
+    const newMaxes = updateMaxes(programSpec, trainingMaxes, liftRecords);
+
+    await Promise.all([
+      this.cycleDashboardRepo.saveCycleDashboard(newCycle),
+      this.trainingMaxRepo.saveTrainingMaxes(program, newMaxes),
+    ]);
+
+    return newCycle;
+  }
+
+  /**
+   * Re-runs training max calculation against the current cycle's lift records
+   * without advancing the cycle. Persists and returns the updated maxes.
+   */
+  async recalculateMaxes(program: string): Promise<TrainingMax[]> {
+    const dashboard = await this.cycleDashboardRepo.getCycleDashboard(program);
+    const [programSpec, trainingMaxes, liftRecords] = await Promise.all([
+      this.programSpecRepo.getProgramSpec(program),
+      this.trainingMaxRepo.getTrainingMaxes(program),
+      this.liftRecordRepo.getLiftRecords(program, dashboard.cycleNum),
+    ]);
+
+    const newMaxes = updateMaxes(programSpec, trainingMaxes, liftRecords);
+    await this.trainingMaxRepo.saveTrainingMaxes(program, newMaxes);
+
+    return newMaxes;
+  }
+}

--- a/apps/api/src/programs/cycle-generation.service.ts
+++ b/apps/api/src/programs/cycle-generation.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import {
   CycleDashboard,
   TrainingMax,
@@ -15,6 +15,7 @@ import {
   LIFTING_PROGRAM_SPEC_REPOSITORY,
   TRAINING_MAX_REPOSITORY,
 } from '../ports';
+import { StartNewCycleDto } from './start-new-cycle.dto';
 
 @Injectable()
 export class CycleGenerationService {
@@ -31,24 +32,56 @@ export class CycleGenerationService {
 
   /**
    * Advances the current cycle: computes the next cycle header, updates
-   * training maxes from the current cycle's lift records, and persists both.
-   * Returns the new `CycleDashboard`.
+   * training maxes from the source cycle's lift records, and persists both.
+   *
+   * When `dto.fromCycleNum` is provided the endpoint advances *from that
+   * cycle* (cycleNum becomes fromCycleNum + 1) and uses its records for max
+   * calculation; the anchor date is min(record.date) for that cycle.
+   * When `dto.cycleDate` is provided the new cycle's start date is pinned to
+   * that ISO string rather than being computed from the previous date.
+   *
+   * Sequential writes bound the blast radius: if the second write fails the
+   * first is already committed, but the caller receives a 500 and can retry
+   * safely. True atomicity requires a transaction primitive — add when real
+   * adapters land.
    */
-  async startNewCycle(program: string): Promise<CycleDashboard> {
+  async startNewCycle(
+    program: string,
+    dto: StartNewCycleDto = {},
+  ): Promise<CycleDashboard> {
     const dashboard = await this.cycleDashboardRepo.getCycleDashboard(program);
+    const sourceCycleNum = dto.fromCycleNum ?? dashboard.cycleNum;
+
     const [programSpec, trainingMaxes, liftRecords] = await Promise.all([
       this.programSpecRepo.getProgramSpec(program),
       this.trainingMaxRepo.getTrainingMaxes(program),
-      this.liftRecordRepo.getLiftRecords(program, dashboard.cycleNum),
+      this.liftRecordRepo.getLiftRecords(program, sourceCycleNum),
     ]);
 
-    const newCycle = updateCycle(dashboard);
+    if (dto.fromCycleNum !== undefined && liftRecords.length === 0) {
+      throw new BadRequestException(
+        `No lift records found for cycle ${dto.fromCycleNum}`,
+      );
+    }
+
+    let prevDashboard = dashboard;
+    if (dto.fromCycleNum !== undefined) {
+      const minDate = liftRecords.reduce(
+        (min, r) => (r.date < min ? r.date : min),
+        liftRecords[0].date,
+      );
+      prevDashboard = { ...dashboard, cycleNum: dto.fromCycleNum, cycleDate: minDate };
+    }
+
+    const cycleOverrides = dto.cycleDate
+      ? { overrideDate: new Date(dto.cycleDate) }
+      : {};
+
+    const newCycle = updateCycle(prevDashboard, cycleOverrides);
     const newMaxes = updateMaxes(programSpec, trainingMaxes, liftRecords);
 
-    await Promise.all([
-      this.cycleDashboardRepo.saveCycleDashboard(newCycle),
-      this.trainingMaxRepo.saveTrainingMaxes(program, newMaxes),
-    ]);
+    await this.cycleDashboardRepo.saveCycleDashboard(newCycle);
+    await this.trainingMaxRepo.saveTrainingMaxes(program, newMaxes);
 
     return newCycle;
   }

--- a/apps/api/src/programs/cycle-generation.service.ts
+++ b/apps/api/src/programs/cycle-generation.service.ts
@@ -40,10 +40,9 @@ export class CycleGenerationService {
    * When `dto.cycleDate` is provided the new cycle's start date is pinned to
    * that ISO string rather than being computed from the previous date.
    *
-   * Sequential writes bound the blast radius: if the second write fails the
-   * first is already committed, but the caller receives a 500 and can retry
-   * safely. True atomicity requires a transaction primitive — add when real
-   * adapters land.
+   * Write order: maxes are saved before the dashboard so that if the second
+   * write fails the cycle counter has not yet advanced and a retry is safe.
+   * True atomicity requires a transaction primitive — add when real adapters land.
    */
   async startNewCycle(
     program: string,
@@ -58,14 +57,13 @@ export class CycleGenerationService {
       this.liftRecordRepo.getLiftRecords(program, sourceCycleNum),
     ]);
 
-    if (dto.fromCycleNum !== undefined && liftRecords.length === 0) {
-      throw new BadRequestException(
-        `No lift records found for cycle ${dto.fromCycleNum}`,
-      );
-    }
-
     let prevDashboard = dashboard;
     if (dto.fromCycleNum !== undefined) {
+      if (liftRecords.length === 0) {
+        throw new BadRequestException(
+          `No lift records found for cycle ${dto.fromCycleNum}`,
+        );
+      }
       const minDate = liftRecords.reduce(
         (min, r) => (r.date < min ? r.date : min),
         liftRecords[0].date,
@@ -80,8 +78,8 @@ export class CycleGenerationService {
     const newCycle = updateCycle(prevDashboard, cycleOverrides);
     const newMaxes = updateMaxes(programSpec, trainingMaxes, liftRecords);
 
-    await this.cycleDashboardRepo.saveCycleDashboard(newCycle);
     await this.trainingMaxRepo.saveTrainingMaxes(program, newMaxes);
+    await this.cycleDashboardRepo.saveCycleDashboard(newCycle);
 
     return newCycle;
   }

--- a/apps/api/src/programs/program.pipe.ts
+++ b/apps/api/src/programs/program.pipe.ts
@@ -1,0 +1,15 @@
+import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
+
+const PROGRAM_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+@Injectable()
+export class ParseProgramPipe implements PipeTransform<string, string> {
+  transform(value: string): string {
+    if (!PROGRAM_PATTERN.test(value)) {
+      throw new BadRequestException(
+        `Program identifier must contain only letters, digits, hyphens, and underscores`,
+      );
+    }
+    return value;
+  }
+}

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -32,6 +32,14 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
   const post = (url: string) =>
     app.getHttpAdapter().getInstance().inject({ method: 'POST', url });
 
+  const postJson = (url: string, body: unknown) =>
+    app.getHttpAdapter().getInstance().inject({
+      method: 'POST',
+      url,
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify(body),
+    });
+
   it('GET /programs/:program/cycles/current returns the seeded cycle', async () => {
     const res = await get(`/programs/${SEED_PROGRAM}/cycles/current`);
     expect(res.statusCode).toBe(200);
@@ -75,46 +83,77 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Write endpoints — these tests mutate singleton adapter state so they run
-  // after all read-only GET tests to avoid interference.
+  // Write endpoints — order-sensitive; each test mutates singleton adapter
+  // state and the next test observes that state. Do not reorder or randomize.
   // -------------------------------------------------------------------------
 
-  it('POST /programs/:program/cycles advances cycleNum and persists new maxes', async () => {
-    const res = await post(`/programs/${SEED_PROGRAM}/cycles`);
-    expect(res.statusCode).toBe(201);
-    const body = res.json();
-    expect(body.program).toBe(SEED_PROGRAM);
-    // Cycle counter must have advanced from the seeded value of 1
-    expect(body.cycleNum).toBe(2);
-    expect(body.cycleStartDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  describe('write operations', () => {
+    it('POST /programs/:program/training-maxes/recalculate updates maxes from lift records', async () => {
+      // Capture seeded Squat max before recalculate (cycle 1 has Squat records)
+      const beforeRes = await get(`/programs/${SEED_PROGRAM}/training-maxes`);
+      const squatBefore = beforeRes
+        .json()
+        .find((m: { lift: string }) => m.lift === 'Squat').weight;
 
-    // Verify the persisted dashboard is readable via GET
-    const getRes = await get(`/programs/${SEED_PROGRAM}/cycles/current`);
-    expect(getRes.statusCode).toBe(200);
-    expect(getRes.json().cycleNum).toBe(2);
-  });
+      const res = await post(`/programs/${SEED_PROGRAM}/training-maxes/recalculate`);
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(Array.isArray(body)).toBe(true);
+      expect(body.length).toBeGreaterThan(0);
+      for (const m of body) {
+        expect(m).toMatchObject({
+          lift: expect.any(String),
+          weight: expect.any(Number),
+          unit: 'lbs',
+          dateUpdated: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        });
+      }
+      // Squat has cycle-1 records — verify the max actually changed
+      const squatAfter = body.find((m: { lift: string }) => m.lift === 'Squat').weight;
+      expect(squatAfter).not.toBe(squatBefore);
+    });
 
-  it('POST /programs/:program/training-maxes/recalculate returns updated maxes', async () => {
-    const res = await post(
-      `/programs/${SEED_PROGRAM}/training-maxes/recalculate`,
-    );
-    expect(res.statusCode).toBe(200);
-    const body = res.json();
-    expect(Array.isArray(body)).toBe(true);
-    expect(body.length).toBeGreaterThan(0);
-    for (const m of body) {
-      expect(m).toMatchObject({
-        lift: expect.any(String),
-        weight: expect.any(Number),
-        unit: 'lbs',
-        dateUpdated: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+    it('POST /programs/:program/cycles advances cycleNum and persists new maxes', async () => {
+      const res = await post(`/programs/${SEED_PROGRAM}/cycles`);
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.program).toBe(SEED_PROGRAM);
+      // Cycle counter must have advanced from the seeded value of 1
+      expect(body.cycleNum).toBe(2);
+      expect(body.cycleStartDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+      // Verify the persisted dashboard is readable via GET
+      const getRes = await get(`/programs/${SEED_PROGRAM}/cycles/current`);
+      expect(getRes.statusCode).toBe(200);
+      expect(getRes.json().cycleNum).toBe(2);
+    });
+
+    it('POST /programs/:program/cycles with fromCycleNum uses that cycle\'s records', async () => {
+      // Cycle is now 2 (no records). Use fromCycleNum=1 to advance from cycle 1 → 2.
+      const res = await postJson(`/programs/${SEED_PROGRAM}/cycles`, { fromCycleNum: 1 });
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.cycleNum).toBe(2);
+      expect(body.cycleStartDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it('POST /programs/:program/cycles with cycleDate pins the new cycle\'s start date', async () => {
+      const res = await postJson(`/programs/${SEED_PROGRAM}/cycles`, {
+        cycleDate: '2026-06-01',
       });
-    }
-  });
+      expect(res.statusCode).toBe(201);
+      expect(res.json().cycleStartDate).toBe('2026-06-01');
+    });
 
-  it('POST /programs/unknown/cycles returns 404', async () => {
-    const res = await post('/programs/does-not-exist/cycles');
-    expect(res.statusCode).toBe(404);
+    it('POST /programs/:program/cycles with fromCycleNum having no records returns 400', async () => {
+      const res = await postJson(`/programs/${SEED_PROGRAM}/cycles`, { fromCycleNum: 99 });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('POST /programs/unknown/cycles returns 404', async () => {
+      const res = await post('/programs/does-not-exist/cycles');
+      expect(res.statusCode).toBe(404);
+    });
   });
 
   // Forcing function for the Scope decision in ProgramsModule. Today adapters

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
 import {
   FastifyAdapter,
   NestFastifyApplication,
@@ -18,6 +19,7 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
       { logger: false },
     );
     app.useGlobalFilters(new DomainNotFoundFilter());
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
     await app.init();
     await app.getHttpAdapter().getInstance().ready();
   });
@@ -114,6 +116,9 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
     });
 
     it('POST /programs/:program/cycles advances cycleNum and persists new maxes', async () => {
+      // Pre-condition: recalculate does not advance the cycle; counter is still 1
+      expect((await get(`/programs/${SEED_PROGRAM}/cycles/current`)).json().cycleNum).toBe(1);
+
       const res = await post(`/programs/${SEED_PROGRAM}/cycles`);
       expect(res.statusCode).toBe(201);
       const body = res.json();
@@ -129,7 +134,10 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
     });
 
     it('POST /programs/:program/cycles with fromCycleNum uses that cycle\'s records', async () => {
-      // Cycle is now 2 (no records). Use fromCycleNum=1 to advance from cycle 1 → 2.
+      // Pre-condition: cycle is at 2 (advanced by previous test).
+      // fromCycleNum=1 re-pins "advance from cycle 1", producing cycleNum=2 again — not normal
+      // advancement, but confirms that fromCycleNum overrides the current counter.
+      expect((await get(`/programs/${SEED_PROGRAM}/cycles/current`)).json().cycleNum).toBe(2);
       const res = await postJson(`/programs/${SEED_PROGRAM}/cycles`, { fromCycleNum: 1 });
       expect(res.statusCode).toBe(201);
       const body = res.json();
@@ -138,6 +146,8 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
     });
 
     it('POST /programs/:program/cycles with cycleDate pins the new cycle\'s start date', async () => {
+      // Pre-condition: fromCycleNum re-pinned cycle to 2; advancing normally moves it to 3.
+      expect((await get(`/programs/${SEED_PROGRAM}/cycles/current`)).json().cycleNum).toBe(2);
       const res = await postJson(`/programs/${SEED_PROGRAM}/cycles`, {
         cycleDate: '2026-06-01',
       });

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -29,6 +29,9 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
   const get = (url: string) =>
     app.getHttpAdapter().getInstance().inject({ method: 'GET', url });
 
+  const post = (url: string) =>
+    app.getHttpAdapter().getInstance().inject({ method: 'POST', url });
+
   it('GET /programs/:program/cycles/current returns the seeded cycle', async () => {
     const res = await get(`/programs/${SEED_PROGRAM}/cycles/current`);
     expect(res.statusCode).toBe(200);
@@ -68,6 +71,49 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
 
   it('GET unknown program returns 404', async () => {
     const res = await get('/programs/does-not-exist/cycles/current');
+    expect(res.statusCode).toBe(404);
+  });
+
+  // -------------------------------------------------------------------------
+  // Write endpoints — these tests mutate singleton adapter state so they run
+  // after all read-only GET tests to avoid interference.
+  // -------------------------------------------------------------------------
+
+  it('POST /programs/:program/cycles advances cycleNum and persists new maxes', async () => {
+    const res = await post(`/programs/${SEED_PROGRAM}/cycles`);
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.program).toBe(SEED_PROGRAM);
+    // Cycle counter must have advanced from the seeded value of 1
+    expect(body.cycleNum).toBe(2);
+    expect(body.cycleStartDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+    // Verify the persisted dashboard is readable via GET
+    const getRes = await get(`/programs/${SEED_PROGRAM}/cycles/current`);
+    expect(getRes.statusCode).toBe(200);
+    expect(getRes.json().cycleNum).toBe(2);
+  });
+
+  it('POST /programs/:program/training-maxes/recalculate returns updated maxes', async () => {
+    const res = await post(
+      `/programs/${SEED_PROGRAM}/training-maxes/recalculate`,
+    );
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBeGreaterThan(0);
+    for (const m of body) {
+      expect(m).toMatchObject({
+        lift: expect.any(String),
+        weight: expect.any(Number),
+        unit: 'lbs',
+        dateUpdated: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      });
+    }
+  });
+
+  it('POST /programs/unknown/cycles returns 404', async () => {
+    const res = await post('/programs/does-not-exist/cycles');
     expect(res.statusCode).toBe(404);
   });
 

--- a/apps/api/src/programs/programs.module.ts
+++ b/apps/api/src/programs/programs.module.ts
@@ -12,6 +12,8 @@ import {
   WORKOUT_REPOSITORY,
 } from '../ports/tokens';
 import { CycleDashboardController } from './cycle-dashboard.controller';
+import { CycleGenerationController } from './cycle-generation.controller';
+import { CycleGenerationService } from './cycle-generation.service';
 import { LiftRecordsController } from './lift-records.controller';
 import { ProgramSpecController } from './program-spec.controller';
 import { TrainingMaxesController } from './training-maxes.controller';
@@ -27,6 +29,7 @@ import { WorkoutsController } from './workouts.controller';
 @Module({
   controllers: [
     CycleDashboardController,
+    CycleGenerationController,
     WorkoutsController,
     TrainingMaxesController,
     LiftRecordsController,
@@ -47,6 +50,7 @@ import { WorkoutsController } from './workouts.controller';
       provide: LIFTING_PROGRAM_SPEC_REPOSITORY,
       useClass: InMemoryLiftingProgramSpecRepository,
     },
+    CycleGenerationService,
   ],
 })
 export class ProgramsModule {}

--- a/apps/api/src/programs/start-new-cycle.dto.ts
+++ b/apps/api/src/programs/start-new-cycle.dto.ts
@@ -1,6 +1,14 @@
+import { IsDateString, IsInt, IsOptional, Min } from 'class-validator';
+
 export class StartNewCycleDto {
   /** Use records from this cycle number instead of the current cycle. */
+  @IsOptional()
+  @IsInt()
+  @Min(1)
   fromCycleNum?: number;
+
   /** ISO date string (YYYY-MM-DD) to pin the new cycle's start date explicitly. */
+  @IsOptional()
+  @IsDateString()
   cycleDate?: string;
 }

--- a/apps/api/src/programs/start-new-cycle.dto.ts
+++ b/apps/api/src/programs/start-new-cycle.dto.ts
@@ -1,0 +1,6 @@
+export class StartNewCycleDto {
+  /** Use records from this cycle number instead of the current cycle. */
+  fromCycleNum?: number;
+  /** ISO date string (YYYY-MM-DD) to pin the new cycle's start date explicitly. */
+  cycleDate?: string;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,8 @@
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-fastify": "^10.0.0",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.15.1",
         "fastify": "^4.0.0",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.0"
@@ -91,6 +93,126 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "typescript": "^5"
+      }
+    },
+    "apps/web/node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
+      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
+      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
+      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
+      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
+      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
+      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
+      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/web/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
+      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "apps/web/node_modules/@types/node": {
@@ -5035,126 +5157,6 @@
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
       "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw=="
     },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
-      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
-      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
-      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
-      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
-      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
-      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
-      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
-      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
@@ -5910,6 +5912,11 @@
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
       }
+    },
+    "node_modules/@types/validator": {
+      "version": "13.15.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
+      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -7604,6 +7611,21 @@
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+    },
+    "node_modules/class-validator": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
+      "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
+      "dependencies": {
+        "@types/validator": "^13.15.3",
+        "libphonenumber-js": "^1.11.1",
+        "validator": "^13.15.22"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -11129,6 +11151,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.12.42",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.42.tgz",
+      "integrity": "sha512-oKQFPTibqQwZZkChCDVMFVJXMZdyJNqDWZWYNn8BgyAaK/6yFJEowxCY0RVFirRyWP63hMRuKlkSEd9qlvbWXg=="
     },
     "node_modules/light-my-request": {
       "version": "6.3.0",
@@ -15806,6 +15833,14 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -16289,126 +16324,6 @@
     "packages/types": {
       "name": "@lifting-logbook/types",
       "version": "0.0.0"
-    },
-    "apps/web/node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
-      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
-      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
-      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
-      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
-      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
-      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
-      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "apps/web/node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
-      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `CycleGenerationService` that orchestrates `updateCycle` + `updateMaxes` via the four existing port interfaces (`ICycleDashboardRepository`, `ILiftingProgramSpecRepository`, `ITrainingMaxRepository`, `ILiftRecordRepository`)
- Adds `CycleGenerationController` with two POST endpoints:
  - `POST /programs/:program/cycles` (201) — advances cycle counter, updates training maxes from current-cycle lift records, persists both, returns `CycleDashboardResponse`
  - `POST /programs/:program/training-maxes/recalculate` (200) — re-runs max calculation without advancing cycle, returns `TrainingMaxResponse[]`
- Registers controller + service in `ProgramsModule`; no new adapters needed (in-memory adapters already implement all required ports)

## Acceptance Criteria

- [x] `ILiftingProgramSpecRepository` port — already existed, no changes needed
- [x] `ITrainingMaxRepository` port — already existed, no changes needed
- [x] `POST /programs/:program/cycles` endpoint
- [x] `POST /programs/:program/training-maxes/recalculate` endpoint
- [x] No dependency on `createGridV2`
- [x] Unit tests for service layer (6 cases across `startNewCycle` and `recalculateMaxes`)
- [x] Integration test for full cycle start turn (e2e spec)

## Test plan

- [ ] `npm run test --workspace=apps/api` — all 23 tests pass (1 pre-existing skipped)
- [ ] `POST /programs/5-3-1/cycles` returns 201 with `cycleNum: 2` and advances persisted state
- [ ] `GET /programs/5-3-1/cycles/current` after POST returns `cycleNum: 2`
- [ ] `POST /programs/5-3-1/training-maxes/recalculate` returns 200 with full maxes array
- [ ] `POST /programs/unknown/cycles` returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)