### PR TITLE
[docs] Add ## Testing section to project CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,28 @@ When implementing `apps/web`, read the relevant standards before writing any `fe
 
 ---
 
+## Testing
+
+Run `npm test` from the repo root to execute the full test suite across all workspaces.
+
+```bash
+npm test
+```
+
+**Prerequisites:**
+- Run `npm run build` first if you have touched compiled output (e.g., API controllers, shared types in `packages/types`).
+- Integration tests that hit the database require `DATABASE_URL` to be set.
+
+Individual workspaces can be verified independently:
+
+```bash
+npm test -w @lifting-logbook/core
+npm test -w @lifting-logbook/api
+npm test -w @lifting-logbook/web
+```
+
+---
+
 ## Documentation and Citations
 
 When writing or updating any architectural documentation (ADRs, design docs, READMEs):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,35 @@ When implementing `apps/web`, read the relevant standards before writing any `fe
 
 ---
 
+## Testing
+
+Run `npm test` from the repo root to execute the full test suite across all workspaces.
+
+```bash
+npm test
+```
+
+**Prerequisites:**
+- Run `npm run build` first if you have touched compiled output (e.g., API controllers, shared types in `packages/types`).
+- Integration tests that hit the database require `DATABASE_URL` to be set.
+
+**Known issue — `parseCycleDashboard` OOM:** The `packages/core` test suite includes a memory-intensive parser test (`tests/core/utils/parser/parseCycleDashboard.test.ts`) that occasionally causes a Jest worker to run out of memory and crash under the default configuration. If `npm test` exits with `Jest worker ran out of memory`, run the core suite in band as a workaround:
+
+```bash
+npm test -w @lifting-logbook/core -- --runInBand
+```
+
+All other workspaces (`apps/api`, `apps/api-legacy`, `apps/web`, `packages/types`) are unaffected and can be verified independently:
+
+```bash
+npm test -w @lifting-logbook/api
+npm test -w @lifting-logbook/web
+```
+
+Tracked in: [lifting-logbook#89](https://github.com/brownm09/lifting-logbook/issues/89) *(pending)*
+
+---
+
 ## Documentation and Citations
 
 When writing or updating any architectural documentation (ADRs, design docs, READMEs):


### PR DESCRIPTION
## Summary

- Adds a `## Testing` section to the project `CLAUDE.md` per the [Per-Project CLAUDE.md Requirements](https://github.com/brownm09/dev-env/blob/feat/pre-pr-test-mandate/claude/CLAUDE.md#per-project-claudemd-requirements) mandate (dev-env#76)
- Documents `npm test` as the primary command, build prerequisites, and the `DATABASE_URL` requirement for integration tests
- Documents the known `parseCycleDashboard` Jest OOM failure with a `--runInBand` workaround; links to tracking issue #89

## Acceptance Criteria

- [x] `## Testing` section added to `CLAUDE.md`
- [x] Command verified — `npm test` runs (OOM failure is pre-existing and tracked separately in #89)

## Notes

`npm test` does not run fully cleanly due to a pre-existing Jest worker OOM in `packages/core/tests/core/utils/parser/parseCycleDashboard.test.ts` (introduced in #53). That failure is out of scope for this documentation PR and is tracked in #89.

Closes #88