### PR TITLE
[docs] Define A/B comparison exit criteria and CI event taxonomy enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,6 @@ jobs:
 
       - name: Lint & Test
         run: npx turbo run lint test
+
+      - name: Validate analytics taxonomy
+        run: node scripts/validate-analytics-taxonomy.mjs

--- a/docs/adr/ADR-008-mobile-strategy.md
+++ b/docs/adr/ADR-008-mobile-strategy.md
@@ -87,6 +87,57 @@ accumulate.
 
 ---
 
+## Comparison Conclusion Criteria
+
+The two-codebase maintenance period is explicitly time-bounded. The following criteria define
+when the comparison is complete and which client becomes the production standard.
+
+### Minimum comparison duration
+
+Both clients must have been deployed to internal testing tracks and instrumented for **at least
+8 weeks** before a conclusion is drawn. This ensures the Firebase Analytics data set is large
+enough to detect meaningful differences in session length, crash rate, and render performance
+with reasonable confidence.
+
+### Decision thresholds
+
+A winner is selected when **at least three of the five primary metrics** show a consistent
+advantage (≥ 10% delta sustained over the final 4 weeks of the comparison period):
+
+| Metric | Source | Direction |
+|---|---|---|
+| Screen render time (p95) | Firebase Performance | Lower is better |
+| Crash-free session rate | Firebase Crashlytics | Higher is better |
+| App startup time (cold, p95) | Firebase Performance | Lower is better |
+| `workout_completed` / `workout_started` ratio | Firebase Analytics | Higher is better |
+| Install size | Play Console | Lower is better |
+
+If no client meets the threshold after 8 weeks, extend the comparison in 4-week increments
+(up to a maximum of 20 weeks) until thresholds are met or the decision is made by judgment
+with documented rationale.
+
+### Decision process
+
+1. Export the full 8-week Firebase Analytics and Performance dataset to BigQuery.
+2. Produce a summary report in `docs/mobile-ab-test-results.md` with metric tables, segment
+   breakdowns by `client` property, and a recommendation.
+3. Decision is finalized by the project owner. Record the outcome in `docs/mobile-ab-test-results.md`
+   and update the Status field of this ADR to `Decided — [React Native | Kotlin]`.
+
+### Archival plan for the losing codebase
+
+After the winner is selected:
+
+1. Tag the losing client's repository state: `git tag ab-comparison-final`.
+2. Move the losing app directory to `apps/archive/<app-name>/` and add a `README.md` noting
+   the comparison outcome, the date archived, and a link to `docs/mobile-ab-test-results.md`.
+3. Remove the losing client's Play Store internal track.
+4. Delete the archived app's CI jobs from `.github/workflows/` (keeping the workflow file with
+   a note that it was retired post-comparison).
+5. Update this ADR status and add a `Decided` date.
+
+---
+
 ## Alternatives Considered
 
 **React Native only (no Kotlin phase):** Faster. Appropriate if native performance is not a

--- a/docs/adr/ADR-012-analytics-and-ab-testing.md
+++ b/docs/adr/ADR-012-analytics-and-ab-testing.md
@@ -144,6 +144,42 @@ ensure consistency.
 
 ---
 
+## CI Taxonomy Enforcement
+
+To prevent silent drift between the TypeScript and Kotlin event taxonomy definitions, a CI
+validation step runs on every pull request targeting `main`.
+
+### How it works
+
+The script `scripts/validate-analytics-taxonomy.mjs`:
+
+1. Parses all string values from the `AnalyticsEvent` const object in
+   `packages/types/src/analytics.ts`.
+2. Checks that each event name string is present as a quoted literal in
+   `apps/mobile-kotlin/app/src/main/java/com/liftinglogbook/analytics/AnalyticsConstants.kt`.
+3. **If `AnalyticsConstants.kt` does not yet exist** (Kotlin app not yet scaffolded), the
+   script exits successfully — this is not treated as drift.
+4. **If `AnalyticsConstants.kt` exists but is missing one or more event names**, the script
+   prints the missing events and exits with code 1, failing the CI job.
+
+### Adding or renaming an event
+
+When a new event is added to `AnalyticsEvent` in `packages/types/src/analytics.ts`:
+
+1. Add the matching constant to `AnalyticsConstants.kt` in the same PR.
+2. The CI step will fail if the Kotlin file is out of sync, preventing the PR from merging.
+
+### CI configuration
+
+The step is defined in `.github/workflows/ci.yml`:
+
+```yaml
+- name: Validate analytics taxonomy
+  run: node scripts/validate-analytics-taxonomy.mjs
+```
+
+---
+
 ## Metrics for the React Native vs. Kotlin A/B Comparison
 
 | Metric | Source | Segmented by `client` |

