### PR TITLE
[chore] Add v0.4 — Alpha Release to ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -99,6 +99,33 @@ Web and mobile clients functional end-to-end. Key user-facing features implement
 
 ---
 
+## v0.4 — Alpha Release `[Current]`
+
+First deployable version. Styled web app running against a real database, deployed and accessible to known users. Mobile deferred to v1.0.
+
+### Active Work
+
+| Work stream | Description | Issues |
+|---|---|---|
+| Design system and styling | Global CSS reset, design tokens, and styled screens informed by Claude Design mockups | [#148](https://github.com/brownm09/lifting-logbook/issues/148) |
+| Deployment infrastructure | Cloud Run or GKE manifests, Terraform shared infra, CI/CD deploy on merge | [#149](https://github.com/brownm09/lifting-logbook/issues/149) |
+| Real database adapter | Prisma schema, `SystemDbRepositoryFactory` implementations, migration runner | [#150](https://github.com/brownm09/lifting-logbook/issues/150) |
+| Database integration tests | E2e suite against real Postgres; covers PATCH endpoint gap and row-level isolation | [#151](https://github.com/brownm09/lifting-logbook/issues/151) |
+
+### Shipped
+
+| Work stream | Description | Issues |
+|---|---|---|
+| *(none yet)* | | |
+
+### Proposals
+
+| Proposal | Description | Issue | Status |
+|---|---|---|---|
+| *(none yet)* | | | |
+
+---
+
 ## Maintenance
 
 - **Adding an item:** run `/propose <idea>` — it creates the proposal doc, the GitHub issue,


### PR DESCRIPTION
## Summary

- Defines the v0.4 Alpha Release milestone: first deployable version with styled web app, real database, and deployment infrastructure
- Four work streams scoped and linked to existing issues: #148 (styling), #149 (deployment), #150 (real DB adapter), #151 (DB integration tests)
- Moves v0.3 milestone marker from `[Current]` implicitly — v0.4 is now the active milestone

## Test plan

- [x] `npm test` — all 10 suites pass (ROADMAP.md is docs-only, no code change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)