### PR TITLE
[feat] Stub StrengthGoal domain types and evaluateStrengthTier utility

### DIFF
--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -1,4 +1,5 @@
 export * from './bodyWeight';
 export * from './dashboard';
 export * from './maxes';
+export * from './strengthGoals';
 export * from './workout';

--- a/packages/core/src/services/strengthGoals.ts
+++ b/packages/core/src/services/strengthGoals.ts
@@ -1,0 +1,31 @@
+import type { StrengthStandard } from '@lifting-logbook/types';
+
+export const DEFAULT_STRENGTH_STANDARDS: readonly StrengthStandard[] = [
+  { liftId: 'back-squat',      tier: 'intermediate', multiplier: 1.6 },
+  { liftId: 'back-squat',      tier: 'advanced',     multiplier: 2.0 },
+  { liftId: 'back-squat',      tier: 'elite',        multiplier: 2.4 },
+  { liftId: 'bench-press',     tier: 'intermediate', multiplier: 1.2 },
+  { liftId: 'bench-press',     tier: 'advanced',     multiplier: 1.5 },
+  { liftId: 'bench-press',     tier: 'elite',        multiplier: 1.8 },
+  { liftId: 'chin-up',         tier: 'intermediate', multiplier: 1.2 },
+  { liftId: 'chin-up',         tier: 'advanced',     multiplier: 1.5 },
+  { liftId: 'chin-up',         tier: 'elite',        multiplier: 1.8 },
+  { liftId: 'deadlift',        tier: 'intermediate', multiplier: 2.0 },
+  { liftId: 'deadlift',        tier: 'advanced',     multiplier: 2.5 },
+  { liftId: 'deadlift',        tier: 'elite',        multiplier: 3.0 },
+  { liftId: 'overhead-press',  tier: 'intermediate', multiplier: 0.75 },
+  { liftId: 'overhead-press',  tier: 'advanced',     multiplier: 1.0 },
+  { liftId: 'overhead-press',  tier: 'elite',        multiplier: 1.25 },
+];
+
+export function evaluateStrengthTier(
+  trainingMax: number,
+  bodyweight: number,
+  multiplier: number,
+): { achieved: boolean; progressRatio: number } {
+  const threshold = bodyweight * multiplier;
+  return {
+    achieved: trainingMax >= threshold,
+    progressRatio: threshold > 0 ? trainingMax / threshold : 0,
+  };
+}

