### PR TITLE
[feat] Initial training max discovery

### DIFF
--- a/apps/api/src/adapters/in-memory/fixtures.ts
+++ b/apps/api/src/adapters/in-memory/fixtures.ts
@@ -21,6 +21,7 @@ export const seedCycleDashboard = (): CycleDashboard => ({
   cycleDate: new Date('2026-04-20T00:00:00.000Z'),
   sheetName: '',
   cycleStartWeekday: Weekday.Monday,
+  currentWeekType: 'training',
 });
 
 export const seedTrainingMaxes = (): TrainingMax[] => [

--- a/apps/api/src/programs/cycle-dashboard.controller.spec.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.spec.ts
@@ -28,6 +28,7 @@ describe('CycleDashboardController', () => {
       cycleDate: new Date('2026-04-20T00:00:00.000Z'),
       sheetName: '',
       cycleStartWeekday: Weekday.Monday,
+      currentWeekType: 'training',
     });
 
     const result = await controller.getCurrentCycle('5-3-1');
@@ -38,6 +39,7 @@ describe('CycleDashboardController', () => {
       cycleNum: 2,
       cycleStartDate: '2026-04-20',
       weeks: [],
+      currentWeekType: 'training',
     });
   });
 });

--- a/apps/api/src/programs/cycle-dashboard.controller.spec.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.spec.ts
@@ -1,39 +1,66 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { Weekday } from '@lifting-logbook/core';
 import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
-import { CYCLE_DASHBOARD_REPOSITORY } from '../ports/tokens';
+import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
+import { CYCLE_DASHBOARD_REPOSITORY, LIFTING_PROGRAM_SPEC_REPOSITORY } from '../ports/tokens';
 import { CycleDashboardController } from './cycle-dashboard.controller';
+
+const stubDashboard = (overrides: Partial<{ currentWeekType: 'training' | 'test' | 'deload' }> = {}) => ({
+  program: '5-3-1',
+  cycleUnit: 'week' as const,
+  cycleNum: 2,
+  cycleDate: new Date('2026-04-20T00:00:00.000Z'),
+  sheetName: '',
+  cycleStartWeekday: Weekday.Monday,
+  currentWeekType: 'training' as const,
+  ...overrides,
+});
+
+const stubSpec = (weekType: 'training' | 'test' | 'deload' = 'training') => [{
+  week: 1,
+  offset: 0,
+  lift: 'Squat' as const,
+  increment: 5,
+  order: 1,
+  sets: 3,
+  reps: 5,
+  amrap: false,
+  warmUpPct: '40,50,60',
+  wtDecrementPct: 0,
+  activation: 'None',
+  weekType,
+}];
 
 describe('CycleDashboardController', () => {
   let controller: CycleDashboardController;
   let repo: jest.Mocked<ICycleDashboardRepository>;
+  let specRepo: jest.Mocked<ILiftingProgramSpecRepository>;
 
   beforeEach(async () => {
     repo = {
       getCycleDashboard: jest.fn(),
       saveCycleDashboard: jest.fn(),
     };
+    specRepo = { getProgramSpec: jest.fn() };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CycleDashboardController],
-      providers: [{ provide: CYCLE_DASHBOARD_REPOSITORY, useValue: repo }],
+      providers: [
+        { provide: CYCLE_DASHBOARD_REPOSITORY, useValue: repo },
+        { provide: LIFTING_PROGRAM_SPEC_REPOSITORY, useValue: specRepo },
+      ],
     }).compile();
     controller = module.get(CycleDashboardController);
   });
 
