### PR TITLE
[test] Database integration tests against real Postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,6 @@ jobs:
           DATABASE_URL: postgresql://lifting:lifting@localhost:5432/lifting_test
 
       - name: DB Integration Tests
-        run: npm run test:db -w @lifting-logbook/api
+        run: npx turbo run test --filter=@lifting-logbook/api -- --testPathPattern=db\\.e2e
         env:
           DATABASE_URL: postgresql://lifting:lifting@localhost:5432/lifting_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,47 @@ jobs:
 
       - name: Validate analytics taxonomy
         run: node scripts/validate-analytics-taxonomy.mjs
+
+  db-integration:
+    name: DB Integration Tests
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: lifting
+          POSTGRES_PASSWORD: lifting
+          POSTGRES_DB: lifting_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.11.1'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npx prisma generate --schema=apps/api/prisma/schema.prisma
+
+      - name: Run migrations
+        run: npx prisma migrate deploy --schema=apps/api/prisma/schema.prisma
+        env:
+          DATABASE_URL: postgresql://lifting:lifting@localhost:5432/lifting_test
+
+      - name: DB Integration Tests
+        run: npm run test:db -w @lifting-logbook/api
+        env:
+          DATABASE_URL: postgresql://lifting:lifting@localhost:5432/lifting_test

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,8 @@
     "dev": "nest start --watch",
     "start": "node dist/main.js",
     "lint": "eslint src",
-    "test": "jest"
+    "test": "jest",
+    "test:db": "jest --testPathPattern=db\\.e2e"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.92.0",

--- a/apps/api/src/programs/programs.db.e2e.spec.ts
+++ b/apps/api/src/programs/programs.db.e2e.spec.ts
@@ -54,11 +54,11 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
       payload: JSON.stringify(body),
     });
 
-  const patchJson = (url: string, body: unknown, headers = AUTH) =>
+  const patchJson = (url: string, body: unknown) =>
     app.getHttpAdapter().getInstance().inject({
       method: 'PATCH',
       url,
-      headers: { 'content-type': 'application/json', ...headers },
+      headers: { 'content-type': 'application/json', ...AUTH },
       payload: JSON.stringify(body),
     });
 

--- a/apps/api/src/programs/programs.db.e2e.spec.ts
+++ b/apps/api/src/programs/programs.db.e2e.spec.ts
@@ -24,12 +24,12 @@ import { DomainNotFoundFilter } from './not-found.filter';
 const TEST_USER = 'db-e2e-primary';
 const USER_ALICE = 'db-e2e-alice';
 const USER_BOB = 'db-e2e-bob';
-const ALL_TEST_USERS = [TEST_USER, USER_ALICE, USER_BOB];
 
 async function cleanTestUsers(prisma: PrismaClient): Promise<void> {
-  await prisma.liftRecord.deleteMany({ where: { userId: { in: ALL_TEST_USERS } } });
-  await prisma.trainingMax.deleteMany({ where: { userId: { in: ALL_TEST_USERS } } });
-  await prisma.cycleDashboard.deleteMany({ where: { userId: { in: ALL_TEST_USERS } } });
+  const users = [TEST_USER, USER_ALICE, USER_BOB];
+  await prisma.liftRecord.deleteMany({ where: { userId: { in: users } } });
+  await prisma.trainingMax.deleteMany({ where: { userId: { in: users } } });
+  await prisma.cycleDashboard.deleteMany({ where: { userId: { in: users } } });
 }
 
 const describeOrSkip = process.env.DATABASE_URL ? describe : describe.skip;
