### PR TITLE
[feat] Implement workout logging screen

### DIFF
--- a/apps/api/src/adapters/in-memory/body-weight.adapter.ts
+++ b/apps/api/src/adapters/in-memory/body-weight.adapter.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { BodyWeightEntry } from '@lifting-logbook/types';
+import { IBodyWeightRepository } from '../../ports/IBodyWeightRepository';
+
+@Injectable()
+export class InMemoryBodyWeightRepository implements IBodyWeightRepository {
+  private entriesByProgram = new Map<string, BodyWeightEntry[]>();
+
+  async recordBodyWeight(program: string, entry: BodyWeightEntry): Promise<void> {
+    const existing = this.entriesByProgram.get(program) ?? [];
+    this.entriesByProgram.set(program, [...existing, entry]);
+  }
+
+  async getLatestBodyWeight(program: string): Promise<BodyWeightEntry | null> {
+    const entries = this.entriesByProgram.get(program) ?? [];
+    return entries.length > 0 ? (entries[entries.length - 1] ?? null) : null;
+  }
+}

--- a/apps/api/src/adapters/in-memory/lift-record.adapter.ts
+++ b/apps/api/src/adapters/in-memory/lift-record.adapter.ts
@@ -18,4 +18,27 @@ export class InMemoryLiftRecordRepository implements ILiftRecordRepository {
     const existing = this.recordsByProgram.get(program) ?? [];
     this.recordsByProgram.set(program, [...existing, ...records]);
   }
+
+  async updateLiftRecord(
+    program: string,
+    id: string,
+    updates: Partial<Pick<LiftRecord, 'weight' | 'reps' | 'notes'>>,
+  ): Promise<LiftRecord | null> {
+    const records = this.recordsByProgram.get(program) ?? [];
+    const idx = records.findIndex(
+      (r) => `${r.program}-${r.cycleNum}-${r.workoutNum}-${r.lift}-${r.setNum}` === id,
+    );
+    if (idx === -1) return null;
+    const current = records[idx] as LiftRecord;
+    const updated: LiftRecord = {
+      ...current,
+      weight: updates.weight ?? current.weight,
+      reps: updates.reps ?? current.reps,
+      notes: updates.notes ?? current.notes,
+    };
+    const next = [...records];
+    next[idx] = updated;
+    this.recordsByProgram.set(program, next);
+    return updated;
+  }
 }

--- a/apps/api/src/ports/IBodyWeightRepository.ts
+++ b/apps/api/src/ports/IBodyWeightRepository.ts
@@ -1,0 +1,9 @@
+import { BodyWeightEntry } from '@lifting-logbook/types';
+
+export interface IBodyWeightRepository {
+  /** Records a body weight observation for the given program. */
+  recordBodyWeight(program: string, entry: BodyWeightEntry): Promise<void>;
+
+  /** Returns the most recent body weight for the given program, or null if none exists. */
+  getLatestBodyWeight(program: string): Promise<BodyWeightEntry | null>;
+}

--- a/apps/api/src/ports/ILiftRecordRepository.ts
+++ b/apps/api/src/ports/ILiftRecordRepository.ts
@@ -4,4 +4,10 @@ export interface ILiftRecordRepository {
   getLiftRecords(program: string, cycleNum: number): Promise<LiftRecord[]>;
 
   appendLiftRecords(program: string, records: LiftRecord[]): Promise<void>;
+
+  updateLiftRecord(
+    program: string,
+    id: string,
+    updates: Partial<Pick<LiftRecord, 'weight' | 'reps' | 'notes'>>,
+  ): Promise<LiftRecord | null>;
 }

--- a/apps/api/src/ports/index.ts
+++ b/apps/api/src/ports/index.ts
@@ -2,6 +2,7 @@ export * from './auth';
 export * from './errors';
 export * from './factory';
 export * from './tokens';
+export * from './IBodyWeightRepository';
 export * from './ICycleDashboardRepository';
 export * from './ILiftingProgramSpecRepository';
 export * from './ILiftRecordRepository';

--- a/apps/api/src/ports/ports.compile-test.ts
+++ b/apps/api/src/ports/ports.compile-test.ts
@@ -6,7 +6,9 @@
  * the TypeScript compiler will error here — no runtime needed.
  */
 import { CycleDashboard, LiftRecord, LiftingProgramSpec, TrainingMax } from '@lifting-logbook/core';
+import { BodyWeightEntry } from '@lifting-logbook/types';
 import { AuthUser, IAuthProvider } from './auth';
+import { IBodyWeightRepository } from './IBodyWeightRepository';
 import { IRepositoryFactory, RepositoryBundle } from './factory';
 import { ICycleDashboardRepository } from './ICycleDashboardRepository';
 import { ILiftingProgramSpecRepository } from './ILiftingProgramSpecRepository';
@@ -52,6 +54,19 @@ const _liftRecordRepo: ILiftRecordRepository = {
     Promise.resolve([]),
   appendLiftRecords: (): Promise<void> =>
     Promise.resolve(),
+  updateLiftRecord: (): Promise<LiftRecord | null> =>
+    Promise.resolve(null),
+};
+
+// ---------------------------------------------------------------------------
+// IBodyWeightRepository
+// ---------------------------------------------------------------------------
+
+const _bodyWeightRepo: IBodyWeightRepository = {
+  recordBodyWeight: (): Promise<void> =>
+    Promise.resolve(),
+  getLatestBodyWeight: (): Promise<BodyWeightEntry | null> =>
+    Promise.resolve(null),
 };
 
 // ---------------------------------------------------------------------------
@@ -95,6 +110,7 @@ const _repositoryFactory: IRepositoryFactory = {
 // Suppress "declared but never read" errors — these variables exist solely
 // to trigger structural type checking at compile time.
 void _authProvider;
+void _bodyWeightRepo;
 void _cycleDashboardRepo;
 void _programSpecRepo;
 void _liftRecordRepo;

--- a/apps/api/src/ports/tokens.ts
+++ b/apps/api/src/ports/tokens.ts
@@ -5,3 +5,4 @@ export const LIFT_RECORD_REPOSITORY = Symbol('ILiftRecordRepository');
 export const LIFTING_PROGRAM_SPEC_REPOSITORY = Symbol(
   'ILiftingProgramSpecRepository',
 );
+export const BODY_WEIGHT_REPOSITORY = Symbol('IBodyWeightRepository');

--- a/apps/api/src/programs/body-weight.controller.ts
+++ b/apps/api/src/programs/body-weight.controller.ts
@@ -1,0 +1,26 @@
+import { Body, Controller, HttpCode, HttpStatus, Inject, Param, Post } from '@nestjs/common';
+import { BodyWeightEntry, RecordBodyWeightRequest } from '@lifting-logbook/types';
+import { IBodyWeightRepository } from '../ports/IBodyWeightRepository';
+import { BODY_WEIGHT_REPOSITORY } from '../ports/tokens';
+
+@Controller('programs/:program')
+export class BodyWeightController {
+  constructor(
+    @Inject(BODY_WEIGHT_REPOSITORY)
+    private readonly bodyWeightRepo: IBodyWeightRepository,
+  ) {}
+
+  @Post('body-weight')
+  @HttpCode(HttpStatus.CREATED)
+  async recordBodyWeight(
+    @Param('program') program: string,
+    @Body() body: RecordBodyWeightRequest,
+  ): Promise<void> {
+    const entry: BodyWeightEntry = {
+      date: new Date(body.date),
+      weight: body.weight,
+      unit: body.unit,
+    };
+    await this.bodyWeightRepo.recordBodyWeight(program, entry);
+  }
+}

--- a/apps/api/src/programs/body-weight.controller.ts
+++ b/apps/api/src/programs/body-weight.controller.ts
@@ -1,5 +1,5 @@
-import { Body, Controller, HttpCode, HttpStatus, Inject, Param, Post } from '@nestjs/common';
-import { BodyWeightEntry, RecordBodyWeightRequest } from '@lifting-logbook/types';
+import { Body, Controller, Get, HttpCode, HttpStatus, Inject, NotFoundException, Param, Post } from '@nestjs/common';
+import { BodyWeightEntry, BodyWeightResponse, RecordBodyWeightRequest } from '@lifting-logbook/types';
 import { IBodyWeightRepository } from '../ports/IBodyWeightRepository';
 import { BODY_WEIGHT_REPOSITORY } from '../ports/tokens';
 
@@ -22,5 +22,20 @@ export class BodyWeightController {
       unit: body.unit,
     };
     await this.bodyWeightRepo.recordBodyWeight(program, entry);
+  }
+
+  @Get('body-weight/latest')
+  async getLatestBodyWeight(
+    @Param('program') program: string,
+  ): Promise<BodyWeightResponse> {
+    const entry = await this.bodyWeightRepo.getLatestBodyWeight(program);
+    if (!entry) {
+      throw new NotFoundException(`No body weight recorded for program '${program}'`);
+    }
+    return {
+      date: entry.date.toISOString().slice(0, 10),
+      weight: entry.weight,
+      unit: entry.unit,
+    };
   }
 }

