### PR TITLE
[feat] Add bodyweight tracking domain types and calculation utility

### DIFF
--- a/packages/core/src/catalog/lifts.ts
+++ b/packages/core/src/catalog/lifts.ts
@@ -33,11 +33,11 @@ export const LIFT_CATALOG: readonly Lift[] = [
   // --- Horizontal push pattern ---
   { id: 'bench-press',         name: 'Bench Press',         classification: 'compound',  movementTags: ['push', 'horizontal'] },
   { id: 'incline-bench-press', name: 'Incline Bench Press', classification: 'compound',  movementTags: ['push', 'horizontal'] },
-  { id: 'dip',                 name: 'Dip',                 classification: 'compound',  movementTags: ['push', 'horizontal'] },
+  { id: 'dip',                 name: 'Dip',                 classification: 'compound',  movementTags: ['push', 'horizontal'], isBodyweightComponent: true },
 
   // --- Vertical pull pattern ---
-  { id: 'chin-up',       name: 'Chin-up',       classification: 'compound',  movementTags: ['pull', 'vertical'] },
-  { id: 'pull-up',       name: 'Pull-up',        classification: 'compound',  movementTags: ['pull', 'vertical'] },
+  { id: 'chin-up',       name: 'Chin-up',       classification: 'compound',  movementTags: ['pull', 'vertical'], isBodyweightComponent: true },
+  { id: 'pull-up',       name: 'Pull-up',        classification: 'compound',  movementTags: ['pull', 'vertical'], isBodyweightComponent: true },
   { id: 'lat-pulldown',  name: 'Lat Pulldown',   classification: 'accessory', movementTags: ['pull', 'vertical'] },
 
   // --- Horizontal pull pattern ---

--- a/packages/core/src/services/bodyWeight.ts
+++ b/packages/core/src/services/bodyWeight.ts
@@ -1,0 +1,12 @@
+import type { Lift } from '@lifting-logbook/types';
+
+export function calculateAddedWeight(
+  targetLoad: number,
+  bodyWeight: number,
+): number {
+  return targetLoad - bodyWeight;
+}
+
+export function getBodyweightComponentLifts(catalog: readonly Lift[]): Lift[] {
+  return catalog.filter((l) => l.isBodyweightComponent === true);
+}

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -1,3 +1,4 @@
+export * from './bodyWeight';
 export * from './dashboard';
 export * from './maxes';
 export * from './workout';

--- a/packages/core/tests/core/services/bodyWeight.test.ts
+++ b/packages/core/tests/core/services/bodyWeight.test.ts
@@ -1,0 +1,45 @@
+import { LIFT_CATALOG, calculateAddedWeight, getBodyweightComponentLifts } from '@src/core';
+
+describe('calculateAddedWeight', () => {
+  it('returns positive added weight when target exceeds body weight', () => {
+    expect(calculateAddedWeight(100, 80)).toBe(20);
+  });
+
+  it('returns zero when target equals body weight', () => {
+    expect(calculateAddedWeight(80, 80)).toBe(0);
+  });
+
+  it('returns negative value when target is less than body weight', () => {
+    expect(calculateAddedWeight(60, 80)).toBe(-20);
+  });
+
+  it('handles fractional weights', () => {
+    expect(calculateAddedWeight(92.5, 80)).toBeCloseTo(12.5);
+  });
+});
+
+describe('getBodyweightComponentLifts', () => {
+  it('returns chin-up, pull-up, and dip from the real catalog', () => {
+    const result = getBodyweightComponentLifts(LIFT_CATALOG);
+    const ids = result.map((l) => l.id);
+    expect(ids).toContain('chin-up');
+    expect(ids).toContain('pull-up');
+    expect(ids).toContain('dip');
+  });
+
+  it('excludes non-bodyweight lifts', () => {
+    const result = getBodyweightComponentLifts(LIFT_CATALOG);
+    const ids = result.map((l) => l.id);
+    expect(ids).not.toContain('back-squat');
+    expect(ids).not.toContain('bench-press');
+    expect(ids).not.toContain('deadlift');
+    expect(ids).not.toContain('barbell-row');
+  });
+
+  it('returns only lifts with isBodyweightComponent === true', () => {
+    const result = getBodyweightComponentLifts(LIFT_CATALOG);
+    for (const lift of result) {
+      expect(lift.isBodyweightComponent).toBe(true);
+    }
+  });
+});

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -47,6 +47,7 @@ export interface WorkoutResponse {
   week: WeekNumber;
   date: string; // ISO 8601 date string
   lifts: WorkoutLiftResponse[];
+  bodyWeightEntry?: { weight: number; unit: WeightUnit };
 }
 
 // ---------------------------------------------------------------------------
@@ -78,6 +79,17 @@ export interface CreateLiftRecordRequest {
   weight: number;
   reps: number;
   notes?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Body Weight
+// ---------------------------------------------------------------------------
+
+/** Request body for recording a body weight observation. */
+export interface RecordBodyWeightRequest {
+  date: string; // ISO 8601 date string
+  weight: number;
+  unit: WeightUnit;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1,4 +1,4 @@
-import { LiftName, WeightUnit, WeekNumber, CycleNumber } from './domain';
+import { BodyWeightEntry, LiftName, WeightUnit, WeekNumber, CycleNumber } from './domain';
 
 // ---------------------------------------------------------------------------
 // Training Maxes
@@ -47,7 +47,7 @@ export interface WorkoutResponse {
   week: WeekNumber;
   date: string; // ISO 8601 date string
   lifts: WorkoutLiftResponse[];
-  bodyWeightEntry?: { weight: number; unit: WeightUnit };
+  bodyWeightEntry?: Pick<BodyWeightEntry, 'weight' | 'unit'>;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -13,6 +13,8 @@ export interface Lift {
   name: string;
   classification: LiftClassification;
   movementTags: MovementTag[];
+  /** True when body weight contributes to the total load (e.g. chin-ups, dips). */
+  isBodyweightComponent?: boolean;
 }
 
 /**
@@ -43,6 +45,13 @@ export const LIFT_NAMES = [
 
 /** Unit of measurement for weights. */
 export type WeightUnit = 'lbs' | 'kg';
+
+/** A single body weight observation recorded at session start. */
+export interface BodyWeightEntry {
+  date: Date;
+  weight: number;
+  unit: WeightUnit;
+}
 
 /** Week number within a training cycle (1-based, 4-week cycles). */
 export type WeekNumber = 1 | 2 | 3 | 4;


### PR DESCRIPTION
## Summary

- Adds `BodyWeightEntry` type and `isBodyweightComponent?: boolean` flag to the `Lift` interface in `packages/types`
- Marks Chin-up, Pull-up, and Dip as bodyweight-component exercises in the lift catalog
- Adds `calculateAddedWeight(targetLoad, bodyWeight)` and `getBodyweightComponentLifts(catalog)` utilities in `packages/core/src/services/bodyWeight.ts`
- Adds `RecordBodyWeightRequest` and optional `bodyWeightEntry` field on `WorkoutResponse` to `packages/types/src/api.ts` (for future API use)

**Scope:** Domain/core layer only. UI session prompt and API persistence are follow-on work.

**Design decision preserved from issue:** Body weight must be entered explicitly each session — no auto-population from prior sessions — to prevent silent errors from day-to-day fluctuation (~2 kg).

## Acceptance Criteria

- [x] `BodyWeightEntry` type exists in `packages/types`
- [x] `Lift.isBodyweightComponent` flag exists; Chin-up, Pull-up, Dip are flagged
- [x] `calculateAddedWeight` utility: `added_weight = target_total_load - body_weight`
- [x] `getBodyweightComponentLifts` filters catalog to bodyweight-component exercises
- [x] Types for future API endpoint added (`RecordBodyWeightRequest`, `bodyWeightEntry` on `WorkoutResponse`)

## Test plan

- [x] `npm test -w @lifting-logbook/core` — 22 suites, 99 tests pass (includes new `bodyWeight.test.ts`)
- [x] `npm test -w @lifting-logbook/types` — passes with no tests (types-only package)
- [x] Pre-commit lint hook passed

Closes #29