### PR TITLE
[fix] Remove duplicate week field in LiftingProgramSpec

### DIFF
--- a/packages/core/src/models/LiftingProgramSpec.ts
+++ b/packages/core/src/models/LiftingProgramSpec.ts
@@ -4,7 +4,6 @@ import { LiftName } from '@lifting-logbook/types';
 export interface LiftingProgramSpec {
   week: number;
   offset: number;
-  week?: number;
   lift: LiftName;
   increment: number;
   order: number;


### PR DESCRIPTION
## Summary

- Removes the stray `week?: number` field that PR #122 accidentally added to `LiftingProgramSpec` alongside the required `week: number` introduced by PR #117
- Without this fix the `@lifting-logbook/web` test suite fails to run (ts-jest emits TS2300/TS2687/TS2717 on the interface)

## Acceptance Criteria

- [x] `packages/core/src/models/LiftingProgramSpec` has exactly one `week` declaration: `week: number`
- [x] `npm test` passes across all workspaces

## Test Results

`npm test` — 10 tasks successful, 43 tests pass (1 skipped), 0 failures.

Closes #125