### PR TITLE
[feat] Configurable week grouping — remove 4-week / 2-workout hardcoding (#116)

### DIFF
--- a/apps/api/src/adapters/in-memory/fixtures.ts
+++ b/apps/api/src/adapters/in-memory/fixtures.ts
@@ -68,6 +68,7 @@ export const seedLiftRecords = (): LiftRecord[] => [
 
 export const seedProgramSpec = (): LiftingProgramSpec[] => [
   {
+    week: 1,
     offset: 0,
     lift: 'Squat',
     increment: 5,
@@ -80,6 +81,7 @@ export const seedProgramSpec = (): LiftingProgramSpec[] => [
     activation: 'compound',
   },
   {
+    week: 1,
     offset: 0,
     lift: 'Bench Press',
     increment: 5,

--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -10,7 +10,6 @@ import {
   LiftingProgramSpecResponse,
   SetResponse,
   TrainingMaxResponse,
-  WeekNumber,
   WorkoutLiftResponse,
   WorkoutResponse,
 } from '@lifting-logbook/types';
@@ -43,6 +42,7 @@ export const toLiftRecordResponse = (r: LiftRecord): LiftRecordResponse => ({
 export const toLiftingProgramSpecResponse = (
   s: LiftingProgramSpec,
 ): LiftingProgramSpecResponse => ({
+  week: s.week,
   lift: s.lift,
   order: s.order,
   offset: s.offset,
@@ -70,23 +70,19 @@ export const toCycleDashboardResponse = (
   weeks: [],
 });
 
-// Largest workoutNum whose derived week still fits in WeekNumber (1..4)
-// assuming 2 workouts per training week. Real programs vary — when that
-// becomes relevant, source week from the program spec instead of deriving.
-export const MAX_WORKOUT_NUM = 8 as const;
-
 export const isValidWorkoutNum = (n: number): boolean =>
-  Number.isInteger(n) && n >= 1 && n <= MAX_WORKOUT_NUM;
+  Number.isInteger(n) && n >= 1;
 
 /**
  * Groups a workout's lift records into the WorkoutResponse shape.
- * Assumes 2 workouts per training week; caller must validate `workoutNum`
- * with `isValidWorkoutNum` before invoking.
+ * Caller must validate `workoutNum` with `isValidWorkoutNum` and supply
+ * the `week` sourced from the program spec before invoking.
  */
 export const toWorkoutResponse = (
   program: string,
   cycleNum: number,
   workoutNum: number,
+  week: number,
   records: LiftRecord[],
 ): WorkoutResponse => {
   const liftMap = new Map<string, SetResponse[]>();
@@ -104,7 +100,6 @@ export const toWorkoutResponse = (
   const lifts: WorkoutLiftResponse[] = Array.from(liftMap.entries()).map(
     ([lift, sets]) => ({ lift, sets }),
   );
-  const week = Math.ceil(workoutNum / 2) as WeekNumber;
   const date = records[0] ? isoDate(records[0].date) : isoDate(new Date());
   return { program, cycleNum, workoutNum, week, date, lifts };
 };

--- a/apps/api/src/programs/workouts.controller.spec.ts
+++ b/apps/api/src/programs/workouts.controller.spec.ts
@@ -2,9 +2,11 @@ import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Weekday } from '@lifting-logbook/core';
 import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
+import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
 import { IWorkoutRepository } from '../ports/IWorkoutRepository';
 import {
   CYCLE_DASHBOARD_REPOSITORY,
+  LIFTING_PROGRAM_SPEC_REPOSITORY,
   WORKOUT_REPOSITORY,
 } from '../ports/tokens';
 import { WorkoutsController } from './workouts.controller';
@@ -13,6 +15,7 @@ describe('WorkoutsController', () => {
   let controller: WorkoutsController;
   let workoutRepo: jest.Mocked<IWorkoutRepository>;
   let dashboardRepo: jest.Mocked<ICycleDashboardRepository>;
+  let specRepo: jest.Mocked<ILiftingProgramSpecRepository>;
 
   beforeEach(async () => {
     workoutRepo = { getWorkout: jest.fn(), saveWorkout: jest.fn() };
@@ -20,17 +23,19 @@ describe('WorkoutsController', () => {
       getCycleDashboard: jest.fn(),
       saveCycleDashboard: jest.fn(),
     };
+    specRepo = { getProgramSpec: jest.fn() };
     const module: TestingModule = await Test.createTestingModule({
       controllers: [WorkoutsController],
       providers: [
         { provide: WORKOUT_REPOSITORY, useValue: workoutRepo },
         { provide: CYCLE_DASHBOARD_REPOSITORY, useValue: dashboardRepo },
+        { provide: LIFTING_PROGRAM_SPEC_REPOSITORY, useValue: specRepo },
       ],
     }).compile();
     controller = module.get(WorkoutsController);
   });
 
-  it('groups records by lift, derives week, and looks up current cycle', async () => {
+  it('groups records by lift, sources week from spec, and looks up current cycle', async () => {
     dashboardRepo.getCycleDashboard.mockResolvedValue({
       program: '5-3-1',
       cycleUnit: 'week',
@@ -39,6 +44,21 @@ describe('WorkoutsController', () => {
       sheetName: '',
       cycleStartWeekday: Weekday.Monday,
     });
+    specRepo.getProgramSpec.mockResolvedValue([
+      {
+        week: 1,
+        offset: 0,
+        lift: 'Squat',
+        increment: 5,
+        order: 1,
+        sets: 3,
+        reps: 5,
+        amrap: true,
+        warmUpPct: '0.4,0.5,0.6',
+        wtDecrementPct: 0.1,
+        activation: 'compound',
+      },
+    ]);
     workoutRepo.getWorkout.mockResolvedValue([
       {
         program: '5-3-1',

--- a/apps/api/src/programs/workouts.controller.spec.ts
+++ b/apps/api/src/programs/workouts.controller.spec.ts
@@ -102,4 +102,34 @@ describe('WorkoutsController', () => {
       BadRequestException,
     );
   });
+
+  it('rejects workoutNum that exceeds the number of offset groups in the spec', async () => {
+    dashboardRepo.getCycleDashboard.mockResolvedValue({
+      program: '5-3-1',
+      cycleUnit: 'week',
+      cycleNum: 3,
+      cycleDate: new Date('2026-04-20T00:00:00.000Z'),
+      sheetName: '',
+      cycleStartWeekday: Weekday.Monday,
+    });
+    specRepo.getProgramSpec.mockResolvedValue([
+      {
+        week: 1,
+        offset: 0,
+        lift: 'Squat',
+        increment: 5,
+        order: 1,
+        sets: 3,
+        reps: 5,
+        amrap: true,
+        warmUpPct: '0.4,0.5,0.6',
+        wtDecrementPct: 0.1,
+        activation: 'compound',
+      },
+    ]);
+
+    await expect(controller.getWorkout('5-3-1', '2')).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
 });

--- a/apps/api/src/programs/workouts.controller.ts
+++ b/apps/api/src/programs/workouts.controller.ts
@@ -49,10 +49,12 @@ export class WorkoutsController {
       (a, b) => a - b,
     );
     const offsetForWorkout = offsetsSorted[workoutNum - 1];
-    const week =
-      offsetForWorkout !== undefined
-        ? (spec.find((s) => s.offset === offsetForWorkout)?.week ?? 1)
-        : 1;
+    if (offsetForWorkout === undefined) {
+      throw new BadRequestException(
+        `workoutNum ${workoutNum} exceeds program spec (${offsetsSorted.length} workout days)`,
+      );
+    }
+    const week = spec.find((s) => s.offset === offsetForWorkout)?.week ?? 1;
 
     const records = await this.workoutRepo.getWorkout(
       program,

--- a/apps/api/src/programs/workouts.controller.ts
+++ b/apps/api/src/programs/workouts.controller.ts
@@ -7,16 +7,14 @@ import {
 } from '@nestjs/common';
 import { WorkoutResponse } from '@lifting-logbook/types';
 import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
+import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
 import { IWorkoutRepository } from '../ports/IWorkoutRepository';
 import {
   CYCLE_DASHBOARD_REPOSITORY,
+  LIFTING_PROGRAM_SPEC_REPOSITORY,
   WORKOUT_REPOSITORY,
 } from '../ports/tokens';
-import {
-  MAX_WORKOUT_NUM,
-  isValidWorkoutNum,
-  toWorkoutResponse,
-} from './mappers';
+import { isValidWorkoutNum, toWorkoutResponse } from './mappers';
 
 @Controller('programs/:program')
 export class WorkoutsController {
@@ -25,6 +23,8 @@ export class WorkoutsController {
     private readonly workoutRepo: IWorkoutRepository,
     @Inject(CYCLE_DASHBOARD_REPOSITORY)
     private readonly cycleDashboardRepo: ICycleDashboardRepository,
+    @Inject(LIFTING_PROGRAM_SPEC_REPOSITORY)
+    private readonly programSpecRepo: ILiftingProgramSpecRepository,
   ) {}
 
   @Get('workouts/:workoutNum')
@@ -35,15 +35,30 @@ export class WorkoutsController {
     const workoutNum = Number.parseInt(workoutNumParam, 10);
     if (!isValidWorkoutNum(workoutNum)) {
       throw new BadRequestException(
-        `workoutNum must be an integer in [1, ${MAX_WORKOUT_NUM}]`,
+        'workoutNum must be a positive integer',
       );
     }
-    const dashboard = await this.cycleDashboardRepo.getCycleDashboard(program);
+    const [dashboard, spec] = await Promise.all([
+      this.cycleDashboardRepo.getCycleDashboard(program),
+      this.programSpecRepo.getProgramSpec(program),
+    ]);
+
+    // Group spec entries by offset (ascending) to map workoutNum → week.
+    // workoutNum 1 = first offset group, workoutNum 2 = second, etc.
+    const offsetsSorted = [...new Set(spec.map((s) => s.offset))].sort(
+      (a, b) => a - b,
+    );
+    const offsetForWorkout = offsetsSorted[workoutNum - 1];
+    const week =
+      offsetForWorkout !== undefined
+        ? (spec.find((s) => s.offset === offsetForWorkout)?.week ?? 1)
+        : 1;
+
     const records = await this.workoutRepo.getWorkout(
       program,
       dashboard.cycleNum,
       workoutNum,
     );
-    return toWorkoutResponse(program, dashboard.cycleNum, workoutNum, records);
+    return toWorkoutResponse(program, dashboard.cycleNum, workoutNum, week, records);
   }
 }

--- a/apps/web/app/cycle/[cycleNum]/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/page.tsx
@@ -43,14 +43,12 @@ export default async function CycleDashboardPage({
   const today = new Date().toISOString().slice(0, 10);
   const maxMap = new Map(maxes.map((m) => [m.lift, m.weight]));
 
-  // Derive week numbers from workout offsets. Assumes 2 workouts per week —
-  // a workouts-per-week value from the program config would generalize this.
-  const weekNums = [...new Set(workoutDays.map((w) => Math.ceil(w.workoutNum / 2)))];
+  const weekNums = [...new Set(workoutDays.map((w) => w.week))];
 
   const weeks: WeekRow[] = weekNums.map((week) => ({
     week,
     workouts: workoutDays
-      .filter((w) => Math.ceil(w.workoutNum / 2) === week)
+      .filter((w) => w.week === week)
       .map((w): WorkoutCell => {
         const response = workoutResponseMap.get(w.workoutNum);
         const logged = response != null && response.lifts.length > 0;

--- a/apps/web/lib/__tests__/workoutPlan.test.ts
+++ b/apps/web/lib/__tests__/workoutPlan.test.ts
@@ -4,6 +4,7 @@ import { buildWorkoutDays, computePlannedSets } from '../workoutPlan';
 const makeSpec = (
   overrides: Partial<LiftingProgramSpecResponse>,
 ): LiftingProgramSpecResponse => ({
+  week: 1,
   lift: 'Squat',
   order: 1,
   offset: 0,
@@ -32,6 +33,19 @@ describe('buildWorkoutDays', () => {
     expect(days[0]?.lifts.map((l) => l.lift)).toEqual(['Squat', 'Bench Press']);
     expect(days[1]?.workoutNum).toBe(2);
     expect(days[1]?.lifts.map((l) => l.lift)).toEqual(['Deadlift']);
+  });
+
+  it('sources week from the first lift in each offset group', () => {
+    const specs: LiftingProgramSpecResponse[] = [
+      makeSpec({ offset: 0, week: 1 }),
+      makeSpec({ lift: 'Bench Press', offset: 0, week: 1 }),
+      makeSpec({ lift: 'Deadlift', offset: 7, week: 2 }),
+    ];
+
+    const days = buildWorkoutDays(specs, '2026-01-05');
+
+    expect(days[0]?.week).toBe(1);
+    expect(days[1]?.week).toBe(2);
   });
 
   it('computes workout dates by adding offset days to cycleStartDate in UTC', () => {

--- a/apps/web/lib/workoutPlan.ts
+++ b/apps/web/lib/workoutPlan.ts
@@ -15,6 +15,7 @@ export interface PlannedSet {
 
 export interface WorkoutDay {
   workoutNum: number;
+  week: number;
   date: string; // YYYY-MM-DD
   lifts: LiftingProgramSpecResponse[];
 }
@@ -58,11 +59,15 @@ export function buildWorkoutDays(
 
   return Array.from(byOffset.keys())
     .sort((a, b) => a - b)
-    .map((offset, i) => ({
-      workoutNum: i + 1,
-      date: addDaysUTC(startDate, offset).toISOString().slice(0, 10),
-      lifts: (byOffset.get(offset) ?? []).sort((a, b) => a.order - b.order),
-    }));
+    .map((offset, i) => {
+      const lifts = (byOffset.get(offset) ?? []).sort((a, b) => a.order - b.order);
+      return {
+        workoutNum: i + 1,
+        week: lifts[0]?.week ?? 1,
+        date: addDaysUTC(startDate, offset).toISOString().slice(0, 10),
+        lifts,
+      };
+    });
 }
 
 /**

--- a/apps/web/tsconfig.spec.json
+++ b/apps/web/tsconfig.spec.json
@@ -7,7 +7,9 @@
     "paths": {
       "@/*": ["./*"],
       "@src/core": ["../../packages/core/src/index.ts"],
-      "@src/core/*": ["../../packages/core/src/*"]
+      "@src/core/*": ["../../packages/core/src/*"],
+      "@lifting-logbook/types": ["../../packages/types/src/index.ts"],
+      "@lifting-logbook/core": ["../../packages/core/src/index.ts"]
     }
   },
   "include": ["**/*.ts", "**/*.tsx"],

--- a/packages/core/src/constants/schema.ts
+++ b/packages/core/src/constants/schema.ts
@@ -27,6 +27,7 @@ export const LIFTING_PROGRAM_SPEC_HEADER_MAP: Record<
   string,
   { key: string; type: string }
 > = {
+  Week: { key: "week", type: "number" },
   Offset: { key: "offset", type: "number" },
   Lift: { key: "lift", type: "string" },
   Increment: { key: "increment", type: "number" },

--- a/packages/core/src/models/LiftingProgramSpec.ts
+++ b/packages/core/src/models/LiftingProgramSpec.ts
@@ -2,6 +2,7 @@ import { LiftName } from '@lifting-logbook/types';
 
 // RptProgramSpec interface for RPT program specification objects
 export interface LiftingProgramSpec {
+  week: number;
   offset: number;
   lift: LiftName;
   increment: number;

--- a/packages/core/tests/core/utils/mapper/mapLiftingProgramSpec.test.ts
+++ b/packages/core/tests/core/utils/mapper/mapLiftingProgramSpec.test.ts
@@ -7,6 +7,7 @@ import {
 
 const specs: LiftingProgramSpec[] = [
   {
+    week: 1,
     offset: 0,
     lift: "Squat",
     increment: 5,
@@ -19,6 +20,7 @@ const specs: LiftingProgramSpec[] = [
     activation: "None",
   },
   {
+    week: 1,
     offset: 0,
     lift: "Bench",
     increment: 2.5,
@@ -37,8 +39,8 @@ describe("mapLiftingProgramSpec", () => {
     const headers = Object.keys(LIFTING_PROGRAM_SPEC_HEADER_MAP);
     const result = mapLiftingProgramSpec(specs);
     expect(result[0]).toEqual(headers);
-    expect(result[1]).toEqual([0, "Squat", 5, 1, 3, 5, "TRUE", "40,50,60", 0, "None"]);
-    expect(result[2]).toEqual([0, "Bench", 2.5, 2, 3, 5, "FALSE", "40,50,60", 0, "None"]);
+    expect(result[1]).toEqual([1, 0, "Squat", 5, 1, 3, 5, "TRUE", "40,50,60", 0, "None"]);
+    expect(result[2]).toEqual([1, 0, "Bench", 2.5, 2, 3, 5, "FALSE", "40,50,60", 0, "None"]);
   });
 
   it("maps amrap boolean to string so parseLiftingProgramSpec can round-trip it", () => {

--- a/packages/core/tests/fixtures/rpt_program_spec.csv
+++ b/packages/core/tests/fixtures/rpt_program_spec.csv
@@ -1,14 +1,14 @@
-Offset,Lift,Increment,Order,Sets,Reps,AMRAP?,Warm-Up %,WT Decrement %,Activation
-0,Bench P.,2.5,1,3,8,TRUE,".4,.6,.8",0.05,Band Flye
-0,BB Row,2.5,2,3,8,TRUE,".4,.6,.8",0.05,S. Pulldown
-0,Calf Raise,2.5,3,2,10,TRUE,0.6,0.1,N/A
-0,C. Lat Raise,1.25,4,3,10,TRUE,0.6,0.1,N/A
-0,OH Press-HV,2.5,5,5,12,TRUE,0.6,0.1,N/A
-2,Squat,2.5,1,3,10,TRUE,".4,.6,.8",0.1,KB Swing
-2,Chin-up,2.5,2,3,8,TRUE,".4,.6,.8",0.05,S. Pulldown
-2,Dip,2.5,3,2,10,TRUE,0.6,0.1,OHT Extension
-2,Upright Row,2.5,4,3,12,TRUE,0.6,0.1,N/A
-4,Deadlift,2.5,1,2,6,TRUE,".4,.6,.8",0.1,KB Swing
-4,OH Press,1.25,2,3,8,TRUE,".4,.6,.8",0.05,Lat Raise
-4,CBL Curls,1.25,3,2,10,TRUE,0.6,0.1,N/A
-4,Face Pulls,1.25,4,2,10,TRUE,0.6,0.1,N/A
+Week,Offset,Lift,Increment,Order,Sets,Reps,AMRAP?,Warm-Up %,WT Decrement %,Activation
+1,0,Bench P.,2.5,1,3,8,TRUE,".4,.6,.8",0.05,Band Flye
+1,0,BB Row,2.5,2,3,8,TRUE,".4,.6,.8",0.05,S. Pulldown
+1,0,Calf Raise,2.5,3,2,10,TRUE,0.6,0.1,N/A
+1,0,C. Lat Raise,1.25,4,3,10,TRUE,0.6,0.1,N/A
+1,0,OH Press-HV,2.5,5,5,12,TRUE,0.6,0.1,N/A
+1,2,Squat,2.5,1,3,10,TRUE,".4,.6,.8",0.1,KB Swing
+1,2,Chin-up,2.5,2,3,8,TRUE,".4,.6,.8",0.05,S. Pulldown
+1,2,Dip,2.5,3,2,10,TRUE,0.6,0.1,OHT Extension
+1,2,Upright Row,2.5,4,3,12,TRUE,0.6,0.1,N/A
+1,4,Deadlift,2.5,1,2,6,TRUE,".4,.6,.8",0.1,KB Swing
+1,4,OH Press,1.25,2,3,8,TRUE,".4,.6,.8",0.05,Lat Raise
+1,4,CBL Curls,1.25,3,2,10,TRUE,0.6,0.1,N/A
+1,4,Face Pulls,1.25,4,2,10,TRUE,0.6,0.1,N/A

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -117,6 +117,7 @@ export interface CycleDashboardResponse {
 
 /** Per-lift specification within a lifting program (e.g., 5/3/1). */
 export interface LiftingProgramSpecResponse {
+  week: number;
   lift: LiftName;
   order: number;
   offset: number;

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -53,8 +53,8 @@ export interface BodyWeightEntry {
   unit: WeightUnit;
 }
 
-/** Week number within a training cycle (1-based, 4-week cycles). */
-export type WeekNumber = 1 | 2 | 3 | 4;
+/** Week number within a training cycle (1-based). */
+export type WeekNumber = number;
 
 /**
  * Cycle number within a training program.

--- a/tests/fixtures/rpt_program_spec.csv
+++ b/tests/fixtures/rpt_program_spec.csv
@@ -1,14 +1,14 @@
-Offset,Lift,Increment,Order,Sets,Reps,AMRAP?,Warm-Up %,WT Decrement %,Activation
-0,Bench P.,2.5,1,3,8,TRUE,".4,.6,.8",0.05,Band Flye
-0,BB Row,2.5,2,3,8,TRUE,".4,.6,.8",0.05,S. Pulldown
-0,Calf Raise,2.5,3,2,10,TRUE,0.6,0.1,N/A
-0,C. Lat Raise,1.25,4,3,10,TRUE,0.6,0.1,N/A
-0,OH Press-HV,2.5,5,5,12,TRUE,0.6,0.1,N/A
-2,Squat,2.5,1,3,10,TRUE,".4,.6,.8",0.1,KB Swing
-2,Chin-up,2.5,2,3,8,TRUE,".4,.6,.8",0.05,S. Pulldown
-2,Dip,2.5,3,2,10,TRUE,0.6,0.1,OHT Extension
-2,Upright Row,2.5,4,3,12,TRUE,0.6,0.1,N/A
-4,Deadlift,2.5,1,2,6,TRUE,".4,.6,.8",0.1,KB Swing
-4,OH Press,1.25,2,3,8,TRUE,".4,.6,.8",0.05,Lat Raise
-4,CBL Curls,1.25,3,2,10,TRUE,0.6,0.1,N/A
-4,Face Pulls,1.25,4,2,10,TRUE,0.6,0.1,N/A
+Week,Offset,Lift,Increment,Order,Sets,Reps,AMRAP?,Warm-Up %,WT Decrement %,Activation
+1,0,Bench P.,2.5,1,3,8,TRUE,".4,.6,.8",0.05,Band Flye
+1,0,BB Row,2.5,2,3,8,TRUE,".4,.6,.8",0.05,S. Pulldown
+1,0,Calf Raise,2.5,3,2,10,TRUE,0.6,0.1,N/A
+1,0,C. Lat Raise,1.25,4,3,10,TRUE,0.6,0.1,N/A
+1,0,OH Press-HV,2.5,5,5,12,TRUE,0.6,0.1,N/A
+1,2,Squat,2.5,1,3,10,TRUE,".4,.6,.8",0.1,KB Swing
+1,2,Chin-up,2.5,2,3,8,TRUE,".4,.6,.8",0.05,S. Pulldown
+1,2,Dip,2.5,3,2,10,TRUE,0.6,0.1,OHT Extension
+1,2,Upright Row,2.5,4,3,12,TRUE,0.6,0.1,N/A
+1,4,Deadlift,2.5,1,2,6,TRUE,".4,.6,.8",0.1,KB Swing
+1,4,OH Press,1.25,2,3,8,TRUE,".4,.6,.8",0.05,Lat Raise
+1,4,CBL Curls,1.25,3,2,10,TRUE,0.6,0.1,N/A
+1,4,Face Pulls,1.25,4,2,10,TRUE,0.6,0.1,N/A


### PR DESCRIPTION
## Summary

- Adds a `Week` column to the program spec CSV so week membership is declared in data, not derived at runtime
- Removes `WeekNumber = 1|2|3|4` type constraint — week is now `number`
- Removes `MAX_WORKOUT_NUM = 8` API limit — workoutNum is validated as any positive integer
- Replaces `Math.ceil(workoutNum / 2)` in the API mapper and web dashboard page with a lookup from the spec's `week` field

## Acceptance Criteria

- [x] `WeekNumber` is `number` (not a `1|2|3|4` union)
- [x] `MAX_WORKOUT_NUM = 8` is removed from the API validator
- [x] `LiftingProgramSpecResponse` includes `week: number`
- [x] Program spec CSVs have a `Week` column
- [x] `Math.ceil(workoutNum / 2)` is eliminated from both `mappers.ts` and `page.tsx`
- [x] `WorkoutsController` sources week from spec instead of deriving it
- [x] Week grouping in the cycle dashboard page uses `w.week` from spec

## Test plan

- All 9 API test suites pass (33 tests + 1 skipped)
- All 10 web workout-plan tests pass including new `sources week from the first lift in each offset group` test
- `tsconfig.spec.json` path fix ensures ts-jest resolves `@lifting-logbook/types` from source (consistent with `moduleNameMapper`)

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)