-  it('GET /programs/:program/cycles/current returns mapped dashboard', async () => {
-    repo.getCycleDashboard.mockResolvedValue({
-      program: '5-3-1',
-      cycleUnit: 'week',
-      cycleNum: 2,
-      cycleDate: new Date('2026-04-20T00:00:00.000Z'),
-      sheetName: '',
-      cycleStartWeekday: Weekday.Monday,
-      currentWeekType: 'training',
-    });
+  it('GET /programs/:program/cycles/current returns mapped dashboard with derived weekType', async () => {
+    repo.getCycleDashboard.mockResolvedValue(stubDashboard());
+    specRepo.getProgramSpec.mockResolvedValue(stubSpec('training'));
 
     const result = await controller.getCurrentCycle('5-3-1');
 
     expect(repo.getCycleDashboard).toHaveBeenCalledWith('5-3-1');
+    expect(specRepo.getProgramSpec).toHaveBeenCalledWith('5-3-1');
     expect(result).toEqual({
       program: '5-3-1',
       cycleNum: 2,
@@ -41,5 +68,15 @@ describe('CycleDashboardController', () => {
       weeks: [],
       currentWeekType: 'training',
     });
+  });
+
+  it('reflects test weekType when program spec contains a test week', async () => {
+    // Cycle started 0 days ago → week 1
+    repo.getCycleDashboard.mockResolvedValue(stubDashboard());
+    specRepo.getProgramSpec.mockResolvedValue(stubSpec('test'));
+
+    const result = await controller.getCurrentCycle('5-3-1');
+
+    expect(result.currentWeekType).toBe('test');
   });
 });

--- a/apps/api/src/programs/cycle-dashboard.controller.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Get, Inject, Param } from '@nestjs/common';
 import { CycleDashboardResponse } from '@lifting-logbook/types';
+import { weekTypeForDate } from '@lifting-logbook/core';
 import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
-import { CYCLE_DASHBOARD_REPOSITORY } from '../ports/tokens';
+import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
+import { CYCLE_DASHBOARD_REPOSITORY, LIFTING_PROGRAM_SPEC_REPOSITORY } from '../ports/tokens';
 import { toCycleDashboardResponse } from './mappers';
 
 @Controller('programs/:program')
@@ -9,13 +11,19 @@ export class CycleDashboardController {
   constructor(
     @Inject(CYCLE_DASHBOARD_REPOSITORY)
     private readonly cycleDashboardRepo: ICycleDashboardRepository,
+    @Inject(LIFTING_PROGRAM_SPEC_REPOSITORY)
+    private readonly programSpecRepo: ILiftingProgramSpecRepository,
   ) {}
 
   @Get('cycles/current')
   async getCurrentCycle(
     @Param('program') program: string,
   ): Promise<CycleDashboardResponse> {
-    const dashboard = await this.cycleDashboardRepo.getCycleDashboard(program);
+    const [dashboard, programSpec] = await Promise.all([
+      this.cycleDashboardRepo.getCycleDashboard(program),
+      this.programSpecRepo.getProgramSpec(program),
+    ]);
+    dashboard.currentWeekType = weekTypeForDate(dashboard.cycleDate, programSpec);
     return toCycleDashboardResponse(dashboard);
   }
 }

--- a/apps/api/src/programs/cycle-generation.controller.spec.ts
+++ b/apps/api/src/programs/cycle-generation.controller.spec.ts
@@ -12,6 +12,7 @@ const stubCycleDashboard = () => ({
   cycleDate: new Date('2026-04-27T00:00:00.000Z'),
   sheetName: '5-3-1_Cycle_2_20260427',
   cycleStartWeekday: Weekday.Monday,
+  currentWeekType: 'training' as const,
 });
 
 describe('CycleGenerationController', () => {
@@ -44,6 +45,7 @@ describe('CycleGenerationController', () => {
         cycleNum: 2,
         cycleStartDate: '2026-04-27',
         weeks: [],
+        currentWeekType: 'training',
       });
     });
 

--- a/apps/api/src/programs/cycle-generation.service.spec.ts
+++ b/apps/api/src/programs/cycle-generation.service.spec.ts
@@ -22,6 +22,7 @@ const stubDashboard = () => ({
   cycleDate: new Date('2026-04-20T00:00:00.000Z'),
   sheetName: '',
   cycleStartWeekday: Weekday.Monday,
+  currentWeekType: 'training' as const,
 });
 
 const stubProgramSpec = () => [

--- a/apps/api/src/programs/lift-records.controller.spec.ts
+++ b/apps/api/src/programs/lift-records.controller.spec.ts
@@ -40,6 +40,7 @@ describe('LiftRecordsController', () => {
       cycleDate: new Date('2026-04-20T00:00:00.000Z'),
       sheetName: '',
       cycleStartWeekday: Weekday.Monday,
+      currentWeekType: 'training' as const,
     });
     liftRecordRepo.getLiftRecords.mockResolvedValue([
       {

--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -69,6 +69,7 @@ export const toCycleDashboardResponse = (
   cycleNum: d.cycleNum,
   cycleStartDate: isoDate(d.cycleDate),
   weeks: [],
+  currentWeekType: d.currentWeekType,
 });
 
 export const isValidWorkoutNum = (n: number): boolean =>

--- a/apps/api/src/programs/workouts.controller.spec.ts
+++ b/apps/api/src/programs/workouts.controller.spec.ts
@@ -43,6 +43,7 @@ describe('WorkoutsController', () => {
       cycleDate: new Date('2026-04-20T00:00:00.000Z'),
       sheetName: '',
       cycleStartWeekday: Weekday.Monday,
+      currentWeekType: 'training' as const,
     });
     specRepo.getProgramSpec.mockResolvedValue([
       {
@@ -119,6 +120,7 @@ describe('WorkoutsController', () => {
       cycleDate: new Date('2026-04-20T00:00:00.000Z'),
       sheetName: '',
       cycleStartWeekday: Weekday.Monday,
+      currentWeekType: 'training' as const,
     });
     workoutRepo.getWorkout.mockResolvedValue([]);
 
@@ -141,6 +143,7 @@ describe('WorkoutsController', () => {
       cycleDate: new Date('2026-04-20T00:00:00.000Z'),
       sheetName: '',
       cycleStartWeekday: Weekday.Monday,
+      currentWeekType: 'training' as const,
     });
     specRepo.getProgramSpec.mockResolvedValue([
       {

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -6,5 +6,6 @@ module.exports = {
   },
   moduleNameMapper: {
     '^@src/core(.*)$': '<rootDir>/src$1',
+    '^@lifting-logbook/types$': '<rootDir>/../types/src/index.ts',
   },
 };

--- a/packages/core/src/constants/schema.ts
+++ b/packages/core/src/constants/schema.ts
@@ -38,6 +38,7 @@ export const LIFTING_PROGRAM_SPEC_HEADER_MAP: Record<
   "Warm-Up %": { key: "warmUpPct", type: "string" },
   "WT Decrement %": { key: "wtDecrementPct", type: "number" },
   Activation: { key: "activation", type: "string" },
+  "Week Type": { key: "weekType", type: "string" },
 };
 
 export const WEEKDAY_MAP: Record<string, number> = {

--- a/packages/core/src/models/CycleDashboard.ts
+++ b/packages/core/src/models/CycleDashboard.ts
@@ -1,3 +1,5 @@
+import { WeekType } from '@lifting-logbook/types';
+
 // DashboardCycle model for dashboard cycle records
 export enum Weekday {
   Sunday = "Sunday",
@@ -16,4 +18,5 @@ export interface CycleDashboard {
   cycleDate: Date;
   sheetName: string;
   cycleStartWeekday: Weekday;
+  currentWeekType: WeekType;
 }

--- a/packages/core/src/models/LiftingProgramSpec.ts
+++ b/packages/core/src/models/LiftingProgramSpec.ts
@@ -1,4 +1,4 @@
-import { LiftName, WeekNumber } from '@lifting-logbook/types';
+import { LiftName, WeekNumber, WeekType } from '@lifting-logbook/types';
 
 // RptProgramSpec interface for RPT program specification objects
 export interface LiftingProgramSpec {
@@ -13,4 +13,5 @@ export interface LiftingProgramSpec {
   warmUpPct: string;
   wtDecrementPct: number;
   activation: string;
+  weekType?: WeekType;
 }

--- a/packages/core/src/services/maxes/estimateTrainingMax.ts
+++ b/packages/core/src/services/maxes/estimateTrainingMax.ts
@@ -1,0 +1,15 @@
+/**
+ * Estimates a training max from a recent performance using the Brzycki formula.
+ * Valid rep range: 1–36 (formula asymptotes beyond that point).
+ * Result is rounded to the nearest 5 lbs.
+ *
+ * Reference: Brzycki, M. (1993). Strength Testing — Predicting a One-Rep Max
+ * from Reps-to-Fatigue. JOPERD 64(1):88–90.
+ */
+export function estimateTrainingMax(weight: number, reps: number): number {
+  if (reps < 1 || reps > 36) {
+    throw new RangeError(`reps must be between 1 and 36, got ${reps}`);
+  }
+  const oneRepMax = weight / (1.0278 - 0.0278 * reps);
+  return Math.round(oneRepMax / 5) * 5;
+}

--- a/packages/core/src/services/maxes/estimateTrainingMax.ts
+++ b/packages/core/src/services/maxes/estimateTrainingMax.ts
@@ -1,11 +1,4 @@
-/**
- * Estimates a training max from a recent performance using the Brzycki formula.
- * Valid rep range: 1–36 (formula asymptotes beyond that point).
- * Result is rounded to the nearest 5 lbs.
- *
- * Reference: Brzycki, M. (1993). Strength Testing — Predicting a One-Rep Max
- * from Reps-to-Fatigue. JOPERD 64(1):88–90.
- */
+// Brzycki formula (1993) JOPERD 64(1):88-90; valid for reps 1-36 (asymptote beyond that).
 export function estimateTrainingMax(weight: number, reps: number): number {
   if (reps < 1 || reps > 36) {
     throw new RangeError(`reps must be between 1 and 36, got ${reps}`);

--- a/packages/core/src/services/maxes/index.ts
+++ b/packages/core/src/services/maxes/index.ts
@@ -1,1 +1,2 @@
+export * from './estimateTrainingMax';
 export * from './updateMaxes';

--- a/packages/core/src/services/maxes/updateMaxes.ts
+++ b/packages/core/src/services/maxes/updateMaxes.ts
@@ -1,67 +1,73 @@
 import { LiftingProgramSpec, LiftRecord, TrainingMax } from "@src/core/models";
+
+const ABNORMAL_KEYWORDS = ['injury', 'unusual stimulus', 'skip'];
+
+function isAbnormal(notes: string): boolean {
+  const lower = notes.toLowerCase();
+  return ABNORMAL_KEYWORDS.some((kw) => lower.includes(kw));
+}
+
 /**
  * Updates training maxes based on lift records and program spec.
- * For any lift record:
- *  - If set number is 1,
- *  - reps for set 1 > reps specified in program spec for the lift,
- *  - lift date is after the training max date for the lift,
- * Then set the training max weight to set 1's weight + increment from program spec.
- * Update the training max date to the lift date.
- * @param trainingMaxes - Array of current training maxes
- * @param liftRecords - Array of lift records
- * @param programSpec - Program specifications including reps and increments
+ *
+ * Behavior varies by weekType:
+ *  - 'training' (default): progression gate is set 1 reps >= spec.reps; new TM = weight + increment.
+ *  - 'test': uses final set (setNum === spec.sets); any non-zero reps without abnormal notes → new TM = weight (no increment).
+ *            Abnormal-notes fallback: walk backwards through sets until an unaffected set is found.
+ *  - 'deload': no progression — returns input maxes unchanged.
  */
 export function updateMaxes(
   programSpec: LiftingProgramSpec[],
   trainingMaxes: TrainingMax[],
   liftRecords: LiftRecord[],
 ): TrainingMax[] {
-  // Clone the training maxes to avoid mutating input
   const newMaxes: TrainingMax[] = trainingMaxes.map((tm) => ({ ...tm }));
-  // console.log(`New maxes initialized: ${JSON.stringify(newMaxes)}.`);
 
   liftRecords.forEach((record) => {
     const liftName = record.lift;
     const tmIndex = newMaxes.findIndex((tm) => tm.lift === liftName);
-    if (record.setNum !== 1) {
-      // console.log(
-      //   `Skipping lift record for ${liftName} set ${record.setNum} (not set 1).`,
-      // );
-      return;
-    }
-    // console.log(`Processing lift record for ${liftName} set 1.`);
-    if (tmIndex === -1)
-      throw new Error(`Training max for lift ${liftName} not found.`);
+
+    if (tmIndex === -1) throw new Error(`Training max for lift ${liftName} not found.`);
 
     const currentMax = newMaxes[tmIndex]!;
     const spec = programSpec.find((ps) => ps.lift === liftName);
     if (!spec) throw new Error(`Program spec for lift ${liftName} not found.`);
 
-    console.log(
-      `Current training max for ${liftName}: weight=${currentMax.weight}, date=${currentMax.dateUpdated}`,
-    );
-    console.log(
-      `Program spec for ${liftName}: reps=${spec.reps}, increment=${spec.increment}`,
-    );
-    console.log(
-      `Lift record for ${liftName}: set=${record.setNum} reps=${record.reps}, date=${record.date}, weight=${record.weight}`,
-    );
+    const weekType = spec.weekType ?? 'training';
 
-    // Check reps and date conditions
+    if (weekType === 'deload') return;
+
+    if (weekType === 'test') {
+      // Only process when we see the final set, then walk backwards to find the best
+      // unaffected set (in case the final set was flagged as abnormal).
+      if (record.setNum !== spec.sets) return;
+
+      // Gather all records for this lift in the same workout
+      const liftSetRecords = liftRecords
+        .filter((r) => r.lift === liftName && r.workoutNum === record.workoutNum)
+        .sort((a, b) => b.setNum - a.setNum); // descending: best attempt first
+
+      const candidate = liftSetRecords.find((r) => r.reps > 0 && !isAbnormal(r.notes));
+      if (
+        candidate &&
+        new Date(candidate.date).getTime() > new Date(currentMax.dateUpdated).getTime()
+      ) {
+        currentMax.weight = candidate.weight; // no increment for test weeks
+        currentMax.dateUpdated = candidate.date;
+      }
+      return;
+    }
+
+    // training week: process set 1 only
+    if (record.setNum !== 1) return;
+
     if (
       record.reps >= spec.reps &&
-      new Date(record.date).getTime() >
-        new Date(currentMax.dateUpdated).getTime()
+      new Date(record.date).getTime() > new Date(currentMax.dateUpdated).getTime()
     ) {
-      // Update training max
       const updatedWeight = record.weight + spec.increment;
-      console.log(
-        `Updating training max for ${liftName} from weight=${currentMax.weight} to weight=${updatedWeight} based on lift record.`,
-      );
       if (typeof updatedWeight !== "number" || isNaN(updatedWeight)) {
-        throw new Error(
-          `Updated weight for ${liftName} is not a valid number: ${updatedWeight}`,
-        );
+        throw new Error(`Updated weight for ${liftName} is not a valid number: ${updatedWeight}`);
       }
       currentMax.weight = updatedWeight;
       currentMax.dateUpdated = record.date;

--- a/packages/core/src/services/workout/generateLiftPlan.ts
+++ b/packages/core/src/services/workout/generateLiftPlan.ts
@@ -6,45 +6,61 @@ import {
 } from "@src/core/constants";
 import { LiftingProgramSpec, SpreadsheetCell, TrainingMax } from "@src/core/models";
 
-/**
- * Creates a lift plan from a training max and program spec.
- * @param {TrainingMax} tm
- * @param {LiftingProgramSpec} ps
- * @param {Date} startDate
- * @return {SpreadsheetCell[][]}
- */
+// Test-week: 5-set ascending ramp-up ending in a heavy single (50/65/80/90/100%)
+const TEST_WEEK_PCTS = [0.50, 0.65, 0.80, 0.90, 1.00];
+const TEST_WEEK_REPS = [5,    3,    2,    1,    1   ];
+
+// Deload week: 3 light sets at 40/50/60%
+const DELOAD_PCTS = [0.40, 0.50, 0.60];
+const DELOAD_REPS = [5,    5,    5   ];
 
 export function generateLiftPlan(
-  tm: TrainingMax,
+  _tm: TrainingMax,
   ps: LiftingProgramSpec,
   _startDate: Date,
 ): SpreadsheetCell[][] {
   const workoutGrid: SpreadsheetCell[][] = [];
-  const progSpecLiftName = ps.lift;
-  const progSpecNumSets = ps.sets;
-  const progSpecIncrement = ps.increment;
-  const progSpecWtDec = ps.wtDecrementPct;
-  // Warm-up percentages
+  const liftName = ps.lift;
+  const increment = ps.increment;
+
+  const dateFormula = `=INDEX(A1:F, MATCH("${liftName}", A1:A, 0), MATCH("${LIFT_DATE_HEADER}", A2:2, 0))`;
+  const weightFormula = (pct: number) =>
+    `=MROUND(PRODUCT(INDEX(A1:D, MATCH("${liftName}", A1:A, 0), MATCH("TM", A2:2, 0)), ${pct}), ${increment})`;
+
+  if (ps.weekType === 'test') {
+    for (let k = 0; k < TEST_WEEK_PCTS.length; k++) {
+      workoutGrid.push([dateFormula, liftName, `Set ${k + 1}`, weightFormula(TEST_WEEK_PCTS[k]!), TEST_WEEK_REPS[k]!, ""]);
+    }
+    return workoutGrid;
+  }
+
+  if (ps.weekType === 'deload') {
+    for (let k = 0; k < DELOAD_PCTS.length; k++) {
+      workoutGrid.push([dateFormula, liftName, `Set ${k + 1}`, weightFormula(DELOAD_PCTS[k]!), DELOAD_REPS[k]!, ""]);
+    }
+    return workoutGrid;
+  }
+
+  // training week (default)
   const progSpecWarmPcts = PROG_SPEC_WARMUP_PCTS(ps.warmUpPct);
-  // Work set percentages
-  const progSpecWorkPcts = PROG_SPEC_WORK_PCTS(progSpecNumSets, progSpecWtDec);
+  const progSpecWorkPcts = PROG_SPEC_WORK_PCTS(ps.sets, ps.wtDecrementPct);
 
   for (let k = 0; k < progSpecWarmPcts.length; k++) {
     workoutGrid.push([
-      `=INDEX(A1:F, MATCH("${progSpecLiftName}", A1:A, 0), MATCH("${LIFT_DATE_HEADER}", A2:2, 0))`,
-      progSpecLiftName,
+      dateFormula,
+      liftName,
       `Warm-up ${k + 1}`,
-      `=MROUND(PRODUCT(INDEX(A1:D, MATCH("${progSpecLiftName}", A1:A, 0), MATCH("TM", A2:2, 0)), ${progSpecWarmPcts[k]}), ${progSpecIncrement})`,
+      weightFormula(progSpecWarmPcts[k]!),
       WARMUP_BASE_REPS - k,
       "",
     ]);
   }
   for (let k = 0; k < progSpecWorkPcts.length; k++) {
     workoutGrid.push([
-      `=INDEX(A1:F, MATCH("${progSpecLiftName}", A1:A, 0), MATCH("${LIFT_DATE_HEADER}", A2:2, 0))`,
-      progSpecLiftName,
+      dateFormula,
+      liftName,
       `Set ${k + 1}`,
-      `=MROUND(PRODUCT(INDEX(A1:D, MATCH("${progSpecLiftName}", A1:A, 0), MATCH("TM", A2:2, 0)), ${progSpecWorkPcts[k]}), ${progSpecIncrement})`,
+      weightFormula(progSpecWorkPcts[k]!),
       "",
       "",
     ]);

--- a/packages/core/src/utils/jsUtil.ts
+++ b/packages/core/src/utils/jsUtil.ts
@@ -1,3 +1,6 @@
+import { WeekType } from "@lifting-logbook/types";
+import { LiftingProgramSpec } from "../models";
+
 /**
  * Returns the next Monday after the given date, at least 7 days later, or the most recent occurrence of a target weekday.
  * @param prevDate Date to start from
@@ -80,4 +83,19 @@ export function formatDateYYYYMMDD(date: string | Date): string {
     return `${date.getUTCFullYear()}${String(date.getUTCMonth() + 1).padStart(2, "0")}${String(date.getUTCDate()).padStart(2, "0")}`;
   }
   return String(date);
+}
+
+// Returns the WeekType for the week containing `today` within a cycle.
+// Week 1 = days 0–6 from cycle start; clamped to max week in spec.
+export function weekTypeForDate(
+  cycleStartDate: Date,
+  programSpec: LiftingProgramSpec[],
+  today: Date = new Date(),
+): WeekType {
+  const msPerWeek = 7 * 24 * 60 * 60 * 1000;
+  const elapsed = Math.max(0, today.getTime() - cycleStartDate.getTime());
+  const rawWeekNum = Math.floor(elapsed / msPerWeek) + 1;
+  const maxWeek = programSpec.reduce((m, ps) => Math.max(m, ps.week), 1);
+  const weekNum = Math.min(rawWeekNum, maxWeek);
+  return programSpec.find((ps) => ps.week === weekNum)?.weekType ?? 'training';
 }

--- a/packages/core/src/utils/parser/parseCycleDashboard.ts
+++ b/packages/core/src/utils/parser/parseCycleDashboard.ts
@@ -1,3 +1,4 @@
+import { WeekType } from "@lifting-logbook/types";
 import { CycleDashboard, SpreadsheetCell, Weekday } from "@src/core/models";
 import {
   CYCLE_DATE_KEY,
@@ -29,5 +30,7 @@ export function parseCycleDashboard(data: SpreadsheetCell[][]): CycleDashboard {
     cycleDate: new Date(String(map[CYCLE_DATE_KEY] ?? "")),
     sheetName: String(map[SHEET_NAME_KEY] ?? ""),
     cycleStartWeekday: toTitleCase(String(map[CYCLE_START_WEEKDAY_KEY] ?? "")) as Weekday,
+    // currentWeekType is derived from the program spec at request time, not stored in the dashboard sheet
+    currentWeekType: 'training' as WeekType,
   };
 }

--- a/packages/core/src/utils/parser/parseLiftingProgramSpec.ts
+++ b/packages/core/src/utils/parser/parseLiftingProgramSpec.ts
@@ -33,6 +33,7 @@ export function parseLiftingProgramSpec(data: SpreadsheetCell[][]): LiftingProgr
 
   // Apply week-level weekType inheritance: blank rows inherit the first non-blank
   // value in the same week; an all-blank week defaults to 'training'.
+  const isBlank = (v: WeekType | undefined): boolean => !v || (v as string) === '';
   const weekGroups = new Map<number, typeof parsed>();
   for (const row of parsed) {
     const grp = weekGroups.get(row.week) ?? [];
@@ -40,7 +41,6 @@ export function parseLiftingProgramSpec(data: SpreadsheetCell[][]): LiftingProgr
     weekGroups.set(row.week, grp);
   }
   for (const rows of weekGroups.values()) {
-    const isBlank = (v: WeekType | undefined): boolean => !v || (v as string) === '';
     const firstNonBlank = rows.find((r) => !isBlank(r.weekType))?.weekType ?? 'training';
     for (const r of rows) {
       if (isBlank(r.weekType)) r.weekType = firstNonBlank as WeekType;

--- a/packages/core/src/utils/parser/parseLiftingProgramSpec.ts
+++ b/packages/core/src/utils/parser/parseLiftingProgramSpec.ts
@@ -1,3 +1,4 @@
+import { WeekType } from "@lifting-logbook/types";
 import { LIFTING_PROGRAM_SPEC_HEADER_MAP } from "@src/core/constants";
 import { LiftingProgramSpec, SpreadsheetCell } from "@src/core/models";
 import { tableToObjects } from "./tableToObjects";
@@ -29,6 +30,22 @@ export function parseLiftingProgramSpec(data: SpreadsheetCell[][]): LiftingProgr
     }
     return result as unknown as LiftingProgramSpec;
   });
+
+  // Apply week-level weekType inheritance: blank rows inherit the first non-blank
+  // value in the same week; an all-blank week defaults to 'training'.
+  const weekGroups = new Map<number, typeof parsed>();
+  for (const row of parsed) {
+    const grp = weekGroups.get(row.week) ?? [];
+    grp.push(row);
+    weekGroups.set(row.week, grp);
+  }
+  for (const rows of weekGroups.values()) {
+    const isBlank = (v: WeekType | undefined): boolean => !v || (v as string) === '';
+    const firstNonBlank = rows.find((r) => !isBlank(r.weekType))?.weekType ?? 'training';
+    for (const r of rows) {
+      if (isBlank(r.weekType)) r.weekType = firstNonBlank as WeekType;
+    }
+  }
 
   // Sort by offset, then order
   parsed.sort((a, b) => {

--- a/packages/core/tests/core/services/dashboard/updateCycle.test.ts
+++ b/packages/core/tests/core/services/dashboard/updateCycle.test.ts
@@ -9,6 +9,7 @@ describe("updateCycle", () => {
       cycleDate: new Date(2026, 0, 5, 0, 0, 0, 0),
       sheetName: "RPT_Cycle_1_20260105",
       cycleStartWeekday: Weekday.Monday,
+      currentWeekType: 'training',
     };
     const overrides = {
       targetWeekday: "Monday" as Weekday,
@@ -28,6 +29,7 @@ describe("updateCycle", () => {
       cycleDate: new Date(2026, 0, 5, 0, 0, 0, 0),
       sheetName: "RPT_Cycle_1_20260105",
       cycleStartWeekday: Weekday.Monday,
+      currentWeekType: 'training',
     };
     const overrides = {
       targetWeekday: "Friday" as Weekday,
@@ -50,6 +52,7 @@ describe("updateCycle", () => {
       cycleDate: new Date(2026, 0, 12, 0, 0, 0, 0), // Monday
       sheetName: "RPT_Cycle_2_20260112",
       cycleStartWeekday: Weekday.Monday,
+      currentWeekType: 'training',
     };
     const overrides = {
       today: new Date(2026, 0, 19, 0, 0, 0, 0),
@@ -69,6 +72,7 @@ describe("updateCycle", () => {
       cycleDate: new Date(2026, 0, 19, 0, 0, 0, 0), // Monday
       sheetName: "RPT_Cycle_3_20260119",
       cycleStartWeekday: Weekday.Monday,
+      currentWeekType: 'training',
     };
     const overrides = {
       targetWeekday: "friday" as Weekday,
@@ -89,6 +93,7 @@ describe("updateCycle", () => {
       cycleDate: new Date(2026, 0, 23, 0, 0, 0, 0), // Friday
       sheetName: "RPT_Cycle_4_20260123",
       cycleStartWeekday: Weekday.Friday,
+      currentWeekType: 'training',
     };
     // Today is before the next Friday
     const overrides = {
@@ -110,6 +115,7 @@ describe("updateCycle", () => {
       cycleDate: new Date(2026, 0, 25, 0, 0, 0, 0), // Sunday
       sheetName: "RPT_Cycle_5_20260125",
       cycleStartWeekday: Weekday.Sunday,
+      currentWeekType: 'training',
     };
     const overrides = {
       targetWeekday: "Sunday" as Weekday,

--- a/packages/core/tests/core/services/maxes/estimateTrainingMax.test.ts
+++ b/packages/core/tests/core/services/maxes/estimateTrainingMax.test.ts
@@ -1,0 +1,29 @@
+import { estimateTrainingMax } from "@src/core";
+
+describe("estimateTrainingMax", () => {
+  it("estimates TM from (225, 5) using Brzycki formula rounded to nearest 5", () => {
+    // 1RM = 225 / (1.0278 - 0.0278 * 5) = 225 / 0.8888 ≈ 253.2 → rounds to 255
+    expect(estimateTrainingMax(225, 5)).toBe(255);
+  });
+
+  it("returns input weight for a single rep", () => {
+    expect(estimateTrainingMax(315, 1)).toBe(315);
+  });
+
+  it("rounds to nearest 5", () => {
+    // 200 / (1.0278 - 0.0278 * 3) = 200 / 0.9444 ≈ 211.8 → rounds to 210
+    expect(estimateTrainingMax(200, 3) % 5).toBe(0);
+  });
+
+  it("throws RangeError for reps = 0", () => {
+    expect(() => estimateTrainingMax(200, 0)).toThrow(RangeError);
+  });
+
+  it("throws RangeError for reps = 37", () => {
+    expect(() => estimateTrainingMax(200, 37)).toThrow(RangeError);
+  });
+
+  it("accepts reps = 36 without throwing", () => {
+    expect(() => estimateTrainingMax(100, 36)).not.toThrow();
+  });
+});

--- a/packages/core/tests/core/services/maxes/updateMaxes.test.ts
+++ b/packages/core/tests/core/services/maxes/updateMaxes.test.ts
@@ -1,4 +1,5 @@
 import {
+  LiftingProgramSpec,
   parseLiftingProgramSpec,
   parseLiftRecords,
   parseTrainingMaxes,
@@ -71,5 +72,74 @@ describe("updateMaxes", () => {
     expect(updateMaxes(programSpec, updatedMaxes, liftRecords)).toEqual(
       expectedMaxes,
     );
+  });
+
+  it("test week: final set weight becomes new TM with no increment", () => {
+    const tmData = loadCsvFixture("training_maxes.csv");
+    const specData = loadCsvFixture("rpt_program_spec_test_week.csv");
+    const liftData = loadCsvFixture("lift_records_test_week.csv");
+    const expectedData = loadCsvFixture("training_maxes_test_week.csv");
+    const trainingMaxes = parseTrainingMaxes(tmData);
+    const programSpec = parseLiftingProgramSpec(specData);
+    const liftRecords = parseLiftRecords(liftData);
+    const expectedMaxes = parseTrainingMaxes(expectedData);
+
+    const updated = updateMaxes(programSpec, trainingMaxes, liftRecords);
+    expect(updated).toEqual(expectedMaxes);
+
+    // Specifically verify no increment was applied
+    const benchMax = updated.find((m) => m.lift === "Bench P.")!;
+    expect(benchMax.weight).toBe(185); // final set weight, not 185 + 2.5 increment
+  });
+
+  it("test week: skips update when final set notes flag abnormal condition", () => {
+    const tmData = loadCsvFixture("training_maxes.csv");
+    const specData = loadCsvFixture("rpt_program_spec_test_week.csv");
+    const trainingMaxes = parseTrainingMaxes(tmData);
+    const programSpec = parseLiftingProgramSpec(specData);
+
+    // All 5 sets flagged as injury
+    const liftRecords = [1, 2, 3, 4, 5].map((setNum) => ({
+      program: "RPT",
+      cycleNum: 1,
+      workoutNum: 1,
+      date: new Date("2026-01-05"),
+      lift: "Bench P." as const,
+      setNum,
+      weight: 100 + setNum * 20,
+      reps: setNum === 5 ? 1 : 3,
+      notes: "injury",
+    }));
+
+    const updated = updateMaxes(programSpec, trainingMaxes, liftRecords);
+    const benchMax = updated.find((m) => m.lift === "Bench P.")!;
+    const originalBenchMax = trainingMaxes.find((m) => m.lift === "Bench P.")!;
+    expect(benchMax.weight).toBe(originalBenchMax.weight); // unchanged
+  });
+
+  it("deload week: returns maxes unchanged", () => {
+    const tmData = loadCsvFixture("training_maxes.csv");
+    const specData = loadCsvFixture("rpt_program_spec_deload_week.csv");
+    const trainingMaxes = parseTrainingMaxes(tmData);
+    const programSpec = parseLiftingProgramSpec(specData);
+
+    // A completed deload set — should never update the max
+    const liftRecords = [1, 2, 3].map((setNum) => ({
+      program: "RPT",
+      cycleNum: 1,
+      workoutNum: 1,
+      date: new Date("2026-01-05"),
+      lift: "Bench P." as const,
+      setNum,
+      weight: 100,
+      reps: 5,
+      notes: "",
+    }));
+
+    const updated = updateMaxes(programSpec, trainingMaxes, liftRecords);
+    const benchMax = updated.find((m) => m.lift === "Bench P.")!;
+    const originalBenchMax = trainingMaxes.find((m) => m.lift === "Bench P.")!;
+    expect(benchMax.weight).toBe(originalBenchMax.weight);
+    expect(benchMax.dateUpdated).toEqual(originalBenchMax.dateUpdated);
   });
 });

--- a/packages/core/tests/core/services/workout/generateLiftPlan.test.ts
+++ b/packages/core/tests/core/services/workout/generateLiftPlan.test.ts
@@ -7,11 +7,15 @@ import { loadCsvFixture } from "../../../testUtils";
 
 const trainingMaxesData = loadCsvFixture("training_maxes.csv");
 const rptProgramSpecData = loadCsvFixture("rpt_program_spec.csv");
+const testWeekSpecData = loadCsvFixture("rpt_program_spec_test_week.csv");
+const deloadWeekSpecData = loadCsvFixture("rpt_program_spec_deload_week.csv");
 const trainingMaxes = parseTrainingMaxes(trainingMaxesData);
 const rptProgramSpec = parseLiftingProgramSpec(rptProgramSpecData);
+const testWeekSpec = parseLiftingProgramSpec(testWeekSpecData);
+const deloadWeekSpec = parseLiftingProgramSpec(deloadWeekSpecData);
 
 describe("generateLiftPlan", () => {
-  it("generates correct lift plan for Bench P.", () => {
+  it("generates correct lift plan for Bench P. (training week)", () => {
     const tm = trainingMaxes.find((t) => t.lift === "Bench P.")!;
     const ps = rptProgramSpec.find((p) => p.lift === "Bench P.")!;
     const startDate = new Date("2026-01-01");
@@ -29,5 +33,32 @@ describe("generateLiftPlan", () => {
     expect(workset).toBeDefined();
     expect(workset![1]).toBe("Bench P.");
     expect(workset![2]).toMatch(/Set \d+/);
+  });
+
+  it("generates 5-set ascending ramp-up for test week", () => {
+    const tm = trainingMaxes.find((t) => t.lift === "Bench P.")!;
+    const ps = testWeekSpec.find((p) => p.lift === "Bench P.")!;
+    expect(ps.weekType).toBe("test");
+    const plan = generateLiftPlan(tm, ps, new Date("2026-01-01"));
+    expect(plan.length).toBe(5);
+    // All rows should be labeled "Set N"
+    plan.forEach((row, i) => expect(row[2]).toBe(`Set ${i + 1}`));
+    // Rep counts should follow the test-week protocol: 5, 3, 2, 1, 1
+    expect(plan[0]![4]).toBe(5);
+    expect(plan[1]![4]).toBe(3);
+    expect(plan[2]![4]).toBe(2);
+    expect(plan[3]![4]).toBe(1);
+    expect(plan[4]![4]).toBe(1);
+  });
+
+  it("generates 3-set light protocol for deload week", () => {
+    const tm = trainingMaxes.find((t) => t.lift === "Bench P.")!;
+    const ps = deloadWeekSpec.find((p) => p.lift === "Bench P.")!;
+    expect(ps.weekType).toBe("deload");
+    const plan = generateLiftPlan(tm, ps, new Date("2026-01-01"));
+    expect(plan.length).toBe(3);
+    plan.forEach((row, i) => expect(row[2]).toBe(`Set ${i + 1}`));
+    // Rep counts: 5, 5, 5
+    plan.forEach((row) => expect(row[4]).toBe(5));
   });
 });

--- a/packages/core/tests/core/utils/mapper/mapCycleDashboard.test.ts
+++ b/packages/core/tests/core/utils/mapper/mapCycleDashboard.test.ts
@@ -19,6 +19,7 @@ describe("mapCycleDashboard", () => {
       cycleDate: new Date("2026-01-01"),
       sheetName: "Week 1",
       cycleStartWeekday: Weekday.Friday,
+      currentWeekType: 'training',
     };
     const result = mapCycleDashboard(obj);
     expect(result).toEqual([

--- a/packages/core/tests/core/utils/mapper/mapLiftingProgramSpec.test.ts
+++ b/packages/core/tests/core/utils/mapper/mapLiftingProgramSpec.test.ts
@@ -18,6 +18,7 @@ const specs: LiftingProgramSpec[] = [
     warmUpPct: "40,50,60",
     wtDecrementPct: 0,
     activation: "None",
+    weekType: "training",
   },
   {
     week: 1,
@@ -31,6 +32,7 @@ const specs: LiftingProgramSpec[] = [
     warmUpPct: "40,50,60",
     wtDecrementPct: 0,
     activation: "None",
+    weekType: "training",
   },
 ];
 
@@ -39,8 +41,8 @@ describe("mapLiftingProgramSpec", () => {
     const headers = Object.keys(LIFTING_PROGRAM_SPEC_HEADER_MAP);
     const result = mapLiftingProgramSpec(specs);
     expect(result[0]).toEqual(headers);
-    expect(result[1]).toEqual([1, 0, "Squat", 5, 1, 3, 5, "TRUE", "40,50,60", 0, "None"]);
-    expect(result[2]).toEqual([1, 0, "Bench", 2.5, 2, 3, 5, "FALSE", "40,50,60", 0, "None"]);
+    expect(result[1]).toEqual([1, 0, "Squat", 5, 1, 3, 5, "TRUE", "40,50,60", 0, "None", "training"]);
+    expect(result[2]).toEqual([1, 0, "Bench", 2.5, 2, 3, 5, "FALSE", "40,50,60", 0, "None", "training"]);
   });
 
   it("maps amrap boolean to string so parseLiftingProgramSpec can round-trip it", () => {

--- a/packages/core/tests/core/utils/parser/parseCycleDashboard.test.ts
+++ b/packages/core/tests/core/utils/parser/parseCycleDashboard.test.ts
@@ -12,6 +12,7 @@ describe("parseCycleDashboard", () => {
       cycleDate: new Date("1/5/2026"),
       sheetName: "RPT_Cycle_1_20260105",
       cycleStartWeekday: Weekday.Monday,
+      currentWeekType: 'training',
     });
   });
 });

--- a/packages/core/tests/fixtures/lift_records_test_week.csv
+++ b/packages/core/tests/fixtures/lift_records_test_week.csv
@@ -1,0 +1,11 @@
+Program,Cycle #,Workout #,Date,Lift,Set #,Weight,Reps,Notes
+RPT,1,1,1/5/2026,Bench P.,1,90,5,
+RPT,1,1,1/5/2026,Bench P.,2,117.5,3,
+RPT,1,1,1/5/2026,Bench P.,3,145,2,
+RPT,1,1,1/5/2026,Bench P.,4,162.5,1,
+RPT,1,1,1/5/2026,Bench P.,5,185,1,
+RPT,1,1,1/5/2026,BB Row,1,90,5,
+RPT,1,1,1/5/2026,BB Row,2,117.5,3,
+RPT,1,1,1/5/2026,BB Row,3,145,2,
+RPT,1,1,1/5/2026,BB Row,4,162.5,1,
+RPT,1,1,1/5/2026,BB Row,5,185,1,

--- a/packages/core/tests/fixtures/rpt_program_spec_deload_week.csv
+++ b/packages/core/tests/fixtures/rpt_program_spec_deload_week.csv
@@ -1,0 +1,2 @@
+Week,Offset,Lift,Increment,Order,Sets,Reps,AMRAP?,Warm-Up %,WT Decrement %,Activation,Week Type
+1,0,Bench P.,2.5,1,3,5,FALSE,".4,.6,.8",0.05,Band Flye,deload

--- a/packages/core/tests/fixtures/rpt_program_spec_test_week.csv
+++ b/packages/core/tests/fixtures/rpt_program_spec_test_week.csv
@@ -1,0 +1,3 @@
+Week,Offset,Lift,Increment,Order,Sets,Reps,AMRAP?,Warm-Up %,WT Decrement %,Activation,Week Type
+1,0,Bench P.,2.5,1,5,1,FALSE,".4,.6,.8",0.05,Band Flye,test
+1,0,BB Row,2.5,2,5,1,FALSE,".4,.6,.8",0.05,S. Pulldown,

--- a/packages/core/tests/fixtures/training_maxes_test_week.csv
+++ b/packages/core/tests/fixtures/training_maxes_test_week.csv
@@ -1,0 +1,14 @@
+Date Updated,Lift,Weight
+1/5/2026,Bench P.,185
+1/5/2026,BB Row,185
+12/29/2025,Calf Raise,217.5
+12/29/2025,C. Lat Raise,12.5
+1/1/2024,OH Press-HV,75
+12/1/2025,Squat,247.5
+12/9/2025,Chin-up,245
+12/9/2025,Dip,237.5
+1/1/2024,Upright Row,45
+12/24/2025,Deadlift,275
+10/20/2025,OH Press,115
+12/11/2025,CBL Curls,77.5
+12/1/2021,Face Pulls,30

--- a/packages/core/tsconfig.spec.json
+++ b/packages/core/tsconfig.spec.json
@@ -2,7 +2,12 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": ".",
-    "noEmit": true
+    "noEmit": true,
+    "paths": {
+      "@src/core": ["src/index.ts"],
+      "@src/core/*": ["src/*"],
+      "@lifting-logbook/types": ["../types/src/index.ts"]
+    }
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"]
 }

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1,4 +1,4 @@
-import { BodyWeightEntry, LiftName, WeightUnit, WeekNumber, CycleNumber } from './domain';
+import { BodyWeightEntry, LiftName, WeightUnit, WeekNumber, CycleNumber, WeekType } from './domain';
 
 // ---------------------------------------------------------------------------
 // Training Maxes
@@ -109,6 +109,7 @@ export interface CycleDashboardResponse {
   cycleNum: CycleNumber;
   cycleStartDate: string; // ISO 8601 date string
   weeks: CycleWeekSummary[];
+  currentWeekType: WeekType;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -56,6 +56,9 @@ export interface BodyWeightEntry {
 /** Week number within a training cycle (1-based). */
 export type WeekNumber = number;
 
+/** Declares the character of a training week. */
+export type WeekType = 'training' | 'test' | 'deload';
+
 /**
  * Cycle number within a training program.
  * 1-indexed: the first cycle is cycle 1.


### PR DESCRIPTION
## Summary

- Adds `WeekType` (`'training' | 'test' | 'deload'`) to shared types and wires it through `LiftingProgramSpec`, `CycleDashboard`, the Sheets parser, `generateLiftPlan`, `updateMaxes`, and the API response
- Adds `estimateTrainingMax(weight, reps)` to `packages/core` using the Brzycki formula (rounds to nearest 5 lbs, enforces reps 1–36)
- `generateLiftPlan` now branches on `weekType`: test = 5-set ramp-up (50/65/80/90/100%), deload = 3-set light protocol (40/50/60%), training = existing behaviour
- `updateMaxes` now branches on `weekType`: test = final set weight → new TM (no increment, abnormal-notes fallback), deload = no progression, training = existing behaviour
- `GET /programs/:program/cycles/current` response includes `currentWeekType`
- Core jest config updated to resolve `@lifting-logbook/types` from source so tests work correctly in git worktrees sharing the main repo's `node_modules`

## Acceptance Criteria

- [x] `WeekType` exported from `packages/types/src/domain.ts`
- [x] `LiftingProgramSpec.weekType?: WeekType` added; parser default is `'training'`
- [x] Sheets parser reads optional `Week Type` column; blank rows inherit first non-blank value in the same week; all-blank week defaults to `'training'`
- [x] `CycleDashboard.currentWeekType: WeekType` added
- [x] `estimateTrainingMax(weight, reps): number` in `packages/core`, exported from public API
- [x] `generateLiftPlan` handles `weekType === 'test'`: 5-set ascending ramp-up
- [x] `generateLiftPlan` handles `weekType === 'deload'`: 3-set light protocol
- [x] `updateMaxes` for test weeks: completed final set weight → new TM (no increment); abnormal-notes fallback
- [x] `updateMaxes` for deload weeks: skip entirely
- [x] `GET /programs/:program/cycles/current` response includes `currentWeekType`
- [x] Unit tests cover `estimateTrainingMax` and all three `weekType` branches of `generateLiftPlan` and `updateMaxes`

## Test plan

- `npm test -w @lifting-logbook/core`: 124 passed (includes new `estimateTrainingMax`, `generateLiftPlan` test/deload, and `updateMaxes` test/deload/abnormal-notes tests)
- `npm test -w @lifting-logbook/api`: 44 passed, 1 skipped
- `npm test` (full suite via turbo): all tasks successful

Closes #129