--- a/packages/core/tests/core/services/strengthGoals.test.ts
+++ b/packages/core/tests/core/services/strengthGoals.test.ts
@@ -1,0 +1,86 @@
+import {
+  DEFAULT_STRENGTH_STANDARDS,
+  evaluateStrengthTier,
+} from '@src/core';
+
+describe('evaluateStrengthTier', () => {
+  it('returns achieved=true when trainingMax meets threshold', () => {
+    const result = evaluateStrengthTier(160, 100, 1.6);
+    expect(result.achieved).toBe(true);
+  });
+
+  it('returns achieved=true when trainingMax exceeds threshold', () => {
+    const result = evaluateStrengthTier(200, 100, 1.6);
+    expect(result.achieved).toBe(true);
+  });
+
+  it('returns achieved=false when trainingMax is below threshold', () => {
+    const result = evaluateStrengthTier(150, 100, 1.6);
+    expect(result.achieved).toBe(false);
+  });
+
+  it('returns correct progressRatio below threshold', () => {
+    const result = evaluateStrengthTier(80, 100, 1.6);
+    expect(result.progressRatio).toBeCloseTo(0.5);
+  });
+
+  it('returns progressRatio of 1.0 exactly at threshold', () => {
+    const result = evaluateStrengthTier(160, 100, 1.6);
+    expect(result.progressRatio).toBeCloseTo(1.0);
+  });
+
+  it('returns progressRatio above 1.0 when threshold is exceeded', () => {
+    const result = evaluateStrengthTier(200, 100, 1.6);
+    expect(result.progressRatio).toBeGreaterThan(1.0);
+  });
+
+  it('multiplierOverride scenario: user override of 1.4 instead of system 1.6', () => {
+    const result = evaluateStrengthTier(150, 100, 1.4);
+    expect(result.achieved).toBe(true);
+    expect(result.progressRatio).toBeCloseTo(150 / 140);
+  });
+
+  it('returns progressRatio of 0 when bodyweight is 0', () => {
+    const result = evaluateStrengthTier(100, 0, 1.6);
+    expect(result.progressRatio).toBe(0);
+  });
+});
+
+describe('DEFAULT_STRENGTH_STANDARDS', () => {
+  const standardFor = (liftId: string, tier: string) =>
+    DEFAULT_STRENGTH_STANDARDS.find((s) => s.liftId === liftId && s.tier === tier);
+
+  it('covers all five lifts across all three tiers (15 entries)', () => {
+    expect(DEFAULT_STRENGTH_STANDARDS).toHaveLength(15);
+  });
+
+  it('has correct squat multipliers', () => {
+    expect(standardFor('back-squat', 'intermediate')?.multiplier).toBe(1.6);
+    expect(standardFor('back-squat', 'advanced')?.multiplier).toBe(2.0);
+    expect(standardFor('back-squat', 'elite')?.multiplier).toBe(2.4);
+  });
+
+  it('has correct bench press multipliers', () => {
+    expect(standardFor('bench-press', 'intermediate')?.multiplier).toBe(1.2);
+    expect(standardFor('bench-press', 'advanced')?.multiplier).toBe(1.5);
+    expect(standardFor('bench-press', 'elite')?.multiplier).toBe(1.8);
+  });
+
+  it('has correct chin-up multipliers', () => {
+    expect(standardFor('chin-up', 'intermediate')?.multiplier).toBe(1.2);
+    expect(standardFor('chin-up', 'advanced')?.multiplier).toBe(1.5);
+    expect(standardFor('chin-up', 'elite')?.multiplier).toBe(1.8);
+  });
+
+  it('has correct deadlift multipliers', () => {
+    expect(standardFor('deadlift', 'intermediate')?.multiplier).toBe(2.0);
+    expect(standardFor('deadlift', 'advanced')?.multiplier).toBe(2.5);
+    expect(standardFor('deadlift', 'elite')?.multiplier).toBe(3.0);
+  });
+
+  it('has correct overhead press multipliers', () => {
+    expect(standardFor('overhead-press', 'intermediate')?.multiplier).toBe(0.75);
+    expect(standardFor('overhead-press', 'advanced')?.multiplier).toBe(1.0);
+    expect(standardFor('overhead-press', 'elite')?.multiplier).toBe(1.25);
+  });
+});

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -61,3 +61,24 @@ export type WeekNumber = number;
  * 1-indexed: the first cycle is cycle 1.
  */
 export type CycleNumber = number;
+
+/** Strength classification tier relative to bodyweight-based standards. */
+export type StrengthTier = 'intermediate' | 'advanced' | 'elite';
+
+/** A bodyweight-multiplier standard for a specific lift and tier. */
+export interface StrengthStandard {
+  liftId: string;
+  tier: StrengthTier;
+  multiplier: number;
+}
+
+/** A per-user strength goal for a specific lift and tier. */
+export interface StrengthGoal {
+  userId: string;
+  liftId: string;
+  tier: StrengthTier;
+  /** Overrides the system-default multiplier when set. */
+  multiplierOverride?: number;
+  targetDate?: Date;
+  observedDate?: Date;
+}


### PR DESCRIPTION
## Summary

- Adds `StrengthTier`, `StrengthStandard`, and `StrengthGoal` types to `packages/types`
- Adds `DEFAULT_STRENGTH_STANDARDS` catalog and `evaluateStrengthTier` utility to `packages/core`
- 14 unit tests covering tier evaluation, progress ratio, multiplier override, and all five default lift standards

## Acceptance Criteria

- [x] `packages/types` exports `StrengthTier`, `StrengthStandard`, and `StrengthGoal`
- [x] `packages/core` exports system-default standards for squat, bench, chin-up, deadlift, and OHP with correct multipliers
- [x] `packages/core` exports `evaluateStrengthTier(trainingMax, bodyweight, multiplier)` → `{ achieved: boolean; progressRatio: number }`
- [x] `StrengthGoal` supports `targetDate?` and `observedDate?`
- [x] User can override system multiplier via `StrengthGoal.multiplierOverride`
- [x] Strict TypeScript compilation passes in `packages/types` and `packages/core`
- [x] Unit tests cover tier evaluation, progress ratio, multiplier override, and all five default lift standards

Closes #111

---
_Generated by [Claude Code](https://claude.ai/code/session_012JEK216NoRnyLguEFKtE4r)_