--- a/packages/types/src/analytics.ts
+++ b/packages/types/src/analytics.ts
@@ -1,0 +1,32 @@
+export const AnalyticsEvent = {
+  // Workout logging
+  WORKOUT_STARTED:        'workout_started',
+  WORKOUT_COMPLETED:      'workout_completed',
+  WORKOUT_ABANDONED:      'workout_abandoned',
+  SET_LOGGED:             'set_logged',
+
+  // Navigation
+  SCREEN_VIEWED:          'screen_viewed',
+
+  // Training maxes
+  TRAINING_MAXES_UPDATED: 'training_maxes_updated',
+
+  // Cycle management
+  CYCLE_STARTED:          'cycle_started',
+  CYCLE_DASHBOARD_VIEWED: 'cycle_dashboard_viewed',
+} as const;
+
+export type AnalyticsEventName = typeof AnalyticsEvent[keyof typeof AnalyticsEvent];
+
+export interface EventProperties {
+  workout_started:        { lift: string; week: number; cycle: number; client: ClientType };
+  workout_completed:      { lift: string; week: number; cycle: number; duration_seconds: number; client: ClientType };
+  workout_abandoned:      { lift: string; week: number; cycle: number; client: ClientType };
+  set_logged:             { lift: string; reps: number; weight: number; unit: 'lbs' | 'kg'; client: ClientType };
+  screen_viewed:          { screen_name: string; client: ClientType };
+  training_maxes_updated: { lift_count: number; client: ClientType };
+  cycle_started:          { cycle: number; client: ClientType };
+  cycle_dashboard_viewed: { cycle: number; client: ClientType };
+}
+
+export type ClientType = 'react_native' | 'kotlin_compose' | 'web';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,2 +1,3 @@
 export * from './domain';
 export * from './api';
+export * from './analytics';

--- a/scripts/validate-analytics-taxonomy.mjs
+++ b/scripts/validate-analytics-taxonomy.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Validates that AnalyticsConstants.kt contains every event name defined in
+ * packages/types/src/analytics.ts. Exits 0 when in sync or when the Kotlin
+ * file does not yet exist (Kotlin app is future work). Exits 1 on drift.
+ *
+ * Usage: node scripts/validate-analytics-taxonomy.mjs
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+const TS_FILE = resolve(root, 'packages/types/src/analytics.ts');
+const KT_FILE = resolve(root, 'apps/mobile-kotlin/app/src/main/java/com/liftinglogbook/analytics/AnalyticsConstants.kt');
+
+// --- Parse TypeScript event values ---
+
+const tsSource = readFileSync(TS_FILE, 'utf8');
+
+// Match string values inside the AnalyticsEvent const object
+const tsEventBlock = tsSource.match(/export const AnalyticsEvent\s*=\s*\{([^}]+)\}/s);
+if (!tsEventBlock) {
+  console.error('ERROR: Could not parse AnalyticsEvent from', TS_FILE);
+  process.exit(1);
+}
+
+const tsEvents = [...tsEventBlock[1].matchAll(/'([^']+)'/g)].map(m => m[1]);
+if (tsEvents.length === 0) {
+  console.error('ERROR: No event names found in AnalyticsEvent.');
+  process.exit(1);
+}
+
+// --- Check Kotlin file ---
+
+if (!existsSync(KT_FILE)) {
+  console.log('INFO: AnalyticsConstants.kt not found — Kotlin app not yet scaffolded. Skipping taxonomy validation.');
+  console.log(`      Expected path: ${KT_FILE}`);
+  process.exit(0);
+}
+
+const ktSource = readFileSync(KT_FILE, 'utf8');
+
+const missing = tsEvents.filter(event => !ktSource.includes(`"${event}"`));
+
+if (missing.length > 0) {
+  console.error('ERROR: Analytics taxonomy drift detected.');
+  console.error('The following events are defined in packages/types/src/analytics.ts but');
+  console.error('are missing from AnalyticsConstants.kt:\n');
+  missing.forEach(e => console.error(`  - ${e}`));
+  console.error('\nUpdate AnalyticsConstants.kt to include all event names from the TypeScript taxonomy.');
+  process.exit(1);
+}
+
+console.log(`OK: All ${tsEvents.length} event names present in AnalyticsConstants.kt.`);
+process.exit(0);


### PR DESCRIPTION
## Summary

- **ADR-008 amendment:** Adds a *Comparison Conclusion Criteria* section with an 8-week minimum comparison duration, five concrete metric thresholds (≥10% delta sustained over 4 weeks), a BigQuery-backed decision process, and an archival plan for the losing codebase — eliminating the open-ended dual-codebase maintenance burden flagged in the ARB review.
- **CI taxonomy enforcement:** Adds `scripts/validate-analytics-taxonomy.mjs` (a Node.js ESM script) and a new CI step that parses event names from `packages/types/src/analytics.ts` and validates they are present in `AnalyticsConstants.kt`. The step skips gracefully when the Kotlin file does not yet exist, and fails on first taxonomy drift once the Kotlin app is scaffolded.
- **ADR-012 amendment:** Adds a *CI Taxonomy Enforcement* section documenting the script, the per-event update workflow, and the CI configuration snippet.
- **`packages/types/src/analytics.ts`:** Creates the shared event taxonomy file that was defined only in ADR-012 prose — now an actual source file exported from the package root.

## Acceptance Criteria

- [x] ADR-008 amended with a "Comparison Conclusion Criteria" section: minimum comparison duration, metric thresholds, decision process for selecting a winner, and archival plan for the losing codebase
- [x] CI step added that extracts event names from `packages/types/src/analytics.ts` and validates they are present in `apps/mobile-kotlin/.../AnalyticsConstants.kt` (or equivalent path); CI fails on drift
- [x] CI validation documented in ADR-012

## Test plan

- `npm test` — all 10 tasks pass (49 tests + 1 skipped)
- `node scripts/validate-analytics-taxonomy.mjs` — exits 0 with INFO message (Kotlin file not yet present; expected)

Closes #41