### PR TITLE
[docs] v0.2 architecture docs: ADR-014, cache invalidation, Express archival policy

### DIFF
--- a/docs/adr-references.md
+++ b/docs/adr-references.md
@@ -149,7 +149,7 @@ Each entry links back to the ADR where it is discussed and provides a brief desc
 
 ---
 
-## Security
+## Security Standards
 
 | Source | Cited In | Relevance |
 |---|---|---|

--- a/docs/adr-references.md
+++ b/docs/adr-references.md
@@ -106,7 +106,7 @@ Each entry links back to the ADR where it is discussed and provides a brief desc
 | [Google Cloud Load Balancing — HTTPS](https://cloud.google.com/load-balancing/docs/https) | [ADR-009](adr/ADR-009-infrastructure-kubernetes-cloud-run.md) | The load balancer used for 90/10 traffic splitting between GKE and Cloud Run. |
 | [Google Artifact Registry — Overview](https://cloud.google.com/artifact-registry/docs/overview) | [ADR-009](adr/ADR-009-infrastructure-kubernetes-cloud-run.md) | Container registry where Docker images are pushed by CI/CD. |
 | [k6 — Load Testing Documentation](https://grafana.com/docs/k6/latest/) | [ADR-009](adr/ADR-009-infrastructure-kubernetes-cloud-run.md) | Load testing tool used for the scale-out time metric in the A/B infrastructure comparison. |
-| [Google Cloud KMS — Envelope Encryption](https://cloud.google.com/kms/docs/envelope-encryption) | [ADR-003](adr/ADR-003-per-user-data-store-config.md) | Encryption strategy for the `adapter_config` column, which stores sensitive Sheets credentials. |
+| [Google Cloud KMS — Envelope Encryption](https://cloud.google.com/kms/docs/envelope-encryption) | [ADR-003](adr/ADR-003-per-user-data-store-config.md), [ADR-014](adr/ADR-014-credential-encryption-at-rest.md) | Encryption strategy for the `adapter_config` column; ADR-014 specifies the full KEK/DEK hierarchy, encrypt/decrypt flow, and re-encryption procedure. |
 
 ---
 
@@ -146,6 +146,16 @@ Each entry links back to the ADR where it is discussed and provides a brief desc
 |---|---|---|
 | [GDPR — Article 17: Right to Erasure](https://gdpr-info.eu/art-17-gdpr/) | [ADR-010](adr/ADR-010-multi-tenancy-data-isolation.md) | The regulatory requirement driving the erasure complexity comparison between shared-schema and schema-per-tenant strategies. |
 | [HHS — HIPAA Security Rule](https://www.hhs.gov/hipaa/for-professionals/security/index.html) | [ADR-010](adr/ADR-010-multi-tenancy-data-isolation.md) | US healthcare data protection regulation discussed in the HIPAA section; relevant if the application is extended to clinical contexts. |
+
+---
+
+## Security
+
+| Source | Cited In | Relevance |
+|---|---|---|
+| [Google Cloud KMS — Key Rotation](https://cloud.google.com/kms/docs/key-rotation) | [ADR-014](adr/ADR-014-credential-encryption-at-rest.md) | Automatic rotation scheduling, prior key version behaviour after rotation, and audit logging for version-level decrypt calls used in the re-encryption procedure. |
+| [Google Tink — AES-GCM AEAD](https://developers.google.com/tink/aead) | [ADR-014](adr/ADR-014-credential-encryption-at-rest.md) | Recommended implementation library for AEAD encryption on GCP; covers AES-256-GCM key generation, encrypt/decrypt API, and key rotation via keyset handles. |
+| [NIST SP 800-38D — Recommendation for Block Cipher Modes of Operation: GCM and GMAC](https://csrc.nist.gov/publications/detail/sp/800-38d/final) | [ADR-014](adr/ADR-014-credential-encryption-at-rest.md) | NIST normative recommendation for GCM mode; documents the 12-byte nonce requirement and authentication tag validation used for `config_ciphertext` integrity. |
 
 ---
 

--- a/docs/adr/ADR-003-per-user-data-store-config.md
+++ b/docs/adr/ADR-003-per-user-data-store-config.md
@@ -3,7 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-04-03
 **Reviewed:** 2026-04-07
-**Review outcome:** Pass with gaps — open items: [#38](https://github.com/brownm09/lifting-logbook/issues/38), [#39](https://github.com/brownm09/lifting-logbook/issues/39)
+**Review outcome:** Pass with gaps — open items resolved: [#38](https://github.com/brownm09/lifting-logbook/issues/38) (ADR-014), [#39](https://github.com/brownm09/lifting-logbook/issues/39) (cache invalidation section below)
 
 ---
 
@@ -77,6 +77,72 @@ interface RepositoryBundle {
   envelope encryption).
 - Adapter config changes (e.g., a user migrates to Postgres) take effect after the cache TTL,
   which is acceptable.
+
+---
+
+## Cache Invalidation
+
+The factory caches the resolved adapter config in memory, keyed by `user_id`, with a TTL of
+approximately 5 minutes. This section documents when and how that cache is invalidated.
+
+### Normal expiry
+
+Cache entries expire automatically after the TTL. Config changes (e.g., migrating a user from
+the Sheets adapter to Postgres) take effect within 5 minutes without any operator action. This
+is the expected path for planned migrations.
+
+### Admin-triggered immediate invalidation
+
+For cases where immediate effect is required — for example, an in-progress migration where
+serving the wrong adapter would corrupt data, or an emergency key revocation (see
+[ADR-014 — Cache Interaction](ADR-014-credential-encryption-at-rest.md#cache-interaction)) —
+an admin can force cache eviction before the TTL expires.
+
+Two mechanisms are supported depending on the cache backend:
+
+**In-process cache (single instance):**
+`POST /admin/users/:userId/invalidate-cache` — a protected admin endpoint that calls
+`cache.delete(userId)` directly. Requires the `admin:cache` scope on the caller's JWT.
+
+**Distributed cache (Redis, multi-instance):**
+`DEL lifting-logbook:factory-cache:<userId>` — executed against the Redis instance via the
+`redis-cli` or an admin script. This is the only mechanism that works when multiple API
+replicas share a Redis cache, because the HTTP endpoint only invalidates the local instance.
+
+### What the user observes during migration
+
+After a user's `adapter_type` is changed in `user_data_source` but before the cache entry
+expires or is evicted:
+- Requests continue to be served by the old adapter (Sheets or Postgres) as configured in
+  the cached entry.
+- No error is surfaced to the user; the old adapter responds normally.
+- Once the cache entry expires or is evicted, the next request re-reads `user_data_source`
+  and routes to the new adapter.
+
+For migrations involving data that must not be double-written, the sequence is:
+1. Pause writes (application-level or by taking the user offline temporarily).
+2. Migrate data.
+3. Update `user_data_source` to the new `adapter_type`.
+4. Trigger immediate cache invalidation via the admin endpoint or Redis `DEL`.
+5. Resume writes.
+
+### Detecting stale cache
+
+Each factory resolve emits a structured log line with the following fields:
+
+```json
+{
+  "event": "factory.resolve",
+  "userId": "<user_id>",
+  "adapterType": "sheets|postgres",
+  "cacheHit": true,
+  "ttlRemainingMs": 240000
+}
+```
+
+A `cacheHit: true` entry with an `adapterType` that does not match the current
+`user_data_source` row indicates a stale cache entry. Operators can detect this by joining
+log output against the `user_data_source` table during or after a migration.
 
 ---
 

--- a/docs/adr/ADR-003-per-user-data-store-config.md
+++ b/docs/adr/ADR-003-per-user-data-store-config.md
@@ -141,8 +141,10 @@ Each factory resolve emits a structured log line with the following fields:
 ```
 
 A `cacheHit: true` entry with an `adapterType` that does not match the current
-`user_data_source` row indicates a stale cache entry. Operators can detect this by joining
-log output against the `user_data_source` table during or after a migration.
+`user_data_source` row indicates a stale cache entry. To detect during or after a migration:
+1. Query `user_data_source` for the user's expected `adapter_type` after the update.
+2. Search structured logs for `factory.resolve` events with `cacheHit: true` and an
+   `adapterType` that does not match the expected value within the migration window.
 
 ---
 

--- a/docs/adr/ADR-011-api-server-nestjs-and-express.md
+++ b/docs/adr/ADR-011-api-server-nestjs-and-express.md
@@ -3,7 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-04-03
 **Reviewed:** 2026-04-07
-**Review outcome:** Pass with gaps — open items: [#42](https://github.com/brownm09/lifting-logbook/issues/42)
+**Review outcome:** Pass with gaps — open items resolved: [#42](https://github.com/brownm09/lifting-logbook/issues/42) (archival policy section below)
 
 ---
 
@@ -129,6 +129,55 @@ swapping the entire transport layer requires zero changes to domain logic.
 - Fastify is not Express: some Express middleware (particularly those that depend on
   `req`/`res` being Express-flavored objects) is incompatible. Third-party middleware must be
   verified for Fastify compatibility or replaced with Fastify equivalents.
+
+---
+
+## Express Archival Policy
+
+`apps/api-legacy` is a reference implementation, not a production service. Without an explicit
+policy, every NestJS feature added creates implicit pressure to maintain parity in Express —
+which ADR-011 explicitly does not intend. This section defines the scope, cutoff, and
+post-comparison disposition.
+
+### Feature parity scope
+
+`apps/api-legacy` is kept current with the **v0.2 Core API** REST endpoints only:
+
+| Endpoint group | Parity required |
+|---|---|
+| Workouts REST (`/workouts`) | Yes |
+| Training maxes REST (`/maxes`) | Yes |
+| Cycle dashboard REST (`/cycles`) | Yes |
+| GraphQL endpoints | No — Express comparison is REST-only by design |
+| Auth middleware (JWT verification) | Initial wiring only; no updates after v0.2 |
+| v0.3 features and beyond | No |
+
+The comparison table in the Decision section above documents the structural differences between
+Express and NestJS; it is not a feature checklist. The Express app does not need to implement
+every NestJS feature — it demonstrates the migration starting point, not the destination.
+
+### Cutoff milestone
+
+The Express comparison is **complete when the v0.2 — Core API milestone is marked shipped**
+(all Active Work items in ROADMAP.md moved to the Shipped table). At that point, the comparison
+narrative is complete and no further parity updates are expected.
+
+### Post-comparison disposition
+
+At the v0.2 cutoff:
+
+1. Tag the repository at HEAD with `legacy-comparison-complete`:
+   ```bash
+   git tag legacy-comparison-complete
+   git push origin legacy-comparison-complete
+   ```
+2. Add a notice to `apps/api-legacy/README.md`:
+   > **Archived reference.** This implementation was kept current with v0.2 Core API endpoints
+   > for comparison purposes. No further updates are planned. See ADR-011 for context.
+3. No further PRs targeting `apps/api-legacy` will be reviewed or merged, except critical
+   security patches.
+4. The directory is retained in the monorepo as a read-only portfolio reference. It is not
+   deleted or moved to a separate repository.
 
 ---
 

--- a/docs/adr/ADR-014-credential-encryption-at-rest.md
+++ b/docs/adr/ADR-014-credential-encryption-at-rest.md
@@ -1,0 +1,232 @@
+# ADR-014: Credential Encryption at Rest for `adapter_config`
+
+**Status:** Accepted
+**Date:** 2026-04-29
+**Closes:** [#38](https://github.com/brownm09/lifting-logbook/issues/38)
+
+---
+
+## Context
+
+[ADR-003](ADR-003-per-user-data-store-config.md) stores per-user adapter configuration in an
+`adapter_config` JSONB column on the `user_data_source` table. For users on the Google Sheets
+adapter, this column contains sensitive credentials — either a service account key (JSON) or
+OAuth 2.0 refresh tokens. This data must be encrypted at rest.
+
+ADR-003 names KMS-backed envelope encryption as the required approach but defers the design.
+This ADR documents the encryption scheme, key hierarchy, rotation procedure, and the interaction
+between key rotation and the in-memory cache maintained by `IRepositoryFactory`.
+
+---
+
+## Decision
+
+Encrypt the `adapter_config` column using **Google Cloud KMS envelope encryption**.
+
+The scope of encryption is the entire `adapter_config` value for all adapter types (Sheets and
+Postgres). Encrypting unconditionally, regardless of whether the current adapter has credentials,
+avoids conditional encryption logic in the factory and ensures future adapters with sensitive
+config are automatically protected.
+
+### Schema change
+
+The original `adapter_config JSONB` column is replaced with three columns:
+
+```sql
+ALTER TABLE user_data_source
+  DROP COLUMN adapter_config,
+  ADD COLUMN config_ciphertext  BYTEA NOT NULL,
+  ADD COLUMN config_dek_ciphertext BYTEA NOT NULL,
+  ADD COLUMN config_nonce       BYTEA NOT NULL;
+```
+
+| Column | Purpose |
+|---|---|
+| `config_ciphertext` | The `adapter_config` JSON, encrypted with the row's DEK |
+| `config_dek_ciphertext` | The DEK, encrypted by Cloud KMS using the project KEK |
+| `config_nonce` | Random nonce (IV) for the symmetric cipher |
+
+### Encryption algorithm
+
+AES-256-GCM is used for data encryption. It provides authenticated encryption (AEAD), meaning
+tampering with `config_ciphertext` is detected at decrypt time. The nonce is 12 bytes, generated
+fresh for every write.
+
+### Key hierarchy
+
+```
+Cloud KMS key ring: lifting-logbook (region: us-central1)
+  └── Key: user-data-source-kek
+        ├── Key version 1 (primary — encrypts new DEKs)
+        └── Key version N (prior versions — kept for DEK decryption, not yet destroyed)
+
+Per-row DEK: 32-byte random key, encrypted by user-data-source-kek
+```
+
+The Key Encryption Key (KEK) lives entirely in Cloud KMS and is never exported or held in
+application memory. Only encrypted DEKs (ciphertext blobs) leave KMS. The Data Encryption
+Keys (DEKs) exist in plaintext only transiently in application memory during a single
+request.
+
+### Encrypt/decrypt flow
+
+**Write (`INSERT` or `UPDATE`):**
+1. Generate a random 32-byte DEK and 12-byte nonce.
+2. Encrypt the `adapter_config` JSON bytes using AES-256-GCM (DEK + nonce).
+3. Call `projects/.../cryptoKeys/user-data-source-kek:encrypt` (Cloud KMS API) to encrypt
+   the DEK, using the current primary key version.
+4. Store `config_ciphertext`, `config_dek_ciphertext`, and `config_nonce`.
+5. Discard the plaintext DEK from memory.
+
+**Read:**
+1. Fetch the row.
+2. Call `projects/.../cryptoKeys/user-data-source-kek:decrypt` (Cloud KMS API) to recover
+   the plaintext DEK. KMS uses the version embedded in the ciphertext automatically.
+3. Decrypt `config_ciphertext` with AES-256-GCM (DEK + nonce). GCM authentication tag
+   validates integrity.
+4. Deserialize JSON → typed adapter config struct.
+5. Discard the plaintext DEK from memory.
+
+The factory caches the **decrypted** adapter config in memory (keyed by `user_id`, TTL ~5
+minutes) so that repeat requests within the TTL window skip both the DB read and the KMS
+decrypt call. See [Cache Interaction](#cache-interaction) below.
+
+### IAM permissions
+
+| Principal | Permission | Scope |
+|---|---|---|
+| API service account | `cloudkms.cryptoKeyVersions.useToDecrypt` | `user-data-source-kek` |
+| API service account | `cloudkms.cryptoKeyVersions.useToEncrypt` | `user-data-source-kek` |
+| Admin service account | `cloudkms.cryptoKeys.get` | `user-data-source-kek` |
+
+No application principal holds `cloudkms.cryptoKeys.destroy` — key destruction is a manual
+operations step (see Key Rotation below).
+
+---
+
+## Key Rotation
+
+Cloud KMS supports automatic key rotation via a configurable rotation period. When a new
+primary key version is created:
+
+- **New writes** use the new primary version to encrypt DEKs.
+- **Existing rows** remain encrypted with their original DEK and key version. KMS preserves
+  all prior key versions in an enabled state until explicitly disabled/destroyed.
+- **Reads** continue to work: the `decrypt` call includes the key version identifier embedded
+  in `config_dek_ciphertext`, so KMS uses the correct version regardless of which version
+  is currently primary.
+
+### Re-encryption after rotation
+
+For forward secrecy, rows written before a rotation should eventually be re-encrypted with a
+DEK wrapped by the new primary key version. The procedure:
+
+1. Query all rows from `user_data_source`.
+2. For each row: decrypt DEK with old key version → generate new DEK → re-encrypt
+   `adapter_config` → encrypt new DEK with current primary key version → `UPDATE` row.
+3. Verify row count and spot-check a sample of decrypted configs.
+4. Once all rows are re-encrypted, disable (do not immediately destroy) the old key version.
+5. After a 30-day observation period with no decrypt calls to the old version (visible in
+   Cloud KMS audit logs), destroy it.
+
+This re-encryption job runs as a one-off migration script (`scripts/reencrypt-adapter-configs.ts`)
+and is not required on every rotation — it is a post-rotation hardening step.
+
+---
+
+## Cache Interaction
+
+`IRepositoryFactory` caches decrypted adapter configs in memory (TTL ~5 minutes, per
+[ADR-003](ADR-003-per-user-data-store-config.md#cache-invalidation)).
+
+The following properties hold:
+
+**Key rotation does not invalidate cached plaintext.** Cached entries hold the already-decrypted
+config. The KMS key version is only consulted during a DB read; a cached hit never calls KMS.
+After key rotation, cached entries remain valid until TTL expiry. This is safe: the plaintext
+was already authorized when it was fetched.
+
+**Key version revocation has a bounded exposure window.** If a key version is compromised and
+must be immediately disabled, cached plaintext derived from DEKs wrapped by that version will
+remain in memory for up to the TTL (~5 minutes). To reduce this window:
+- Use the admin cache invalidation endpoint (see
+  [ADR-003 — Cache Invalidation](ADR-003-per-user-data-store-config.md#cache-invalidation)) to
+  immediately evict all entries, forcing re-fetch after the version is disabled. New fetches
+  will fail if the old version is disabled before re-encryption completes.
+- As a result, emergency key revocation requires a coordinated sequence: disable key version →
+  flush cache → complete re-encryption with new key version → validate.
+
+**Factory never holds a plaintext DEK past a single request.** Plaintext DEKs are local
+variables discarded at the end of the read path. Only the final typed config struct is cached.
+
+---
+
+## Rationale
+
+**Why envelope encryption rather than Postgres column-level encryption?**
+Postgres column-level encryption (e.g., `pgcrypto`) places the key management burden in the
+database layer, complicates schema tooling (Prisma does not understand encrypted columns
+natively), and does not provide the audit trail or IAM integration of Cloud KMS. Envelope
+encryption keeps key management in a dedicated service with automatic versioning, audit logs,
+and IAM-gated access.
+
+**Why encrypt all adapter types, not just Sheets?**
+Conditional encryption (encrypt only if `adapter_type = 'sheets'`) requires the factory to
+branch on adapter type at every read and write. Any future adapter with credentials would
+require a schema change and conditional update. Unconditional encryption is simpler and safer.
+
+**Why per-row DEKs rather than a single application-level key?**
+A single application key means all rows share a compromise surface. Per-row DEKs limit
+the blast radius of any individual DEK exposure to one user row. The KMS cost difference
+(one encrypt/decrypt call per request vs. one per application start) is acceptable given
+the ~5-minute cache TTL reduces KMS calls to at most one per user per 5 minutes.
+
+**Why AES-256-GCM?**
+AEAD provides both confidentiality and integrity in one operation. GCM is hardware-accelerated
+on modern CPUs. The 256-bit key size provides adequate security margin. This is the algorithm
+used by the Google Tink library (the recommended implementation vehicle for envelope encryption
+on GCP).
+
+---
+
+## Alternatives Considered
+
+**Postgres `pgcrypto` (column-level):** Encrypt/decrypt happens inside Postgres using
+`pgp_sym_encrypt` / `pgp_sym_decrypt`. Key management is manual; no native IAM integration.
+Ruled out: Cloud KMS is already used for infrastructure secrets; consistent key management
+is preferred.
+
+**Whole-row encryption (application-level, single shared key):** Simpler — one key per
+environment. No per-row DEK. Ruled out: single shared key means all rows share a compromise
+surface; per-row DEKs are the standard envelope encryption pattern.
+
+**Transparent Data Encryption (TDE) at the Cloud SQL level:** Cloud SQL for PostgreSQL supports
+encryption at rest by default (at the disk level). This does not protect against a compromised
+database principal that can read plaintext via SQL. Application-level envelope encryption is
+additive to disk-level encryption. TDE alone does not satisfy the requirement.
+
+---
+
+## Consequences
+
+- **Schema migration required.** The `adapter_config JSONB` column is replaced with three
+  columns. All existing rows must be migrated. The migration script reads existing unencrypted
+  data and writes the encrypted form in a single transaction per row.
+- **KMS latency.** Each uncached factory lookup adds one Cloud KMS API round trip (~5–10 ms
+  at GCP p50). The cache TTL absorbs this for repeat requests.
+- **KMS cost.** Cloud KMS charges per cryptographic operation. At personal-use scale
+  (single user, ~5-minute cache TTL), this is negligible (<$0.01/month).
+- **Operational dependency.** If Cloud KMS is unavailable, the factory cannot decrypt
+  `adapter_config` for cache-miss requests. Cached entries remain available for up to the
+  TTL, providing a partial availability buffer. This is accepted for a non-production portfolio
+  project.
+
+---
+
+## References
+
+- [Google Cloud KMS — Envelope Encryption](https://cloud.google.com/kms/docs/envelope-encryption) — The definitive GCP guide to envelope encryption; documents the KEK/DEK hierarchy, encrypt/decrypt API calls, and the re-encryption pattern used in the key rotation procedure.
+- [Google Cloud KMS — Key Rotation](https://cloud.google.com/kms/docs/key-rotation) — Documents automatic rotation scheduling, the behaviour of prior key versions after rotation (enabled until explicitly destroyed), and audit logging for version-level decrypt calls.
+- [Google Tink — AES-GCM AEAD](https://developers.google.com/tink/aead) — The recommended implementation library for AEAD encryption on GCP; covers AES-256-GCM key generation, encrypt/decrypt API, and key rotation via keyset handles.
+- [NIST SP 800-38D — AES-GCM Recommendation](https://csrc.nist.gov/publications/detail/sp/800-38d/final) — NIST's normative recommendation for GCM mode; documents the 12-byte nonce requirement and authentication tag validation.
+- [ADR-003 — Per-User Data Store Configuration](ADR-003-per-user-data-store-config.md) — The parent ADR that introduced the `adapter_config` column and required KMS encryption at rest; ADR-003's cache TTL design is directly relevant to the Cache Interaction section above.

--- a/docs/adr/ADR-014-credential-encryption-at-rest.md
+++ b/docs/adr/ADR-014-credential-encryption-at-rest.md
@@ -98,6 +98,11 @@ decrypt call. See [Cache Interaction](#cache-interaction) below.
 | API service account | `cloudkms.cryptoKeyVersions.useToDecrypt` | `user-data-source-kek` |
 | API service account | `cloudkms.cryptoKeyVersions.useToEncrypt` | `user-data-source-kek` |
 | Admin service account | `cloudkms.cryptoKeys.get` | `user-data-source-kek` |
+| Re-encryption operator¹ | `cloudkms.cryptoKeyVersions.useToDecrypt` | `user-data-source-kek` |
+| Re-encryption operator¹ | `cloudkms.cryptoKeyVersions.useToEncrypt` | `user-data-source-kek` |
+
+¹ The re-encryption operator is whichever principal runs `scripts/reencrypt-adapter-configs.ts`
+— typically a dedicated CI/CD service account or the API service account if reused for ops jobs.
 
 No application principal holds `cloudkms.cryptoKeys.destroy` — key destruction is a manual
 operations step (see Key Rotation below).
@@ -122,8 +127,9 @@ For forward secrecy, rows written before a rotation should eventually be re-encr
 DEK wrapped by the new primary key version. The procedure:
 
 1. Query all rows from `user_data_source`.
-2. For each row: decrypt DEK with old key version → generate new DEK → re-encrypt
-   `adapter_config` → encrypt new DEK with current primary key version → `UPDATE` row.
+2. For each row: call `kek:decrypt` on `config_dek_ciphertext` (KMS resolves the key version
+   automatically from the ciphertext) → generate new DEK → re-encrypt `adapter_config` →
+   encrypt new DEK with current primary key version → `UPDATE` row.
 3. Verify row count and spot-check a sample of decrypted configs.
 4. Once all rows are re-encrypted, disable (do not immediately destroy) the old key version.
 5. After a 30-day observation period with no decrypt calls to the old version (visible in
@@ -151,10 +157,15 @@ must be immediately disabled, cached plaintext derived from DEKs wrapped by that
 remain in memory for up to the TTL (~5 minutes). To reduce this window:
 - Use the admin cache invalidation endpoint (see
   [ADR-003 — Cache Invalidation](ADR-003-per-user-data-store-config.md#cache-invalidation)) to
-  immediately evict all entries, forcing re-fetch after the version is disabled. New fetches
-  will fail if the old version is disabled before re-encryption completes.
-- As a result, emergency key revocation requires a coordinated sequence: disable key version →
-  flush cache → complete re-encryption with new key version → validate.
+  immediately evict all entries, forcing re-reads that will use the newly re-encrypted rows.
+- Emergency key revocation requires a coordinated sequence:
+  1. **Complete re-encryption** — run `scripts/reencrypt-adapter-configs.ts` while the
+     compromised version is still enabled (the script needs it to decrypt existing DEKs).
+  2. **Flush cache** — evict all cached entries so subsequent requests re-read from the
+     database and use the newly re-encrypted rows (wrapped by the new primary key version).
+  3. **Disable the compromised key version** — safe only after all rows have been
+     re-encrypted and confirmed. New fetches will no longer call the disabled version.
+  4. **Validate** — confirm no decrypt audit log entries for the disabled version.
 
 **Factory never holds a plaintext DEK past a single request.** Plaintext DEKs are local
 variables discarded at the end of the read path. Only the final typed config struct is cached.


### PR DESCRIPTION
## Summary

Closes three ARB review gaps filed against the v0.1 Foundation close. All changes are docs-only — no code, schema, or config changes.

- **ADR-014** (new): KMS envelope encryption design for `adapter_config`. Covers the AES-256-GCM + per-row DEK scheme, key hierarchy (key ring → KEK → per-row DEKs), encrypt/decrypt flow, key rotation procedure, and cache interaction (rotation vs. plaintext in the factory cache, emergency revocation window).
- **ADR-003** (amended): New `## Cache Invalidation` section documenting admin-triggered eviction (HTTP endpoint for single-instance; Redis `DEL` for multi-instance), the user-visible migration window, and structured log fields for detecting stale cache entries.
- **ADR-011** (amended): New `## Express Archival Policy` section defining the v0.2 REST parity scope, the cutoff milestone (v0.2 Core API shipped), and post-comparison disposition (`legacy-comparison-complete` tag + README notice, no further PRs).
- **adr-references.md** (amended): New Security section (KMS Key Rotation, Google Tink AES-GCM, NIST SP 800-38D); existing KMS Envelope Encryption entry updated to cite both ADR-003 and ADR-014.

## Acceptance Criteria

- [x] ADR-014 written at `docs/adr/ADR-014-credential-encryption-at-rest.md` (#38)
- [x] Encrypted fields, KMS key hierarchy, envelope encryption approach, and key rotation procedure documented (#38)
- [x] Cache-interaction section covers key rotation while a cached factory entry holds decrypted credentials (#38)
- [x] Google Cloud KMS official documentation cited as primary source (#38)
- [x] `docs/adr-references.md` updated with new references (#38)
- [x] ADR-003 amended with cache invalidation section — admin trigger, user-observable migration window, stale-cache detection (#39)
- [x] ADR-011 amended with Express Archival Policy — parity scope, cutoff milestone, post-comparison disposition (#42)

## Testing

`npm test` — 10 tasks successful, 33 tests passed, 0 failures. Docs-only change; no compiled output touched.

Closes #38
Closes #39
Closes #42