### PR TITLE
[feat] Cloud Run service-to-service auth (web → API)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,6 +129,8 @@ jobs:
           tags: |
             ${{ needs.terraform-staging.outputs.ar_repo }}/web:${{ github.sha }}
             ${{ needs.terraform-staging.outputs.ar_repo }}/web:latest
+          build-args: |
+            NEXT_PUBLIC_API_URL=${{ needs.terraform-staging.outputs.cloud_run_api_url }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ name: Deploy
 #   GCP_PROD_WORKLOAD_IDENTITY_PROVIDER
 #   GCP_PROD_SERVICE_ACCOUNT
 #   TF_STATE_BUCKET
+#   GCP_BILLING_ACCOUNT   — never commit real value to tfvars; pass here instead
 
 on:
   push:
@@ -39,6 +40,7 @@ jobs:
       ar_repo: ${{ steps.tf-outputs.outputs.ar_repo }}
       kms_key_name: ${{ steps.tf-outputs.outputs.kms_key_name }}
       api_wi_sa: ${{ steps.tf-outputs.outputs.api_wi_sa }}
+      web_workload_sa: ${{ steps.tf-outputs.outputs.web_workload_sa }}
 
     steps:
       - uses: actions/checkout@v4
@@ -67,7 +69,8 @@ jobs:
         working-directory: ${{ env.TF_DIR }}
         run: |
           terraform apply -auto-approve \
-            -var-file=terraform.tfvars.staging
+            -var-file=terraform.tfvars.staging \
+            -var="billing_account=${{ secrets.GCP_BILLING_ACCOUNT }}"
 
       - name: Capture Terraform outputs
         id: tf-outputs
@@ -79,6 +82,7 @@ jobs:
           echo "ar_repo=$(terraform output -raw artifact_registry_repo)" >> "$GITHUB_OUTPUT"
           echo "kms_key_name=$(terraform output -raw kms_key_name)" >> "$GITHUB_OUTPUT"
           echo "api_wi_sa=$(terraform output -raw cicd_service_account_email)" >> "$GITHUB_OUTPUT"
+          echo "web_workload_sa=$(terraform output -raw web_workload_sa)" >> "$GITHUB_OUTPUT"
 
   # ── 2. Build and push Docker images ─────────────────────────────────────
   build-images:
@@ -234,6 +238,7 @@ jobs:
             --project="${{ secrets.GCP_STAGING_PROJECT_ID }}" \
             --platform=managed \
             --allow-unauthenticated \
+            --service-account="${{ needs.terraform-staging.outputs.web_workload_sa }}" \
             --set-env-vars="API_URL=${{ needs.terraform-staging.outputs.cloud_run_api_url }}" \
             --quiet
 
@@ -305,7 +310,8 @@ jobs:
             -backend-config="prefix=terraform/state"
           terraform workspace select production || terraform workspace new production
           terraform apply -auto-approve \
-            -var-file=terraform.tfvars.production
+            -var-file=terraform.tfvars.production \
+            -var="billing_account=${{ secrets.GCP_BILLING_ACCOUNT }}"
 
       - name: Capture production Terraform outputs
         id: tf-prod
@@ -317,6 +323,7 @@ jobs:
           echo "ar_repo=$(terraform output -raw artifact_registry_repo)" >> "$GITHUB_OUTPUT"
           echo "kms_key_name=$(terraform output -raw kms_key_name)" >> "$GITHUB_OUTPUT"
           echo "api_wi_sa=$(terraform output -raw cicd_service_account_email)" >> "$GITHUB_OUTPUT"
+          echo "web_workload_sa=$(terraform output -raw web_workload_sa)" >> "$GITHUB_OUTPUT"
 
       - name: Set up GKE credentials (production)
         uses: google-github-actions/get-gke-credentials@v2
@@ -403,6 +410,7 @@ jobs:
             --project="${{ secrets.GCP_PROD_PROJECT_ID }}" \
             --platform=managed \
             --allow-unauthenticated \
+            --service-account="${{ steps.tf-prod.outputs.web_workload_sa }}" \
             --set-env-vars="API_URL=${{ steps.tf-prod.outputs.cloud_run_api_url }}" \
             --quiet
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -21,6 +21,7 @@ RUN npm ci
 
 # Copy full source and build.
 COPY --from=installer /app/out/full/ .
+ARG NEXT_PUBLIC_API_URL
 RUN npx turbo run build --filter=@lifting-logbook/web
 
 # ── Stage 3: runner ──────────────────────────────────────────────────────────

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
@@ -7,7 +7,7 @@ import {
   createLiftRecord,
   recordBodyWeight,
   updateLiftRecord,
-} from '@/lib/api';
+} from '@/lib/client-api';
 import styles from './WorkoutLogger.module.css';
 import type { LiftData, WorkingSetData, WorkoutLoggerProps } from './types';
 

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -25,7 +25,8 @@ async function getAuthHeaders(): Promise<Record<string, string>> {
     _auth ??= new GoogleAuth();
     const client = await _auth.getIdTokenClient(API_URL);
     return (await client.getRequestHeaders()) as Record<string, string>;
-  } catch {
+  } catch (e) {
+    console.error('[getAuthHeaders] GCP token acquisition failed:', e);
     return {};
   }
 }
