### PR TITLE
[feat] Cycle dashboard screen — /cycle and /cycle/:cycleNum

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,5 @@
+# URL of the NestJS API server, reachable from the Next.js process (server-side only)
+API_URL=http://localhost:3001
+
+# Default lifting program identifier — used as the :program path param in all API calls
+NEXT_PUBLIC_DEFAULT_PROGRAM=531

--- a/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.module.css
+++ b/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.module.css
@@ -1,0 +1,142 @@
+.container {
+  padding: 1rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.heading {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.weekSection {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.weekToggle {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #f5f5f5;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 600;
+  text-align: left;
+}
+
+.weekToggle:hover {
+  background: #ebebeb;
+}
+
+.toggleIcon {
+  font-size: 0.75rem;
+  color: #666;
+}
+
+.workouts {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.workoutCard {
+  padding: 1rem;
+  border: 1px solid #eee;
+  border-radius: 6px;
+  min-width: 0;
+}
+
+.card_completed {
+  background: #f0fff0;
+  border-color: #c3e6cb;
+}
+
+.card_upcoming {
+  background: #fffdf0;
+  border-color: #ffeaa7;
+}
+
+.card_missed {
+  background: #fff5f5;
+  border-color: #f5c6cb;
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+  gap: 0.5rem;
+}
+
+.cardHeader time {
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.badge {
+  padding: 0.2rem 0.6rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.badge_completed {
+  background: #d4edda;
+  color: #155724;
+}
+
+.badge_upcoming {
+  background: #fff3cd;
+  color: #856404;
+}
+
+.badge_missed {
+  background: #f8d7da;
+  color: #721c24;
+}
+
+.liftList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.liftItem {
+  font-size: 0.95rem;
+}
+
+.setList {
+  margin: 0.25rem 0 0 1.25rem;
+  padding: 0;
+  font-size: 0.875rem;
+  color: #444;
+}
+
+@media (min-width: 540px) {
+  .workouts {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .workoutCard {
+    flex: 1;
+    min-width: 200px;
+  }
+}

--- a/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.tsx
+++ b/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.tsx
@@ -10,7 +10,7 @@ function findCurrentWeek(weeks: WeekRow[]): number {
       return row.week;
     }
   }
-  return 4;
+  return weeks[weeks.length - 1]?.week ?? 1;
 }
 
 function StatusBadge({ status }: { status: WorkoutCell['status'] }) {

--- a/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.tsx
+++ b/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useState } from 'react';
+import type { WeekRow, WorkoutCell } from '@/lib/workoutPlan';
+import styles from './CycleDashboardGrid.module.css';
+
+function findCurrentWeek(weeks: WeekRow[]): number {
+  for (const row of weeks) {
+    if (row.workouts.some((w) => w.status === 'upcoming')) {
+      return row.week;
+    }
+  }
+  return 4;
+}
+
+function StatusBadge({ status }: { status: WorkoutCell['status'] }) {
+  const label =
+    status === 'completed'
+      ? 'Completed'
+      : status === 'upcoming'
+        ? 'Upcoming'
+        : 'Missed';
+  return (
+    <span className={`${styles.badge} ${styles[`badge_${status}`]}`}>
+      {label}
+    </span>
+  );
+}
+
+function WorkoutCard({ cell }: { cell: WorkoutCell }) {
+  return (
+    <div className={`${styles.workoutCard} ${styles[`card_${cell.status}`]}`}>
+      <div className={styles.cardHeader}>
+        <time dateTime={cell.date}>{cell.date}</time>
+        <StatusBadge status={cell.status} />
+      </div>
+      <ul className={styles.liftList}>
+        {cell.lifts.map((lift) => (
+          <li key={lift.name} className={styles.liftItem}>
+            <strong>{lift.name}</strong>
+            <ol className={styles.setList}>
+              {lift.sets.map((s) => (
+                <li key={s.setLabel}>
+                  {s.setLabel}: {s.weight} lbs × {s.reps}
+                </li>
+              ))}
+            </ol>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default function CycleDashboardGrid({
+  cycleNum,
+  weeks,
+}: {
+  cycleNum: number;
+  weeks: WeekRow[];
+}) {
+  const currentWeek = findCurrentWeek(weeks);
+
+  const [expanded, setExpanded] = useState<Record<number, boolean>>(() => {
+    const initial: Record<number, boolean> = {};
+    for (const row of weeks) {
+      initial[row.week] = row.week === currentWeek;
+    }
+    return initial;
+  });
+
+  return (
+    <section className={styles.container}>
+      <h2 className={styles.heading}>Cycle {cycleNum}</h2>
+      <div className={styles.grid}>
+        {weeks.map((row) => {
+          const isExpanded = expanded[row.week] ?? row.week === currentWeek;
+          return (
+            <div key={row.week} className={styles.weekSection}>
+              <button
+                type="button"
+                className={styles.weekToggle}
+                onClick={() =>
+                  setExpanded((prev) => ({
+                    ...prev,
+                    [row.week]: !prev[row.week],
+                  }))
+                }
+                aria-expanded={isExpanded}
+              >
+                <span>Week {row.week}</span>
+                <span
+                  className={styles.toggleIcon}
+                  aria-hidden="true"
+                >
+                  {isExpanded ? '▲' : '▼'}
+                </span>
+              </button>
+              {isExpanded && (
+                <div className={styles.workouts}>
+                  {row.workouts.map((cell) => (
+                    <WorkoutCard key={cell.workoutNum} cell={cell} />
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/cycle/[cycleNum]/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/page.tsx
@@ -32,20 +32,27 @@ export default async function CycleDashboardPage({
     notFound();
   }
 
-  const workoutResponses = await Promise.all(
-    Array.from({ length: 8 }, (_, i) => fetchWorkout(program, i + 1)),
+  const workoutDays = buildWorkoutDays(specs, dashboard.cycleStartDate);
+  const workoutResponseList = await Promise.all(
+    workoutDays.map((w) => fetchWorkout(program, w.workoutNum)),
+  );
+  const workoutResponseMap = new Map(
+    workoutDays.map((w, i) => [w.workoutNum, workoutResponseList[i]]),
   );
 
-  const workoutDays = buildWorkoutDays(specs, dashboard.cycleStartDate);
   const today = new Date().toISOString().slice(0, 10);
   const maxMap = new Map(maxes.map((m) => [m.lift, m.weight]));
 
-  const weeks: WeekRow[] = ([1, 2, 3, 4] as const).map((week) => ({
+  // Derive week numbers from workout offsets. Assumes 2 workouts per week —
+  // a workouts-per-week value from the program config would generalize this.
+  const weekNums = [...new Set(workoutDays.map((w) => Math.ceil(w.workoutNum / 2)))];
+
+  const weeks: WeekRow[] = weekNums.map((week) => ({
     week,
     workouts: workoutDays
       .filter((w) => Math.ceil(w.workoutNum / 2) === week)
       .map((w): WorkoutCell => {
-        const response = workoutResponses[w.workoutNum - 1];
+        const response = workoutResponseMap.get(w.workoutNum);
         const logged = response != null && response.lifts.length > 0;
         const status: WorkoutCell['status'] = logged
           ? 'completed'

--- a/apps/web/app/cycle/[cycleNum]/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/page.tsx
@@ -1,0 +1,68 @@
+import { notFound } from 'next/navigation';
+import {
+  fetchCycleDashboard,
+  fetchProgramSpec,
+  fetchTrainingMaxes,
+  fetchWorkout,
+} from '@/lib/api';
+import {
+  buildWorkoutDays,
+  computePlannedSets,
+  type WeekRow,
+  type WorkoutCell,
+} from '@/lib/workoutPlan';
+import CycleDashboardGrid from './CycleDashboardGrid';
+
+export default async function CycleDashboardPage({
+  params,
+}: {
+  params: Promise<{ cycleNum: string }>;
+}) {
+  const { cycleNum: cycleNumParam } = await params;
+  const requestedCycleNum = Number(cycleNumParam);
+  const program = process.env.NEXT_PUBLIC_DEFAULT_PROGRAM ?? '531';
+
+  const [dashboard, specs, maxes] = await Promise.all([
+    fetchCycleDashboard(program),
+    fetchProgramSpec(program),
+    fetchTrainingMaxes(program),
+  ]);
+
+  if (dashboard.cycleNum !== requestedCycleNum) {
+    notFound();
+  }
+
+  const workoutResponses = await Promise.all(
+    Array.from({ length: 8 }, (_, i) => fetchWorkout(program, i + 1)),
+  );
+
+  const workoutDays = buildWorkoutDays(specs, dashboard.cycleStartDate);
+  const today = new Date().toISOString().slice(0, 10);
+  const maxMap = new Map(maxes.map((m) => [m.lift, m.weight]));
+
+  const weeks: WeekRow[] = ([1, 2, 3, 4] as const).map((week) => ({
+    week,
+    workouts: workoutDays
+      .filter((w) => Math.ceil(w.workoutNum / 2) === week)
+      .map((w): WorkoutCell => {
+        const response = workoutResponses[w.workoutNum - 1];
+        const logged = response != null && response.lifts.length > 0;
+        const status: WorkoutCell['status'] = logged
+          ? 'completed'
+          : w.date < today
+            ? 'missed'
+            : 'upcoming';
+        return {
+          workoutNum: w.workoutNum,
+          date: w.date,
+          status,
+          lifts: w.lifts.map((spec) => ({
+            name: spec.lift,
+            sets: computePlannedSets(spec, maxMap.get(spec.lift) ?? 0),
+          })),
+        };
+      }),
+  }));
+
+  return <CycleDashboardGrid cycleNum={dashboard.cycleNum} weeks={weeks} />;
+}

--- a/apps/web/app/cycle/layout.tsx
+++ b/apps/web/app/cycle/layout.tsx
@@ -1,0 +1,14 @@
+export default function CycleLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <main>
+      <header>
+        <h1>Lifting Logbook</h1>
+      </header>
+      {children}
+    </main>
+  );
+}

--- a/apps/web/app/cycle/page.tsx
+++ b/apps/web/app/cycle/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from 'next/navigation';
+import { fetchCycleDashboard } from '@/lib/api';
+
+export default async function CyclePage() {
+  const program = process.env.NEXT_PUBLIC_DEFAULT_PROGRAM ?? '531';
+  const dashboard = await fetchCycleDashboard(program);
+  redirect(`/cycle/${dashboard.cycleNum}`);
+}

--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -1,0 +1,17 @@
+const base = require('../../jest.config.base.js');
+
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  ...base,
+  testMatch: ['**/*.test.ts', '**/*.test.tsx'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleNameMapper: {
+    '^@src/core$': '<rootDir>/../../packages/core/src/index.ts',
+    '^@src/core/(.*)$': '<rootDir>/../../packages/core/src/$1',
+    '^@lifting-logbook/core$': '<rootDir>/../../packages/core/src/index.ts',
+    '^@lifting-logbook/types$': '<rootDir>/../../packages/types/src/index.ts',
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+};

--- a/apps/web/lib/__tests__/workoutPlan.test.ts
+++ b/apps/web/lib/__tests__/workoutPlan.test.ts
@@ -1,0 +1,122 @@
+import type { LiftingProgramSpecResponse } from '@lifting-logbook/types';
+import { buildWorkoutDays, computePlannedSets } from '../workoutPlan';
+
+const makeSpec = (
+  overrides: Partial<LiftingProgramSpecResponse>,
+): LiftingProgramSpecResponse => ({
+  lift: 'Squat',
+  order: 1,
+  offset: 0,
+  increment: 5,
+  sets: 3,
+  reps: 5,
+  amrap: false,
+  warmUpPct: '0.4,0.5,0.6',
+  wtDecrementPct: 0,
+  activation: '',
+  ...overrides,
+});
+
+describe('buildWorkoutDays', () => {
+  it('groups specs by offset and assigns workoutNum 1-based in offset order', () => {
+    const specs: LiftingProgramSpecResponse[] = [
+      makeSpec({ lift: 'Squat', offset: 0, order: 1 }),
+      makeSpec({ lift: 'Bench Press', offset: 0, order: 2 }),
+      makeSpec({ lift: 'Deadlift', offset: 2, order: 1 }),
+    ];
+
+    const days = buildWorkoutDays(specs, '2026-01-05');
+
+    expect(days).toHaveLength(2);
+    expect(days[0]?.workoutNum).toBe(1);
+    expect(days[0]?.lifts.map((l) => l.lift)).toEqual(['Squat', 'Bench Press']);
+    expect(days[1]?.workoutNum).toBe(2);
+    expect(days[1]?.lifts.map((l) => l.lift)).toEqual(['Deadlift']);
+  });
+
+  it('computes workout dates by adding offset days to cycleStartDate in UTC', () => {
+    const specs = [
+      makeSpec({ offset: 0 }),
+      makeSpec({ lift: 'Bench Press', offset: 3 }),
+    ];
+
+    const days = buildWorkoutDays(specs, '2026-01-05');
+
+    expect(days[0]?.date).toBe('2026-01-05');
+    expect(days[1]?.date).toBe('2026-01-08');
+  });
+
+  it('sorts lifts within a workout day by order field', () => {
+    const specs = [
+      makeSpec({ lift: 'B', offset: 0, order: 2 }),
+      makeSpec({ lift: 'A', offset: 0, order: 1 }),
+    ];
+
+    const days = buildWorkoutDays(specs, '2026-01-01');
+
+    expect(days[0]?.lifts.map((l) => l.lift)).toEqual(['A', 'B']);
+  });
+
+  it('handles end-of-month date arithmetic correctly', () => {
+    const specs = [makeSpec({ offset: 3 })];
+    const days = buildWorkoutDays(specs, '2026-01-30');
+    expect(days[0]?.date).toBe('2026-02-02');
+  });
+});
+
+describe('computePlannedSets', () => {
+  it('computes warmup and work sets from training max', () => {
+    const spec = makeSpec({
+      warmUpPct: '0.4,0.5,0.6',
+      sets: 3,
+      reps: 5,
+      wtDecrementPct: 0,
+      increment: 5,
+    });
+
+    const sets = computePlannedSets(spec, 200);
+
+    const warmups = sets.filter((s) => s.setLabel.startsWith('Warm-up'));
+    const worksets = sets.filter((s) => s.setLabel.startsWith('Set'));
+
+    expect(warmups).toHaveLength(3);
+    expect(warmups[0]).toMatchObject({ weight: 80, reps: 5 }); // 200 * 0.4 = 80
+    expect(warmups[1]).toMatchObject({ weight: 100, reps: 4 }); // 200 * 0.5 = 100
+    expect(warmups[2]).toMatchObject({ weight: 120, reps: 3 }); // 200 * 0.6 = 120
+
+    expect(worksets).toHaveLength(3);
+    expect(worksets[0]).toMatchObject({ weight: 200, reps: 5 }); // 200 * 1.0
+  });
+
+  it('rounds weights to the nearest increment using MROUND', () => {
+    const spec = makeSpec({ warmUpPct: '0.4', sets: 1, wtDecrementPct: 0, increment: 5 });
+    const sets = computePlannedSets(spec, 205);
+    // 205 * 0.4 = 82 → MROUND(82, 5) = 80
+    expect(sets[0]?.weight).toBe(80);
+    // 205 * 1.0 = 205 → MROUND(205, 5) = 205
+    expect(sets[1]?.weight).toBe(205);
+  });
+
+  it('applies weight decrement across work sets', () => {
+    const spec = makeSpec({
+      warmUpPct: '',
+      sets: 3,
+      reps: 8,
+      wtDecrementPct: 0.05,
+      increment: 2.5,
+    });
+
+    const sets = computePlannedSets(spec, 100);
+    const worksets = sets.filter((s) => s.setLabel.startsWith('Set'));
+
+    expect(worksets[0]?.weight).toBe(100); // 100 * 1.0
+    expect(worksets[1]?.weight).toBe(95); // 100 * 0.95 = 95 → MROUND(95, 2.5) = 95
+    expect(worksets[2]?.weight).toBe(90); // 100 * 0.90 = 90 → MROUND(90, 2.5) = 90
+  });
+
+  it('omits warmup sets when warmUpPct is empty', () => {
+    const spec = makeSpec({ warmUpPct: '', sets: 2, wtDecrementPct: 0 });
+    const sets = computePlannedSets(spec, 100);
+    expect(sets.every((s) => s.setLabel.startsWith('Set'))).toBe(true);
+  });
+});

--- a/apps/web/lib/__tests__/workoutPlan.test.ts
+++ b/apps/web/lib/__tests__/workoutPlan.test.ts
@@ -119,4 +119,12 @@ describe('computePlannedSets', () => {
     const sets = computePlannedSets(spec, 100);
     expect(sets.every((s) => s.setLabel.startsWith('Set'))).toBe(true);
   });
+
+  it('clamps warmup reps to 1 for programs with more than 5 warmup sets', () => {
+    const spec = makeSpec({ warmUpPct: '0.4,0.45,0.5,0.55,0.6,0.65', sets: 1, wtDecrementPct: 0 });
+    const sets = computePlannedSets(spec, 200);
+    const warmups = sets.filter((s) => s.setLabel.startsWith('Warm-up'));
+    expect(warmups).toHaveLength(6);
+    expect(warmups[5]?.reps).toBe(1);
+  });
 });

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,0 +1,52 @@
+import type {
+  CycleDashboardResponse,
+  LiftingProgramSpecResponse,
+  TrainingMaxResponse,
+  WorkoutResponse,
+} from '@lifting-logbook/types';
+
+const API_URL = process.env.API_URL ?? 'http://localhost:3001';
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${API_URL}${path}`, init);
+  if (!res.ok) {
+    throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+export function fetchCycleDashboard(
+  program: string,
+): Promise<CycleDashboardResponse> {
+  return apiFetch(
+    `/programs/${encodeURIComponent(program)}/cycles/current`,
+    { cache: 'no-store' },
+  );
+}
+
+export function fetchProgramSpec(
+  program: string,
+): Promise<LiftingProgramSpecResponse[]> {
+  return apiFetch(`/programs/${encodeURIComponent(program)}/spec`, {
+    next: { revalidate: 3600 },
+  } as RequestInit);
+}
+
+export function fetchTrainingMaxes(
+  program: string,
+): Promise<TrainingMaxResponse[]> {
+  return apiFetch(
+    `/programs/${encodeURIComponent(program)}/training-maxes`,
+    { cache: 'no-store' },
+  );
+}
+
+export function fetchWorkout(
+  program: string,
+  workoutNum: number,
+): Promise<WorkoutResponse> {
+  return apiFetch(
+    `/programs/${encodeURIComponent(program)}/workouts/${workoutNum}`,
+    { cache: 'no-store' },
+  );
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -41,12 +41,15 @@ export function fetchTrainingMaxes(
   );
 }
 
-export function fetchWorkout(
+export async function fetchWorkout(
   program: string,
   workoutNum: number,
-): Promise<WorkoutResponse> {
-  return apiFetch(
-    `/programs/${encodeURIComponent(program)}/workouts/${workoutNum}`,
-    { cache: 'no-store' },
-  );
+): Promise<WorkoutResponse | null> {
+  const path = `/programs/${encodeURIComponent(program)}/workouts/${workoutNum}`;
+  const res = await fetch(`${API_URL}${path}`, { cache: 'no-store' });
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
+  }
+  return res.json() as Promise<WorkoutResponse>;
 }

--- a/apps/web/lib/workoutPlan.ts
+++ b/apps/web/lib/workoutPlan.ts
@@ -27,7 +27,7 @@ export interface WorkoutCell {
 }
 
 export interface WeekRow {
-  week: 1 | 2 | 3 | 4;
+  week: number;
   workouts: WorkoutCell[];
 }
 
@@ -84,7 +84,7 @@ export function computePlannedSets(
   const warmupSets: PlannedSet[] = warmupPcts.map((pct, i) => ({
     setLabel: `Warm-up ${i + 1}`,
     weight: MROUND(trainingMax * pct, spec.increment),
-    reps: WARMUP_BASE_REPS - i,
+    reps: Math.max(1, WARMUP_BASE_REPS - i),
   }));
 
   const workSets: PlannedSet[] = workPcts.map((pct, i) => ({

--- a/apps/web/lib/workoutPlan.ts
+++ b/apps/web/lib/workoutPlan.ts
@@ -1,0 +1,97 @@
+import {
+  MROUND,
+  PROG_SPEC_WARMUP_PCTS,
+  PROG_SPEC_WORK_PCTS,
+  WARMUP_BASE_REPS,
+  addDaysUTC,
+} from '@lifting-logbook/core';
+import type { LiftingProgramSpecResponse } from '@lifting-logbook/types';
+
+export interface PlannedSet {
+  setLabel: string;
+  weight: number;
+  reps: number;
+}
+
+export interface WorkoutDay {
+  workoutNum: number;
+  date: string; // YYYY-MM-DD
+  lifts: LiftingProgramSpecResponse[];
+}
+
+export interface WorkoutCell {
+  workoutNum: number;
+  date: string; // YYYY-MM-DD
+  status: 'completed' | 'upcoming' | 'missed';
+  lifts: { name: string; sets: PlannedSet[] }[];
+}
+
+export interface WeekRow {
+  week: 1 | 2 | 3 | 4;
+  workouts: WorkoutCell[];
+}
+
+/**
+ * Groups program specs by their offset (workout day) and returns an ordered
+ * list of workout days with derived dates.
+ *
+ * Lifts sharing the same offset belong to the same workout session. Offsets
+ * are sorted ascending so workoutNum maps 1:1 to chronological order.
+ */
+export function buildWorkoutDays(
+  specs: LiftingProgramSpecResponse[],
+  cycleStartDate: string,
+): WorkoutDay[] {
+  const [y, m, d] = cycleStartDate.split('-').map(Number) as [
+    number,
+    number,
+    number,
+  ];
+  const startDate = new Date(Date.UTC(y, m - 1, d));
+
+  const byOffset = new Map<number, LiftingProgramSpecResponse[]>();
+  for (const spec of specs) {
+    const lifts = byOffset.get(spec.offset) ?? [];
+    lifts.push(spec);
+    byOffset.set(spec.offset, lifts);
+  }
+
+  return Array.from(byOffset.keys())
+    .sort((a, b) => a - b)
+    .map((offset, i) => ({
+      workoutNum: i + 1,
+      date: addDaysUTC(startDate, offset).toISOString().slice(0, 10),
+      lifts: (byOffset.get(offset) ?? []).sort((a, b) => a.order - b.order),
+    }));
+}
+
+/**
+ * Computes planned warmup and work sets for a lift given a training max.
+ *
+ * Uses PROG_SPEC_WARMUP_PCTS / PROG_SPEC_WORK_PCTS / MROUND from
+ * @lifting-logbook/core — the same math as the spreadsheet layer, without
+ * the SpreadsheetCell[][] wrapper.
+ */
+export function computePlannedSets(
+  spec: LiftingProgramSpecResponse,
+  trainingMax: number,
+): PlannedSet[] {
+  const warmupPcts = PROG_SPEC_WARMUP_PCTS(spec.warmUpPct).filter(
+    (p) => !isNaN(p) && p > 0,
+  );
+  const workPcts = PROG_SPEC_WORK_PCTS(spec.sets, spec.wtDecrementPct) as number[];
+
+  const warmupSets: PlannedSet[] = warmupPcts.map((pct, i) => ({
+    setLabel: `Warm-up ${i + 1}`,
+    weight: MROUND(trainingMax * pct, spec.increment),
+    reps: WARMUP_BASE_REPS - i,
+  }));
+
+  const workSets: PlannedSet[] = workPcts.map((pct, i) => ({
+    setLabel: `Set ${i + 1}`,
+    weight: MROUND(trainingMax * pct, spec.increment),
+    reps: spec.reps,
+  }));
+
+  return [...warmupSets, ...workSets];
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
+    "@lifting-logbook/core": "*",
     "@lifting-logbook/types": "*",
     "next": "16.2.4",
     "react": "19.2.4",

--- a/apps/web/tsconfig.spec.json
+++ b/apps/web/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"],
+      "@src/core": ["../../packages/core/src/index.ts"],
+      "@src/core/*": ["../../packages/core/src/*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
       "name": "@lifting-logbook/web",
       "version": "0.0.0",
       "dependencies": {
+        "@lifting-logbook/core": "*",
         "@lifting-logbook/types": "*",
         "next": "16.2.4",
         "react": "19.2.4",
@@ -5169,6 +5170,41 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@nuxtjs/opencollective": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@nuxtjs/opencollective/-/opencollective-0.3.2.tgz",
@@ -6861,6 +6897,15 @@
       "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
       "dev": true
     },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -8245,6 +8290,18 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
@@ -9152,6 +9209,34 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -9693,6 +9778,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/getenv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
@@ -9752,6 +9849,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/gopd": {
@@ -11619,6 +11745,15 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "license": "MIT"
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -12381,6 +12516,19 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "node_modules/mylas": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.14.tgz",
+      "integrity": "sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/raouldeheer"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -13006,6 +13154,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/plimit-lit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
+      "integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
+      "dev": true,
+      "dependencies": {
+        "queue-lit": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -13220,6 +13380,35 @@
       "dependencies": {
         "inherits": "~2.0.3"
       }
+    },
+    "node_modules/queue-lit": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
+      "integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
@@ -14026,6 +14215,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve-workspace-root": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/resolve-workspace-root/-/resolve-workspace-root-2.0.1.tgz",
@@ -14142,6 +14340,29 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/rxjs": {
@@ -15492,6 +15713,36 @@
         }
       }
     },
+    "node_modules/tsc-alias": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.16.tgz",
+      "integrity": "sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "commander": "^9.0.0",
+        "get-tsconfig": "^4.10.0",
+        "globby": "^11.0.4",
+        "mylas": "^2.1.9",
+        "normalize-path": "^3.0.0",
+        "plimit-lit": "^1.2.6"
+      },
+      "bin": {
+        "tsc-alias": "dist/bin/index.js"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      }
+    },
+    "node_modules/tsc-alias/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
@@ -16318,7 +16569,8 @@
         "@lifting-logbook/types": "*"
       },
       "devDependencies": {
-        "csv-parse": "^6.1.0"
+        "csv-parse": "^6.1.0",
+        "tsc-alias": "^1.8.16"
       }
     },
     "packages/types": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --project tsconfig.json",
+    "build": "tsc --project tsconfig.json && tsc-alias --project tsconfig.json",
     "lint": "eslint src",
     "test": "jest"
   },
@@ -13,6 +13,7 @@
     "@lifting-logbook/types": "*"
   },
   "devDependencies": {
-    "csv-parse": "^6.1.0"
+    "csv-parse": "^6.1.0",
+    "tsc-alias": "^1.8.16"
   }
 }


### PR DESCRIPTION
## Summary

- Adds `/cycle` and `/cycle/[cycleNum]` routes in `apps/web` — the first real screen in the app
- Implements a 4-week × 2-workout grid with planned lift weights, workout dates, and completion badges (Completed / Upcoming / Missed)
- Adds `tsc-alias` to `packages/core` to fix `@src/core/*` path aliases in dist output (required for Next.js Turbopack to resolve the package)

## Acceptance Criteria

- [x] `/cycle` resolves to the current active cycle and renders the dashboard
- [x] `/cycle/:cycleNum` renders the dashboard for an explicit cycle number; shows a 404-equivalent state if the cycle does not exist
- [x] Dashboard displays a 4-week grid; each cell shows the workout date, completion badge (Completed / Upcoming / Missed), and the planned lifts with target weights
- [x] Planned weights are derived from `GET /program-spec` + `GET /training-maxes` via `PROG_SPEC_WARMUP_PCTS` / `PROG_SPEC_WORK_PCTS` / `MROUND` in `packages/core` — no recalculation in the UI
- [x] Bodyweight-component exercises display total training load (the training max weight is used as-is; added-weight breakdown is deferred to #106)
- [ ] Clicking a completed workout navigates to the workout detail screen — deferred to #106
- [ ] Clicking an upcoming workout navigates to the workout logging screen — deferred to #106
- [x] Screen is usable at mobile browser viewport widths (≥ 375px) without horizontal scroll; completed weeks collapse by default, current week is expanded

## Key Decisions

**`weeks: []` gap**: The cycle dashboard API mapper always returns `weeks: []` (documented in `mappers.ts`). The week grid is built client-side using `cycleStartDate` + `LiftingProgramSpec.offset` (day offset from cycle start per lift). No API change needed.

**`calculateLiftWeights` not suitable for UI**: It takes `SpreadsheetCell[][]` and emits formula strings for Google Sheets. The AC's intent is fulfilled by using the underlying helpers directly: `PROG_SPEC_WARMUP_PCTS`, `PROG_SPEC_WORK_PCTS`, `MROUND` from `@lifting-logbook/core`.

**Historical cycles**: `/cycle/[cycleNum]` returns a 404-equivalent for any cycle number that doesn't match the current active cycle. Historical cycle viewing is deferred.

**`tsc-alias`**: TypeScript does not rewrite path aliases in compiled output. `packages/core` used `@src/core/*` internally, which broke Next.js Turbopack resolution. `tsc-alias` post-processes the `dist/` output to replace aliases with relative paths.

## Testing

```bash
npm test          # 42 tests pass across all workspaces
npm run build     # Next.js build succeeds — /cycle and /cycle/[cycleNum] are Dynamic routes
```

Manual:
1. Start API: `cd apps/api && npm run start:dev`
2. Copy `apps/web/.env.example` → `.env.local`; set `API_URL` and `NEXT_PUBLIC_DEFAULT_PROGRAM`
3. Start web: `cd apps/web && npm run dev`
4. Visit `http://localhost:3000/cycle` — should redirect to `/cycle/:N` and render the grid
5. Resize to 375px — current week should be expanded, others collapsed

Closes #104