### PR TITLE
[chore] Advance milestone markers: v0.2 Shipped, v0.3 Current

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,7 @@ is codified.
 
 ---
 
-## v0.2 — Core API `[Current]`
+## v0.2 — Core API `[Shipped]`
 
 A working REST + GraphQL API backed by real adapters. Core module quality gates enforced.
 Architecture decisions for data access and security documented.
@@ -62,7 +62,7 @@ Architecture decisions for data access and security documented.
 
 ---
 
-## v0.3 — Client Applications `[Next]`
+## v0.3 — Client Applications `[Current]`
 
 Web and mobile clients functional end-to-end. Key user-facing features implemented.
 
@@ -70,10 +70,15 @@ Web and mobile clients functional end-to-end. Key user-facing features implement
 
 | Work stream | Description | Issues |
 |---|---|---|
-| Bodyweight exercise tracking | Track body weight; calculate added weight for exercises like weighted chin-ups and dips (J4 from PRD) | [#29](https://github.com/brownm09/lifting-logbook/issues/29) |
 | Cycle planning — implementation | LLM-powered training cycle recommendations, using design from ADR-016 | [#54](https://github.com/brownm09/lifting-logbook/issues/54) |
 | Mobile dependency wiring | Add `@logbook/types` workspace dependency to `apps/mobile` | [#50](https://github.com/brownm09/lifting-logbook/issues/50) |
 | A/B comparison documentation | Define exit criteria and CI event taxonomy enforcement for Express/NestJS comparison | [#41](https://github.com/brownm09/lifting-logbook/issues/41) |
+
+### Shipped
+
+| Work stream | Description | Issues |
+|---|---|---|
+| Bodyweight exercise tracking | Track body weight; calculate added weight for exercises like weighted chin-ups and dips (J4 from PRD) | [#29](https://github.com/brownm09/lifting-logbook/issues/29) |
 
 ### Proposals
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,7 +71,6 @@ Web and mobile clients functional end-to-end. Key user-facing features implement
 | Work stream | Description | Issues |
 |---|---|---|
 | Cycle planning — implementation | LLM-powered training cycle recommendations, using design from ADR-016 | [#54](https://github.com/brownm09/lifting-logbook/issues/54) |
-| Mobile dependency wiring | Add `@logbook/types` workspace dependency to `apps/mobile` | [#50](https://github.com/brownm09/lifting-logbook/issues/50) |
 | A/B comparison documentation | Define exit criteria and CI event taxonomy enforcement for Express/NestJS comparison | [#41](https://github.com/brownm09/lifting-logbook/issues/41) |
 
 ### Shipped
@@ -79,6 +78,7 @@ Web and mobile clients functional end-to-end. Key user-facing features implement
 | Work stream | Description | Issues |
 |---|---|---|
 | Bodyweight exercise tracking | Track body weight; calculate added weight for exercises like weighted chin-ups and dips (J4 from PRD) | [#29](https://github.com/brownm09/lifting-logbook/issues/29) |
+| Mobile dependency wiring | `@logbook/types` already declared in `apps/mobile/package.json`; hoisted by npm workspaces — no code change needed | [#50](https://github.com/brownm09/lifting-logbook/issues/50) |
 
 ### Proposals
 


### PR DESCRIPTION
## Summary

- Marks v0.2 — Core API as `[Shipped]` (all active work completed with PR #101)
- Promotes v0.3 — Client Applications to `[Current]`
- Moves bodyweight exercise tracking (#29) to the v0.3 Shipped table

## Test plan

- [ ] ROADMAP.md renders with correct `[Shipped]` / `[Current]` labels
- [ ] Bodyweight row appears under v0.3 Shipped, not Active Work
- [ ] No other content changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)