### PR TITLE
[fix] Use barrel import for UpdateCycleOverrides in updateCycle.ts

### DIFF
--- a/packages/core/src/services/dashboard/updateCycle.ts
+++ b/packages/core/src/services/dashboard/updateCycle.ts
@@ -1,7 +1,7 @@
 import { WEEKDAY_MAP } from "@src/core/constants";
 import { CycleDashboard, Weekday } from "@src/core/models";
 import { formatDateYYYYMMDD, getNextDate } from "@src/core/utils/jsUtil";
-import { UpdateCycleOverrides } from "../../models/UpdateCycleOverrides";
+import { UpdateCycleOverrides } from "@src/core/models";
 
 export function updateCycle(
   prevCycle: CycleDashboard,

--- a/packages/core/src/services/dashboard/updateCycle.ts
+++ b/packages/core/src/services/dashboard/updateCycle.ts
@@ -1,7 +1,6 @@
 import { WEEKDAY_MAP } from "@src/core/constants";
-import { CycleDashboard, Weekday } from "@src/core/models";
+import { CycleDashboard, UpdateCycleOverrides, Weekday } from "@src/core/models";
 import { formatDateYYYYMMDD, getNextDate } from "@src/core/utils/jsUtil";
-import { UpdateCycleOverrides } from "@src/core/models";
 
 export function updateCycle(
   prevCycle: CycleDashboard,


### PR DESCRIPTION
## Summary

- Replaces the lone relative import (`../../models/UpdateCycleOverrides`) in `updateCycle.ts` with the `@src/core/models` barrel, consistent with every other import in the file
- No barrel changes needed — `UpdateCycleOverrides` was already exported from `packages/core/src/models/index.ts`

## Acceptance Criteria

- [x] `updateCycle.ts` line 4 uses `@src/core/models` instead of the relative path
- [x] `npm test -w @lifting-logbook/core` passes (21 suites, 92 tests — all green)

## Test plan

- [x] `npm test -w @lifting-logbook/core` — 21/21 suites, 92/92 tests passed

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)