### PR TITLE
[feat] Auth guard — Clerk adapter, DevAuthProvider, and NestJS global guard

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.92.0",
+    "@clerk/backend": "^3.4.4",
     "@lifting-logbook/core": "*",
     "@lifting-logbook/types": "*",
     "@nestjs/common": "^10.0.0",

--- a/apps/api/src/adapters/clerk/clerk-auth.adapter.ts
+++ b/apps/api/src/adapters/clerk/clerk-auth.adapter.ts
@@ -1,0 +1,26 @@
+import { createClerkClient, verifyToken } from '@clerk/backend';
+import { UnauthorizedException } from '@nestjs/common';
+import { AuthUser, IAuthProvider } from '../../ports/auth';
+
+export class ClerkAuthProvider implements IAuthProvider {
+  private readonly client = createClerkClient({
+    secretKey: process.env.CLERK_SECRET_KEY,
+  });
+
+  async verifyToken(token: string): Promise<AuthUser> {
+    try {
+      const payload = await verifyToken(token, {
+        secretKey: process.env.CLERK_SECRET_KEY!,
+      });
+      const user = await this.client.users.getUser(payload.sub);
+      return {
+        id: user.id,
+        email: user.primaryEmailAddress?.emailAddress ?? '',
+        provider: 'clerk',
+        displayName: user.fullName ?? undefined,
+      };
+    } catch {
+      throw new UnauthorizedException('Invalid or expired token');
+    }
+  }
+}

