### PR TITLE
[fix] Ban @src/core root barrel import inside packages/core

### DIFF
--- a/packages/core/eslint.config.js
+++ b/packages/core/eslint.config.js
@@ -12,6 +12,19 @@ module.exports = [
       // workspaces or infrastructure packages. Violations mean the dependency
       // rule is inverted; use a port interface instead.
       'no-restricted-imports': ['error', {
+        // Exact-match ban: prevents regression of the circular barrel import
+        // that caused Jest worker OOM (issue #89, fixed in PR #91).
+        // `paths` matches the literal specifier only — sub-paths like
+        // @src/core/models are unaffected.
+        paths: [
+          {
+            name: '@src/core',
+            message:
+              "Import from the root barrel '@src/core' is not allowed inside " +
+              "packages/core/src — use '@src/core/models', '@src/core/constants', " +
+              "or '@src/core/utils/jsUtil' instead.",
+          },
+        ],
         patterns: [
           {
             group: [

--- a/packages/core/eslint.config.js
+++ b/packages/core/eslint.config.js
@@ -21,8 +21,17 @@ module.exports = [
             name: '@src/core',
             message:
               "Import from the root barrel '@src/core' is not allowed inside " +
-              "packages/core/src — use '@src/core/models', '@src/core/constants', " +
-              "or '@src/core/utils/jsUtil' instead.",
+              "packages/core/src — use a direct sub-path such as '@src/core/models', " +
+              "'@src/core/constants', or '@src/core/utils/jsUtil' instead.",
+          },
+          // '@src/core/*' in tsconfig maps @src/core/index → src/index.ts, so
+          // the explicit-index form resolves to the same barrel and must also be banned.
+          {
+            name: '@src/core/index',
+            message:
+              "Import from the root barrel '@src/core/index' is not allowed inside " +
+              "packages/core/src — use a direct sub-path such as '@src/core/models', " +
+              "'@src/core/constants', or '@src/core/utils/jsUtil' instead.",
           },
         ],
         patterns: [


### PR DESCRIPTION
## Summary

- Adds a `no-restricted-imports` `paths` rule to `packages/core/eslint.config.js` that bans the exact specifier `@src/core` inside `packages/core/src`
- Uses `paths` (exact string match) rather than `patterns` (glob) so sub-path imports like `@src/core/models`, `@src/core/constants`, and `@src/core/utils/jsUtil` remain allowed and unaffected
- Error message directs developers to the correct sub-path alternatives

## Motivation

PR #91 (issue #89) fixed a circular barrel import in `updateCycle.ts` that caused Jest worker OOM failures. Without a lint rule, the same pattern could be reintroduced inadvertently.

## Acceptance Criteria (from #93)

- [x] `packages/core/eslint.config.js` contains a `no-restricted-imports` `paths` entry for `@src/core` with a descriptive error message
- [x] `npm run lint -w @lifting-logbook/core` passes with no violations
- [x] Sub-path imports (`@src/core/models`, etc.) are unaffected — confirmed by lint pass across all 36 existing files using those paths

## Test Plan

- [x] `npm run lint -w @lifting-logbook/core` — passes (0 errors)
- [x] Pre-commit hook ran lint across all 4 other packages — all cached green

Closes #93