@@ -34,7 +35,7 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const authHeaders = await getAuthHeaders();
   const res = await fetch(`${API_URL}${path}`, {
     ...init,
-    headers: { ...authHeaders, ...(init?.headers as Record<string, string> | undefined) },
+    headers: { ...(init?.headers as Record<string, string> | undefined), ...authHeaders },
   });
   if (!res.ok) {
     throw new Error(`API ${res.status} ${res.statusText} for ${path}`);

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,3 +1,6 @@
+import 'server-only';
+
+import { GoogleAuth } from 'google-auth-library';
 import type {
   BodyWeightResponse,
   CreateLiftRecordRequest,
@@ -12,9 +15,27 @@ import type {
 } from '@lifting-logbook/types';
 
 const API_URL = process.env.API_URL ?? 'http://localhost:3001';
+const isCloudRun = API_URL.startsWith('https://');
+
+let _auth: GoogleAuth | undefined;
+
+async function getAuthHeaders(): Promise<Record<string, string>> {
+  if (!isCloudRun) return {};
+  try {
+    _auth ??= new GoogleAuth();
+    const client = await _auth.getIdTokenClient(API_URL);
+    return (await client.getRequestHeaders()) as Record<string, string>;
+  } catch {
+    return {};
+  }
+}
 
 async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(`${API_URL}${path}`, init);
+  const authHeaders = await getAuthHeaders();
+  const res = await fetch(`${API_URL}${path}`, {
+    ...init,
+    headers: { ...authHeaders, ...(init?.headers as Record<string, string> | undefined) },
+  });
   if (!res.ok) {
     throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
   }
@@ -67,7 +88,11 @@ export async function fetchWorkout(
   workoutNum: number,
 ): Promise<WorkoutResponse | null> {
   const path = `/programs/${encodeURIComponent(program)}/workouts/${workoutNum}`;
-  const res = await fetch(`${API_URL}${path}`, { cache: 'no-store' });
+  const authHeaders = await getAuthHeaders();
+  const res = await fetch(`${API_URL}${path}`, {
+    cache: 'no-store',
+    headers: authHeaders,
+  });
   if (res.status === 404) return null;
   if (!res.ok) {
     throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
@@ -134,7 +159,11 @@ export async function fetchLatestBodyWeight(
   program: string,
 ): Promise<BodyWeightResponse | null> {
   const path = `/programs/${encodeURIComponent(program)}/body-weight/latest`;
-  const res = await fetch(`${API_URL}${path}`, { cache: 'no-store' });
+  const authHeaders = await getAuthHeaders();
+  const res = await fetch(`${API_URL}${path}`, {
+    cache: 'no-store',
+    headers: authHeaders,
+  });
   if (res.status === 404) return null;
   if (!res.ok) {
     throw new Error(`API ${res.status} ${res.statusText} for ${path}`);

--- a/apps/web/lib/client-api.ts
+++ b/apps/web/lib/client-api.ts
@@ -1,0 +1,66 @@
+// Write operations called directly from the browser (Client Components).
+// These do not carry GCP identity tokens — browser code cannot obtain them.
+// In Cloud Run environments, browser-to-API auth is handled separately (e.g., JWT/Clerk).
+
+import type {
+  CreateLiftRecordRequest,
+  LiftRecordResponse,
+  RecordBodyWeightRequest,
+  UpdateLiftRecordRequest,
+} from '@lifting-logbook/types';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+
+async function clientFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${API_URL}${path}`, init);
+  if (!res.ok) {
+    throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+export function createLiftRecord(
+  program: string,
+  body: CreateLiftRecordRequest,
+): Promise<LiftRecordResponse> {
+  return clientFetch(
+    `/programs/${encodeURIComponent(program)}/lift-records`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      cache: 'no-store',
+    },
+  );
+}
+
+export function updateLiftRecord(
+  program: string,
+  id: string,
+  body: UpdateLiftRecordRequest,
+): Promise<LiftRecordResponse> {
+  return clientFetch(
+    `/programs/${encodeURIComponent(program)}/lift-records/${encodeURIComponent(id)}`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      cache: 'no-store',
+    },
+  );
+}
+
+export function recordBodyWeight(
+  program: string,
+  body: RecordBodyWeightRequest,
+): Promise<void> {
+  return clientFetch(
+    `/programs/${encodeURIComponent(program)}/body-weight`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      cache: 'no-store',
+    },
+  );
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,9 +12,11 @@
   "dependencies": {
     "@lifting-logbook/core": "*",
     "@lifting-logbook/types": "*",
+    "google-auth-library": "^9.0.0",
     "next": "16.2.4",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "server-only": "^0.0.1"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/infra/kubernetes/charts/web/values.yaml
+++ b/infra/kubernetes/charts/web/values.yaml
@@ -38,9 +38,8 @@ gcp:
 
 ingress:
   enabled: true
-  className: ""   # GKE uses "gce" ingress class
-  annotations:
-    kubernetes.io/ingress.class: "gce"
+  className: "gce"
+  annotations: {}
   host: ""   # generated URL — empty means use the LB IP
 
 livenessProbe:

--- a/infra/terraform/cloud-run.tf
+++ b/infra/terraform/cloud-run.tf
@@ -107,6 +107,8 @@ resource "google_cloud_run_v2_service" "web" {
   location = var.region
 
   template {
+    service_account = google_service_account.web_workload.email
+
     scaling {
       min_instance_count = var.environment == "production" ? 1 : 0
       max_instance_count = var.environment == "production" ? 10 : 3
@@ -165,14 +167,18 @@ resource "google_cloud_run_v2_service" "web" {
   ]
 }
 
+# ─── Cloud Run workload identities ────────────────────────────────────────────
+
+resource "google_service_account" "web_workload" {
+  account_id   = "${local.name_prefix}-web-wi"
+  display_name = "${var.app_name} web workload identity (${var.environment})"
+}
+
 # ─── Access control ───────────────────────────────────────────────────────────
 #
 # Web service is publicly accessible (serves the Next.js frontend to browsers).
-# API service requires Cloud Run IAM authentication — allUsers is NOT granted.
-#
-# TODO: grant the web Cloud Run service account roles/run.invoker on the API service
-# to enable service-to-service auth. The Next.js app must also attach GCP identity
-# tokens to server-side API calls until that is wired up.
+# API service requires Cloud Run IAM authentication — only the web workload SA
+# is granted roles/run.invoker so server-side API calls from Next.js succeed.
 # See: https://cloud.google.com/run/docs/authenticating/service-to-service
 
 resource "google_cloud_run_v2_service_iam_member" "web_public" {
@@ -181,6 +187,14 @@ resource "google_cloud_run_v2_service_iam_member" "web_public" {
   name     = google_cloud_run_v2_service.web.name
   role     = "roles/run.invoker"
   member   = "allUsers"
+}
+
+resource "google_cloud_run_v2_service_iam_member" "web_invoker_on_api" {
+  project  = google_cloud_run_v2_service.api.project
+  location = google_cloud_run_v2_service.api.location
+  name     = google_cloud_run_v2_service.api.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.web_workload.email}"
 }
 
 # ─── Serverless VPC Connector (private Cloud SQL access from Cloud Run) ───────

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -47,3 +47,8 @@ output "kms_key_name" {
   description = "Cloud KMS crypto key name for credential encryption (ADR-014)"
   value       = google_kms_crypto_key.user_data_source.id
 }
+
+output "web_workload_sa" {
+  description = "Web Cloud Run workload identity service account email"
+  value       = google_service_account.web_workload.email
+}

--- a/infra/terraform/terraform.tfvars.production
+++ b/infra/terraform/terraform.tfvars.production
@@ -1,5 +1,7 @@
 # Production environment variable values
-# Replace project_id and billing_account with your actual values (see docs/deploy.md)
+# Replace project_id with your actual value (see docs/deploy.md)
+# billing_account: do NOT commit a real value here — pass via CI/CD secret instead:
+#   terraform apply -var="billing_account=$GCP_BILLING_ACCOUNT"
 
 project_id      = "lifting-logbook-prod"
 billing_account = "XXXXXX-XXXXXX-XXXXXX"

--- a/infra/terraform/terraform.tfvars.staging
+++ b/infra/terraform/terraform.tfvars.staging
@@ -1,5 +1,7 @@
 # Staging environment variable values
-# Replace project_id and billing_account with your actual values (see docs/deploy.md)
+# Replace project_id with your actual value (see docs/deploy.md)
+# billing_account: do NOT commit a real value here — pass via CI/CD secret instead:
+#   terraform apply -var="billing_account=$GCP_BILLING_ACCOUNT"
 
 project_id      = "lifting-logbook-staging"
 billing_account = "XXXXXX-XXXXXX-XXXXXX"

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,9 +92,11 @@
       "dependencies": {
         "@lifting-logbook/core": "*",
         "@lifting-logbook/types": "*",
+        "google-auth-library": "^9.0.0",
         "next": "16.2.4",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "server-only": "^0.0.1"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -7395,6 +7397,14 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -7571,6 +7581,11 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -8519,6 +8534,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -9351,6 +9374,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -9880,6 +9908,47 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -10056,6 +10125,30 @@
         "node": ">= 4"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -10072,6 +10165,18 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/handlebars": {
       "version": "4.7.8",
@@ -10529,7 +10634,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11349,6 +11453,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -11423,6 +11535,25 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -14900,6 +15031,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="
     },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",


### PR DESCRIPTION
## Summary

Wires up Cloud Run service-to-service authentication so the Next.js web service can reach the authenticated API service, and addresses all remaining non-blocking findings from the PR #157 review.

**Closes #158**

### Issue #158 — Service-to-service auth

- **Terraform (`infra/terraform/cloud-run.tf`):** New `web_workload` service account; wired as `service_account` on the web Cloud Run template; granted `roles/run.invoker` on the API service. Removes the TODO comment that tracked this gap.
- **Terraform (`infra/terraform/outputs.tf`):** Exports `web_workload_sa` for CI/CD use.
- **Application (`apps/web/lib/api.ts`):** Marked `server-only`; adds `getAuthHeaders()` helper that fetches a GCP identity token via `google-auth-library` when `API_URL` is `https://` (Cloud Run). All server-side `fetch` calls now carry an `Authorization: Bearer <identity-token>` header when deployed.
- **Application (`apps/web/lib/client-api.ts`):** New file exporting the three write operations (`createLiftRecord`, `updateLiftRecord`, `recordBodyWeight`) for use by `WorkoutLogger.tsx` (a Client Component that cannot use `server-only` imports). Browser-originating calls don't carry GCP identity tokens; that's a separate auth concern.
- **CI/CD (`.github/workflows/deploy.yml`):** Both `gcloud run deploy` web steps now pass `--service-account=<web_workload_sa>`; both Terraform apply steps pass `-var="billing_account=${{ secrets.GCP_BILLING_ACCOUNT }}"` so the real value never lives in committed tfvars.

### PR #157 non-blocking findings

- **`infra/kubernetes/charts/web/values.yaml`:** Set `ingress.className: "gce"` and removed the deprecated `kubernetes.io/ingress.class` annotation (Kubernetes ≥ 1.18 uses `ingressClassName`).
- **`infra/terraform/terraform.tfvars.{staging,production}`:** Added a do-not-commit comment on `billing_account`; real value now injected from `GCP_BILLING_ACCOUNT` CI/CD secret.

## Acceptance Criteria

- [x] Terraform creates `web_workload` SA and grants it `roles/run.invoker` on the API service
- [x] Web Cloud Run service runs as `web_workload` SA (via `--service-account` in CI/CD)
- [x] Server-side API calls in `apps/web` attach a GCP identity token when `API_URL` is `https://`
- [x] Build succeeds (`npm run build -w @lifting-logbook/web`)

## Test Results

```
npm test (unit + integration across all workspaces)

@lifting-logbook/web:   10 passed
@lifting-logbook/core: 124 passed
@lifting-logbook/api-legacy: 1 passed
@lifting-logbook/api: 2 failures (pre-existing DB integration tests that require a live database — unchanged from main)
```

```
npm run build -w @lifting-logbook/web
✓ Compiled successfully — all 5 routes generated
```

## References

- [Cloud Run service-to-service authentication](https://cloud.google.com/run/docs/authenticating/service-to-service)
- [google-auth-library-nodejs](https://github.com/googleapis/google-auth-library-nodejs)