### PR TITLE
[chore] Narrow LiftingProgramSpec.week to WeekNumber

### DIFF
--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -10,6 +10,7 @@ import {
   LiftingProgramSpecResponse,
   SetResponse,
   TrainingMaxResponse,
+  WeekNumber,
   WorkoutLiftResponse,
   WorkoutResponse,
 } from '@lifting-logbook/types';
@@ -83,7 +84,7 @@ export const isValidWorkoutNum = (n: number): boolean =>
 export const weekForWorkoutNum = (
   spec: LiftingProgramSpec[],
   workoutNum: number,
-): number | undefined => {
+): WeekNumber | undefined => {
   const offsets = [...new Set(spec.map((s) => s.offset))].sort((a, b) => a - b);
   const offset = offsets[workoutNum - 1];
   return offset !== undefined
@@ -100,7 +101,7 @@ export const toWorkoutResponse = (
   program: string,
   cycleNum: number,
   workoutNum: number,
-  week: number,
+  week: WeekNumber,
   records: LiftRecord[],
 ): WorkoutResponse => {
   const liftMap = new Map<string, SetResponse[]>();

--- a/packages/core/src/models/LiftingProgramSpec.ts
+++ b/packages/core/src/models/LiftingProgramSpec.ts
@@ -1,8 +1,8 @@
-import { LiftName } from '@lifting-logbook/types';
+import { LiftName, WeekNumber } from '@lifting-logbook/types';
 
 // RptProgramSpec interface for RPT program specification objects
 export interface LiftingProgramSpec {
-  week: number;
+  week: WeekNumber;
   offset: number;
   lift: LiftName;
   increment: number;


### PR DESCRIPTION
## Summary

- Narrows `LiftingProgramSpec.week` from `number` to `WeekNumber` (imported from `@lifting-logbook/types`)
- Narrows `weekForWorkoutNum` return type from `number | undefined` to `WeekNumber | undefined`
- Narrows `toWorkoutResponse` `week` parameter from `number` to `WeekNumber`

No runtime behaviour changes — `WeekNumber` is a structural alias for `number`, so any `number` remains assignable. The change is semantic: it documents intent at the type level and aligns the domain model with the API layer's existing use of `WeekNumber`.

## Acceptance Criteria

- [x] `LiftingProgramSpec.week` typed as `WeekNumber` (imported from `@lifting-logbook/types`)
- [x] Cast `week as WeekNumber` was already absent from `WorkoutsController` after #122 — no change needed
- [x] All existing tests pass; no changes to parsers, fixtures, or adapters

## Test Results

```
Test Suites: 10 passed, 10 total
Tests:       1 skipped, 42 passed, 43 total
```

Closes #124