@@ -252,6 +252,11 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
       const body = res.json();
       expect(body.cycleNum).toBe(2);
       expect(body.cycleStartDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+      // Verify the re-pinned cycle is persisted to the DB (not just returned in the response).
+      const getRes = await get(`/programs/${SEED_PROGRAM}/cycles/current`);
+      expect(getRes.statusCode).toBe(200);
+      expect(getRes.json().cycleNum).toBe(2);
     });
 
     it('POST /programs/:program/cycles with cycleDate pins the new cycle\'s start date', async () => {

--- a/apps/api/src/programs/programs.db.e2e.spec.ts
+++ b/apps/api/src/programs/programs.db.e2e.spec.ts
@@ -1,0 +1,323 @@
+// Runs only when DATABASE_URL is set; skipped in the normal npm test / CI lint-and-test job.
+// CI: the db-integration job injects DATABASE_URL via a postgres service container.
+// Local: docker-compose.test.yml spins up Postgres on port 5433, then:
+//   DATABASE_URL=postgresql://lifting:lifting@localhost:5433/lifting_test \
+//   npx prisma migrate deploy --schema=apps/api/prisma/schema.prisma && \
+//   npm test -w @lifting-logbook/api -- --testPathPattern=db.e2e
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import { PrismaClient } from '@prisma/client';
+import { AppModule } from '../app.module';
+import {
+  SEED_PROGRAM,
+  seedCycleDashboard,
+  seedLiftRecords,
+  seedTrainingMaxes,
+} from '../adapters/in-memory/fixtures';
+import { DomainNotFoundFilter } from './not-found.filter';
+
+const TEST_USER = 'db-e2e-primary';
+const USER_ALICE = 'db-e2e-alice';
+const USER_BOB = 'db-e2e-bob';
+const ALL_TEST_USERS = [TEST_USER, USER_ALICE, USER_BOB];
+
+async function cleanTestUsers(prisma: PrismaClient): Promise<void> {
+  await prisma.liftRecord.deleteMany({ where: { userId: { in: ALL_TEST_USERS } } });
+  await prisma.trainingMax.deleteMany({ where: { userId: { in: ALL_TEST_USERS } } });
+  await prisma.cycleDashboard.deleteMany({ where: { userId: { in: ALL_TEST_USERS } } });
+}
+
+const describeOrSkip = process.env.DATABASE_URL ? describe : describe.skip;
+
+describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
+  let app: NestFastifyApplication;
+  let prisma: PrismaClient;
+
+  const AUTH = { authorization: `Bearer ${TEST_USER}` };
+
+  const get = (url: string) =>
+    app.getHttpAdapter().getInstance().inject({ method: 'GET', url, headers: AUTH });
+
+  const post = (url: string) =>
+    app.getHttpAdapter().getInstance().inject({ method: 'POST', url, headers: AUTH });
+
+  const postJson = (url: string, body: unknown) =>
+    app.getHttpAdapter().getInstance().inject({
+      method: 'POST',
+      url,
+      headers: { 'content-type': 'application/json', ...AUTH },
+      payload: JSON.stringify(body),
+    });
+
+  const patchJson = (url: string, body: unknown, headers = AUTH) =>
+    app.getHttpAdapter().getInstance().inject({
+      method: 'PATCH',
+      url,
+      headers: { 'content-type': 'application/json', ...headers },
+      payload: JSON.stringify(body),
+    });
+
+  beforeAll(async () => {
+    prisma = new PrismaClient();
+
+    // Clean any leftover data from an interrupted previous run before seeding.
+    await cleanTestUsers(prisma);
+
+    const dashboard = seedCycleDashboard();
+    await prisma.cycleDashboard.create({
+      data: {
+        userId: TEST_USER,
+        program: SEED_PROGRAM,
+        cycleUnit: dashboard.cycleUnit,
+        cycleNum: dashboard.cycleNum,
+        cycleDate: dashboard.cycleDate,
+        sheetName: dashboard.sheetName,
+        cycleStartWeekday: dashboard.cycleStartWeekday,
+        currentWeekType: dashboard.currentWeekType,
+        programType: dashboard.programType ?? null,
+      },
+    });
+
+    await prisma.trainingMax.createMany({
+      data: seedTrainingMaxes().map((m) => ({
+        userId: TEST_USER,
+        program: SEED_PROGRAM,
+        lift: m.lift,
+        weight: m.weight,
+        dateUpdated: m.dateUpdated,
+      })),
+    });
+
+    await prisma.liftRecord.createMany({
+      data: seedLiftRecords().map((r) => ({
+        userId: TEST_USER,
+        program: r.program,
+        cycleNum: r.cycleNum,
+        workoutNum: r.workoutNum,
+        date: r.date,
+        lift: r.lift,
+        setNum: r.setNum,
+        weight: r.weight,
+        reps: r.reps,
+        notes: r.notes,
+      })),
+    });
+
+    // DATABASE_URL is set in the environment, so RepositoryFactoryModule selects PrismaRepositoryFactory.
+    app = await NestFactory.create<NestFastifyApplication>(
+      AppModule,
+      new FastifyAdapter(),
+      { logger: false },
+    );
+    app.useGlobalFilters(new DomainNotFoundFilter());
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+    await app.getHttpAdapter().getInstance().ready();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    await cleanTestUsers(prisma);
+    await prisma?.$disconnect();
+  });
+
+  it('GET /health returns ok without auth', async () => {
+    const res = await app
+      .getHttpAdapter()
+      .getInstance()
+      .inject({ method: 'GET', url: '/health' });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('GET /programs/:program/cycles/current returns 401 without auth', async () => {
+    const res = await app
+      .getHttpAdapter()
+      .getInstance()
+      .inject({ method: 'GET', url: `/programs/${SEED_PROGRAM}/cycles/current` });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('GET /programs/:program/cycles/current returns the seeded cycle', async () => {
+    const res = await get(`/programs/${SEED_PROGRAM}/cycles/current`);
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.program).toBe(SEED_PROGRAM);
+    expect(body.cycleNum).toBe(1);
+    expect(body.cycleStartDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('GET /programs/:program/workouts/:workoutNum returns grouped lifts', async () => {
+    const res = await get(`/programs/${SEED_PROGRAM}/workouts/1`);
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.workoutNum).toBe(1);
+    expect(body.lifts.length).toBeGreaterThan(0);
+  });
+
+  it('GET /programs/:program/training-maxes returns the seeded maxes', async () => {
+    const res = await get(`/programs/${SEED_PROGRAM}/training-maxes`);
+    expect(res.statusCode).toBe(200);
+    expect(res.json().length).toBeGreaterThan(0);
+  });
+
+  it('GET /programs/:program/lift-records returns records for current cycle', async () => {
+    const res = await get(`/programs/${SEED_PROGRAM}/lift-records`);
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.every((r: { cycleNum: number }) => r.cycleNum === 1)).toBe(true);
+  });
+
+  it('GET /programs/:program/spec returns the seeded program spec', async () => {
+    const res = await get(`/programs/${SEED_PROGRAM}/spec`);
+    expect(res.statusCode).toBe(200);
+    expect(res.json().length).toBeGreaterThan(0);
+  });
+
+  it('GET unknown program returns 404', async () => {
+    const res = await get('/programs/does-not-exist/cycles/current');
+    expect(res.statusCode).toBe(404);
+  });
+
+  // -------------------------------------------------------------------------
+  // Write endpoints — order-sensitive; each test mutates DB state for TEST_USER
+  // and the next test observes that state. Do not reorder or randomize.
+  // -------------------------------------------------------------------------
+
+  describe('write operations', () => {
+    it('PATCH /programs/:program/training-maxes updates maxes and returns the full set', async () => {
+      const res = await patchJson(`/programs/${SEED_PROGRAM}/training-maxes`, {
+        maxes: [{ lift: 'Squat', weight: 300 }],
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(Array.isArray(body)).toBe(true);
+      const squat = body.find((m: { lift: string }) => m.lift === 'Squat');
+      expect(squat).toMatchObject({
+        lift: 'Squat',
+        weight: 300,
+        unit: 'lbs',
+        dateUpdated: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      });
+    });
+
+    it('POST /programs/:program/training-maxes/recalculate updates maxes from lift records', async () => {
+      // Pre-condition: PATCH above set Squat to 300; recalculate will derive a new value from records.
+      const beforeRes = await get(`/programs/${SEED_PROGRAM}/training-maxes`);
+      const squatBefore = beforeRes
+        .json()
+        .find((m: { lift: string }) => m.lift === 'Squat').weight;
+
+      const res = await post(`/programs/${SEED_PROGRAM}/training-maxes/recalculate`);
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(Array.isArray(body)).toBe(true);
+      expect(body.length).toBeGreaterThan(0);
+      for (const m of body) {
+        expect(m).toMatchObject({
+          lift: expect.any(String),
+          weight: expect.any(Number),
+          unit: 'lbs',
+          dateUpdated: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        });
+      }
+      const squatAfter = body.find((m: { lift: string }) => m.lift === 'Squat').weight;
+      expect(squatAfter).not.toBe(squatBefore);
+    });
+
+    it('POST /programs/:program/cycles advances cycleNum and persists new maxes', async () => {
+      expect((await get(`/programs/${SEED_PROGRAM}/cycles/current`)).json().cycleNum).toBe(1);
+
+      const res = await post(`/programs/${SEED_PROGRAM}/cycles`);
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.program).toBe(SEED_PROGRAM);
+      expect(body.cycleNum).toBe(2);
+      expect(body.cycleStartDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+      const getRes = await get(`/programs/${SEED_PROGRAM}/cycles/current`);
+      expect(getRes.statusCode).toBe(200);
+      expect(getRes.json().cycleNum).toBe(2);
+    });
+
+    it('POST /programs/:program/cycles with fromCycleNum uses that cycle\'s records', async () => {
+      expect((await get(`/programs/${SEED_PROGRAM}/cycles/current`)).json().cycleNum).toBe(2);
+      const res = await postJson(`/programs/${SEED_PROGRAM}/cycles`, { fromCycleNum: 1 });
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.cycleNum).toBe(2);
+      expect(body.cycleStartDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it('POST /programs/:program/cycles with cycleDate pins the new cycle\'s start date', async () => {
+      expect((await get(`/programs/${SEED_PROGRAM}/cycles/current`)).json().cycleNum).toBe(2);
+      const res = await postJson(`/programs/${SEED_PROGRAM}/cycles`, {
+        cycleDate: '2026-06-01',
+      });
+      expect(res.statusCode).toBe(201);
+      expect(res.json().cycleStartDate).toBe('2026-06-01');
+    });
+
+    it('POST /programs/:program/cycles with fromCycleNum having no records returns 400', async () => {
+      const res = await postJson(`/programs/${SEED_PROGRAM}/cycles`, { fromCycleNum: 99 });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('POST /programs/unknown/cycles returns 404', async () => {
+      const res = await post('/programs/does-not-exist/cycles');
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  it('isolates row-level data between users in Postgres', async () => {
+    const injectRaw = app.getHttpAdapter().getInstance().inject.bind(
+      app.getHttpAdapter().getInstance(),
+    );
+
+    const AS_ALICE = { authorization: `Bearer ${USER_ALICE}` };
+    const AS_BOB = { authorization: `Bearer ${USER_BOB}` };
+
+    // Alice writes a distinctive training max — her rows start empty, this creates it.
+    const patchRes = await injectRaw({
+      method: 'PATCH',
+      url: `/programs/${SEED_PROGRAM}/training-maxes`,
+      headers: { 'content-type': 'application/json', ...AS_ALICE },
+      payload: JSON.stringify({ maxes: [{ lift: 'Squat', weight: 999 }] }),
+    });
+    expect(patchRes.statusCode).toBe(200);
+
+    // Alice sees her value.
+    const aliceRes = await injectRaw({
+      method: 'GET',
+      url: `/programs/${SEED_PROGRAM}/training-maxes`,
+      headers: AS_ALICE,
+    });
+    expect(aliceRes.json().find((m: { lift: string }) => m.lift === 'Squat')?.weight).toBe(999);
+
+    // Bob reads the same program — his rows are independent; Alice's write must not appear.
+    const bobRes = await injectRaw({
+      method: 'GET',
+      url: `/programs/${SEED_PROGRAM}/training-maxes`,
+      headers: AS_BOB,
+    });
+    expect(bobRes.statusCode).toBe(200);
+    const bobSquat = bobRes.json().find((m: { lift: string }) => m.lift === 'Squat');
+    expect(bobSquat).toBeUndefined();
+
+    // Verify at the DB layer — Alice's row exists and Bob's does not.
+    const aliceRow = await prisma.trainingMax.findFirst({
+      where: { userId: USER_ALICE, program: SEED_PROGRAM, lift: 'Squat' },
+    });
+    expect(aliceRow?.weight).toBe(999);
+
+    const bobRow = await prisma.trainingMax.findFirst({
+      where: { userId: USER_BOB, program: SEED_PROGRAM, lift: 'Squat' },
+    });
+    expect(bobRow).toBeNull();
+  });
+});

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,14 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: lifting
+      POSTGRES_PASSWORD: lifting
+      POSTGRES_DB: lifting_test
+    ports:
+      - '5433:5432'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U lifting -d lifting_test']
+      interval: 5s
+      timeout: 3s
+      retries: 5


### PR DESCRIPTION
## Summary

- Adds `programs.db.e2e.spec.ts` — a second e2e suite that runs against a real Postgres instance via `PrismaRepositoryFactory`, mirroring the full in-memory spec plus two gaps it could not cover
- Adds explicit `PATCH /programs/:program/training-maxes` coverage (the `_patchJson` helper existed but had no `it()` block)
- Extends the user isolation test with a direct Prisma assertion verifying row-level separation in the DB
- Adds `docker-compose.test.yml` for local Postgres on port 5433
- Adds `test:db` script to `apps/api/package.json` for targeted local runs
- Adds `db-integration` CI job (separate from `lint-and-test`) with a Postgres service container that runs migrations then fires the DB suite

## Acceptance Criteria

- [x] `programs.db.e2e.spec.ts` runs against real Postgres when `DATABASE_URL` is set
- [x] Test database spun up via `docker-compose.test.yml`; `DATABASE_URL` injected at test time
- [x] Covers all read endpoints currently tested in the in-memory suite
- [x] Covers `PATCH /programs/:program/training-maxes` (previously untested write path)
- [x] CI pipeline runs DB integration tests in a separate job with a Postgres service container
- [x] In-memory e2e suite retained as a fast smoke test — suite skips cleanly when `DATABASE_URL` is unset

## Test Results

`npm test -w @lifting-logbook/api` (no DATABASE_URL):
- **77 passed, 16 skipped** (DB suite skips), 0 failures — in-memory smoke tests unaffected

DB suite (with DATABASE_URL + migrations applied):
- Runs via `npm run test:db -w @lifting-logbook/api`

Closes #151