### PR TITLE
[chore] Move bodyweight tracking to Shipped in v0.3 ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,10 +70,15 @@ Web and mobile clients functional end-to-end. Key user-facing features implement
 
 | Work stream | Description | Issues |
 |---|---|---|
-| Bodyweight exercise tracking | Track body weight; calculate added weight for exercises like weighted chin-ups and dips (J4 from PRD) | [#29](https://github.com/brownm09/lifting-logbook/issues/29) |
 | Cycle planning — implementation | LLM-powered training cycle recommendations, using design from ADR-016 | [#54](https://github.com/brownm09/lifting-logbook/issues/54) |
 | Mobile dependency wiring | Add `@logbook/types` workspace dependency to `apps/mobile` | [#50](https://github.com/brownm09/lifting-logbook/issues/50) |
 | A/B comparison documentation | Define exit criteria and CI event taxonomy enforcement for Express/NestJS comparison | [#41](https://github.com/brownm09/lifting-logbook/issues/41) |
+
+### Shipped
+
+| Work stream | Description | Issues |
+|---|---|---|
+| Bodyweight exercise tracking | Domain/core layer: `BodyWeightEntry` type, `isBodyweightComponent` flag, catalog metadata, `calculateAddedWeight` utility | [#29](https://github.com/brownm09/lifting-logbook/issues/29) |
 
 ### Proposals
 


### PR DESCRIPTION
Moves the bodyweight exercise tracking row from v0.3 Active Work to Shipped following the merge of #101.

Updates the description to reflect actual scope: domain/core layer only (types, catalog metadata, utility). UI prompt and API persistence remain as follow-on work.