### PR TITLE
[docs] Update ROADMAP.md and CLAUDE.md post-merge workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ If `--format json` is not supported by the installed `gh` version, fall back to 
      console.log(item.id);
    ")
    rm -f "$TMPFILE"
-   gh project item-edit --project-id PVT_kwHOAjEKvM4BTuEF --id "\$ITEM_ID" \
+   gh project item-edit --project-id PVT_kwHOAjEKvM4BTuEF --id "$ITEM_ID" \
      --field-id PVTSSF_lAHOAjEKvM4BTuEFzhA7F7E \
      --single-select-option-id 47fc9ee4
    ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ If `--format json` is not supported by the installed `gh` version, fall back to 
 2. Create a branch: `git checkout -b <type>/issue-<N>-<slug>` (see Branch Naming)
 3. Move the issue to **In Progress** on the project board:
    ```bash
-   TMPFILE="tmp_item_<N>.json"
+   TMPFILE="C:/Users/brown/.claude/scratch/tmp_item_<N>.json"
    gh project item-list 2 --owner brownm09 --format json > "$TMPFILE"
    ITEM_ID=$(node -e "
      const d=JSON.parse(require('fs').readFileSync('$TMPFILE','utf8'));
@@ -127,12 +127,27 @@ If `--format json` is not supported by the installed `gh` version, fall back to 
 6. Push: `git push -u origin <branch>`
 7. Open a PR: `gh pr create --title "<prefix> <title>" --body "..."`
 8. After PR approval: squash merge with `gh pr merge <N> --squash --delete-branch`
-9. Pull main: `git checkout main && git pull`
-10. Close the issue if not auto-closed: `gh issue close <N>`
-11. Update journals:
+9. Move the issue to **Done** on the project board:
+   ```bash
+   TMPFILE="C:/Users/brown/.claude/scratch/tmp_item_<N>.json"
+   gh project item-list 2 --owner brownm09 --format json > "$TMPFILE"
+   ITEM_ID=$(node -e "
+     const d=JSON.parse(require('fs').readFileSync('$TMPFILE','utf8'));
+     const item=d.items.find(i=>i.content&&i.content.number===<N>);
+     console.log(item.id);
+   ")
+   rm -f "$TMPFILE"
+   gh project item-edit --project-id PVT_kwHOAjEKvM4BTuEF --id "$ITEM_ID" \
+     --field-id PVTSSF_lAHOAjEKvM4BTuEFzhA7F7E \
+     --single-select-option-id 98236657
+   ```
+10. Pull main: `git checkout main && git pull`
+11. Close the issue if not auto-closed: `gh issue close <N>`
+12. Update journals and tracking:
     - **Project journal** (`sessions/lifting-logbook/`): append to the day's draft (PR merged, decisions made)
     - **Meta journal** (`sessions/meta/`): update if `CLAUDE.md` was modified or a new platform constraint was discovered
-12. Write a `<!-- next-session-context -->` block to the draft and display it as the closing output of the session
+    - **ROADMAP.md**: if this PR completes a work stream listed in a milestone's Active Work table, move that row to the milestone's Shipped table; if the Active Work table becomes empty, replace it with `| *(all shipped)* | | |`
+13. Write a `<!-- next-session-context -->` block to the draft and display it as the closing output of the session
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,13 +10,13 @@ below. Status is updated manually as work progresses.
 
 ---
 
-## v0.1 — Foundation `[Current]`
+## v0.1 — Foundation `[Shipped]`
 
 Monorepo scaffolding, port interfaces, shared types, and CI/CD. The goal is a working
 skeleton where every app and package is wired together and the core hexagonal architecture
 is codified.
 
-### Active Work
+### Shipped
 
 | Work stream | Description | Issues |
 |---|---|---|
@@ -34,7 +34,7 @@ is codified.
 
 ---
 
-## v0.2 — Core API `[Next]`
+## v0.2 — Core API `[Current]`
 
 A working REST + GraphQL API backed by real adapters. Core module quality gates enforced.
 Architecture decisions for data access and security documented.
@@ -43,19 +43,25 @@ Architecture decisions for data access and security documented.
 
 | Work stream | Description | Issues |
 |---|---|---|
+| Architecture documentation | ADR-014 credential encryption; cache invalidation strategy; Express legacy archival policy | [#38](https://github.com/brownm09/lifting-logbook/issues/38), [#39](https://github.com/brownm09/lifting-logbook/issues/39), [#42](https://github.com/brownm09/lifting-logbook/issues/42) |
+
+### Shipped
+
+| Work stream | Description | Issues |
+|---|---|---|
 | Core module cleanup | Enable strict TypeScript; remove GAS Logger dependency | [#51](https://github.com/brownm09/lifting-logbook/issues/51), [#52](https://github.com/brownm09/lifting-logbook/issues/52) |
-| Architecture documentation | ADR-014 credential encryption; cache invalidation strategy; ADR-015 GraphQL DataLoader; Express legacy archival policy | [#38](https://github.com/brownm09/lifting-logbook/issues/38), [#39](https://github.com/brownm09/lifting-logbook/issues/39), [#40](https://github.com/brownm09/lifting-logbook/issues/40), [#42](https://github.com/brownm09/lifting-logbook/issues/42) |
-| Cycle planning — design | ADR-016: LLM integration, tool schema, and adapter boundary for the cycle planning agent | [#55](https://github.com/brownm09/lifting-logbook/issues/55) |
+| ADR-015 | GraphQL DataLoader design: scope, batching, and request isolation | [#40](https://github.com/brownm09/lifting-logbook/issues/40) |
+| ADR-016 | Cycle planning agent: LLM integration, tool schema, and adapter boundary | [#55](https://github.com/brownm09/lifting-logbook/issues/55) |
 
 ### Proposals
 
-| Proposal | Description | Issue |
-|---|---|---|
-| [Lift Library and Exercise Tagging](docs/proposals/2026-04-13-lift-library-exercise-tagging.md) | First-class `Lift` domain type with compound/accessory classification, movement tags, and configurable program exercise slots | [#64](https://github.com/brownm09/lifting-logbook/issues/64) |
+| Proposal | Description | Issue | Status |
+|---|---|---|---|
+| [Lift Library and Exercise Tagging](docs/proposals/2026-04-13-lift-library-exercise-tagging.md) | First-class `Lift` domain type with compound/accessory classification, movement tags, and configurable program exercise slots | [#64](https://github.com/brownm09/lifting-logbook/issues/64) | shipped |
 
 ---
 
-## v0.3 — Client Applications `[Later]`
+## v0.3 — Client Applications `[Next]`
 
 Web and mobile clients functional end-to-end. Key user-facing features implemented.
 


### PR DESCRIPTION
## Summary

- Advances v0.1 to `[Shipped]` and v0.2 to `[Current]`; adds `### Shipped` tables for all completed v0.1 work streams and the three completed v0.2 items (core module cleanup #51/#52, ADR-015 #40, ADR-016 #55)
- Marks the Lift Library proposal (#64) as `shipped` in the v0.2 Proposals table
- Adds step 9 to the Standard Issue Workflow: move project board item → Done immediately after squash merge
- Extends step 12 to require a ROADMAP.md update when a work stream completes
- Fixes temp file paths in board steps to use `C:/Users/brown/.claude/scratch/` consistently

## Acceptance Criteria

- [x] ROADMAP.md Active Work tables match open issues only
- [x] CLAUDE.md Standard Issue Workflow includes board Done step after merge
- [x] CLAUDE.md step 12 includes ROADMAP update instruction

## Test plan

- No code changes — no test run required
- Manually verified Active Work rows against open issues (#38, #39, #42, #29, #54, #50, #41)

## Related

- Closes #97
- Filed [dev-env#104](https://github.com/brownm09/dev-env/issues/104) to add the same principle (minus project-specific IDs) to the global CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)