### PR TITLE
[chore] Advance to v0.3: milestone sync, close #50, three web UI proposals

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,7 @@ is codified.
 
 ---
 
-## v0.2 — Core API `[Current]`
+## v0.2 — Core API `[Shipped]`
 
 A working REST + GraphQL API backed by real adapters. Core module quality gates enforced.
 Architecture decisions for data access and security documented.
@@ -62,7 +62,7 @@ Architecture decisions for data access and security documented.
 
 ---
 
-## v0.3 — Client Applications `[Next]`
+## v0.3 — Client Applications `[Current]`
 
 Web and mobile clients functional end-to-end. Key user-facing features implemented.
 
@@ -71,7 +71,6 @@ Web and mobile clients functional end-to-end. Key user-facing features implement
 | Work stream | Description | Issues |
 |---|---|---|
 | Cycle planning — implementation | LLM-powered training cycle recommendations, using design from ADR-016 | [#54](https://github.com/brownm09/lifting-logbook/issues/54) |
-| Mobile dependency wiring | Add `@logbook/types` workspace dependency to `apps/mobile` | [#50](https://github.com/brownm09/lifting-logbook/issues/50) |
 | A/B comparison documentation | Define exit criteria and CI event taxonomy enforcement for Express/NestJS comparison | [#41](https://github.com/brownm09/lifting-logbook/issues/41) |
 
 ### Shipped
@@ -79,12 +78,15 @@ Web and mobile clients functional end-to-end. Key user-facing features implement
 | Work stream | Description | Issues |
 |---|---|---|
 | Bodyweight exercise tracking | Domain/core layer: `BodyWeightEntry` type, `isBodyweightComponent` flag, catalog metadata, `calculateAddedWeight` utility | [#29](https://github.com/brownm09/lifting-logbook/issues/29) |
+| Mobile dependency wiring | `@logbook/types` already declared in `apps/mobile/package.json`; hoisted by npm workspaces — no code change needed | [#50](https://github.com/brownm09/lifting-logbook/issues/50) |
 
 ### Proposals
 
 | Proposal | Description | Issue |
 |---|---|---|
-| *(none yet)* | | |
+| [Cycle Dashboard Screen](docs/proposals/2026-04-29-cycle-dashboard-screen.md) | Week-by-week workout status and planned lift weights; `/cycle` bookmarkable route | [#104](https://github.com/brownm09/lifting-logbook/issues/104) |
+| [Workout Logging Screen](docs/proposals/2026-04-29-workout-logging-screen.md) | Per-exercise logging with warm-ups, bodyweight gate, and whole-workout overview toggle | [#106](https://github.com/brownm09/lifting-logbook/issues/106) |
+| [Training Max Management Screen](docs/proposals/2026-04-29-training-max-management.md) | View and edit per-lift 1RMs at `/settings/training-maxes`; drives all working set calculations | [#108](https://github.com/brownm09/lifting-logbook/issues/108) |
 
 ---
 

--- a/docs/proposals/2026-04-29-cycle-dashboard-screen.md
+++ b/docs/proposals/2026-04-29-cycle-dashboard-screen.md
@@ -1,0 +1,57 @@
+# Proposal: Cycle Dashboard Screen
+
+**Status:** `draft`
+**Date:** 2026-04-29
+**Issue:** [#104](https://github.com/brownm09/lifting-logbook/issues/104)
+
+---
+
+## Problem
+
+The application has a complete API for cycle data (`GET /cycle-dashboard`, `GET /program-spec`)
+and all progression math in `packages/core`, but no web UI. A lifter preparing for a session
+has no way to see their current training cycle — which weeks are done, what workouts are coming
+up, or what target weights are planned — without querying the API directly. This screen is the
+central navigation hub the rest of the client application depends on.
+
+## Proposed Solution
+
+Build a cycle dashboard screen at `/cycle` (resolves automatically to the current active cycle;
+bookmarkable) and `/cycle/:cycleNum` (specific cycle by number). The screen displays a
+week-by-week grid (4 weeks × planned workouts) showing each workout's date, completion status,
+and planned lift weights. Planned weights are computed client-side using `calculateLiftWeights`
+from `packages/core` against the program spec and current training maxes — no duplicate math in
+the UI layer. Bodyweight-component exercises show their total training load (same format as
+barbell lifts); the added-weight breakdown is deferred to the workout logging screen.
+
+Clicking a completed workout navigates to `/cycle/:cycleNum/workout/:workoutNum` in read-only
+review mode. Clicking an upcoming workout navigates to the same route in logging mode.
+
+## Acceptance Criteria
+
+- [ ] `/cycle` resolves to the current active cycle and renders the dashboard
+- [ ] `/cycle/:cycleNum` renders the dashboard for an explicit cycle number; shows a
+      404-equivalent state if the cycle does not exist
+- [ ] Dashboard displays a 4-week grid; each cell shows the workout date, completion badge
+      (Completed / Upcoming / Missed), and the planned lifts with target weights
+- [ ] Planned weights are derived from `GET /program-spec` + `GET /training-maxes` via
+      `calculateLiftWeights` in `packages/core` — no recalculation in the UI
+- [ ] Bodyweight-component exercises display total training load (not added weight) in the
+      dashboard; added-weight breakdown is shown only in the workout logging screen
+- [ ] Clicking a completed workout navigates to the workout detail screen (read-only)
+- [ ] Clicking an upcoming workout navigates to the workout logging screen
+- [ ] Screen is usable at mobile browser viewport widths (≥ 375px) without horizontal scroll;
+      completed weeks collapse by default on mobile, current week is expanded
+
+## Out of Scope
+
+- Cycle-to-cycle navigation or a history browser (past cycles)
+- Creating or editing cycle configuration from the dashboard
+- Inline editing of workout records from the dashboard
+- React Native (`apps/mobile`) — web only for this proposal
+
+## References
+
+- [`packages/core/src/services/workout/calculateLiftWeights.ts`](../../packages/core/src/services/workout/calculateLiftWeights.ts) — progression math to reuse client-side
+- [`packages/types/src/api.ts`](../../packages/types/src/api.ts) — `CycleDashboardResponse`, `LiftingProgramSpecResponse`, `TrainingMaxResponse`
+- ADR-015 (`docs/adr/ADR-015-graphql-dataloader.md`) — DataLoader design for batch-loading cycle data if this screen moves to GraphQL

--- a/docs/proposals/2026-04-29-training-max-management.md
+++ b/docs/proposals/2026-04-29-training-max-management.md
@@ -1,0 +1,55 @@
+# Proposal: Training Max Management Screen
+
+**Status:** `draft`
+**Date:** 2026-04-29
+**Issue:** [#108](https://github.com/brownm09/lifting-logbook/issues/108)
+
+---
+
+## Problem
+
+Training maxes (1RMs) are the single input that drives every working set weight calculation in
+the app. The API supports reading and updating them (`GET /training-maxes`,
+`PATCH /training-maxes`), but there is no web UI. A lifter who wants to review their current
+maxes, correct an entry, or manually set a starting max for a new cycle has no way to do so
+without querying the API directly. Without this screen the calculated weights shown on the
+cycle dashboard and workout logging screen cannot be trusted or corrected.
+
+## Proposed Solution
+
+Build a training max management screen at `/settings/training-maxes`. The screen lists every
+lift in the user's program alongside its current training max and the date it was last updated.
+Each row is editable — the lifter taps a weight to change it, then saves. Saving submits the
+changed values via `PATCH /training-maxes` and confirms the update in-place. The screen
+respects the user's unit preference (lbs / kg) throughout. It is accessible from the cycle
+dashboard via a Settings link in the nav and is usable before the first cycle is created to
+set opening maxes.
+
+## Acceptance Criteria
+
+- [ ] `GET /training-maxes` is called on load; each lift is shown with its current training
+      max and last-updated date
+- [ ] Each row is editable; tapping the weight field opens an inline editor (or number input
+      on desktop)
+- [ ] Saving changed values submits via `PATCH /training-maxes`; the row reflects the updated
+      value and date on success
+- [ ] Validation rejects non-positive weights and non-numeric input before submission
+- [ ] Unit preference (lbs / kg) is respected: values are displayed and accepted in the user's
+      preferred unit
+- [ ] Lifts with no recorded max are shown with a placeholder and can be set for the first
+      time
+- [ ] Screen is usable at ≥ 375 px viewport width; touch targets ≥ 44 px
+
+## Out of Scope
+
+- Training max history or trend view (past values over time)
+- Automated progression — the API and `packages/core` handle max progression after a logged
+  workout; this screen is for manual review and correction only
+- Per-lift progression configuration (increment, decrement percentages)
+- React Native (`apps/mobile`) — web only
+
+## References
+
+- [`packages/types/src/api.ts`](../../packages/types/src/api.ts) — `TrainingMaxResponse`, `UpdateTrainingMaxesRequest`
+- [`packages/core/src/services/maxes/updateMaxes.ts`](../../packages/core/src/services/maxes/updateMaxes.ts) — progression logic (context for what this screen does *not* duplicate)
+- PRD §Jobs to Be Done — J2 (know what weight to use next session)

--- a/docs/proposals/2026-04-29-workout-logging-screen.md
+++ b/docs/proposals/2026-04-29-workout-logging-screen.md
@@ -1,0 +1,99 @@
+# Proposal: Workout Logging Screen
+
+**Status:** `draft`
+**Date:** 2026-04-29
+**Issue:** [#106](https://github.com/brownm09/lifting-logbook/issues/106)
+
+---
+
+## Problem
+
+The API has endpoints for reading planned workouts (`GET /workouts`) and recording lift data
+(`POST /lift-records`, `POST /body-weight`), but there is no web UI for a lifter to log a
+session at the gym. Without this screen the primary job-to-be-done — recording a completed
+workout in under 2 minutes — is impossible. It is also the delivery point for the
+bodyweight-component added-weight calculation (J4): bodyweight is entered at session start and
+used to compute added weight for exercises like weighted chin-ups and dips.
+
+## Proposed Solution
+
+Build a workout logging screen at `/cycle/:cycleNum/workout/:workoutNum`. The screen presents
+one exercise at a time, with navigation dots to jump between exercises and a toggle to a
+whole-workout overview.
+
+**Bodyweight gate:** If the workout contains bodyweight-component exercises, a bodyweight entry
+prompt appears before the lift list is shown. The entered value is posted to `POST /body-weight`
+and used client-side by `calculateAddedWeight` to compute added weight for those lifts.
+
+**Per-exercise view:** Each exercise shows warm-up sets (read-only, calculated from
+`warmUpPct` in the program spec via `packages/core` math) followed by working sets with
+editable weight and reps fields. Warm-up weights for bodyweight-component exercises are
+calculated identically to barbell exercises (same percentage formula applied to total training
+load). For exercises where warm-up sets fall below the lifter's bodyweight, the sets are
+shown as `BW × n`; once warm-up percentages exceed bodyweight they display added weight
+(`+X lb × n`). The warm-up implement (e.g., lat pulldown for weighted chin-ups, unweighted
+dips for weighted dips) is hard-coded per exercise in this iteration. A bottom strip previews
+the next exercise's name and first warm-up weight; when the current exercise is last, the
+strip reads "Last exercise."
+
+**Working sets:** Weight and reps are pre-filled from the program spec. The lifter adjusts
+actuals and taps Log per set; each submission posts to `POST /lift-records` and marks the set
+complete. When all sets across all exercises are logged, a "Finish workout" action navigates
+back to the cycle dashboard.
+
+**Whole-workout view:** A toggle (⊞) switches to a scrollable list of all exercises showing
+warm-up weights (compressed to a summary line) and working set status. Each exercise has a
+"Resume" / "Go to" button that returns to the per-exercise view at that exercise.
+
+**Read-only mode:** When navigated to from a completed workout, all inputs are disabled and
+existing lift records are displayed.
+
+## Acceptance Criteria
+
+- [ ] `/cycle/:cycleNum/workout/:workoutNum` fetches and renders the workout plan from
+      `GET /workouts`
+- [ ] If the workout contains ≥ 1 bodyweight-component lift, a bodyweight entry step is shown
+      first; submission posts to `POST /body-weight` before the lift list is revealed
+- [ ] Warm-up sets are shown read-only above working sets for every exercise; weights are
+      derived from `warmUpPct` in `LiftingProgramSpecResponse` via `packages/core` — no
+      warm-up math duplicated in the UI
+- [ ] Warm-up sets for bodyweight-component exercises display `BW × n` when the calculated
+      weight is at or below bodyweight, and `+X lb × n` when above; the warm-up implement
+      name (e.g., "lat pulldown", "dips") is shown as a label above the warm-up list
+- [ ] Working set weights are pre-filled: barbell lifts use `calculateLiftWeights`, bodyweight-
+      component lifts use `calculateAddedWeight(targetLoad, bodyWeight)` from `packages/core`
+- [ ] The lifter can adjust weight and reps per set; tapping Log posts to `POST /lift-records`
+      and marks the set complete (inputs locked, ✓ shown)
+- [ ] Navigation dots above the exercise name are tappable to jump to any exercise
+- [ ] A bottom strip shows the next exercise name and its first warm-up weight; on the last
+      exercise the strip reads "Last exercise"
+- [ ] When all sets across all exercises are logged, "Finish workout" navigates to
+      `/cycle/:cycleNum`
+- [ ] A ⊞ toggle switches to a whole-workout overview listing all exercises with warm-up
+      summary, working set status, and Resume / Go to buttons
+- [ ] When reached from a completed workout (read-only mode), all inputs are disabled and
+      existing lift records are displayed
+- [ ] Touch targets are ≥ 44 px; screen is usable at ≥ 375 px viewport width without
+      horizontal scroll
+
+## Out of Scope
+
+- Editing a previously submitted set (read-only review is in scope; edit is not)
+- Per-set or per-lift notes
+- Rest timer between sets
+- Offline / service-worker support
+- React Native (`apps/mobile`) — web only
+
+## Open Questions
+
+The warm-up implement for each exercise (e.g., lat pulldown for weighted chin-ups, unweighted
+dips for weighted dips) is hard-coded in this iteration. A follow-on issue should make
+warm-up protocols configurable per exercise — including the implement name, the number of
+warm-up sets, and the percentage steps — so users can match their actual gym warm-up routine.
+
+## References
+
+- [`packages/core/src/services/bodyWeight.ts`](../../packages/core/src/services/bodyWeight.ts) — `calculateAddedWeight` to reuse client-side
+- [`packages/core/src/services/workout/calculateLiftWeights.ts`](../../packages/core/src/services/workout/calculateLiftWeights.ts) — working set weight calculation
+- [`packages/types/src/api.ts`](../../packages/types/src/api.ts) — `WorkoutResponse`, `CreateLiftRecordRequest`, `RecordBodyWeightRequest`, `LiftingProgramSpecResponse`
+- PRD §Jobs to Be Done — J1 (log without friction, ≤ 2 min), J4 (bodyweight-component target weight)


### PR DESCRIPTION
## Summary

- Mark v0.2 as `[Shipped]`, promote v0.3 to `[Current]`
- Close issue #50 (mobile dep wiring): `@lifting-logbook/types` was already declared in `apps/mobile/package.json` and hoisted by npm workspaces; `tsc --noEmit` confirmed clean; moved to Shipped
- Add three v0.3 web UI proposal docs and link them in the ROADMAP Proposals table:
  - [Cycle Dashboard Screen](docs/proposals/2026-04-29-cycle-dashboard-screen.md) — issue #104
  - [Workout Logging Screen](docs/proposals/2026-04-29-workout-logging-screen.md) — issue #106
  - [Training Max Management Screen](docs/proposals/2026-04-29-training-max-management.md) — issue #108

Consolidates PRs #103, #105, #107, #109 (closed without merging due to sequential ROADMAP conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)