--- a/apps/api/src/adapters/clerk/clerk-auth.adapter.ts
+++ b/apps/api/src/adapters/clerk/clerk-auth.adapter.ts
@@ -1,18 +1,35 @@
+import {
+  Injectable,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { createClerkClient, verifyToken } from '@clerk/backend';
-import { UnauthorizedException } from '@nestjs/common';
 import { AuthUser, IAuthProvider } from '../../ports/auth';
 
+@Injectable()
 export class ClerkAuthProvider implements IAuthProvider {
   private readonly client = createClerkClient({
     secretKey: process.env.CLERK_SECRET_KEY,
   });
 
   async verifyToken(token: string): Promise<AuthUser> {
+    // Step 1: verify the JWT — throws UnauthorizedException on invalid/expired token
+    let sub: string;
     try {
       const payload = await verifyToken(token, {
         secretKey: process.env.CLERK_SECRET_KEY!,
+        ...(process.env.CLERK_AUTHORIZED_PARTY
+          ? { authorizedParties: [process.env.CLERK_AUTHORIZED_PARTY] }
+          : {}),
       });
-      const user = await this.client.users.getUser(payload.sub);
+      sub = payload.sub;
+    } catch {
+      throw new UnauthorizedException('Invalid or expired token');
+    }
+
+    // Step 2: fetch user profile — throws ServiceUnavailableException on Clerk API error
+    try {
+      const user = await this.client.users.getUser(sub);
       return {
         id: user.id,
         email: user.primaryEmailAddress?.emailAddress ?? '',
@@ -20,7 +37,7 @@ export class ClerkAuthProvider implements IAuthProvider {
         displayName: user.fullName ?? undefined,
       };
     } catch {
-      throw new UnauthorizedException('Invalid or expired token');
+      throw new ServiceUnavailableException('Auth service unavailable');
     }
   }
 }

--- a/apps/api/src/adapters/dev/dev-auth.adapter.ts
+++ b/apps/api/src/adapters/dev/dev-auth.adapter.ts
@@ -1,0 +1,13 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { AuthUser, IAuthProvider } from '../../ports/auth';
+
+export class DevAuthProvider implements IAuthProvider {
+  async verifyToken(token: string): Promise<AuthUser> {
+    if (!token) throw new UnauthorizedException();
+    return {
+      id: process.env.DEV_USER_ID ?? 'dev-user',
+      email: process.env.DEV_USER_EMAIL ?? 'dev@example.com',
+      provider: 'dev',
+    };
+  }
+}

--- a/apps/api/src/adapters/dev/dev-auth.adapter.ts
+++ b/apps/api/src/adapters/dev/dev-auth.adapter.ts
@@ -1,6 +1,7 @@
-import { UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { AuthUser, IAuthProvider } from '../../ports/auth';
 
+@Injectable()
 export class DevAuthProvider implements IAuthProvider {
   async verifyToken(token: string): Promise<AuthUser> {
     if (!token) throw new UnauthorizedException();

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
+import { AuthModule } from './auth/auth.module';
 import { HealthModule } from './health/health.module';
 import { ProgramsModule } from './programs/programs.module';
 
 @Module({
-  imports: [HealthModule, ProgramsModule],
+  imports: [AuthModule, HealthModule, ProgramsModule],
 })
 export class AppModule {}

--- a/apps/api/src/auth/auth.guard.ts
+++ b/apps/api/src/auth/auth.guard.ts
@@ -1,0 +1,38 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { IAuthProvider } from '../ports/auth';
+import { AUTH_PROVIDER } from '../ports/tokens';
+import { IS_PUBLIC_KEY } from './public.decorator';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    @Inject(AUTH_PROVIDER) private readonly authProvider: IAuthProvider,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) return true;
+
+    const request = context.switchToHttp().getRequest();
+    const authHeader: string | undefined = request.headers['authorization'];
+    const token = authHeader?.startsWith('Bearer ')
+      ? authHeader.slice(7)
+      : undefined;
+
+    if (!token) throw new UnauthorizedException();
+
+    request.user = await this.authProvider.verifyToken(token);
+    return true;
+  }
+}

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
+import { ClerkAuthProvider } from '../adapters/clerk/clerk-auth.adapter';
+import { DevAuthProvider } from '../adapters/dev/dev-auth.adapter';
+import { AUTH_PROVIDER } from '../ports/tokens';
+import { AuthGuard } from './auth.guard';
+
+@Module({
+  providers: [
+    {
+      provide: AUTH_PROVIDER,
+      useClass: process.env.CLERK_SECRET_KEY
+        ? ClerkAuthProvider
+        : DevAuthProvider,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: AuthGuard,
+    },
+  ],
+})
+export class AuthModule {}

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -5,6 +5,15 @@ import { DevAuthProvider } from '../adapters/dev/dev-auth.adapter';
 import { AUTH_PROVIDER } from '../ports/tokens';
 import { AuthGuard } from './auth.guard';
 
+// Fail fast if the variable is defined but empty — a common Helm/container
+// misconfiguration that would otherwise silently fall back to DevAuthProvider.
+if (process.env.CLERK_SECRET_KEY === '') {
+  throw new Error(
+    'CLERK_SECRET_KEY is set but empty — refusing to fall back to DevAuthProvider. ' +
+      'Unset the variable entirely to use DevAuthProvider intentionally.',
+  );
+}
+
 @Module({
   providers: [
     {

--- a/apps/api/src/auth/current-user.decorator.ts
+++ b/apps/api/src/auth/current-user.decorator.ts
@@ -2,8 +2,8 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { AuthUser } from '../ports/auth';
 
 export const CurrentUser = createParamDecorator(
-  (_data: unknown, ctx: ExecutionContext): AuthUser => {
+  (_data: unknown, ctx: ExecutionContext): AuthUser | undefined => {
     const request = ctx.switchToHttp().getRequest();
-    return request.user as AuthUser;
+    return request.user as AuthUser | undefined;
   },
 );

--- a/apps/api/src/auth/current-user.decorator.ts
+++ b/apps/api/src/auth/current-user.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { AuthUser } from '../ports/auth';
+
+export const CurrentUser = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): AuthUser => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user as AuthUser;
+  },
+);

--- a/apps/api/src/auth/public.decorator.ts
+++ b/apps/api/src/auth/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Get } from '@nestjs/common';
+import { Public } from '../auth/public.decorator';
 
 @Controller()
 export class HealthController {
+  @Public()
   @Get('health')
   health(): { status: string; timestamp: string } {
     return { status: 'ok', timestamp: new Date().toISOString() };

--- a/apps/api/src/ports/tokens.ts
+++ b/apps/api/src/ports/tokens.ts
@@ -10,3 +10,4 @@ export const PROGRAM_PHILOSOPHY_REPOSITORY = Symbol(
   'IProgramPhilosophyRepository',
 );
 export const CYCLE_PLANNING_AGENT = Symbol('ICyclePlanningAgent');
+export const AUTH_PROVIDER = Symbol('IAuthProvider');

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -28,19 +28,45 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
     await app.close();
   });
 
+  const AUTH = { authorization: 'Bearer dev-token' };
+
   const get = (url: string) =>
-    app.getHttpAdapter().getInstance().inject({ method: 'GET', url });
+    app.getHttpAdapter().getInstance().inject({ method: 'GET', url, headers: AUTH });
 
   const post = (url: string) =>
-    app.getHttpAdapter().getInstance().inject({ method: 'POST', url });
+    app.getHttpAdapter().getInstance().inject({ method: 'POST', url, headers: AUTH });
 
   const postJson = (url: string, body: unknown) =>
     app.getHttpAdapter().getInstance().inject({
       method: 'POST',
       url,
-      headers: { 'content-type': 'application/json' },
+      headers: { 'content-type': 'application/json', ...AUTH },
       payload: JSON.stringify(body),
     });
+
+  const _patchJson = (url: string, body: unknown) =>
+    app.getHttpAdapter().getInstance().inject({
+      method: 'PATCH',
+      url,
+      headers: { 'content-type': 'application/json', ...AUTH },
+      payload: JSON.stringify(body),
+    });
+
+  it('GET /health returns ok without auth', async () => {
+    const res = await app
+      .getHttpAdapter()
+      .getInstance()
+      .inject({ method: 'GET', url: '/health' });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('GET /programs/:program/cycles/current returns 401 without auth', async () => {
+    const res = await app
+      .getHttpAdapter()
+      .getInstance()
+      .inject({ method: 'GET', url: `/programs/${SEED_PROGRAM}/cycles/current` });
+    expect(res.statusCode).toBe(401);
+  });
 
   it('GET /programs/:program/cycles/current returns the seeded cycle', async () => {
     const res = await get(`/programs/${SEED_PROGRAM}/cycles/current`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
+        "@clerk/backend": "^3.4.4",
         "@lifting-logbook/core": "*",
         "@lifting-logbook/types": "*",
         "@nestjs/common": "^10.0.0",
@@ -2034,6 +2035,57 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@clerk/backend": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.4.4.tgz",
+      "integrity": "sha512-EGdpxBG1joIYzRBtpzTq2FGyM2ErSSF2UB7FZXrHiSb6V/uRUcvVcX7IWvYeEyg1AG100gJWr0KpbutajVCLMA==",
+      "dependencies": {
+        "@clerk/shared": "^4.9.0",
+        "standardwebhooks": "^1.0.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      }
+    },
+    "node_modules/@clerk/backend/node_modules/@clerk/shared": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.9.0.tgz",
+      "integrity": "sha512-YU9Fv6FK1EwxM7uz1hGPrLpvcHRhHm8Quuh5RL343oXakE+/JHtYy4OhwVgqYVA+j63pw+7lpghL3CYQTgk0hA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@tanstack/query-core": "^5.100.6",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.5",
+        "std-env": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/backend/node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -5554,12 +5606,26 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
       "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.7.tgz",
+      "integrity": "sha512-5R7i6ENJLhVeeJrrUz7jKBXUXv/BJrxf9FQJSkR13bPrb3zOcE8A0Z0PxYCcsKPOsiIlTibrBL/zZbtUO1TFyQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tokenizer/inflate": {
@@ -8265,6 +8331,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -9314,6 +9388,11 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="
+    },
     "node_modules/fast-uri": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.4.0.tgz",
@@ -9856,8 +9935,7 @@
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "node_modules/globals": {
       "version": "14.0.0",
@@ -11150,6 +11228,14 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/jimp-compact/-/jimp-compact-0.16.1.tgz",
       "integrity": "sha512-dZ6Ra7u1G8c4Letq/B5EzAxj4tLFHL+cGtdpR+PVm4yzPDj+lCk+AbivWt1eOM+ikzkowtyV7qSqX6qr3t71Ww=="
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -14925,6 +15011,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -14932,6 +15027,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="
     },
     "node_modules/stream-buffers": {
       "version": "2.2.0",


### PR DESCRIPTION
## Summary

Implements the NestJS auth guard per ADR-005. All API endpoints now require `Authorization: Bearer <token>`; `GET /health` is exempt via `@Public()`.

- **`DevAuthProvider`** — selected when `CLERK_SECRET_KEY` is absent (local dev, CI, e2e tests); accepts any Bearer value and returns a configurable `AuthUser` via `DEV_USER_ID` / `DEV_USER_EMAIL` env vars
- **`ClerkAuthProvider`** — selected when `CLERK_SECRET_KEY` is present; verifies JWT via `@clerk/backend`, fetches user profile from Clerk API
- **`AuthGuard`** — global `APP_GUARD`; extracts Bearer token, calls `verifyToken`, stores `AuthUser` on `request.user`; returns 401 on missing or invalid token
- **`@Public()`** — metadata decorator to exempt endpoints from the guard
- **`@CurrentUser()`** — param decorator to inject `AuthUser` into controller methods (ready for issue #144)
- **`AuthModule`** — env-driven adapter selection, registers guard globally via `APP_GUARD`
- e2e spec updated: all requests send `Authorization: Bearer dev-token`; new tests assert 401 without auth and that health is public

## Acceptance Criteria

- [x] `GET /health` returns 200 without auth
- [x] All other endpoints return 401 when no `Authorization` header is present
- [x] With `CLERK_SECRET_KEY` unset, any Bearer value resolves to the configured dev user
- [x] `AuthUser` is accessible via `@CurrentUser()` in any controller method
- [x] Existing e2e suite passes (70 tests, 1 intentionally skipped pending #144)

## Test plan

```
npm test -w @lifting-logbook/api
```

All 70 tests pass, 1 skipped (adapter isolation — unblocked by #144).

## Notes

Controllers are unchanged — they still use injected singleton repositories. Per-user data scoping is issue #144, which depends on this PR.

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)