--- a/apps/api/src/programs/lift-records.controller.spec.ts
+++ b/apps/api/src/programs/lift-records.controller.spec.ts
@@ -1,3 +1,4 @@
+import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Weekday } from '@lifting-logbook/core';
 import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
@@ -8,6 +9,28 @@ import {
 } from '../ports/tokens';
 import { LiftRecordsController } from './lift-records.controller';
 
+const SEED_DASHBOARD = {
+  program: '5-3-1',
+  cycleUnit: 'week' as const,
+  cycleNum: 4,
+  cycleDate: new Date('2026-04-20T00:00:00.000Z'),
+  sheetName: '',
+  cycleStartWeekday: Weekday.Monday,
+  currentWeekType: 'training' as const,
+};
+
+const SEED_RECORD = {
+  program: '5-3-1',
+  cycleNum: 4,
+  workoutNum: 1,
+  date: new Date('2026-04-20T00:00:00.000Z'),
+  lift: 'Bench Press',
+  setNum: 1,
+  weight: 180,
+  reps: 5,
+  notes: '',
+};
+
 describe('LiftRecordsController', () => {
   let controller: LiftRecordsController;
   let liftRecordRepo: jest.Mocked<ILiftRecordRepository>;
@@ -17,6 +40,7 @@ describe('LiftRecordsController', () => {
     liftRecordRepo = {
       getLiftRecords: jest.fn(),
       appendLiftRecords: jest.fn(),
+      updateLiftRecord: jest.fn(),
     };
     dashboardRepo = {
       getCycleDashboard: jest.fn(),
@@ -32,35 +56,90 @@ describe('LiftRecordsController', () => {
     controller = module.get(LiftRecordsController);
   });
 
-  it('fetches lift records scoped to current cycle', async () => {
-    dashboardRepo.getCycleDashboard.mockResolvedValue({
-      program: '5-3-1',
-      cycleUnit: 'week',
-      cycleNum: 4,
-      cycleDate: new Date('2026-04-20T00:00:00.000Z'),
-      sheetName: '',
-      cycleStartWeekday: Weekday.Monday,
-      currentWeekType: 'training' as const,
+  describe('GET lift-records', () => {
+    it('fetches lift records scoped to current cycle', async () => {
+      dashboardRepo.getCycleDashboard.mockResolvedValue(SEED_DASHBOARD);
+      liftRecordRepo.getLiftRecords.mockResolvedValue([SEED_RECORD]);
+
+      const result = await controller.getLiftRecords('5-3-1');
+
+      expect(liftRecordRepo.getLiftRecords).toHaveBeenCalledWith('5-3-1', 4);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.lift).toBe('Bench Press');
+      expect(result[0]?.date).toBe('2026-04-20');
     });
-    liftRecordRepo.getLiftRecords.mockResolvedValue([
-      {
+  });
+
+  describe('POST lift-records', () => {
+    it('appends the record and returns the serialized response', async () => {
+      liftRecordRepo.appendLiftRecords.mockResolvedValue(undefined);
+
+      const result = await controller.createLiftRecord('5-3-1', {
         program: '5-3-1',
         cycleNum: 4,
         workoutNum: 1,
-        date: new Date('2026-04-20T00:00:00.000Z'),
+        date: '2026-04-20',
         lift: 'Bench Press',
         setNum: 1,
         weight: 180,
         reps: 5,
-        notes: '',
-      },
-    ]);
+      });
 
-    const result = await controller.getLiftRecords('5-3-1');
+      expect(liftRecordRepo.appendLiftRecords).toHaveBeenCalledWith(
+        '5-3-1',
+        expect.arrayContaining([
+          expect.objectContaining({ lift: 'Bench Press', setNum: 1, notes: '' }),
+        ]),
+      );
+      expect(result.id).toBe('5-3-1-4-1-Bench Press-1');
+      expect(result.notes).toBe('');
+    });
 
-    expect(liftRecordRepo.getLiftRecords).toHaveBeenCalledWith('5-3-1', 4);
-    expect(result).toHaveLength(1);
-    expect(result[0]?.lift).toBe('Bench Press');
-    expect(result[0]?.date).toBe('2026-04-20');
+    it('forwards optional notes to the record', async () => {
+      liftRecordRepo.appendLiftRecords.mockResolvedValue(undefined);
+
+      const result = await controller.createLiftRecord('5-3-1', {
+        program: '5-3-1',
+        cycleNum: 4,
+        workoutNum: 1,
+        date: '2026-04-20',
+        lift: 'Squat',
+        setNum: 2,
+        weight: 225,
+        reps: 5,
+        notes: 'felt good',
+      });
+
+      expect(result.notes).toBe('felt good');
+    });
+  });
+
+  describe('PATCH lift-records/:id', () => {
+    it('returns the updated record when found', async () => {
+      const updated = { ...SEED_RECORD, weight: 185, reps: 4 };
+      liftRecordRepo.updateLiftRecord.mockResolvedValue(updated);
+
+      const result = await controller.updateLiftRecord(
+        '5-3-1',
+        '5-3-1-4-1-Bench Press-1',
+        { weight: 185, reps: 4 },
+      );
+
+      expect(liftRecordRepo.updateLiftRecord).toHaveBeenCalledWith(
+        '5-3-1',
+        '5-3-1-4-1-Bench Press-1',
+        { weight: 185, reps: 4 },
+      );
+      expect(result.weight).toBe(185);
+      expect(result.reps).toBe(4);
+    });
+
+    it('throws NotFoundException when record does not exist', async () => {
+      liftRecordRepo.updateLiftRecord.mockResolvedValue(null);
+
+      await expect(
+        controller.updateLiftRecord('5-3-1', 'unknown-id', { weight: 200 }),
+      ).rejects.toThrow(NotFoundException);
+    });
   });
 });

--- a/apps/api/src/programs/lift-records.controller.ts
+++ b/apps/api/src/programs/lift-records.controller.ts
@@ -1,5 +1,20 @@
-import { Controller, Get, Inject, Param } from '@nestjs/common';
-import { LiftRecordResponse } from '@lifting-logbook/types';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  NotFoundException,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import {
+  CreateLiftRecordRequest,
+  LiftRecordResponse,
+  UpdateLiftRecordRequest,
+} from '@lifting-logbook/types';
 import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
 import { ILiftRecordRepository } from '../ports/ILiftRecordRepository';
 import {
@@ -27,5 +42,41 @@ export class LiftRecordsController {
       dashboard.cycleNum,
     );
     return records.map(toLiftRecordResponse);
+  }
+
+  @Post('lift-records')
+  @HttpCode(HttpStatus.CREATED)
+  async createLiftRecord(
+    @Param('program') program: string,
+    @Body() body: CreateLiftRecordRequest,
+  ): Promise<LiftRecordResponse> {
+    const record = {
+      program,
+      cycleNum: body.cycleNum,
+      workoutNum: body.workoutNum,
+      date: new Date(body.date),
+      lift: body.lift,
+      setNum: body.setNum,
+      weight: body.weight,
+      reps: body.reps,
+      notes: body.notes ?? '',
+    };
+    await this.liftRecordRepo.appendLiftRecords(program, [record]);
+    return toLiftRecordResponse(record);
+  }
+
+  @Patch('lift-records/:id')
+  async updateLiftRecord(
+    @Param('program') program: string,
+    @Param('id') id: string,
+    @Body() body: UpdateLiftRecordRequest,
+  ): Promise<LiftRecordResponse> {
+    const updated = await this.liftRecordRepo.updateLiftRecord(program, id, body);
+    if (!updated) {
+      throw new NotFoundException(
+        `Lift record '${id}' not found for program '${program}'`,
+      );
+    }
+    return toLiftRecordResponse(updated);
   }
 }

--- a/apps/api/src/programs/programs.module.ts
+++ b/apps/api/src/programs/programs.module.ts
@@ -1,16 +1,19 @@
 import { Module } from '@nestjs/common';
+import { InMemoryBodyWeightRepository } from '../adapters/in-memory/body-weight.adapter';
 import { InMemoryCycleDashboardRepository } from '../adapters/in-memory/cycle-dashboard.adapter';
 import { InMemoryLiftRecordRepository } from '../adapters/in-memory/lift-record.adapter';
 import { InMemoryLiftingProgramSpecRepository } from '../adapters/in-memory/lifting-program-spec.adapter';
 import { InMemoryTrainingMaxRepository } from '../adapters/in-memory/training-max.adapter';
 import { InMemoryWorkoutRepository } from '../adapters/in-memory/workout.adapter';
 import {
+  BODY_WEIGHT_REPOSITORY,
   CYCLE_DASHBOARD_REPOSITORY,
   LIFT_RECORD_REPOSITORY,
   LIFTING_PROGRAM_SPEC_REPOSITORY,
   TRAINING_MAX_REPOSITORY,
   WORKOUT_REPOSITORY,
 } from '../ports/tokens';
+import { BodyWeightController } from './body-weight.controller';
 import { CycleDashboardController } from './cycle-dashboard.controller';
 import { CycleGenerationController } from './cycle-generation.controller';
 import { CycleGenerationService } from './cycle-generation.service';
@@ -28,6 +31,7 @@ import { WorkoutsController } from './workouts.controller';
  */
 @Module({
   controllers: [
+    BodyWeightController,
     CycleDashboardController,
     CycleGenerationController,
     WorkoutsController,
@@ -36,6 +40,7 @@ import { WorkoutsController } from './workouts.controller';
     ProgramSpecController,
   ],
   providers: [
+    { provide: BODY_WEIGHT_REPOSITORY, useClass: InMemoryBodyWeightRepository },
     {
       provide: CYCLE_DASHBOARD_REPOSITORY,
       useClass: InMemoryCycleDashboardRepository,

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.module.css
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.module.css
@@ -1,0 +1,478 @@
+/* ---------------------------------------------------------------------------
+   Layout
+   --------------------------------------------------------------------------- */
+
+.container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 0 16px 80px; /* bottom padding for fixed footer */
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 0 8px;
+}
+
+.screenTitle {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+/* ---------------------------------------------------------------------------
+   Overview toggle / view toggle button
+   --------------------------------------------------------------------------- */
+
+.viewToggle {
+  min-width: 44px;
+  min-height: 44px;
+  background: none;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 1.25rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.viewToggle:hover {
+  background: #f5f5f5;
+}
+
+/* ---------------------------------------------------------------------------
+   Navigation dots
+   --------------------------------------------------------------------------- */
+
+.navDots {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  padding: 8px 0 16px;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #ccc;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.dot::after {
+  content: '';
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #ccc;
+}
+
+.dotActive::after {
+  background: #1a1a1a;
+}
+
+.dotDone::after {
+  background: #22c55e;
+}
+
+/* ---------------------------------------------------------------------------
+   Lift view
+   --------------------------------------------------------------------------- */
+
+.liftView {
+  flex: 1;
+}
+
+.liftName {
+  font-size: 1.375rem;
+  font-weight: 700;
+  margin: 0 0 16px;
+}
+
+/* ---------------------------------------------------------------------------
+   Warm-up section
+   --------------------------------------------------------------------------- */
+
+.warmUpSection {
+  margin-bottom: 24px;
+}
+
+.warmUpImplement {
+  font-size: 0.875rem;
+  color: #555;
+  margin: 0 0 8px;
+}
+
+.warmUpList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.warmUpRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  background: #f8f8f8;
+  border-radius: 6px;
+  font-size: 0.9375rem;
+}
+
+.warmUpLabel {
+  color: #555;
+  font-size: 0.875rem;
+}
+
+.warmUpWeight {
+  font-weight: 500;
+}
+
+/* ---------------------------------------------------------------------------
+   Working sets
+   --------------------------------------------------------------------------- */
+
+.workingSection {
+  margin-bottom: 16px;
+}
+
+.setList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.setRow {
+  padding: 12px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+}
+
+.setRowLogged {
+  border-color: #bbf7d0;
+  background: #f0fdf4;
+}
+
+.setForm {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.setNum {
+  font-weight: 600;
+  font-size: 0.9375rem;
+  min-width: 48px;
+}
+
+.amrapBadge {
+  font-size: 0.75rem;
+  background: #fef9c3;
+  border: 1px solid #fde047;
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-weight: 600;
+}
+
+.setInput {
+  width: 72px;
+  min-height: 44px;
+  padding: 0 8px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 1rem;
+  text-align: center;
+}
+
+.inputSep {
+  font-size: 0.9375rem;
+  color: #555;
+}
+
+.notesInput {
+  flex: 1;
+  min-width: 120px;
+  min-height: 44px;
+  padding: 0 8px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 0.9375rem;
+}
+
+.setError {
+  width: 100%;
+  color: #dc2626;
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.logBtn,
+.editBtn,
+.cancelBtn {
+  min-height: 44px;
+  min-width: 64px;
+  padding: 0 14px;
+  border-radius: 6px;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+}
+
+.logBtn {
+  background: #1a1a1a;
+  color: #fff;
+}
+
+.logBtn:disabled {
+  opacity: 0.5;
+}
+
+.editBtn {
+  background: none;
+  border: 1px solid #ccc;
+  color: #1a1a1a;
+}
+
+.cancelBtn {
+  background: none;
+  border: 1px solid #ccc;
+  color: #555;
+}
+
+.setCheck {
+  color: #16a34a;
+  font-weight: 700;
+  font-size: 1.125rem;
+}
+
+.setSummary {
+  font-size: 0.9375rem;
+  color: #1a1a1a;
+  flex: 1;
+}
+
+.setNotes {
+  width: 100%;
+  font-size: 0.875rem;
+  color: #555;
+  font-style: italic;
+}
+
+/* ---------------------------------------------------------------------------
+   Bottom strip
+   --------------------------------------------------------------------------- */
+
+.bottomStrip {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  background: #fff;
+  border-top: 1px solid #e0e0e0;
+  font-size: 0.9375rem;
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.nextLabel {
+  color: #555;
+  font-size: 0.875rem;
+}
+
+.nextName {
+  font-weight: 600;
+  flex: 1;
+}
+
+.nextWeight {
+  color: #555;
+  font-size: 0.875rem;
+}
+
+.nextBtn {
+  min-width: 44px;
+  min-height: 44px;
+  background: none;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 1.125rem;
+  cursor: pointer;
+}
+
+.lastExercise {
+  flex: 1;
+  color: #555;
+  font-style: italic;
+}
+
+.finishBtn {
+  min-height: 44px;
+  padding: 0 18px;
+  background: #16a34a;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  cursor: pointer;
+  margin-left: auto;
+}
+
+/* ---------------------------------------------------------------------------
+   Body weight gate
+   --------------------------------------------------------------------------- */
+
+.gate {
+  max-width: 360px;
+  margin: 64px auto 0;
+  padding: 0 16px;
+}
+
+.gateHeading {
+  font-size: 1.375rem;
+  font-weight: 700;
+  margin: 0 0 8px;
+}
+
+.gateHint {
+  color: #555;
+  font-size: 0.9375rem;
+  margin: 0 0 24px;
+}
+
+.gateForm {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.gateLabel {
+  font-weight: 600;
+  font-size: 0.9375rem;
+}
+
+.gateInput {
+  min-height: 52px;
+  padding: 0 12px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font-size: 1.125rem;
+  text-align: center;
+  width: 100%;
+}
+
+.gateError {
+  color: #dc2626;
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.gateSubmit {
+  min-height: 52px;
+  background: #1a1a1a;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.gateSubmit:disabled {
+  opacity: 0.5;
+}
+
+/* ---------------------------------------------------------------------------
+   Overview
+   --------------------------------------------------------------------------- */
+
+.overviewList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.overviewRow {
+  padding: 14px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+}
+
+.overviewRowHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.overviewLiftName {
+  flex: 1;
+  font-size: 1rem;
+}
+
+.overviewProgress {
+  font-size: 0.875rem;
+  color: #555;
+}
+
+.goToBtn {
+  min-height: 44px;
+  min-width: 72px;
+  padding: 0 12px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: none;
+}
+
+.overviewWarmUp {
+  margin: 8px 0 0;
+  font-size: 0.875rem;
+  color: #555;
+}
+
+/* ---------------------------------------------------------------------------
+   Utilities
+   --------------------------------------------------------------------------- */
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
@@ -166,8 +166,13 @@ function WorkingSetRow({
     bodyWeight,
     isBodyweightComponent,
   );
-  const [weightInput, setWeightInput] = useState(String(defaultWeight));
-  const [repsInput, setRepsInput] = useState(String(set.reps));
+  // Pre-fill from the logged record when entering edit mode; fall back to plan defaults for new logs.
+  const [weightInput, setWeightInput] = useState(
+    loggedRecord
+      ? String(formatWorkingWeight(loggedRecord.weight, null, false).value)
+      : String(defaultWeight),
+  );
+  const [repsInput, setRepsInput] = useState(String(loggedRecord?.reps ?? set.reps));
   const [notesInput, setNotesInput] = useState(loggedRecord?.notes ?? '');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -178,7 +183,7 @@ function WorkingSetRow({
     e.preventDefault();
     const weight = Number(weightInput);
     const reps = Number(repsInput);
-    if (!weight || weight < 0 || !reps || reps < 0) {
+    if (isNaN(weight) || weight < 0 || isNaN(reps) || reps <= 0) {
       setError('Enter valid weight and reps.');
       return;
     }
@@ -208,7 +213,7 @@ function WorkingSetRow({
     if (!loggedRecord) return;
     const weight = Number(weightInput);
     const reps = Number(repsInput);
-    if (!weight || weight < 0 || !reps || reps < 0) {
+    if (isNaN(weight) || weight < 0 || isNaN(reps) || reps <= 0) {
       setError('Enter valid weight and reps.');
       return;
     }
@@ -469,6 +474,7 @@ export default function WorkoutLogger({
   lifts,
   hasBodyweightComponent,
   isReadOnly,
+  initialBodyWeight,
 }: WorkoutLoggerProps) {
   const router = useRouter();
 
@@ -489,8 +495,11 @@ export default function WorkoutLogger({
   const [editingSet, setEditingSet] = useState<string | null>(null);
   const [currentLiftIdx, setCurrentLiftIdx] = useState(0);
   const [viewMode, setViewMode] = useState<'per-lift' | 'overview'>('per-lift');
-  const [bodyWeight, setBodyWeight] = useState<number | null>(null);
-  const [bodyWeightDone, setBodyWeightDone] = useState(!hasBodyweightComponent || isReadOnly);
+  // initialBodyWeight is non-null when the server found a same-day body weight entry.
+  const [bodyWeight, setBodyWeight] = useState<number | null>(initialBodyWeight);
+  const [bodyWeightDone, setBodyWeightDone] = useState(
+    !hasBodyweightComponent || isReadOnly || initialBodyWeight !== null,
+  );
 
   async function handleBodyWeightSubmit(weight: number) {
     await recordBodyWeight(program, {

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
@@ -1,0 +1,664 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import type { LiftRecordResponse } from '@lifting-logbook/types';
+import {
+  createLiftRecord,
+  recordBodyWeight,
+  updateLiftRecord,
+} from '@/lib/api';
+import styles from './WorkoutLogger.module.css';
+import type { LiftData, WorkingSetData, WorkoutLoggerProps } from './types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatWarmUpWeight(
+  totalLoad: number,
+  bodyWeight: number | null,
+  isBodyweightComponent: boolean,
+): string {
+  if (!isBodyweightComponent || bodyWeight === null) {
+    return `${totalLoad} lbs`;
+  }
+  if (totalLoad <= bodyWeight) {
+    return 'BW';
+  }
+  return `+${totalLoad - bodyWeight} lbs`;
+}
+
+function formatWorkingWeight(
+  totalLoad: number,
+  bodyWeight: number | null,
+  isBodyweightComponent: boolean,
+): { display: string; value: number } {
+  if (!isBodyweightComponent || bodyWeight === null) {
+    return { display: `${totalLoad} lbs`, value: totalLoad };
+  }
+  const added = Math.max(0, totalLoad - bodyWeight);
+  return { display: `+${added} lbs`, value: added };
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function BodyWeightGate({
+  onSubmit,
+}: {
+  onSubmit: (weight: number) => Promise<void>;
+}) {
+  const [input, setInput] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const weight = Number(input);
+    if (!weight || weight <= 0) {
+      setError('Enter a valid body weight.');
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      await onSubmit(weight);
+    } catch {
+      setError('Failed to save body weight. Try again.');
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className={styles.gate}>
+      <h2 className={styles.gateHeading}>Body Weight</h2>
+      <p className={styles.gateHint}>
+        This workout includes bodyweight exercises. Enter your weight to
+        calculate added load.
+      </p>
+      <form className={styles.gateForm} onSubmit={handleSubmit}>
+        <label className={styles.gateLabel} htmlFor="bw-input">
+          Body weight (lbs)
+        </label>
+        <input
+          id="bw-input"
+          className={styles.gateInput}
+          type="number"
+          min="50"
+          max="500"
+          step="0.5"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          autoFocus
+        />
+        {error && <p className={styles.gateError}>{error}</p>}
+        <button
+          className={styles.gateSubmit}
+          type="submit"
+          disabled={submitting}
+        >
+          {submitting ? 'Saving…' : 'Continue'}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+function WarmUpRow({
+  label,
+  totalLoad,
+  reps,
+  bodyWeight,
+  isBodyweightComponent,
+}: {
+  label: string;
+  totalLoad: number;
+  reps: number;
+  bodyWeight: number | null;
+  isBodyweightComponent: boolean;
+}) {
+  const weightStr = formatWarmUpWeight(totalLoad, bodyWeight, isBodyweightComponent);
+  return (
+    <li className={styles.warmUpRow}>
+      <span className={styles.warmUpLabel}>{label}</span>
+      <span className={styles.warmUpWeight}>
+        {weightStr} × {reps}
+      </span>
+    </li>
+  );
+}
+
+function WorkingSetRow({
+  lift,
+  set,
+  bodyWeight,
+  isBodyweightComponent,
+  isReadOnly,
+  loggedRecord,
+  isEditing,
+  program,
+  cycleNum,
+  workoutNum,
+  date,
+  onLogged,
+  onEditStart,
+  onEditSave,
+}: {
+  lift: string;
+  set: WorkingSetData;
+  bodyWeight: number | null;
+  isBodyweightComponent: boolean;
+  isReadOnly: boolean;
+  loggedRecord?: LiftRecordResponse;
+  isEditing: boolean;
+  program: string;
+  cycleNum: number;
+  workoutNum: number;
+  date: string;
+  onLogged: (record: LiftRecordResponse) => void;
+  onEditStart: () => void;
+  onEditSave: (record: LiftRecordResponse) => void;
+}) {
+  const { value: defaultWeight } = formatWorkingWeight(
+    set.totalLoad,
+    bodyWeight,
+    isBodyweightComponent,
+  );
+  const [weightInput, setWeightInput] = useState(String(defaultWeight));
+  const [repsInput, setRepsInput] = useState(String(set.reps));
+  const [notesInput, setNotesInput] = useState(loggedRecord?.notes ?? '');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isLogged = !!loggedRecord && !isEditing;
+
+  async function handleLog(e: React.FormEvent) {
+    e.preventDefault();
+    const weight = Number(weightInput);
+    const reps = Number(repsInput);
+    if (!weight || weight < 0 || !reps || reps < 0) {
+      setError('Enter valid weight and reps.');
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      const record = await createLiftRecord(program, {
+        program,
+        cycleNum,
+        workoutNum,
+        date,
+        lift,
+        setNum: set.setNum,
+        weight,
+        reps,
+        notes: notesInput || undefined,
+      });
+      onLogged(record);
+    } catch {
+      setError('Failed to log set. Try again.');
+      setSubmitting(false);
+    }
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    if (!loggedRecord) return;
+    const weight = Number(weightInput);
+    const reps = Number(repsInput);
+    if (!weight || weight < 0 || !reps || reps < 0) {
+      setError('Enter valid weight and reps.');
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      const record = await updateLiftRecord(program, loggedRecord.id, {
+        weight,
+        reps,
+        notes: notesInput || undefined,
+      });
+      onEditSave(record);
+    } catch {
+      setError('Failed to save changes. Try again.');
+      setSubmitting(false);
+    }
+  }
+
+  if (isReadOnly || isLogged) {
+    const displayWeight = loggedRecord
+      ? formatWorkingWeight(loggedRecord.weight, null, false).display
+      : formatWorkingWeight(set.totalLoad, bodyWeight, isBodyweightComponent).display;
+    return (
+      <li className={`${styles.setRow} ${styles.setRowLogged}`}>
+        <span className={styles.setNum}>Set {set.setNum}</span>
+        <span className={styles.setCheck}>✓</span>
+        <span className={styles.setSummary}>
+          {loggedRecord
+            ? `${loggedRecord.weight} lbs × ${loggedRecord.reps}`
+            : `${displayWeight} × ${set.reps}`}
+          {set.amrap ? ' (AMRAP)' : ''}
+        </span>
+        {loggedRecord?.notes && (
+          <span className={styles.setNotes}>{loggedRecord.notes}</span>
+        )}
+        {!isReadOnly && (
+          <button
+            className={styles.editBtn}
+            type="button"
+            onClick={onEditStart}
+            aria-label={`Edit set ${set.setNum}`}
+          >
+            Edit
+          </button>
+        )}
+      </li>
+    );
+  }
+
+  const isEdit = isEditing && !!loggedRecord;
+  return (
+    <li className={styles.setRow}>
+      <form
+        className={styles.setForm}
+        onSubmit={isEdit ? handleSave : handleLog}
+      >
+        <span className={styles.setNum}>Set {set.setNum}</span>
+        {set.amrap && <span className={styles.amrapBadge}>AMRAP</span>}
+        <label className={styles.srOnly} htmlFor={`weight-${lift}-${set.setNum}`}>
+          Weight (lbs)
+        </label>
+        <input
+          id={`weight-${lift}-${set.setNum}`}
+          className={styles.setInput}
+          type="number"
+          min="0"
+          step="2.5"
+          value={weightInput}
+          onChange={(e) => setWeightInput(e.target.value)}
+          disabled={submitting}
+          aria-label="Weight in lbs"
+        />
+        <span className={styles.inputSep}>lbs ×</span>
+        <label className={styles.srOnly} htmlFor={`reps-${lift}-${set.setNum}`}>
+          Reps
+        </label>
+        <input
+          id={`reps-${lift}-${set.setNum}`}
+          className={styles.setInput}
+          type="number"
+          min="0"
+          step="1"
+          value={repsInput}
+          onChange={(e) => setRepsInput(e.target.value)}
+          disabled={submitting}
+          aria-label="Reps"
+        />
+        <label className={styles.srOnly} htmlFor={`notes-${lift}-${set.setNum}`}>
+          Notes (optional)
+        </label>
+        <input
+          id={`notes-${lift}-${set.setNum}`}
+          className={styles.notesInput}
+          type="text"
+          placeholder="Notes (optional)"
+          value={notesInput}
+          onChange={(e) => setNotesInput(e.target.value)}
+          disabled={submitting}
+        />
+        {error && <p className={styles.setError}>{error}</p>}
+        <button
+          className={styles.logBtn}
+          type="submit"
+          disabled={submitting}
+        >
+          {submitting ? '…' : isEdit ? 'Save' : 'Log'}
+        </button>
+        {isEdit && (
+          <button
+            className={styles.cancelBtn}
+            type="button"
+            onClick={() => onEditSave(loggedRecord!)}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+        )}
+      </form>
+    </li>
+  );
+}
+
+function LiftView({
+  lift,
+  bodyWeight,
+  isReadOnly,
+  loggedSets,
+  editingSet,
+  program,
+  cycleNum,
+  workoutNum,
+  date,
+  onLogged,
+  onEditStart,
+  onEditSave,
+}: {
+  lift: LiftData;
+  bodyWeight: number | null;
+  isReadOnly: boolean;
+  loggedSets: Map<string, LiftRecordResponse>;
+  editingSet: string | null;
+  program: string;
+  cycleNum: number;
+  workoutNum: number;
+  date: string;
+  onLogged: (key: string, record: LiftRecordResponse) => void;
+  onEditStart: (key: string) => void;
+  onEditSave: (key: string, record: LiftRecordResponse) => void;
+}) {
+  return (
+    <div className={styles.liftView}>
+      <h2 className={styles.liftName}>{lift.lift}</h2>
+
+      {lift.warmUpSets.length > 0 && (
+        <section className={styles.warmUpSection} aria-label="Warm-up sets">
+          {lift.warmUpImplement && (
+            <p className={styles.warmUpImplement}>
+              Warm-up on: <strong>{lift.warmUpImplement}</strong>
+            </p>
+          )}
+          <ul className={styles.warmUpList}>
+            {lift.warmUpSets.map((s, i) => (
+              <WarmUpRow
+                key={i}
+                label={`Warm-up ${i + 1}`}
+                totalLoad={s.totalLoad}
+                reps={s.reps}
+                bodyWeight={bodyWeight}
+                isBodyweightComponent={lift.isBodyweightComponent}
+              />
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <section className={styles.workingSection} aria-label="Working sets">
+        <ul className={styles.setList}>
+          {lift.workingSets.map((ws) => {
+            const key = `${lift.lift}-${ws.setNum}`;
+            return (
+              <WorkingSetRow
+                key={key}
+                lift={lift.lift}
+                set={ws}
+                bodyWeight={bodyWeight}
+                isBodyweightComponent={lift.isBodyweightComponent}
+                isReadOnly={isReadOnly}
+                loggedRecord={loggedSets.get(key)}
+                isEditing={editingSet === key}
+                program={program}
+                cycleNum={cycleNum}
+                workoutNum={workoutNum}
+                date={date}
+                onLogged={(record) => onLogged(key, record)}
+                onEditStart={() => onEditStart(key)}
+                onEditSave={(record) => onEditSave(key, record)}
+              />
+            );
+          })}
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+function OverviewRow({
+  lift,
+  bodyWeight,
+  loggedSets,
+  onGoTo,
+}: {
+  lift: LiftData;
+  bodyWeight: number | null;
+  loggedSets: Map<string, LiftRecordResponse>;
+  onGoTo: () => void;
+}) {
+  const logged = lift.workingSets.filter((ws) =>
+    loggedSets.has(`${lift.lift}-${ws.setNum}`),
+  ).length;
+  const total = lift.workingSets.length;
+  const firstWarmUp = lift.warmUpSets[0];
+  return (
+    <li className={styles.overviewRow}>
+      <div className={styles.overviewRowHeader}>
+        <strong className={styles.overviewLiftName}>{lift.lift}</strong>
+        <span className={styles.overviewProgress}>
+          {logged}/{total} sets
+        </span>
+        <button className={styles.goToBtn} type="button" onClick={onGoTo}>
+          {logged === total ? 'Review' : logged > 0 ? 'Resume' : 'Go to'}
+        </button>
+      </div>
+      {firstWarmUp && (
+        <p className={styles.overviewWarmUp}>
+          Warm-up:{' '}
+          {formatWarmUpWeight(
+            firstWarmUp.totalLoad,
+            bodyWeight,
+            lift.isBodyweightComponent,
+          )}{' '}
+          × {firstWarmUp.reps}
+          {lift.warmUpSets.length > 1 ? ` (+${lift.warmUpSets.length - 1} more)` : ''}
+        </p>
+      )}
+    </li>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export default function WorkoutLogger({
+  program,
+  cycleNum,
+  workoutNum,
+  date,
+  lifts,
+  hasBodyweightComponent,
+  isReadOnly,
+}: WorkoutLoggerProps) {
+  const router = useRouter();
+
+  // Initialize loggedSets from any pre-existing records passed via server props
+  const [loggedSets, setLoggedSets] = useState<Map<string, LiftRecordResponse>>(
+    () => {
+      const m = new Map<string, LiftRecordResponse>();
+      for (const lift of lifts) {
+        for (const ws of lift.workingSets) {
+          if (ws.existing) {
+            m.set(`${lift.lift}-${ws.setNum}`, ws.existing);
+          }
+        }
+      }
+      return m;
+    },
+  );
+  const [editingSet, setEditingSet] = useState<string | null>(null);
+  const [currentLiftIdx, setCurrentLiftIdx] = useState(0);
+  const [viewMode, setViewMode] = useState<'per-lift' | 'overview'>('per-lift');
+  const [bodyWeight, setBodyWeight] = useState<number | null>(null);
+  const [bodyWeightDone, setBodyWeightDone] = useState(!hasBodyweightComponent || isReadOnly);
+
+  async function handleBodyWeightSubmit(weight: number) {
+    await recordBodyWeight(program, {
+      date,
+      weight,
+      unit: 'lbs',
+    });
+    setBodyWeight(weight);
+    setBodyWeightDone(true);
+  }
+
+  function handleLogged(key: string, record: LiftRecordResponse) {
+    setLoggedSets((prev) => new Map(prev).set(key, record));
+    setEditingSet(null);
+  }
+
+  function handleEditStart(key: string) {
+    setEditingSet(key);
+  }
+
+  function handleEditSave(key: string, record: LiftRecordResponse) {
+    setLoggedSets((prev) => new Map(prev).set(key, record));
+    setEditingSet(null);
+  }
+
+  // Total sets logged across all lifts
+  const totalSets = lifts.reduce((n, l) => n + l.workingSets.length, 0);
+  const allLogged = loggedSets.size === totalSets && totalSets > 0;
+
+  // Body weight gate
+  if (!bodyWeightDone) {
+    return <BodyWeightGate onSubmit={handleBodyWeightSubmit} />;
+  }
+
+  const currentLift = lifts[currentLiftIdx];
+  const nextLift = lifts[currentLiftIdx + 1];
+
+  // Overview mode
+  if (viewMode === 'overview') {
+    return (
+      <div className={styles.container}>
+        <header className={styles.header}>
+          <h1 className={styles.screenTitle}>Workout {workoutNum}</h1>
+          <button
+            className={styles.viewToggle}
+            type="button"
+            aria-label="Switch to per-exercise view"
+            onClick={() => setViewMode('per-lift')}
+          >
+            ✕
+          </button>
+        </header>
+        <ul className={styles.overviewList}>
+          {lifts.map((lift, i) => (
+            <OverviewRow
+              key={lift.lift}
+              lift={lift}
+              bodyWeight={bodyWeight}
+              loggedSets={loggedSets}
+              onGoTo={() => {
+                setCurrentLiftIdx(i);
+                setViewMode('per-lift');
+              }}
+            />
+          ))}
+        </ul>
+        {allLogged && (
+          <button
+            className={styles.finishBtn}
+            type="button"
+            onClick={() => router.push(`/cycle/${cycleNum}`)}
+          >
+            Finish workout
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  // Per-lift view
+  return (
+    <div className={styles.container}>
+      <header className={styles.header}>
+        <h1 className={styles.screenTitle}>Workout {workoutNum}</h1>
+        <button
+          className={styles.viewToggle}
+          type="button"
+          aria-label="Switch to overview"
+          onClick={() => setViewMode('overview')}
+        >
+          ⊞
+        </button>
+      </header>
+
+      {/* Navigation dots */}
+      <nav className={styles.navDots} aria-label="Exercise navigation">
+        {lifts.map((lift, i) => {
+          const liftLogged = lift.workingSets.every((ws) =>
+            loggedSets.has(`${lift.lift}-${ws.setNum}`),
+          );
+          return (
+            <button
+              key={lift.lift}
+              className={`${styles.dot} ${i === currentLiftIdx ? styles.dotActive : ''} ${liftLogged ? styles.dotDone : ''}`}
+              type="button"
+              aria-label={`Go to ${lift.lift}`}
+              aria-current={i === currentLiftIdx ? 'true' : undefined}
+              onClick={() => setCurrentLiftIdx(i)}
+            />
+          );
+        })}
+      </nav>
+
+      {/* Current lift */}
+      {currentLift && (
+        <LiftView
+          lift={currentLift}
+          bodyWeight={bodyWeight}
+          isReadOnly={isReadOnly}
+          loggedSets={loggedSets}
+          editingSet={editingSet}
+          program={program}
+          cycleNum={cycleNum}
+          workoutNum={workoutNum}
+          date={date}
+          onLogged={handleLogged}
+          onEditStart={handleEditStart}
+          onEditSave={handleEditSave}
+        />
+      )}
+
+      {/* Bottom strip */}
+      <footer className={styles.bottomStrip}>
+        {nextLift ? (
+          <>
+            <span className={styles.nextLabel}>Next:</span>
+            <span className={styles.nextName}>{nextLift.lift}</span>
+            {nextLift.warmUpSets[0] && (
+              <span className={styles.nextWeight}>
+                {formatWarmUpWeight(
+                  nextLift.warmUpSets[0].totalLoad,
+                  bodyWeight,
+                  nextLift.isBodyweightComponent,
+                )}{' '}
+                × {nextLift.warmUpSets[0].reps}
+              </span>
+            )}
+            <button
+              className={styles.nextBtn}
+              type="button"
+              onClick={() => setCurrentLiftIdx((i) => i + 1)}
+            >
+              →
+            </button>
+          </>
+        ) : (
+          <span className={styles.lastExercise}>Last exercise</span>
+        )}
+        {allLogged && (
+          <button
+            className={styles.finishBtn}
+            type="button"
+            onClick={() => router.push(`/cycle/${cycleNum}`)}
+          >
+            Finish workout
+          </button>
+        )}
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/page.tsx
@@ -1,0 +1,123 @@
+import { notFound } from 'next/navigation';
+import {
+  LIFT_CATALOG,
+  MROUND,
+  PROG_SPEC_WARMUP_PCTS,
+  WARMUP_BASE_REPS,
+  DEFAULT_SLOT_MAP,
+} from '@lifting-logbook/core';
+import {
+  fetchLiftRecords,
+  fetchProgramSpec,
+  fetchTrainingMaxes,
+  fetchWorkout,
+} from '@/lib/api';
+import WorkoutLogger from './WorkoutLogger';
+import type { LiftData, WarmUpSetData, WorkingSetData, WorkoutLoggerProps } from './types';
+
+/**
+ * Hard-coded warm-up implement names for bodyweight-component exercises.
+ * Follow-on: make these configurable per exercise (see proposal open questions).
+ */
+const WARMUP_IMPLEMENT: Record<string, string> = {
+  'Chin-up': 'lat pulldown',
+  'Pull-up': 'lat pulldown',
+  'Dips': 'dips (unweighted)',
+};
+
+function isBodyweightComponent(liftName: string): boolean {
+  const catalogId = DEFAULT_SLOT_MAP[liftName];
+  if (!catalogId) return false;
+  return LIFT_CATALOG.find((l) => l.id === catalogId)?.isBodyweightComponent ?? false;
+}
+
+export default async function WorkoutLoggingPage({
+  params,
+}: {
+  params: Promise<{ cycleNum: string; workoutNum: string }>;
+}) {
+  const { cycleNum: cycleNumParam, workoutNum: workoutNumParam } = await params;
+  const cycleNum = Number(cycleNumParam);
+  const workoutNum = Number(workoutNumParam);
+
+  if (!Number.isInteger(cycleNum) || !Number.isInteger(workoutNum) || workoutNum < 1) {
+    notFound();
+  }
+
+  const program = process.env.NEXT_PUBLIC_DEFAULT_PROGRAM ?? '5-3-1';
+
+  const [workout, specs, maxes, allRecords] = await Promise.all([
+    fetchWorkout(program, workoutNum),
+    fetchProgramSpec(program),
+    fetchTrainingMaxes(program),
+    fetchLiftRecords(program),
+  ]);
+
+  if (!workout) {
+    notFound();
+    return null; // unreachable; notFound() throws but TypeScript can't verify without Next.js types
+  }
+
+  // Only care about records for this specific workout
+  const workoutRecords = allRecords.filter((r) => r.workoutNum === workoutNum);
+
+  const maxMap = new Map(maxes.map((m) => [m.lift, m.weight]));
+
+  const lifts: LiftData[] = workout.lifts.map((wl) => {
+    const tm = maxMap.get(wl.lift) ?? 0;
+
+    // Spec entry for this (week, lift) — provides warmUpPct and increment
+    const spec = specs.find((s) => s.week === workout.week && s.lift === wl.lift);
+
+    const warmUpSets: WarmUpSetData[] = spec
+      ? PROG_SPEC_WARMUP_PCTS(spec.warmUpPct)
+          .filter((p) => !isNaN(p) && p > 0)
+          .map((pct, i) => ({
+            reps: Math.max(1, WARMUP_BASE_REPS - i),
+            totalLoad: MROUND(tm * pct, spec.increment),
+          }))
+      : [];
+
+    const workingSets: WorkingSetData[] = wl.sets.map((s) => ({
+      setNum: s.setNum,
+      totalLoad: s.weight,
+      reps: s.reps,
+      amrap: s.amrap,
+      existing: workoutRecords.find(
+        (r) => r.lift === wl.lift && r.setNum === s.setNum,
+      ),
+    }));
+
+    const bwComponent = isBodyweightComponent(wl.lift);
+
+    return {
+      lift: wl.lift,
+      isBodyweightComponent: bwComponent,
+      warmUpImplement: bwComponent ? WARMUP_IMPLEMENT[wl.lift] : undefined,
+      warmUpSets,
+      workingSets,
+    };
+  });
+
+  const hasBodyweightComponent = lifts.some((l) => l.isBodyweightComponent);
+
+  // A workout is read-only when every working set across every lift has a logged record.
+  const totalWorkingSets = lifts.reduce((n, l) => n + l.workingSets.length, 0);
+  const loggedCount = lifts.reduce(
+    (n, l) => n + l.workingSets.filter((s) => s.existing).length,
+    0,
+  );
+  const isReadOnly = totalWorkingSets > 0 && loggedCount === totalWorkingSets;
+
+  const props: WorkoutLoggerProps = {
+    program,
+    cycleNum,
+    workoutNum,
+    date: workout.date,
+    lifts,
+    hasBodyweightComponent,
+    isReadOnly,
+  };
+
+  return <WorkoutLogger {...props} />;
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/page.tsx
@@ -7,6 +7,7 @@ import {
   DEFAULT_SLOT_MAP,
 } from '@lifting-logbook/core';
 import {
+  fetchLatestBodyWeight,
   fetchLiftRecords,
   fetchProgramSpec,
   fetchTrainingMaxes,
@@ -46,11 +47,12 @@ export default async function WorkoutLoggingPage({
 
   const program = process.env.NEXT_PUBLIC_DEFAULT_PROGRAM ?? '5-3-1';
 
-  const [workout, specs, maxes, allRecords] = await Promise.all([
+  const [workout, specs, maxes, allRecords, latestBodyWeight] = await Promise.all([
     fetchWorkout(program, workoutNum),
     fetchProgramSpec(program),
     fetchTrainingMaxes(program),
     fetchLiftRecords(program),
+    fetchLatestBodyWeight(program),
   ]);
 
   if (!workout) {
@@ -109,6 +111,13 @@ export default async function WorkoutLoggingPage({
   );
   const isReadOnly = totalWorkingSets > 0 && loggedCount === totalWorkingSets;
 
+  // Re-use a same-day body weight so the gate doesn't re-fire mid-session.
+  // If the stored entry is from a different day, pass null → gate fires again.
+  const initialBodyWeight =
+    latestBodyWeight && latestBodyWeight.date === workout.date
+      ? latestBodyWeight.weight
+      : null;
+
   const props: WorkoutLoggerProps = {
     program,
     cycleNum,
@@ -117,6 +126,7 @@ export default async function WorkoutLoggingPage({
     lifts,
     hasBodyweightComponent,
     isReadOnly,
+    initialBodyWeight,
   };
 
   return <WorkoutLogger {...props} />;

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/types.ts
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/types.ts
@@ -42,4 +42,10 @@ export interface WorkoutLoggerProps {
   lifts: LiftData[];
   hasBodyweightComponent: boolean;
   isReadOnly: boolean;
+  /**
+   * Body weight (lbs) already recorded for this workout's date, if any.
+   * When set, the bodyweight gate is skipped and this value is used directly.
+   * When null, the gate fires on first render (unless isReadOnly or !hasBodyweightComponent).
+   */
+  initialBodyWeight: number | null;
 }

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/types.ts
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/types.ts
@@ -1,0 +1,45 @@
+import type { LiftRecordResponse } from '@lifting-logbook/types';
+
+export interface WarmUpSetData {
+  /** Number of reps for this warm-up set. */
+  reps: number;
+  /**
+   * Total planned load in lbs (TM × pct, MROUND'd).
+   * For bodyweight-component lifts this is the total load —
+   * the UI derives added weight after the bodyweight gate.
+   */
+  totalLoad: number;
+}
+
+export interface WorkingSetData {
+  setNum: number;
+  /** Total planned load (barbell: bar weight; BW-component: targetLoad). */
+  totalLoad: number;
+  reps: number;
+  amrap: boolean;
+  /** Pre-populated when a logged record already exists for this set. */
+  existing?: LiftRecordResponse;
+}
+
+export interface LiftData {
+  lift: string;
+  isBodyweightComponent: boolean;
+  /**
+   * For bodyweight-component lifts, the warm-up implement name shown
+   * above the warm-up set list (e.g. "lat pulldown", "dips").
+   */
+  warmUpImplement?: string;
+  warmUpSets: WarmUpSetData[];
+  workingSets: WorkingSetData[];
+}
+
+export interface WorkoutLoggerProps {
+  program: string;
+  cycleNum: number;
+  workoutNum: number;
+  /** ISO date string for this workout (used when creating lift records). */
+  date: string;
+  lifts: LiftData[];
+  hasBodyweightComponent: boolean;
+  isReadOnly: boolean;
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,7 +1,11 @@
 import type {
+  CreateLiftRecordRequest,
   CycleDashboardResponse,
   LiftingProgramSpecResponse,
+  LiftRecordResponse,
+  RecordBodyWeightRequest,
   TrainingMaxResponse,
+  UpdateLiftRecordRequest,
   UpdateTrainingMaxesRequest,
   WorkoutResponse,
 } from '@lifting-logbook/types';
@@ -68,4 +72,59 @@ export async function fetchWorkout(
     throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
   }
   return res.json() as Promise<WorkoutResponse>;
+}
+
+export function fetchLiftRecords(
+  program: string,
+): Promise<LiftRecordResponse[]> {
+  return apiFetch(
+    `/programs/${encodeURIComponent(program)}/lift-records`,
+    { cache: 'no-store' },
+  );
+}
+
+export function createLiftRecord(
+  program: string,
+  body: CreateLiftRecordRequest,
+): Promise<LiftRecordResponse> {
+  return apiFetch(
+    `/programs/${encodeURIComponent(program)}/lift-records`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      cache: 'no-store',
+    } as RequestInit,
+  );
+}
+
+export function updateLiftRecord(
+  program: string,
+  id: string,
+  body: UpdateLiftRecordRequest,
+): Promise<LiftRecordResponse> {
+  return apiFetch(
+    `/programs/${encodeURIComponent(program)}/lift-records/${encodeURIComponent(id)}`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      cache: 'no-store',
+    } as RequestInit,
+  );
+}
+
+export function recordBodyWeight(
+  program: string,
+  body: RecordBodyWeightRequest,
+): Promise<void> {
+  return apiFetch(
+    `/programs/${encodeURIComponent(program)}/body-weight`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      cache: 'no-store',
+    } as RequestInit,
+  );
 }

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,4 +1,5 @@
 import type {
+  BodyWeightResponse,
   CreateLiftRecordRequest,
   CycleDashboardResponse,
   LiftingProgramSpecResponse,
@@ -94,7 +95,7 @@ export function createLiftRecord(
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
       cache: 'no-store',
-    } as RequestInit,
+    },
   );
 }
 
@@ -110,7 +111,7 @@ export function updateLiftRecord(
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
       cache: 'no-store',
-    } as RequestInit,
+    },
   );
 }
 
@@ -125,6 +126,18 @@ export function recordBodyWeight(
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
       cache: 'no-store',
-    } as RequestInit,
+    },
   );
+}
+
+export async function fetchLatestBodyWeight(
+  program: string,
+): Promise<BodyWeightResponse | null> {
+  const path = `/programs/${encodeURIComponent(program)}/body-weight/latest`;
+  const res = await fetch(`${API_URL}${path}`, { cache: 'no-store' });
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
+  }
+  return res.json() as Promise<BodyWeightResponse>;
 }

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -99,6 +99,13 @@ export interface RecordBodyWeightRequest {
   unit: WeightUnit;
 }
 
+/** Serialized body weight entry as returned by the API. */
+export interface BodyWeightResponse {
+  date: string; // ISO 8601 date string ("YYYY-MM-DD")
+  weight: number;
+  unit: WeightUnit;
+}
+
 // ---------------------------------------------------------------------------
 // Cycle Dashboard
 // ---------------------------------------------------------------------------

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -81,6 +81,13 @@ export interface CreateLiftRecordRequest {
   notes?: string;
 }
 
+/** Request body for updating an existing lift record (in-session editing). */
+export interface UpdateLiftRecordRequest {
+  weight?: number;
+  reps?: number;
+  notes?: string;
+}
+
 // ---------------------------------------------------------------------------
 // Body Weight
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds the workout logging screen at `/cycle/:cycleNum/workout/:workoutNum` — the primary job-to-be-done (log a workout in under 2 min, J1)
- Closes the two API gaps identified in the accepted proposal: `POST /lift-records` and `PATCH /lift-records/:id`
- Adds `POST /body-weight` and `IBodyWeightRepository` for the bodyweight gate (J4)
- Adds `UpdateLiftRecordRequest` type to `packages/types`

## What changed

**API (`apps/api`, `packages/types`):**
- `UpdateLiftRecordRequest` interface in `packages/types/src/api.ts`
- `updateLiftRecord()` on `ILiftRecordRepository` port + `InMemoryLiftRecordRepository` adapter
- `IBodyWeightRepository` port + `InMemoryBodyWeightRepository` adapter
- `POST /programs/:program/lift-records` — log a working set
- `PATCH /programs/:program/lift-records/:id` — edit a logged set in-session
- `POST /programs/:program/body-weight` — record body weight before lift list
- Updated `lift-records.controller.spec.ts`: added GET group + new POST and PATCH tests
- Updated `ports.compile-test.ts` for new port methods

**Web (`apps/web`):**
- `app/cycle/[cycleNum]/workout/[workoutNum]/page.tsx` — server component; fetches workout plan, spec, maxes, and existing records; computes warm-up weights via `PROG_SPEC_WARMUP_PCTS` + `MROUND`
- `WorkoutLogger.tsx` — client component; per-exercise view, bodyweight gate, navigation dots, in-session editing, bottom strip, whole-workout overview (⊞), finish workout nav
- `WorkoutLogger.module.css` — touch target ≥ 44 px; 375 px+ usable
- `lib/api.ts` — `fetchLiftRecords`, `createLiftRecord`, `updateLiftRecord`, `recordBodyWeight`

## Acceptance Criteria

- [x] `/cycle/:cycleNum/workout/:workoutNum` fetches and renders the workout plan
- [x] Bodyweight gate shown when workout contains bodyweight-component lifts; posts to `POST /body-weight`
- [x] Warm-up sets shown read-only; weights derived from `warmUpPct` + TM via `packages/core`
- [x] BW-component warm-up sets display `BW × n` or `+X lb × n`; warm-up implement label shown
- [x] Working set weights pre-filled from workout response
- [x] Log per set posts to `POST /lift-records`; set locked with ✓ on success
- [x] Logged set re-openable for editing; re-submission sends `PATCH /lift-records/:id`
- [x] Optional notes field per working set
- [x] Navigation dots tappable to jump between exercises
- [x] Bottom strip shows next exercise name and first warm-up weight; reads "Last exercise" on last
- [x] Finish workout navigates to `/cycle/:cycleNum` when all sets logged
- [x] ⊞ toggle switches to whole-workout overview with Resume / Go to buttons
- [x] Read-only mode when all sets already logged (inputs disabled, records displayed)
- [x] Touch targets ≥ 44 px; usable at ≥ 375 px viewport width

## Testing

```
npm test -w @lifting-logbook/core   # 124 tests pass
npm test -w @lifting-logbook/api    # 49 tests pass (50 total, 1 skipped pre-existing)
```

API build: `npm run build -w @lifting-logbook/api` — clean.

Web type-check: `tsc --noEmit` in `apps/web` — only pre-existing module-not-found errors for `next/*` paths (environment artifact of the worktree setup; not new errors from this PR). `UpdateLiftRecordRequest` resolution is confirmed correct via the API build, which imports the same package and builds cleanly.

Closes #133