### PR TITLE
[fix] Break circular barrel imports to resolve Jest worker OOM (#89)

### DIFF
--- a/apps/api/src/programs/cycle-generation.service.ts
+++ b/apps/api/src/programs/cycle-generation.service.ts
@@ -66,7 +66,7 @@ export class CycleGenerationService {
       }
       const minDate = liftRecords.reduce(
         (min, r) => (r.date < min ? r.date : min),
-        liftRecords[0].date,
+        liftRecords[0]!.date,
       );
       prevDashboard = { ...dashboard, cycleNum: dto.fromCycleNum, cycleDate: minDate };
     }

--- a/packages/core/src/services/dashboard/updateCycle.ts
+++ b/packages/core/src/services/dashboard/updateCycle.ts
@@ -1,10 +1,6 @@
-import {
-  CycleDashboard,
-  formatDateYYYYMMDD,
-  getNextDate,
-  Weekday,
-  WEEKDAY_MAP,
-} from "@src/core";
+import { WEEKDAY_MAP } from "@src/core/constants";
+import { CycleDashboard, Weekday } from "@src/core/models";
+import { formatDateYYYYMMDD, getNextDate } from "@src/core/utils/jsUtil";
 import { UpdateCycleOverrides } from "../../models/UpdateCycleOverrides";
 
 export function updateCycle(

--- a/packages/core/src/services/maxes/updateMaxes.ts
+++ b/packages/core/src/services/maxes/updateMaxes.ts
@@ -1,4 +1,4 @@
-import { LiftingProgramSpec, LiftRecord, TrainingMax } from "@src/core";
+import { LiftingProgramSpec, LiftRecord, TrainingMax } from "@src/core/models";
 /**
  * Updates training maxes based on lift records and program spec.
  * For any lift record:

--- a/packages/core/src/services/workout/calculateLiftWeights.ts
+++ b/packages/core/src/services/workout/calculateLiftWeights.ts
@@ -3,15 +3,14 @@ import {
   LIFT_DATE_HEADER,
   LIFT_HEADER,
   LIFT_WEIGHT_HEADER,
-  LiftingProgramSpec,
   MROUND,
   NOTES_HEADER,
   PROG_SPEC_WARMUP_PCTS,
   PROG_SPEC_WORK_PCTS,
   SET_HEADER,
-  SpreadsheetCell,
   SPEC_WEIGHT_HEADER,
-} from "@src/core";
+} from "@src/core/constants";
+import { LiftingProgramSpec, SpreadsheetCell } from "@src/core/models";
 
 /**
  * Updates lift dates for lifts with the same offset as the edited lift.

--- a/packages/core/src/services/workout/createGridV2.ts
+++ b/packages/core/src/services/workout/createGridV2.ts
@@ -1,12 +1,5 @@
-import {
-  CycleDashboard,
-  LIFT_PLAN_HEADERS,
-  LIFT_SPEC_HEADERS,
-  LiftingProgramSpec,
-  SpreadsheetCell,
-  TrainingMax,
-  WORKOUT_SHEET_HEADERS,
-} from "@src/core";
+import { LIFT_PLAN_HEADERS, LIFT_SPEC_HEADERS, WORKOUT_SHEET_HEADERS } from "@src/core/constants";
+import { CycleDashboard, LiftingProgramSpec, SpreadsheetCell, TrainingMax } from "@src/core/models";
 import { generateLiftPlan } from "./generateLiftPlan";
 import { generateLiftSpec } from "./generateLiftSpec";
 

--- a/packages/core/src/services/workout/extractLiftRecords.ts
+++ b/packages/core/src/services/workout/extractLiftRecords.ts
@@ -1,4 +1,5 @@
-import { LiftRecord, LiftRecordRequiredKeys, REPS_HEADER, SpreadsheetCell } from "@src/core";
+import { REPS_HEADER } from "@src/core/constants";
+import { LiftRecord, LiftRecordRequiredKeys, SpreadsheetCell } from "@src/core/models";
 
 /**
  * Extract lift records from a 2D grid of data.

--- a/packages/core/src/services/workout/findWorkoutRowsToHideOnEdit.ts
+++ b/packages/core/src/services/workout/findWorkoutRowsToHideOnEdit.ts
@@ -1,5 +1,5 @@
 import { REPS_HEADER } from "@src/core/constants";
-import { SpreadsheetCell } from "@src/core";
+import { SpreadsheetCell } from "@src/core/models";
 
 /**
  * Given the sheet data and the edited row,

--- a/packages/core/src/services/workout/generateLiftSpec.ts
+++ b/packages/core/src/services/workout/generateLiftSpec.ts
@@ -1,11 +1,6 @@
-import {
-  addDaysLocal,
-  CORE_LIFT_HEADER,
-  LIFT_SPEC_HEADERS,
-  LiftingProgramSpec,
-  SpreadsheetCell,
-  TrainingMax,
-} from "@src/core";
+import { CORE_LIFT_HEADER, LIFT_SPEC_HEADERS } from "@src/core/constants";
+import { LiftingProgramSpec, SpreadsheetCell, TrainingMax } from "@src/core/models";
+import { addDaysLocal } from "@src/core/utils/jsUtil";
 
 /**
  * Creates a lift specification from a training max and program spec.

--- a/packages/core/src/services/workout/updateLiftDates.ts
+++ b/packages/core/src/services/workout/updateLiftDates.ts
@@ -3,10 +3,9 @@ import {
   DATE_HEADER,
   LIFT_DATE_HEADER,
   LIFT_HEADER,
-  LiftingProgramSpec,
   NOTES_HEADER,
-  SpreadsheetCell,
-} from "@src/core";
+} from "@src/core/constants";
+import { LiftingProgramSpec, SpreadsheetCell } from "@src/core/models";
 
 /**
  * Updates lift dates for lifts with the same offset as the edited lift.

--- a/packages/core/src/utils/mapper/mapCycleDashboard.ts
+++ b/packages/core/src/utils/mapper/mapCycleDashboard.ts
@@ -1,4 +1,4 @@
-import { CycleDashboard, SpreadsheetCell } from "@src/core";
+import { CycleDashboard, SpreadsheetCell } from "@src/core/models";
 import {
   CYCLE_DATE_KEY,
   CYCLE_NUM_KEY,

--- a/packages/core/src/utils/mapper/mapLiftRecords.ts
+++ b/packages/core/src/utils/mapper/mapLiftRecords.ts
@@ -1,4 +1,5 @@
-import { LIFT_RECORD_HEADER_MAP, LiftRecord, SpreadsheetCell } from "@src/core";
+import { LIFT_RECORD_HEADER_MAP } from "@src/core/constants";
+import { LiftRecord, SpreadsheetCell } from "@src/core/models";
 /**
  * Converts an array of LiftRecord objects to a 2D array (for writing to a sheet)
  * @param {LiftRecord[]} records

--- a/packages/core/src/utils/mapper/mapLiftingProgramSpec.ts
+++ b/packages/core/src/utils/mapper/mapLiftingProgramSpec.ts
@@ -1,4 +1,5 @@
-import { LIFTING_PROGRAM_SPEC_HEADER_MAP, LiftingProgramSpec, SpreadsheetCell } from "@src/core";
+import { LIFTING_PROGRAM_SPEC_HEADER_MAP } from "@src/core/constants";
+import { LiftingProgramSpec, SpreadsheetCell } from "@src/core/models";
 /**
  * Converts an array of LiftingProgramSpec objects to a 2D array (for writing to a sheet)
  * @param {LiftingProgramSpec[]} specs

--- a/packages/core/src/utils/mapper/mapTrainingMaxes.ts
+++ b/packages/core/src/utils/mapper/mapTrainingMaxes.ts
@@ -1,4 +1,5 @@
-import { TRAINING_MAX_HEADER_MAP, TrainingMax, SpreadsheetCell } from "@src/core";
+import { TRAINING_MAX_HEADER_MAP } from "@src/core/constants";
+import { TrainingMax, SpreadsheetCell } from "@src/core/models";
 /**
  * Converts an array of TrainingMax objects to a 2D array (for writing to a sheet)
  * @param {TrainingMax[]} maxes

--- a/packages/core/src/utils/parser/parseCycleDashboard.ts
+++ b/packages/core/src/utils/parser/parseCycleDashboard.ts
@@ -1,4 +1,4 @@
-import { CycleDashboard, SpreadsheetCell, Weekday } from "@src/core";
+import { CycleDashboard, SpreadsheetCell, Weekday } from "@src/core/models";
 import {
   CYCLE_DATE_KEY,
   CYCLE_NUM_KEY,

--- a/packages/core/src/utils/parser/parseLiftRecords.ts
+++ b/packages/core/src/utils/parser/parseLiftRecords.ts
@@ -1,4 +1,5 @@
-import { LIFT_RECORD_HEADER_MAP, LiftRecord, SpreadsheetCell } from "@src/core";
+import { LIFT_RECORD_HEADER_MAP } from "@src/core/constants";
+import { LiftRecord, SpreadsheetCell } from "@src/core/models";
 import { tableToObjects } from "./tableToObjects";
 
 /**

--- a/packages/core/src/utils/parser/parseLiftingProgramSpec.ts
+++ b/packages/core/src/utils/parser/parseLiftingProgramSpec.ts
@@ -1,4 +1,5 @@
-import { LIFTING_PROGRAM_SPEC_HEADER_MAP, LiftingProgramSpec, SpreadsheetCell } from "@src/core";
+import { LIFTING_PROGRAM_SPEC_HEADER_MAP } from "@src/core/constants";
+import { LiftingProgramSpec, SpreadsheetCell } from "@src/core/models";
 import { tableToObjects } from "./tableToObjects";
 
 /**

--- a/packages/core/src/utils/parser/parseTrainingMaxes.ts
+++ b/packages/core/src/utils/parser/parseTrainingMaxes.ts
@@ -1,4 +1,5 @@
-import { TRAINING_MAX_HEADER_MAP, TrainingMax, SpreadsheetCell } from "@src/core";
+import { TRAINING_MAX_HEADER_MAP } from "@src/core/constants";
+import { TrainingMax, SpreadsheetCell } from "@src/core/models";
 import { tableToObjects } from "./tableToObjects";
 
 /**

--- a/packages/core/src/utils/parser/tableToObjects.ts
+++ b/packages/core/src/utils/parser/tableToObjects.ts
@@ -1,4 +1,4 @@
-import { SpreadsheetCell } from "@src/core";
+import { SpreadsheetCell } from "@src/core/models";
 
 /**
  * Converts a 2D array (as from Sheet.getDataRange().getValues() or parsed CSV) to an array of objects using the first row as headers.


### PR DESCRIPTION
## Summary

- All source files within \`packages/core/src/\` were importing from the root \`@src/core\` barrel, which re-exports those same files — creating circular dependency chains that caused ts-jest workers to exhaust memory.
- Replaced every \`from \"@src/core\"\` inside \`src/\` with direct sub-path imports: \`@src/core/models\`, \`@src/core/constants\`, or \`@src/core/utils/jsUtil\`.
- Also fixes a pre-existing \`TS2532: Object is possibly 'undefined'\` in \`apps/api\` that had been failing CI since 2026-04-21 (tracked in #92).
- 18 files changed.

## Root cause (OOM)

\`packages/core/src/index.ts\` is a barrel that re-exports all sub-modules (\`catalog\`, \`constants\`, \`models\`, \`services\`, \`utils\`). Files within those sub-modules were themselves importing from \`@src/core\`, completing the cycle. ts-jest's module resolution entered a pathologically deep graph traversal and OOM'd the worker.

## Acceptance criteria

- [x] \`parseCycleDashboard.test.ts\` runs without OOM
- [x] Full core test suite (\`npm test -w @lifting-logbook/core\`) passes: **92 tests, 21 suites, all green**
- [x] No \`from \"@src/core\"\` barrel imports remain in \`packages/core/src/**\`
- [x] \`apps/api\` builds without TypeScript errors (fixes #92)

## Test plan

\`\`\`bash
npm test -w @lifting-logbook/core
# Expected: 92 passed, 21 suites, 0 failures
\`\`\`

Closes #89
Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)