### PR TITLE
[feat] Design system and global styling foundation

### DIFF
--- a/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.module.css
+++ b/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.module.css
@@ -1,112 +1,113 @@
 .container {
-  padding: 1rem;
+  padding: var(--space-4);
   max-width: 800px;
   margin: 0 auto;
 }
 
 .heading {
-  font-size: 1.5rem;
-  margin-bottom: 1rem;
+  font-size: var(--font-size-xl);
+  margin-bottom: var(--space-4);
 }
 
 .grid {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 .weekSection {
-  border: 1px solid #ddd;
-  border-radius: 8px;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-lg);
   overflow: hidden;
 }
 
 .weekToggle {
   width: 100%;
-  padding: 0.75rem 1rem;
+  padding: var(--space-3) var(--space-4);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: #f5f5f5;
+  background: var(--color-surface);
   border: none;
   cursor: pointer;
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   font-weight: 600;
   text-align: left;
+  transition: background var(--transition-fast);
 }
 
 .weekToggle:hover {
-  background: #ebebeb;
+  background: var(--color-surface-alt);
 }
 
 .toggleIcon {
-  font-size: 0.75rem;
-  color: #666;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
 }
 
 .workouts {
-  padding: 1rem;
+  padding: var(--space-4);
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 .workoutCard {
-  padding: 1rem;
-  border: 1px solid #eee;
-  border-radius: 6px;
+  padding: var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
   min-width: 0;
 }
 
 .card_completed {
-  background: #f0fff0;
-  border-color: #c3e6cb;
+  background: var(--color-completed-bg);
+  border-color: var(--color-success-border);
 }
 
 .card_upcoming {
-  background: #fffdf0;
-  border-color: #ffeaa7;
+  background: var(--color-upcoming-bg);
+  border-color: var(--color-warn-border);
 }
 
 .card_missed {
-  background: #fff5f5;
-  border-color: #f5c6cb;
+  background: var(--color-missed-bg);
+  border-color: var(--color-missed-border);
 }
 
 .cardHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 0.75rem;
-  gap: 0.5rem;
+  margin-bottom: var(--space-3);
+  gap: var(--space-2);
 }
 
 .cardHeader time {
-  font-size: 0.9rem;
-  color: #555;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
 }
 
 .badge {
-  padding: 0.2rem 0.6rem;
-  border-radius: 4px;
-  font-size: 0.75rem;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
   font-weight: 600;
   white-space: nowrap;
 }
 
 .badge_completed {
-  background: #d4edda;
-  color: #155724;
+  background: var(--color-success-bg);
+  color: var(--color-success-text);
 }
 
 .badge_upcoming {
-  background: #fff3cd;
-  color: #856404;
+  background: var(--color-warn-bg);
+  color: var(--color-warn-text);
 }
 
 .badge_missed {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--color-missed-bg);
+  color: var(--color-upcoming-text);
 }
 
 .liftList {
@@ -115,18 +116,18 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--space-3);
 }
 
 .liftItem {
-  font-size: 0.95rem;
+  font-size: var(--font-size-sm);
 }
 
 .setList {
-  margin: 0.25rem 0 0 1.25rem;
+  margin: var(--space-1) 0 0 var(--space-5);
   padding: 0;
-  font-size: 0.875rem;
-  color: #444;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
 }
 
 @media (min-width: 540px) {

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.module.css
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.module.css
@@ -260,7 +260,7 @@
 
 .logBtn {
   background: var(--color-text);
-  color: #fff;
+  color: var(--color-text-inverted);
 }
 
 .logBtn:disabled {
@@ -353,7 +353,7 @@
   min-height: 44px;
   padding: 0 var(--space-5);
   background: var(--color-accent);
-  color: #fff;
+  color: var(--color-on-accent);
   border: none;
   border-radius: var(--radius-md);
   font-size: var(--font-size-sm);
@@ -426,7 +426,7 @@
 .gateSubmit {
   min-height: 52px;
   background: var(--color-text);
-  color: #fff;
+  color: var(--color-text-inverted);
   border: none;
   border-radius: var(--radius-lg);
   font-size: var(--font-size-base);

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.module.css
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.module.css
@@ -8,18 +8,18 @@
   min-height: 100dvh;
   max-width: 480px;
   margin: 0 auto;
-  padding: 0 16px 80px; /* bottom padding for fixed footer */
+  padding: 0 var(--space-4) 80px; /* bottom padding for fixed footer */
 }
 
 .header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 0 8px;
+  padding: var(--space-4) 0 var(--space-2);
 }
 
 .screenTitle {
-  font-size: 1.125rem;
+  font-size: var(--font-size-lg);
   font-weight: 600;
   margin: 0;
 }
@@ -32,17 +32,18 @@
   min-width: 44px;
   min-height: 44px;
   background: none;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  font-size: 1.25rem;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-lg);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
+  transition: background var(--transition-fast);
 }
 
 .viewToggle:hover {
-  background: #f5f5f5;
+  background: var(--color-surface);
 }
 
 /* ---------------------------------------------------------------------------
@@ -51,16 +52,16 @@
 
 .navDots {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   justify-content: center;
-  padding: 8px 0 16px;
+  padding: var(--space-2) 0 var(--space-4);
 }
 
 .dot {
   width: 10px;
   height: 10px;
-  border-radius: 50%;
-  background: #ccc;
+  border-radius: var(--radius-full);
+  background: var(--color-border-strong);
   border: none;
   padding: 0;
   cursor: pointer;
@@ -77,16 +78,17 @@
   position: absolute;
   width: 10px;
   height: 10px;
-  border-radius: 50%;
-  background: #ccc;
+  border-radius: var(--radius-full);
+  background: var(--color-border-strong);
+  transition: background var(--transition-fast);
 }
 
 .dotActive::after {
-  background: #1a1a1a;
+  background: var(--color-text);
 }
 
 .dotDone::after {
-  background: #22c55e;
+  background: var(--color-accent);
 }
 
 /* ---------------------------------------------------------------------------
@@ -98,9 +100,9 @@
 }
 
 .liftName {
-  font-size: 1.375rem;
-  font-weight: 700;
-  margin: 0 0 16px;
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  margin: 0 0 var(--space-4);
 }
 
 /* ---------------------------------------------------------------------------
@@ -108,13 +110,13 @@
    --------------------------------------------------------------------------- */
 
 .warmUpSection {
-  margin-bottom: 24px;
+  margin-bottom: var(--space-6);
 }
 
 .warmUpImplement {
-  font-size: 0.875rem;
-  color: #555;
-  margin: 0 0 8px;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin: 0 0 var(--space-2);
 }
 
 .warmUpList {
@@ -123,26 +125,26 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .warmUpRow {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 12px;
-  background: #f8f8f8;
-  border-radius: 6px;
-  font-size: 0.9375rem;
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
 }
 
 .warmUpLabel {
-  color: #555;
-  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
 }
 
 .warmUpWeight {
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 /* ---------------------------------------------------------------------------
@@ -150,7 +152,7 @@
    --------------------------------------------------------------------------- */
 
 .workingSection {
-  margin-bottom: 16px;
+  margin-bottom: var(--space-4);
 }
 
 .setList {
@@ -159,71 +161,86 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--space-2);
 }
 
 .setRow {
-  padding: 12px;
-  border: 1px solid #e0e0e0;
-  border-radius: 8px;
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  transition: background var(--transition-fast), border-color var(--transition-fast);
 }
 
 .setRowLogged {
-  border-color: #bbf7d0;
-  background: #f0fdf4;
+  border-color: var(--color-success-border);
+  background: var(--color-success-bg);
 }
 
 .setForm {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .setNum {
   font-weight: 600;
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm);
   min-width: 48px;
 }
 
 .amrapBadge {
-  font-size: 0.75rem;
-  background: #fef9c3;
-  border: 1px solid #fde047;
-  border-radius: 4px;
-  padding: 1px 6px;
+  font-size: var(--font-size-xs);
+  background: var(--color-warn-bg);
+  border: 1px solid var(--color-warn-border);
+  border-radius: var(--radius-sm);
+  padding: 1px var(--space-2);
   font-weight: 600;
 }
 
 .setInput {
   width: 72px;
   min-height: 44px;
-  padding: 0 8px;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  font-size: 1rem;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
   text-align: center;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.setInput:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-glow);
 }
 
 .inputSep {
-  font-size: 0.9375rem;
-  color: #555;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
 }
 
 .notesInput {
   flex: 1;
   min-width: 120px;
   min-height: 44px;
-  padding: 0 8px;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  font-size: 0.9375rem;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.notesInput:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-glow);
 }
 
 .setError {
   width: 100%;
-  color: #dc2626;
-  font-size: 0.875rem;
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
   margin: 0;
 }
 
@@ -232,16 +249,17 @@
 .cancelBtn {
   min-height: 44px;
   min-width: 64px;
-  padding: 0 14px;
-  border-radius: 6px;
-  font-size: 0.9375rem;
+  padding: 0 var(--space-4);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
   font-weight: 600;
   cursor: pointer;
   border: none;
+  transition: background var(--transition-fast), opacity var(--transition-fast);
 }
 
 .logBtn {
-  background: #1a1a1a;
+  background: var(--color-text);
   color: #fff;
 }
 
@@ -251,32 +269,32 @@
 
 .editBtn {
   background: none;
-  border: 1px solid #ccc;
-  color: #1a1a1a;
+  border: 1px solid var(--color-border-strong);
+  color: var(--color-text);
 }
 
 .cancelBtn {
   background: none;
-  border: 1px solid #ccc;
-  color: #555;
+  border: 1px solid var(--color-border-strong);
+  color: var(--color-text-muted);
 }
 
 .setCheck {
-  color: #16a34a;
-  font-weight: 700;
-  font-size: 1.125rem;
+  color: var(--color-success-text);
+  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-lg);
 }
 
 .setSummary {
-  font-size: 0.9375rem;
-  color: #1a1a1a;
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
   flex: 1;
 }
 
 .setNotes {
   width: 100%;
-  font-size: 0.875rem;
-  color: #555;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
   font-style: italic;
 }
 
@@ -291,18 +309,18 @@
   right: 0;
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 12px 16px;
-  background: #fff;
-  border-top: 1px solid #e0e0e0;
-  font-size: 0.9375rem;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-bg);
+  border-top: 1px solid var(--color-border);
+  font-size: var(--font-size-sm);
   max-width: 480px;
   margin: 0 auto;
 }
 
 .nextLabel {
-  color: #555;
-  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
 }
 
 .nextName {
@@ -311,37 +329,42 @@
 }
 
 .nextWeight {
-  color: #555;
-  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
 }
 
 .nextBtn {
   min-width: 44px;
   min-height: 44px;
   background: none;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  font-size: 1.125rem;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-lg);
   cursor: pointer;
 }
 
 .lastExercise {
   flex: 1;
-  color: #555;
+  color: var(--color-text-muted);
   font-style: italic;
 }
 
 .finishBtn {
   min-height: 44px;
-  padding: 0 18px;
-  background: #16a34a;
+  padding: 0 var(--space-5);
+  background: var(--color-accent);
   color: #fff;
   border: none;
-  border-radius: 6px;
-  font-size: 0.9375rem;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
   font-weight: 600;
   cursor: pointer;
   margin-left: auto;
+  transition: background var(--transition-fast);
+}
+
+.finishBtn:hover {
+  background: var(--color-accent-hover);
 }
 
 /* ---------------------------------------------------------------------------
@@ -350,58 +373,66 @@
 
 .gate {
   max-width: 360px;
-  margin: 64px auto 0;
-  padding: 0 16px;
+  margin: var(--space-16) auto 0;
+  padding: 0 var(--space-4);
 }
 
 .gateHeading {
-  font-size: 1.375rem;
-  font-weight: 700;
-  margin: 0 0 8px;
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  margin: 0 0 var(--space-2);
 }
 
 .gateHint {
-  color: #555;
-  font-size: 0.9375rem;
-  margin: 0 0 24px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  margin: 0 0 var(--space-6);
 }
 
 .gateForm {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .gateLabel {
   font-weight: 600;
-  font-size: 0.9375rem;
+  font-size: var(--font-size-sm);
 }
 
 .gateInput {
   min-height: 52px;
-  padding: 0 12px;
-  border: 1px solid #ccc;
-  border-radius: 8px;
-  font-size: 1.125rem;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-lg);
+  font-size: var(--font-size-lg);
   text-align: center;
   width: 100%;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.gateInput:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-glow);
 }
 
 .gateError {
-  color: #dc2626;
-  font-size: 0.875rem;
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
   margin: 0;
 }
 
 .gateSubmit {
   min-height: 52px;
-  background: #1a1a1a;
+  background: var(--color-text);
   color: #fff;
   border: none;
-  border-radius: 8px;
-  font-size: 1rem;
+  border-radius: var(--radius-lg);
+  font-size: var(--font-size-base);
   font-weight: 600;
   cursor: pointer;
+  transition: opacity var(--transition-fast);
 }
 
 .gateSubmit:disabled {
@@ -418,47 +449,47 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--space-2);
 }
 
 .overviewRow {
-  padding: 14px;
-  border: 1px solid #e0e0e0;
-  border-radius: 8px;
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
 }
 
 .overviewRowHeader {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .overviewLiftName {
   flex: 1;
-  font-size: 1rem;
+  font-size: var(--font-size-base);
 }
 
 .overviewProgress {
-  font-size: 0.875rem;
-  color: #555;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
 }
 
 .goToBtn {
   min-height: 44px;
   min-width: 72px;
-  padding: 0 12px;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  font-size: 0.875rem;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
   font-weight: 600;
   cursor: pointer;
   background: none;
 }
 
 .overviewWarmUp {
-  margin: 8px 0 0;
-  font-size: 0.875rem;
-  color: #555;
+  margin: var(--space-2) 0 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
 }
 
 /* ---------------------------------------------------------------------------

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,205 @@
+/* ===========================================================================
+   Reset
+   =========================================================================== */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body,
+h1, h2, h3, h4, h5, h6,
+p, ul, ol, li, figure, blockquote,
+fieldset, legend {
+  margin: 0;
+  padding: 0;
+}
+
+ul, ol {
+  list-style: none;
+}
+
+img,
+picture,
+video,
+canvas,
+svg {
+  display: block;
+  max-width: 100%;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+  color: inherit;
+}
+
+button {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+/* ===========================================================================
+   Shared tokens (theme-independent)
+   =========================================================================== */
+
+:root {
+  /* Typography */
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.125rem;
+  --font-size-xl: 1.375rem;
+  --font-size-2xl: 1.75rem;
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-bold: 700;
+  --line-height-base: 1.5;
+
+  /* Spacing scale (4px base) */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-full: 9999px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.12);
+
+  /* Transitions */
+  --transition-fast: 0.2s ease;
+  --transition-base: 0.3s ease;
+}
+
+/* ===========================================================================
+   Theme: navy (default)
+   =========================================================================== */
+
+:root,
+[data-theme="navy"] {
+  --color-bg: #fafaf8;
+  --color-surface: #f8f9fa;
+  --color-surface-alt: #ecf0f1;
+  --color-border: #ecf0f1;
+  --color-border-strong: #ddd;
+  --color-text: #1a1a1a;
+  --color-text-muted: #7f8c8d;
+  --color-text-heading: #2c3e50;
+  --color-header-from: #2c3e50;
+  --color-header-to: #34495e;
+  --color-accent: #3498db;
+  --color-accent-hover: #2980b9;
+  --color-accent-glow: rgba(52, 152, 219, 0.3);
+  --color-success: #27ae60;
+  --color-success-text: #00b894;
+  --color-success-bg: #a8e6cf;
+  --color-success-border: #c3e6cb;
+  --color-error: #dc2626;
+  --color-error-text: #c0392b;
+  --color-warn-bg: #fff3cd;
+  --color-warn-text: #856404;
+  --color-warn-border: #ffeaa7;
+  --color-info-bg: #ecf0f1;
+  --color-completed-bg: #f0fff0;
+  --color-upcoming-bg: #fffdf0;
+  --color-upcoming-text: #d63031;
+  --color-missed-bg: #fff5f5;
+  --color-missed-border: #f5c6cb;
+}
+
+/* ===========================================================================
+   Theme: iron
+   =========================================================================== */
+
+[data-theme="iron"] {
+  --color-bg: #ffffff;
+  --color-surface: #f5f5f5;
+  --color-surface-alt: #eeeeee;
+  --color-border: #dddddd;
+  --color-border-strong: #cccccc;
+  --color-text: #1a1a1a;
+  --color-text-muted: #6b7280;
+  --color-text-heading: #1a1a1a;
+  --color-header-from: #1a1a1a;
+  --color-header-to: #2d2d2d;
+  --color-accent: #22c55e;
+  --color-accent-hover: #16a34a;
+  --color-accent-glow: rgba(34, 197, 94, 0.3);
+  --color-success: #22c55e;
+  --color-success-text: #16a34a;
+  --color-success-bg: #f0fdf4;
+  --color-success-border: #bbf7d0;
+  --color-error: #dc2626;
+  --color-error-text: #dc2626;
+  --color-warn-bg: #fef9c3;
+  --color-warn-text: #856404;
+  --color-warn-border: #fde047;
+  --color-info-bg: #f5f5f5;
+  --color-completed-bg: #f0fdf4;
+  --color-upcoming-bg: #fef9c3;
+  --color-upcoming-text: #dc2626;
+  --color-missed-bg: #fef2f2;
+  --color-missed-border: #fecaca;
+}
+
+/* ===========================================================================
+   Base
+   =========================================================================== */
+
+html {
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: var(--line-height-base);
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-normal);
+  line-height: var(--line-height-base);
+  min-height: 100dvh;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: var(--color-text-heading);
+  font-weight: var(--font-weight-bold);
+  line-height: 1.25;
+}
+
+/* ===========================================================================
+   Utilities
+   =========================================================================== */
+
+.focus-ring:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -106,6 +106,9 @@ a {
 
 :root,
 [data-theme="navy"] {
+  --color-text-inverted: #fff;
+  --color-on-accent: #fff;
+  --color-on-success: #fff;
   --color-bg: #fafaf8;
   --color-surface: #f8f9fa;
   --color-surface-alt: #ecf0f1;
@@ -138,6 +141,9 @@ a {
    =========================================================================== */
 
 [data-theme="iron"] {
+  --color-text-inverted: #fff;
+  --color-on-accent: #1a1a1a;
+  --color-on-success: #1a1a1a;
   --color-bg: #ffffff;
   --color-surface: #f5f5f5;
   --color-surface-alt: #eeeeee;

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -93,6 +93,11 @@ a {
   /* Transitions */
   --transition-fast: 0.2s ease;
   --transition-base: 0.3s ease;
+
+  /* Semantic colors that do not vary by theme */
+  --color-text: #1a1a1a;
+  --color-error: #dc2626;
+  --color-warn-text: #856404;
 }
 
 /* ===========================================================================
@@ -106,7 +111,6 @@ a {
   --color-surface-alt: #ecf0f1;
   --color-border: #ecf0f1;
   --color-border-strong: #ddd;
-  --color-text: #1a1a1a;
   --color-text-muted: #7f8c8d;
   --color-text-heading: #2c3e50;
   --color-header-from: #2c3e50;
@@ -118,10 +122,8 @@ a {
   --color-success-text: #00b894;
   --color-success-bg: #a8e6cf;
   --color-success-border: #c3e6cb;
-  --color-error: #dc2626;
   --color-error-text: #c0392b;
   --color-warn-bg: #fff3cd;
-  --color-warn-text: #856404;
   --color-warn-border: #ffeaa7;
   --color-info-bg: #ecf0f1;
   --color-completed-bg: #f0fff0;
@@ -141,7 +143,6 @@ a {
   --color-surface-alt: #eeeeee;
   --color-border: #dddddd;
   --color-border-strong: #cccccc;
-  --color-text: #1a1a1a;
   --color-text-muted: #6b7280;
   --color-text-heading: #1a1a1a;
   --color-header-from: #1a1a1a;
@@ -153,10 +154,8 @@ a {
   --color-success-text: #16a34a;
   --color-success-bg: #f0fdf4;
   --color-success-border: #bbf7d0;
-  --color-error: #dc2626;
   --color-error-text: #dc2626;
   --color-warn-bg: #fef9c3;
-  --color-warn-text: #856404;
   --color-warn-border: #fde047;
   --color-info-bg: #f5f5f5;
   --color-completed-bg: #f0fdf4;

--- a/apps/web/app/home.module.css
+++ b/apps/web/app/home.module.css
@@ -1,0 +1,99 @@
+.page {
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-6) var(--space-4);
+}
+
+.card {
+  width: 100%;
+  max-width: 480px;
+  background: var(--color-bg);
+  border-radius: var(--radius-lg);
+  padding: var(--space-8) var(--space-6);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-6);
+}
+
+.brand {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.wordmark {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: -0.02em;
+  background: linear-gradient(135deg, var(--color-header-from), var(--color-header-to));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  margin: 0;
+}
+
+.tagline {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-base);
+  margin: 0;
+}
+
+.ctaList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.cta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5);
+  background: var(--color-accent);
+  color: #fff;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  text-decoration: none;
+  transition: background var(--transition-fast), transform var(--transition-fast);
+  min-height: 56px;
+  border-left: 3px solid var(--color-accent-hover);
+}
+
+.cta:hover {
+  background: var(--color-accent-hover);
+}
+
+.cta:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.ctaSecondary {
+  background: var(--color-surface);
+  color: var(--color-text-heading);
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-accent);
+}
+
+.ctaSecondary:hover {
+  background: var(--color-surface-alt);
+}
+
+.ctaArrow {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+}
+
+@media (min-width: 720px) {
+  .card {
+    box-shadow: var(--shadow-md);
+    background: var(--color-surface);
+    padding: var(--space-10) var(--space-8);
+  }
+}

--- a/apps/web/app/home.module.css
+++ b/apps/web/app/home.module.css
@@ -55,7 +55,7 @@
   gap: var(--space-4);
   padding: var(--space-4) var(--space-5);
   background: var(--color-accent);
-  color: #fff;
+  color: var(--color-on-accent);
   border-radius: var(--radius-md);
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-medium);

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,7 +7,8 @@ export const metadata: Metadata = {
 };
 
 const themeInitScript =
-  "(function(){try{var t=localStorage.getItem('theme')||'navy';" +
+  "(function(){try{var t=localStorage.getItem('theme');" +
+  "if(t!=='navy'&&t!=='iron')t='navy';" +
   "document.documentElement.setAttribute('data-theme',t);}catch(e){" +
   "document.documentElement.setAttribute('data-theme','navy');}})();";
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,9 +1,15 @@
 import type { Metadata } from "next";
+import "./globals.css";
 
 export const metadata: Metadata = {
   title: "Lifting Logbook",
   description: "Track your lifts.",
 };
+
+const themeInitScript =
+  "(function(){try{var t=localStorage.getItem('theme')||'navy';" +
+  "document.documentElement.setAttribute('data-theme',t);}catch(e){" +
+  "document.documentElement.setAttribute('data-theme','navy');}})();";
 
 export default function RootLayout({
   children,
@@ -12,7 +18,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body>{children}</body>
+      <body>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+        {children}
+      </body>
     </html>
   );
 }

--- a/apps/web/app/onboarding/OnboardingFlow.tsx
+++ b/apps/web/app/onboarding/OnboardingFlow.tsx
@@ -1,0 +1,492 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import styles from './onboarding.module.css';
+
+type DiscoveryMethod = 'estimate' | 'test' | 'manual';
+
+type LiftKey = 'bench' | 'squat' | 'deadlift';
+
+type LiftEntry = { weight: string; reps: string };
+
+type Experience = 'beginner' | 'intermediate' | 'advanced';
+
+type Program = {
+  id: string;
+  name: string;
+  experience: Experience;
+  meta: string;
+  description: string;
+};
+
+const PROGRAMS: Program[] = [
+  {
+    id: 'starting-strength',
+    name: 'Starting Strength',
+    experience: 'beginner',
+    meta: '3 days/week · Linear progression',
+    description:
+      'Mark Rippetoe’s linear progression program. Squat, press, deadlift, bench, and power clean — add weight every session until stalls require a deload.',
+  },
+  {
+    id: 'stronglifts',
+    name: 'StrongLifts 5×5',
+    experience: 'beginner',
+    meta: '3 days/week · 5×5 alternating workouts',
+    description:
+      'Two alternating workouts (A/B) with five compound lifts at 5 sets of 5 reps. Add 5 lb every session until plateau.',
+  },
+  {
+    id: 'rpt',
+    name: 'Reverse Pyramid Training (Lyle/Eric Helms)',
+    experience: 'intermediate',
+    meta: '3-4 days/week · Top-set focused',
+    description:
+      'Heaviest set first, then back-off sets at reduced load. Emphasizes intensity on the first work set with clear progression rules tied to top-set rep targets.',
+  },
+  {
+    id: 'ppl',
+    name: 'Push / Pull / Legs',
+    experience: 'intermediate',
+    meta: '6 days/week · Hypertrophy split',
+    description:
+      'Classic split that lets you train each major movement pattern twice per week. Volume scales with recovery; popular as PHUL/PHAT variants too.',
+  },
+  {
+    id: 'upper-lower',
+    name: 'Upper / Lower',
+    experience: 'intermediate',
+    meta: '4 days/week · Balanced split',
+    description:
+      'Upper body and lower body alternated four days per week. Good middle ground between full-body frequency and bodypart split volume.',
+  },
+  {
+    id: '531',
+    name: '5/3/1',
+    experience: 'intermediate',
+    meta: '4 days/week · Wave-loaded',
+    description:
+      'Jim Wendler’s 4-week wave with a top set on each main lift, then assistance work. Conservative training maxes (90% of 1RM) drive long-term progress.',
+  },
+  {
+    id: '531-bbb',
+    name: '5/3/1 Boring But Big',
+    experience: 'intermediate',
+    meta: '4 days/week · BBB volume template',
+    description:
+      'Standard 5/3/1 main work followed by 5×10 of the same lift (or its complement) at 50–70% TM. High-volume hypertrophy template most lifters can recover from.',
+  },
+  {
+    id: '531-forever',
+    name: '5/3/1 Forever',
+    experience: 'advanced',
+    meta: '3-5 days/week · Multi-cycle leader/anchor',
+    description:
+      'The latest evolution of 5/3/1 organized into "leader" volume blocks and "anchor" intensity blocks. Drops the deload week in favor of programmed light days.',
+  },
+  {
+    id: 'leangains',
+    name: 'Leangains (Berkhan)',
+    experience: 'intermediate',
+    meta: '3 days/week · RPT + IF protocol',
+    description:
+      'Reverse-pyramid lifting paired with intermittent fasting. Three compound-focused sessions per week with macros tuned to training and rest days.',
+  },
+  {
+    id: 'conjugate',
+    name: 'Westside Conjugate',
+    experience: 'advanced',
+    meta: '4 days/week · Max effort + dynamic effort',
+    description:
+      'Westside Barbell’s max-effort and dynamic-effort waves rotated across upper and lower days. Heavy emphasis on accommodating resistance and weak-point training.',
+  },
+  {
+    id: 'smolov',
+    name: 'Smolov (Squat)',
+    experience: 'advanced',
+    meta: '4 days/week · 13-week squat cycle',
+    description:
+      'Soviet squat specialization program. Brutal intro phase, base mesocycle, switching, and intense mesocycle. Use only with deep recovery support.',
+  },
+  {
+    id: 'juggernaut',
+    name: 'Juggernaut Method',
+    experience: 'advanced',
+    meta: '4 days/week · Block periodization',
+    description:
+      'Chad Wesley Smith’s block model with accumulation, intensification, and realization phases. Long-term progression with built-in volume waves.',
+  },
+  {
+    id: 'creeping-death-2',
+    name: 'Creeping Death II',
+    experience: 'advanced',
+    meta: '4 days/week · 5/3/1 program of programs',
+    description:
+      'A long-haul 5/3/1 template that stretches each cycle’s pace and increases supplemental work over time. Built for advanced lifters chasing slow PRs.',
+  },
+];
+
+const STEP_LABELS = [
+  'Choose Method',
+  'Enter Lifts',
+  'Confirm Maxes',
+  'Choose Program',
+];
+
+function brzycki1RM(weight: number, reps: number): number {
+  if (reps <= 0 || weight <= 0) return 0;
+  if (reps === 1) return Math.round(weight);
+  const denom = 37 - reps;
+  if (denom <= 0) return 0;
+  return Math.round((weight * 36) / denom);
+}
+
+const LIFT_LABELS: Record<LiftKey, string> = {
+  bench: 'Bench Press',
+  squat: 'Back Squat',
+  deadlift: 'Deadlift',
+};
+
+const METHOD_OPTIONS: { id: DiscoveryMethod; title: string; description: string }[] = [
+  {
+    id: 'estimate',
+    title: 'Estimate from a recent lift',
+    description:
+      'Enter a recent set (weight × reps) and we’ll calculate your 1RM with the Brzycki formula.',
+  },
+  {
+    id: 'test',
+    title: 'Run a Test Week',
+    description:
+      'Spend a week working up to heavy singles in each lift. Best accuracy for experienced lifters.',
+  },
+  {
+    id: 'manual',
+    title: 'Enter manually',
+    description:
+      'You already know your 1RMs. Enter them directly and we’ll set training maxes at 90%.',
+  },
+];
+
+export function OnboardingFlow() {
+  const [step, setStep] = useState(0);
+  const [method, setMethod] = useState<DiscoveryMethod>('estimate');
+  const [lifts, setLifts] = useState<Record<LiftKey, LiftEntry>>({
+    bench: { weight: '', reps: '' },
+    squat: { weight: '', reps: '' },
+    deadlift: { weight: '', reps: '' },
+  });
+  const [experience, setExperience] = useState<Experience>('beginner');
+  const [selectedProgramId, setSelectedProgramId] = useState<string | null>(null);
+  const [confirmed, setConfirmed] = useState(false);
+
+  const canAdvanceFromLifts = (Object.keys(lifts) as LiftKey[]).every((k) => {
+    const entry = lifts[k];
+    if (method === 'manual') return Number(entry.weight) > 0;
+    return Number(entry.weight) > 0 && Number(entry.reps) > 0;
+  });
+
+  const computedMaxes = useMemo(() => {
+    return (Object.keys(lifts) as LiftKey[]).map((k) => {
+      const entry = lifts[k];
+      const w = Number(entry.weight);
+      const r = Number(entry.reps);
+      const oneRm = method === 'manual' ? Math.round(w) : brzycki1RM(w, r);
+      return { lift: k, oneRm };
+    });
+  }, [lifts, method]);
+
+  const visiblePrograms = PROGRAMS.filter((p) => p.experience === experience);
+  const selectedProgram = PROGRAMS.find((p) => p.id === selectedProgramId) ?? null;
+
+  function updateLift(key: LiftKey, field: keyof LiftEntry, value: string) {
+    setLifts((prev) => ({
+      ...prev,
+      [key]: { ...prev[key], [field]: value },
+    }));
+  }
+
+  function goNext() {
+    setStep((s) => Math.min(s + 1, STEP_LABELS.length - 1));
+  }
+
+  function goBack() {
+    setStep((s) => Math.max(s - 1, 0));
+  }
+
+  return (
+    <main className={styles.page}>
+      <div className={styles.shell}>
+        <header className={styles.header}>
+          <h1 className={styles.headerTitle}>Get Started</h1>
+          <p className={styles.headerSubtitle}>
+            Step {step + 1} of {STEP_LABELS.length} · {STEP_LABELS[step]}
+          </p>
+          <nav
+            className={styles.progressDots}
+            aria-label="Onboarding progress"
+          >
+            {STEP_LABELS.map((label, i) => {
+              const dotClass = [
+                styles.dot,
+                i === step ? styles.dotActive : '',
+                i < step ? styles.dotDone : '',
+              ]
+                .filter(Boolean)
+                .join(' ');
+              return (
+                <span
+                  key={label}
+                  className={dotClass}
+                  aria-current={i === step ? 'step' : undefined}
+                  aria-label={label}
+                />
+              );
+            })}
+          </nav>
+        </header>
+
+        <section className={styles.body}>
+          {step === 0 && (
+            <>
+              <h2 className={styles.stepTitle}>How do you want to find your maxes?</h2>
+              <p className={styles.stepHint}>
+                Pick the option that matches your training history.
+              </p>
+              <div className={styles.optionList}>
+                {METHOD_OPTIONS.map((opt) => {
+                  const cls = [
+                    styles.option,
+                    method === opt.id ? styles.optionSelected : '',
+                  ]
+                    .filter(Boolean)
+                    .join(' ');
+                  return (
+                    <button
+                      type="button"
+                      key={opt.id}
+                      className={cls}
+                      onClick={() => setMethod(opt.id)}
+                      aria-pressed={method === opt.id}
+                    >
+                      <span className={styles.optionTitle}>{opt.title}</span>
+                      <span className={styles.optionDescription}>
+                        {opt.description}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </>
+          )}
+
+          {step === 1 && (
+            <>
+              <h2 className={styles.stepTitle}>Enter your lifts</h2>
+              <p className={styles.stepHint}>
+                {method === 'manual'
+                  ? 'Enter your current 1-rep max for each lift.'
+                  : 'Enter a recent heavy set (weight × reps) for each lift.'}
+              </p>
+              <div className={styles.dataRows}>
+                {(Object.keys(LIFT_LABELS) as LiftKey[]).map((key) => (
+                  <div key={key} className={styles.dataRow}>
+                    <span className={styles.dataRowLabel}>
+                      {LIFT_LABELS[key]}
+                    </span>
+                    <input
+                      type="number"
+                      inputMode="decimal"
+                      min="0"
+                      placeholder="Weight"
+                      className={styles.numberInput}
+                      value={lifts[key].weight}
+                      onChange={(e) => updateLift(key, 'weight', e.target.value)}
+                      aria-label={`${LIFT_LABELS[key]} weight`}
+                    />
+                    <span className={styles.unitLabel}>lb</span>
+                    {method !== 'manual' && (
+                      <>
+                        <span className={styles.unitLabel}>×</span>
+                        <input
+                          type="number"
+                          inputMode="numeric"
+                          min="1"
+                          max="20"
+                          placeholder="Reps"
+                          className={styles.numberInput}
+                          value={lifts[key].reps}
+                          onChange={(e) => updateLift(key, 'reps', e.target.value)}
+                          aria-label={`${LIFT_LABELS[key]} reps`}
+                        />
+                        <span className={styles.unitLabel}>reps</span>
+                      </>
+                    )}
+                  </div>
+                ))}
+              </div>
+              <p className={styles.infoBox}>
+                We use the Brzycki formula:{' '}
+                <strong>1RM = weight × 36 ÷ (37 − reps)</strong>. Stay under
+                10 reps for accuracy.
+              </p>
+            </>
+          )}
+
+          {step === 2 && (
+            <>
+              <h2 className={styles.stepTitle}>Confirm your training maxes</h2>
+              <p className={styles.stepHint}>
+                Estimated 1-rep maxes based on what you entered. Training maxes
+                use 90% of the 1RM.
+              </p>
+              <div className={styles.maxesGrid}>
+                {computedMaxes.map(({ lift, oneRm }) => (
+                  <div key={lift} className={styles.maxRow}>
+                    <span className={styles.maxRowLabel}>
+                      {LIFT_LABELS[lift]}
+                    </span>
+                    <span className={styles.maxRowValue}>
+                      {oneRm > 0 ? `${oneRm} lb` : '—'}
+                      {oneRm > 0 && (
+                        <span
+                          className={styles.unitLabel}
+                          style={{ marginLeft: 'var(--space-2)' }}
+                        >
+                          (TM {Math.round(oneRm * 0.9)} lb)
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+
+          {step === 3 && (
+            <>
+              <h2 className={styles.stepTitle}>Choose a program</h2>
+              <p className={styles.stepHint}>
+                Filter by experience, then pick a template to see details.
+              </p>
+              <div
+                className={styles.experienceFilter}
+                role="tablist"
+                aria-label="Experience level"
+              >
+                {(['beginner', 'intermediate', 'advanced'] as Experience[]).map(
+                  (level) => {
+                    const cls = [
+                      styles.filterChip,
+                      experience === level ? styles.filterChipActive : '',
+                    ]
+                      .filter(Boolean)
+                      .join(' ');
+                    return (
+                      <button
+                        key={level}
+                        type="button"
+                        role="tab"
+                        aria-selected={experience === level}
+                        className={cls}
+                        onClick={() => {
+                          setExperience(level);
+                          setSelectedProgramId(null);
+                        }}
+                      >
+                        {level.charAt(0).toUpperCase() + level.slice(1)}
+                      </button>
+                    );
+                  },
+                )}
+              </div>
+
+              {selectedProgram ? (
+                <div className={styles.programDetail}>
+                  <div className={styles.programDetailHeader}>
+                    <h3 className={styles.programDetailName}>
+                      {selectedProgram.name}
+                    </h3>
+                    <span className={styles.programDetailMeta}>
+                      {selectedProgram.meta}
+                    </span>
+                  </div>
+                  <p className={styles.programDetailDescription}>
+                    {selectedProgram.description}
+                  </p>
+                  {confirmed ? (
+                    <div className={styles.successBanner}>
+                      <p className={styles.successTitle}>You’re all set.</p>
+                      <p className={styles.successBody}>
+                        {selectedProgram.name} is queued up for your first cycle.
+                        Wiring this to the API comes next.
+                      </p>
+                    </div>
+                  ) : (
+                    <div style={{ display: 'flex', gap: 'var(--space-3)' }}>
+                      <button
+                        type="button"
+                        className={styles.btnSecondary}
+                        onClick={() => setSelectedProgramId(null)}
+                      >
+                        Back
+                      </button>
+                      <button
+                        type="button"
+                        className={styles.btnSuccess}
+                        onClick={() => setConfirmed(true)}
+                      >
+                        Choose This Program
+                      </button>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className={styles.programList}>
+                  {visiblePrograms.map((p) => (
+                    <button
+                      key={p.id}
+                      type="button"
+                      className={styles.programItem}
+                      onClick={() => {
+                        setSelectedProgramId(p.id);
+                        setConfirmed(false);
+                      }}
+                    >
+                      <span className={styles.programName}>{p.name}</span>
+                      <span className={styles.programMeta}>{p.meta}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </section>
+
+        {!(step === 3 && confirmed) && (
+          <div className={styles.actionRow}>
+            {step > 0 && (
+              <button
+                type="button"
+                className={styles.btnSecondary}
+                onClick={goBack}
+              >
+                Back
+              </button>
+            )}
+            {step < 3 && (
+              <button
+                type="button"
+                className={styles.btnPrimary}
+                onClick={goNext}
+                disabled={step === 1 ? !canAdvanceFromLifts : false}
+              >
+                {step === 2 ? 'Continue to Programs' : 'Next'}
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/onboarding/OnboardingFlow.tsx
+++ b/apps/web/app/onboarding/OnboardingFlow.tsx
@@ -2,170 +2,23 @@
 
 import { useMemo, useState } from 'react';
 import styles from './onboarding.module.css';
-
-type DiscoveryMethod = 'estimate' | 'test' | 'manual';
-
-type LiftKey = 'bench' | 'squat' | 'deadlift';
-
-type LiftEntry = { weight: string; reps: string };
-
-type Experience = 'beginner' | 'intermediate' | 'advanced';
-
-type Program = {
-  id: string;
-  name: string;
-  experience: Experience;
-  meta: string;
-  description: string;
-};
-
-const PROGRAMS: Program[] = [
-  {
-    id: 'starting-strength',
-    name: 'Starting Strength',
-    experience: 'beginner',
-    meta: '3 days/week · Linear progression',
-    description:
-      'Mark Rippetoe’s linear progression program. Squat, press, deadlift, bench, and power clean — add weight every session until stalls require a deload.',
-  },
-  {
-    id: 'stronglifts',
-    name: 'StrongLifts 5×5',
-    experience: 'beginner',
-    meta: '3 days/week · 5×5 alternating workouts',
-    description:
-      'Two alternating workouts (A/B) with five compound lifts at 5 sets of 5 reps. Add 5 lb every session until plateau.',
-  },
-  {
-    id: 'rpt',
-    name: 'Reverse Pyramid Training (Lyle/Eric Helms)',
-    experience: 'intermediate',
-    meta: '3-4 days/week · Top-set focused',
-    description:
-      'Heaviest set first, then back-off sets at reduced load. Emphasizes intensity on the first work set with clear progression rules tied to top-set rep targets.',
-  },
-  {
-    id: 'ppl',
-    name: 'Push / Pull / Legs',
-    experience: 'intermediate',
-    meta: '6 days/week · Hypertrophy split',
-    description:
-      'Classic split that lets you train each major movement pattern twice per week. Volume scales with recovery; popular as PHUL/PHAT variants too.',
-  },
-  {
-    id: 'upper-lower',
-    name: 'Upper / Lower',
-    experience: 'intermediate',
-    meta: '4 days/week · Balanced split',
-    description:
-      'Upper body and lower body alternated four days per week. Good middle ground between full-body frequency and bodypart split volume.',
-  },
-  {
-    id: '531',
-    name: '5/3/1',
-    experience: 'intermediate',
-    meta: '4 days/week · Wave-loaded',
-    description:
-      'Jim Wendler’s 4-week wave with a top set on each main lift, then assistance work. Conservative training maxes (90% of 1RM) drive long-term progress.',
-  },
-  {
-    id: '531-bbb',
-    name: '5/3/1 Boring But Big',
-    experience: 'intermediate',
-    meta: '4 days/week · BBB volume template',
-    description:
-      'Standard 5/3/1 main work followed by 5×10 of the same lift (or its complement) at 50–70% TM. High-volume hypertrophy template most lifters can recover from.',
-  },
-  {
-    id: '531-forever',
-    name: '5/3/1 Forever',
-    experience: 'advanced',
-    meta: '3-5 days/week · Multi-cycle leader/anchor',
-    description:
-      'The latest evolution of 5/3/1 organized into "leader" volume blocks and "anchor" intensity blocks. Drops the deload week in favor of programmed light days.',
-  },
-  {
-    id: 'leangains',
-    name: 'Leangains (Berkhan)',
-    experience: 'intermediate',
-    meta: '3 days/week · RPT + IF protocol',
-    description:
-      'Reverse-pyramid lifting paired with intermittent fasting. Three compound-focused sessions per week with macros tuned to training and rest days.',
-  },
-  {
-    id: 'conjugate',
-    name: 'Westside Conjugate',
-    experience: 'advanced',
-    meta: '4 days/week · Max effort + dynamic effort',
-    description:
-      'Westside Barbell’s max-effort and dynamic-effort waves rotated across upper and lower days. Heavy emphasis on accommodating resistance and weak-point training.',
-  },
-  {
-    id: 'smolov',
-    name: 'Smolov (Squat)',
-    experience: 'advanced',
-    meta: '4 days/week · 13-week squat cycle',
-    description:
-      'Soviet squat specialization program. Brutal intro phase, base mesocycle, switching, and intense mesocycle. Use only with deep recovery support.',
-  },
-  {
-    id: 'juggernaut',
-    name: 'Juggernaut Method',
-    experience: 'advanced',
-    meta: '4 days/week · Block periodization',
-    description:
-      'Chad Wesley Smith’s block model with accumulation, intensification, and realization phases. Long-term progression with built-in volume waves.',
-  },
-  {
-    id: 'creeping-death-2',
-    name: 'Creeping Death II',
-    experience: 'advanced',
-    meta: '4 days/week · 5/3/1 program of programs',
-    description:
-      'A long-haul 5/3/1 template that stretches each cycle’s pace and increases supplemental work over time. Built for advanced lifters chasing slow PRs.',
-  },
-];
+import {
+  brzycki1RM,
+  type DiscoveryMethod,
+  type LiftEntry,
+  type LiftKey,
+} from './lib';
+import type { Experience } from './programs';
+import { StepMethod } from './steps/StepMethod';
+import { StepLifts } from './steps/StepLifts';
+import { StepConfirm } from './steps/StepConfirm';
+import { StepProgram } from './steps/StepProgram';
 
 const STEP_LABELS = [
   'Choose Method',
   'Enter Lifts',
   'Confirm Maxes',
   'Choose Program',
-];
-
-function brzycki1RM(weight: number, reps: number): number {
-  if (reps <= 0 || weight <= 0) return 0;
-  if (reps === 1) return Math.round(weight);
-  const denom = 37 - reps;
-  if (denom <= 0) return 0;
-  return Math.round((weight * 36) / denom);
-}
-
-const LIFT_LABELS: Record<LiftKey, string> = {
-  bench: 'Bench Press',
-  squat: 'Back Squat',
-  deadlift: 'Deadlift',
-};
-
-const METHOD_OPTIONS: { id: DiscoveryMethod; title: string; description: string }[] = [
-  {
-    id: 'estimate',
-    title: 'Estimate from a recent lift',
-    description:
-      'Enter a recent set (weight × reps) and we’ll calculate your 1RM with the Brzycki formula.',
-  },
-  {
-    id: 'test',
-    title: 'Run a Test Week',
-    description:
-      'Spend a week working up to heavy singles in each lift. Best accuracy for experienced lifters.',
-  },
-  {
-    id: 'manual',
-    title: 'Enter manually',
-    description:
-      'You already know your 1RMs. Enter them directly and we’ll set training maxes at 90%.',
-  },
 ];
 
 export function OnboardingFlow() {
@@ -196,9 +49,6 @@ export function OnboardingFlow() {
     });
   }, [lifts, method]);
 
-  const visiblePrograms = PROGRAMS.filter((p) => p.experience === experience);
-  const selectedProgram = PROGRAMS.find((p) => p.id === selectedProgramId) ?? null;
-
   function updateLift(key: LiftKey, field: keyof LiftEntry, value: string) {
     setLifts((prev) => ({
       ...prev,
@@ -222,10 +72,7 @@ export function OnboardingFlow() {
           <p className={styles.headerSubtitle}>
             Step {step + 1} of {STEP_LABELS.length} · {STEP_LABELS[step]}
           </p>
-          <nav
-            className={styles.progressDots}
-            aria-label="Onboarding progress"
-          >
+          <nav className={styles.progressDots} aria-label="Onboarding progress">
             {STEP_LABELS.map((label, i) => {
               const dotClass = [
                 styles.dot,
@@ -247,230 +94,34 @@ export function OnboardingFlow() {
         </header>
 
         <section className={styles.body}>
-          {step === 0 && (
-            <>
-              <h2 className={styles.stepTitle}>How do you want to find your maxes?</h2>
-              <p className={styles.stepHint}>
-                Pick the option that matches your training history.
-              </p>
-              <div className={styles.optionList}>
-                {METHOD_OPTIONS.map((opt) => {
-                  const cls = [
-                    styles.option,
-                    method === opt.id ? styles.optionSelected : '',
-                  ]
-                    .filter(Boolean)
-                    .join(' ');
-                  return (
-                    <button
-                      type="button"
-                      key={opt.id}
-                      className={cls}
-                      onClick={() => setMethod(opt.id)}
-                      aria-pressed={method === opt.id}
-                    >
-                      <span className={styles.optionTitle}>{opt.title}</span>
-                      <span className={styles.optionDescription}>
-                        {opt.description}
-                      </span>
-                    </button>
-                  );
-                })}
-              </div>
-            </>
-          )}
-
+          {step === 0 && <StepMethod method={method} onSelect={setMethod} />}
           {step === 1 && (
-            <>
-              <h2 className={styles.stepTitle}>Enter your lifts</h2>
-              <p className={styles.stepHint}>
-                {method === 'manual'
-                  ? 'Enter your current 1-rep max for each lift.'
-                  : 'Enter a recent heavy set (weight × reps) for each lift.'}
-              </p>
-              <div className={styles.dataRows}>
-                {(Object.keys(LIFT_LABELS) as LiftKey[]).map((key) => (
-                  <div key={key} className={styles.dataRow}>
-                    <span className={styles.dataRowLabel}>
-                      {LIFT_LABELS[key]}
-                    </span>
-                    <input
-                      type="number"
-                      inputMode="decimal"
-                      min="0"
-                      placeholder="Weight"
-                      className={styles.numberInput}
-                      value={lifts[key].weight}
-                      onChange={(e) => updateLift(key, 'weight', e.target.value)}
-                      aria-label={`${LIFT_LABELS[key]} weight`}
-                    />
-                    <span className={styles.unitLabel}>lb</span>
-                    {method !== 'manual' && (
-                      <>
-                        <span className={styles.unitLabel}>×</span>
-                        <input
-                          type="number"
-                          inputMode="numeric"
-                          min="1"
-                          max="20"
-                          placeholder="Reps"
-                          className={styles.numberInput}
-                          value={lifts[key].reps}
-                          onChange={(e) => updateLift(key, 'reps', e.target.value)}
-                          aria-label={`${LIFT_LABELS[key]} reps`}
-                        />
-                        <span className={styles.unitLabel}>reps</span>
-                      </>
-                    )}
-                  </div>
-                ))}
-              </div>
-              <p className={styles.infoBox}>
-                We use the Brzycki formula:{' '}
-                <strong>1RM = weight × 36 ÷ (37 − reps)</strong>. Stay under
-                10 reps for accuracy.
-              </p>
-            </>
+            <StepLifts method={method} lifts={lifts} onChange={updateLift} />
           )}
-
-          {step === 2 && (
-            <>
-              <h2 className={styles.stepTitle}>Confirm your training maxes</h2>
-              <p className={styles.stepHint}>
-                Estimated 1-rep maxes based on what you entered. Training maxes
-                use 90% of the 1RM.
-              </p>
-              <div className={styles.maxesGrid}>
-                {computedMaxes.map(({ lift, oneRm }) => (
-                  <div key={lift} className={styles.maxRow}>
-                    <span className={styles.maxRowLabel}>
-                      {LIFT_LABELS[lift]}
-                    </span>
-                    <span className={styles.maxRowValue}>
-                      {oneRm > 0 ? `${oneRm} lb` : '—'}
-                      {oneRm > 0 && (
-                        <span
-                          className={styles.unitLabel}
-                          style={{ marginLeft: 'var(--space-2)' }}
-                        >
-                          (TM {Math.round(oneRm * 0.9)} lb)
-                        </span>
-                      )}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </>
-          )}
-
+          {step === 2 && <StepConfirm maxes={computedMaxes} />}
           {step === 3 && (
-            <>
-              <h2 className={styles.stepTitle}>Choose a program</h2>
-              <p className={styles.stepHint}>
-                Filter by experience, then pick a template to see details.
-              </p>
-              <div
-                className={styles.experienceFilter}
-                role="tablist"
-                aria-label="Experience level"
-              >
-                {(['beginner', 'intermediate', 'advanced'] as Experience[]).map(
-                  (level) => {
-                    const cls = [
-                      styles.filterChip,
-                      experience === level ? styles.filterChipActive : '',
-                    ]
-                      .filter(Boolean)
-                      .join(' ');
-                    return (
-                      <button
-                        key={level}
-                        type="button"
-                        role="tab"
-                        aria-selected={experience === level}
-                        className={cls}
-                        onClick={() => {
-                          setExperience(level);
-                          setSelectedProgramId(null);
-                        }}
-                      >
-                        {level.charAt(0).toUpperCase() + level.slice(1)}
-                      </button>
-                    );
-                  },
-                )}
-              </div>
-
-              {selectedProgram ? (
-                <div className={styles.programDetail}>
-                  <div className={styles.programDetailHeader}>
-                    <h3 className={styles.programDetailName}>
-                      {selectedProgram.name}
-                    </h3>
-                    <span className={styles.programDetailMeta}>
-                      {selectedProgram.meta}
-                    </span>
-                  </div>
-                  <p className={styles.programDetailDescription}>
-                    {selectedProgram.description}
-                  </p>
-                  {confirmed ? (
-                    <div className={styles.successBanner}>
-                      <p className={styles.successTitle}>You’re all set.</p>
-                      <p className={styles.successBody}>
-                        {selectedProgram.name} is queued up for your first cycle.
-                        Wiring this to the API comes next.
-                      </p>
-                    </div>
-                  ) : (
-                    <div style={{ display: 'flex', gap: 'var(--space-3)' }}>
-                      <button
-                        type="button"
-                        className={styles.btnSecondary}
-                        onClick={() => setSelectedProgramId(null)}
-                      >
-                        Back
-                      </button>
-                      <button
-                        type="button"
-                        className={styles.btnSuccess}
-                        onClick={() => setConfirmed(true)}
-                      >
-                        Choose This Program
-                      </button>
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <div className={styles.programList}>
-                  {visiblePrograms.map((p) => (
-                    <button
-                      key={p.id}
-                      type="button"
-                      className={styles.programItem}
-                      onClick={() => {
-                        setSelectedProgramId(p.id);
-                        setConfirmed(false);
-                      }}
-                    >
-                      <span className={styles.programName}>{p.name}</span>
-                      <span className={styles.programMeta}>{p.meta}</span>
-                    </button>
-                  ))}
-                </div>
-              )}
-            </>
+            <StepProgram
+              experience={experience}
+              selectedProgramId={selectedProgramId}
+              confirmed={confirmed}
+              onExperienceChange={(level) => {
+                setExperience(level);
+                setSelectedProgramId(null);
+              }}
+              onSelectProgram={(id) => {
+                setSelectedProgramId(id);
+                setConfirmed(false);
+              }}
+              onClearSelection={() => setSelectedProgramId(null)}
+              onConfirm={() => setConfirmed(true)}
+            />
           )}
         </section>
 
         {!(step === 3 && confirmed) && (
           <div className={styles.actionRow}>
             {step > 0 && (
-              <button
-                type="button"
-                className={styles.btnSecondary}
-                onClick={goBack}
-              >
+              <button type="button" className={styles.btnSecondary} onClick={goBack}>
                 Back
               </button>
             )}

--- a/apps/web/app/onboarding/lib.ts
+++ b/apps/web/app/onboarding/lib.ts
@@ -1,0 +1,19 @@
+export type DiscoveryMethod = 'estimate' | 'test' | 'manual';
+
+export type LiftKey = 'bench' | 'squat' | 'deadlift';
+
+export type LiftEntry = { weight: string; reps: string };
+
+export const LIFT_LABELS: Record<LiftKey, string> = {
+  bench: 'Bench Press',
+  squat: 'Back Squat',
+  deadlift: 'Deadlift',
+};
+
+export function brzycki1RM(weight: number, reps: number): number {
+  if (reps <= 0 || weight <= 0) return 0;
+  if (reps === 1) return Math.round(weight);
+  const denom = 37 - reps;
+  if (denom <= 0) return 0;
+  return Math.round((weight * 36) / denom);
+}

--- a/apps/web/app/onboarding/onboarding.module.css
+++ b/apps/web/app/onboarding/onboarding.module.css
@@ -14,7 +14,7 @@
 
 .header {
   background: linear-gradient(135deg, var(--color-header-from), var(--color-header-to));
-  color: #fff;
+  color: var(--color-text-inverted);
   padding: var(--space-6) var(--space-5);
   display: flex;
   flex-direction: column;
@@ -25,7 +25,7 @@
   font-size: var(--font-size-xl);
   font-weight: var(--font-weight-bold);
   margin: 0;
-  color: #fff;
+  color: var(--color-text-inverted);
 }
 
 .headerSubtitle {
@@ -231,7 +231,7 @@
 .filterChipActive {
   background: var(--color-accent);
   border-color: var(--color-accent);
-  color: #fff;
+  color: var(--color-on-accent);
 }
 
 .programList {
@@ -323,7 +323,7 @@
   min-height: 48px;
   padding: 0 var(--space-5);
   background: var(--color-accent);
-  color: #fff;
+  color: var(--color-on-accent);
   border: none;
   border-radius: var(--radius-md);
   font-size: var(--font-size-base);
@@ -346,7 +346,7 @@
   min-height: 48px;
   padding: 0 var(--space-5);
   background: var(--color-success);
-  color: #fff;
+  color: var(--color-on-success);
   border: none;
   border-radius: var(--radius-md);
   font-size: var(--font-size-base);

--- a/apps/web/app/onboarding/onboarding.module.css
+++ b/apps/web/app/onboarding/onboarding.module.css
@@ -1,0 +1,397 @@
+.page {
+  min-height: 100dvh;
+  display: flex;
+  justify-content: center;
+  background: var(--color-bg);
+}
+
+.shell {
+  width: 100%;
+  max-width: 480px;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  background: linear-gradient(135deg, var(--color-header-from), var(--color-header-to));
+  color: #fff;
+  padding: var(--space-6) var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.headerTitle {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  margin: 0;
+  color: #fff;
+}
+
+.headerSubtitle {
+  font-size: var(--font-size-sm);
+  opacity: 0.85;
+  margin: 0;
+}
+
+.progressDots {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-4) 0 var(--space-2);
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background: var(--color-border-strong);
+  transition: width var(--transition-base), background var(--transition-base),
+    border-radius var(--transition-base);
+}
+
+.dotActive {
+  width: 24px;
+  border-radius: var(--radius-sm);
+  background: var(--color-accent);
+}
+
+.dotDone {
+  background: var(--color-success);
+}
+
+.body {
+  flex: 1;
+  padding: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.stepTitle {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  margin: 0;
+}
+
+.stepHint {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.infoBox {
+  background: var(--color-info-bg);
+  border-left: 3px solid var(--color-accent);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+}
+
+.optionList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.option {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-accent);
+  border-radius: var(--radius-md);
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.option:hover {
+  background: var(--color-surface-alt);
+}
+
+.optionSelected {
+  background: var(--color-surface-alt);
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 2px var(--color-accent-glow);
+}
+
+.optionTitle {
+  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-base);
+  color: var(--color-text);
+}
+
+.optionDescription {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.dataRows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.dataRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-surface);
+  border-left: 3px solid var(--color-accent);
+  border-radius: var(--radius-md);
+  flex-wrap: wrap;
+}
+
+.dataRowLabel {
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-sm);
+  flex: 0 0 80px;
+}
+
+.numberInput {
+  width: 80px;
+  min-height: 44px;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-base);
+  text-align: center;
+  background: var(--color-bg);
+  color: var(--color-text);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.numberInput:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-glow);
+}
+
+.unitLabel {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.maxesGrid {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.maxRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-success-bg);
+  border-left: 3px solid var(--color-success);
+  border-radius: var(--radius-md);
+}
+
+.maxRowLabel {
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+}
+
+.maxRowValue {
+  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-lg);
+  color: var(--color-success-text);
+}
+
+.experienceFilter {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.filterChip {
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.filterChip:hover {
+  background: var(--color-surface-alt);
+}
+
+.filterChipActive {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #fff;
+}
+
+.programList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.programItem {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-accent);
+  border-radius: var(--radius-md);
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.programItem:hover {
+  background: var(--color-surface-alt);
+}
+
+.programItemSelected {
+  background: var(--color-surface-alt);
+  box-shadow: 0 0 0 2px var(--color-accent-glow);
+}
+
+.programName {
+  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-base);
+  color: var(--color-text);
+}
+
+.programMeta {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.programDetail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+}
+
+.programDetailHeader {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.programDetailName {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  margin: 0;
+}
+
+.programDetailMeta {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.programDetailDescription {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  line-height: 1.6;
+  margin: 0;
+}
+
+.actionRow {
+  display: flex;
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-5);
+  background: var(--color-bg);
+  border-top: 1px solid var(--color-border);
+  position: sticky;
+  bottom: 0;
+}
+
+.btnPrimary {
+  flex: 1;
+  min-height: 48px;
+  padding: 0 var(--space-5);
+  background: var(--color-accent);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: background var(--transition-fast), opacity var(--transition-fast);
+}
+
+.btnPrimary:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+}
+
+.btnPrimary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btnSuccess {
+  flex: 1;
+  min-height: 48px;
+  padding: 0 var(--space-5);
+  background: var(--color-success);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.btnSecondary {
+  flex: 0 0 auto;
+  min-height: 48px;
+  padding: 0 var(--space-4);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.btnSecondary:hover {
+  background: var(--color-surface-alt);
+}
+
+.successBanner {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-5);
+  background: var(--color-success-bg);
+  border-left: 3px solid var(--color-success);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+}
+
+.successTitle {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-success-text);
+  margin: 0;
+}
+
+.successBody {
+  font-size: var(--font-size-sm);
+  margin: 0;
+}

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import { OnboardingFlow } from "./OnboardingFlow";
+
+export const metadata: Metadata = {
+  title: "Get Started — Lifting Logbook",
+  description: "Discover your training maxes and choose a program.",
+};
+
+export default function OnboardingPage() {
+  return <OnboardingFlow />;
+}

--- a/apps/web/app/onboarding/programs.ts
+++ b/apps/web/app/onboarding/programs.ts
@@ -1,0 +1,116 @@
+export type Experience = 'beginner' | 'intermediate' | 'advanced';
+
+export type Program = {
+  id: string;
+  name: string;
+  experience: Experience;
+  meta: string;
+  description: string;
+};
+
+export const PROGRAMS: Program[] = [
+  {
+    id: 'starting-strength',
+    name: 'Starting Strength',
+    experience: 'beginner',
+    meta: '3 days/week · Linear progression',
+    description:
+      'Mark Rippetoe’s linear progression program. Squat, press, deadlift, bench, and power clean — add weight every session until stalls require a deload.',
+  },
+  {
+    id: 'stronglifts',
+    name: 'StrongLifts 5×5',
+    experience: 'beginner',
+    meta: '3 days/week · 5×5 alternating workouts',
+    description:
+      'Two alternating workouts (A/B) with five compound lifts at 5 sets of 5 reps. Add 5 lb every session until plateau.',
+  },
+  {
+    id: 'rpt',
+    name: 'Reverse Pyramid Training (Lyle/Eric Helms)',
+    experience: 'intermediate',
+    meta: '3-4 days/week · Top-set focused',
+    description:
+      'Heaviest set first, then back-off sets at reduced load. Emphasizes intensity on the first work set with clear progression rules tied to top-set rep targets.',
+  },
+  {
+    id: 'ppl',
+    name: 'Push / Pull / Legs',
+    experience: 'intermediate',
+    meta: '6 days/week · Hypertrophy split',
+    description:
+      'Classic split that lets you train each major movement pattern twice per week. Volume scales with recovery; popular as PHUL/PHAT variants too.',
+  },
+  {
+    id: 'upper-lower',
+    name: 'Upper / Lower',
+    experience: 'intermediate',
+    meta: '4 days/week · Balanced split',
+    description:
+      'Upper body and lower body alternated four days per week. Good middle ground between full-body frequency and bodypart split volume.',
+  },
+  {
+    id: '531',
+    name: '5/3/1',
+    experience: 'intermediate',
+    meta: '4 days/week · Wave-loaded',
+    description:
+      'Jim Wendler’s 4-week wave with a top set on each main lift, then assistance work. Conservative training maxes (90% of 1RM) drive long-term progress.',
+  },
+  {
+    id: '531-bbb',
+    name: '5/3/1 Boring But Big',
+    experience: 'intermediate',
+    meta: '4 days/week · BBB volume template',
+    description:
+      'Standard 5/3/1 main work followed by 5×10 of the same lift (or its complement) at 50–70% TM. High-volume hypertrophy template most lifters can recover from.',
+  },
+  {
+    id: '531-forever',
+    name: '5/3/1 Forever',
+    experience: 'advanced',
+    meta: '3-5 days/week · Multi-cycle leader/anchor',
+    description:
+      'The latest evolution of 5/3/1 organized into "leader" volume blocks and "anchor" intensity blocks. Drops the deload week in favor of programmed light days.',
+  },
+  {
+    id: 'leangains',
+    name: 'Leangains (Berkhan)',
+    experience: 'intermediate',
+    meta: '3 days/week · RPT + IF protocol',
+    description:
+      'Reverse-pyramid lifting paired with intermittent fasting. Three compound-focused sessions per week with macros tuned to training and rest days.',
+  },
+  {
+    id: 'conjugate',
+    name: 'Westside Conjugate',
+    experience: 'advanced',
+    meta: '4 days/week · Max effort + dynamic effort',
+    description:
+      'Westside Barbell’s max-effort and dynamic-effort waves rotated across upper and lower days. Heavy emphasis on accommodating resistance and weak-point training.',
+  },
+  {
+    id: 'smolov',
+    name: 'Smolov (Squat)',
+    experience: 'advanced',
+    meta: '4 days/week · 13-week squat cycle',
+    description:
+      'Soviet squat specialization program. Brutal intro phase, base mesocycle, switching, and intense mesocycle. Use only with deep recovery support.',
+  },
+  {
+    id: 'juggernaut',
+    name: 'Juggernaut Method',
+    experience: 'advanced',
+    meta: '4 days/week · Block periodization',
+    description:
+      'Chad Wesley Smith’s block model with accumulation, intensification, and realization phases. Long-term progression with built-in volume waves.',
+  },
+  {
+    id: 'creeping-death-2',
+    name: 'Creeping Death II',
+    experience: 'advanced',
+    meta: '4 days/week · 5/3/1 program of programs',
+    description:
+      'A long-haul 5/3/1 template that stretches each cycle’s pace and increases supplemental work over time. Built for advanced lifters chasing slow PRs.',
+  },
+];

--- a/apps/web/app/onboarding/steps/StepConfirm.tsx
+++ b/apps/web/app/onboarding/steps/StepConfirm.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import styles from '../onboarding.module.css';
+import { LIFT_LABELS, type LiftKey } from '../lib';
+
+type Max = { lift: LiftKey; oneRm: number };
+
+type Props = {
+  maxes: Max[];
+};
+
+export function StepConfirm({ maxes }: Props) {
+  return (
+    <>
+      <h2 className={styles.stepTitle}>Confirm your training maxes</h2>
+      <p className={styles.stepHint}>
+        Estimated 1-rep maxes based on what you entered. Training maxes use 90% of the 1RM.
+      </p>
+      <div className={styles.maxesGrid}>
+        {maxes.map(({ lift, oneRm }) => (
+          <div key={lift} className={styles.maxRow}>
+            <span className={styles.maxRowLabel}>{LIFT_LABELS[lift]}</span>
+            <span className={styles.maxRowValue}>
+              {oneRm > 0 ? `${oneRm} lb` : '—'}
+              {oneRm > 0 && (
+                <span
+                  className={styles.unitLabel}
+                  style={{ marginLeft: 'var(--space-2)' }}
+                >
+                  (TM {Math.round(oneRm * 0.9)} lb)
+                </span>
+              )}
+            </span>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/apps/web/app/onboarding/steps/StepLifts.tsx
+++ b/apps/web/app/onboarding/steps/StepLifts.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import styles from '../onboarding.module.css';
+import { LIFT_LABELS, type DiscoveryMethod, type LiftEntry, type LiftKey } from '../lib';
+
+type Props = {
+  method: DiscoveryMethod;
+  lifts: Record<LiftKey, LiftEntry>;
+  onChange: (key: LiftKey, field: keyof LiftEntry, value: string) => void;
+};
+
+export function StepLifts({ method, lifts, onChange }: Props) {
+  return (
+    <>
+      <h2 className={styles.stepTitle}>Enter your lifts</h2>
+      <p className={styles.stepHint}>
+        {method === 'manual'
+          ? 'Enter your current 1-rep max for each lift.'
+          : 'Enter a recent heavy set (weight × reps) for each lift.'}
+      </p>
+      <div className={styles.dataRows}>
+        {(Object.keys(LIFT_LABELS) as LiftKey[]).map((key) => (
+          <div key={key} className={styles.dataRow}>
+            <span className={styles.dataRowLabel}>{LIFT_LABELS[key]}</span>
+            <input
+              type="number"
+              inputMode="decimal"
+              min="0"
+              placeholder="Weight"
+              className={styles.numberInput}
+              value={lifts[key].weight}
+              onChange={(e) => onChange(key, 'weight', e.target.value)}
+              aria-label={`${LIFT_LABELS[key]} weight`}
+            />
+            <span className={styles.unitLabel}>lb</span>
+            {method !== 'manual' && (
+              <>
+                <span className={styles.unitLabel}>×</span>
+                <input
+                  type="number"
+                  inputMode="numeric"
+                  min="1"
+                  max="20"
+                  placeholder="Reps"
+                  className={styles.numberInput}
+                  value={lifts[key].reps}
+                  onChange={(e) => onChange(key, 'reps', e.target.value)}
+                  aria-label={`${LIFT_LABELS[key]} reps`}
+                />
+                <span className={styles.unitLabel}>reps</span>
+              </>
+            )}
+          </div>
+        ))}
+      </div>
+      <p className={styles.infoBox}>
+        We use the Brzycki formula:{' '}
+        <strong>1RM = weight × 36 ÷ (37 − reps)</strong>. Stay under 10 reps for accuracy.
+      </p>
+    </>
+  );
+}

--- a/apps/web/app/onboarding/steps/StepMethod.tsx
+++ b/apps/web/app/onboarding/steps/StepMethod.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import styles from '../onboarding.module.css';
+import type { DiscoveryMethod } from '../lib';
+
+const METHOD_OPTIONS: { id: DiscoveryMethod; title: string; description: string }[] = [
+  {
+    id: 'estimate',
+    title: 'Estimate from a recent lift',
+    description:
+      'Enter a recent set (weight × reps) and we’ll calculate your 1RM with the Brzycki formula.',
+  },
+  {
+    id: 'test',
+    title: 'Run a Test Week',
+    description:
+      'Spend a week working up to heavy singles in each lift. Best accuracy for experienced lifters.',
+  },
+  {
+    id: 'manual',
+    title: 'Enter manually',
+    description:
+      'You already know your 1RMs. Enter them directly and we’ll set training maxes at 90%.',
+  },
+];
+
+type Props = {
+  method: DiscoveryMethod;
+  onSelect: (method: DiscoveryMethod) => void;
+};
+
+export function StepMethod({ method, onSelect }: Props) {
+  return (
+    <>
+      <h2 className={styles.stepTitle}>How do you want to find your maxes?</h2>
+      <p className={styles.stepHint}>
+        Pick the option that matches your training history.
+      </p>
+      <div className={styles.optionList}>
+        {METHOD_OPTIONS.map((opt) => {
+          const cls = [
+            styles.option,
+            method === opt.id ? styles.optionSelected : '',
+          ]
+            .filter(Boolean)
+            .join(' ');
+          return (
+            <button
+              type="button"
+              key={opt.id}
+              className={cls}
+              onClick={() => onSelect(opt.id)}
+              aria-pressed={method === opt.id}
+            >
+              <span className={styles.optionTitle}>{opt.title}</span>
+              <span className={styles.optionDescription}>{opt.description}</span>
+            </button>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/apps/web/app/onboarding/steps/StepProgram.tsx
+++ b/apps/web/app/onboarding/steps/StepProgram.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import styles from '../onboarding.module.css';
+import { PROGRAMS, type Experience, type Program } from '../programs';
+
+const EXPERIENCE_LEVELS: Experience[] = ['beginner', 'intermediate', 'advanced'];
+
+type Props = {
+  experience: Experience;
+  selectedProgramId: string | null;
+  confirmed: boolean;
+  onExperienceChange: (level: Experience) => void;
+  onSelectProgram: (id: string) => void;
+  onClearSelection: () => void;
+  onConfirm: () => void;
+};
+
+export function StepProgram({
+  experience,
+  selectedProgramId,
+  confirmed,
+  onExperienceChange,
+  onSelectProgram,
+  onClearSelection,
+  onConfirm,
+}: Props) {
+  const visiblePrograms = PROGRAMS.filter((p) => p.experience === experience);
+  const selectedProgram: Program | null =
+    PROGRAMS.find((p) => p.id === selectedProgramId) ?? null;
+
+  return (
+    <>
+      <h2 className={styles.stepTitle}>Choose a program</h2>
+      <p className={styles.stepHint}>
+        Filter by experience, then pick a template to see details.
+      </p>
+      <div
+        className={styles.experienceFilter}
+        role="tablist"
+        aria-label="Experience level"
+      >
+        {EXPERIENCE_LEVELS.map((level) => {
+          const cls = [
+            styles.filterChip,
+            experience === level ? styles.filterChipActive : '',
+          ]
+            .filter(Boolean)
+            .join(' ');
+          return (
+            <button
+              key={level}
+              type="button"
+              role="tab"
+              aria-selected={experience === level}
+              className={cls}
+              onClick={() => onExperienceChange(level)}
+            >
+              {level.charAt(0).toUpperCase() + level.slice(1)}
+            </button>
+          );
+        })}
+      </div>
+
+      {selectedProgram ? (
+        <div className={styles.programDetail}>
+          <div className={styles.programDetailHeader}>
+            <h3 className={styles.programDetailName}>{selectedProgram.name}</h3>
+            <span className={styles.programDetailMeta}>{selectedProgram.meta}</span>
+          </div>
+          <p className={styles.programDetailDescription}>
+            {selectedProgram.description}
+          </p>
+          {confirmed ? (
+            <div className={styles.successBanner}>
+              <p className={styles.successTitle}>You’re all set.</p>
+              <p className={styles.successBody}>
+                {selectedProgram.name} is queued up for your first cycle. Wiring this to
+                the API comes next.
+              </p>
+            </div>
+          ) : (
+            <div style={{ display: 'flex', gap: 'var(--space-3)' }}>
+              <button
+                type="button"
+                className={styles.btnSecondary}
+                onClick={onClearSelection}
+              >
+                Back
+              </button>
+              <button
+                type="button"
+                className={styles.btnSuccess}
+                onClick={onConfirm}
+              >
+                Choose This Program
+              </button>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className={styles.programList}>
+          {visiblePrograms.map((p) => (
+            <button
+              key={p.id}
+              type="button"
+              className={styles.programItem}
+              onClick={() => onSelectProgram(p.id)}
+            >
+              <span className={styles.programName}>{p.name}</span>
+              <span className={styles.programMeta}>{p.meta}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,8 +1,38 @@
+import Link from "next/link";
+import styles from "./home.module.css";
+
 export default function Home() {
   return (
-    <main>
-      <h1>Lifting Logbook</h1>
-      <p>Coming soon.</p>
+    <main className={styles.page}>
+      <div className={styles.card}>
+        <div className={styles.brand}>
+          <h1 className={styles.wordmark}>Lifting Logbook</h1>
+          <p className={styles.tagline}>Track your lifts. Run the program.</p>
+        </div>
+        <nav className={styles.ctaList} aria-label="Primary navigation">
+          <Link href="/cycle" className={styles.cta}>
+            <span>Current Cycle</span>
+            <span className={styles.ctaArrow} aria-hidden="true">
+              →
+            </span>
+          </Link>
+          <Link href="/settings/training-maxes" className={styles.cta}>
+            <span>Training Maxes</span>
+            <span className={styles.ctaArrow} aria-hidden="true">
+              →
+            </span>
+          </Link>
+          <Link
+            href="/onboarding"
+            className={`${styles.cta} ${styles.ctaSecondary}`}
+          >
+            <span>Get Started</span>
+            <span className={styles.ctaArrow} aria-hidden="true">
+              →
+            </span>
+          </Link>
+        </nav>
+      </div>
     </main>
   );
 }

--- a/apps/web/app/settings/training-maxes/TrainingMaxesForm.module.css
+++ b/apps/web/app/settings/training-maxes/TrainingMaxesForm.module.css
@@ -1,12 +1,12 @@
 .container {
-  padding: 1rem;
+  padding: var(--space-4);
   max-width: 640px;
   margin: 0 auto;
 }
 
 .heading {
-  font-size: 1.25rem;
-  margin-bottom: 1rem;
+  font-size: var(--font-size-lg);
+  margin-bottom: var(--space-4);
 }
 
 .tableWrapper {
@@ -17,25 +17,25 @@
 .table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.9rem;
+  font-size: var(--font-size-sm);
 }
 
 .table th {
   text-align: left;
-  padding: 0.5rem 0.75rem;
-  border-bottom: 2px solid #ddd;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 2px solid var(--color-border-strong);
   white-space: nowrap;
 }
 
 .table td {
-  padding: 0.25rem 0.75rem;
-  border-bottom: 1px solid #eee;
+  padding: var(--space-1) var(--space-3);
+  border-bottom: 1px solid var(--color-border);
   vertical-align: middle;
 }
 
 .liftName {
   min-width: 140px;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 .weightCell {
@@ -45,61 +45,65 @@
 .weightInput {
   width: 90px;
   min-height: 44px;
-  padding: 0.25rem 0.5rem;
-  font-size: 1rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-base);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
   box-sizing: border-box;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .weightInput:focus {
   outline: none;
-  border-color: #555;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-glow);
 }
 
 .rowError .weightInput {
-  border-color: #c0392b;
+  border-color: var(--color-error-text);
 }
 
 .errorText {
   display: block;
-  color: #c0392b;
-  font-size: 0.75rem;
+  color: var(--color-error-text);
+  font-size: var(--font-size-xs);
   margin-top: 2px;
 }
 
 .unit {
-  color: #666;
+  color: var(--color-text-muted);
   white-space: nowrap;
 }
 
 .date {
-  color: #666;
+  color: var(--color-text-muted);
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
 }
 
 .placeholder {
-  color: #bbb;
+  color: var(--color-text-muted);
+  opacity: 0.6;
 }
 
 .saveError {
-  color: #c0392b;
-  margin: 0.75rem 0 0.5rem;
-  font-size: 0.875rem;
+  color: var(--color-error-text);
+  margin: var(--space-3) 0 var(--space-2);
+  font-size: var(--font-size-sm);
 }
 
 .saveButton {
   display: block;
-  margin-top: 1rem;
-  padding: 0.75rem 2rem;
+  margin-top: var(--space-4);
+  padding: var(--space-3) var(--space-8);
   min-height: 44px;
-  font-size: 1rem;
-  background: #333;
+  font-size: var(--font-size-base);
+  background: var(--color-accent);
   color: #fff;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
+  transition: background var(--transition-fast), opacity var(--transition-fast);
 }
 
 .saveButton:disabled {
@@ -108,7 +112,7 @@
 }
 
 .saveButton:hover:not(:disabled) {
-  background: #555;
+  background: var(--color-accent-hover);
 }
 
 /* Stack to card layout on narrow viewports */
@@ -127,12 +131,12 @@
   }
 
   .table tr {
-    padding: 0.75rem 0;
-    border-bottom: 1px solid #ddd;
+    padding: var(--space-3) 0;
+    border-bottom: 1px solid var(--color-border-strong);
   }
 
   .table td {
-    padding: 0.25rem 0;
+    padding: var(--space-1) 0;
     border-bottom: none;
   }
 
@@ -141,7 +145,7 @@
     font-weight: 600;
     display: inline-block;
     min-width: 110px;
-    color: #555;
+    color: var(--color-text-muted);
   }
 
   .weightInput {

--- a/apps/web/app/settings/training-maxes/TrainingMaxesForm.module.css
+++ b/apps/web/app/settings/training-maxes/TrainingMaxesForm.module.css
@@ -99,7 +99,7 @@
   min-height: 44px;
   font-size: var(--font-size-base);
   background: var(--color-accent);
-  color: #fff;
+  color: var(--color-on-accent);
   border: none;
   border-radius: var(--radius-sm);
   cursor: pointer;


### PR DESCRIPTION
## Summary
- Introduces two CSS themes (`navy` default, `iron`) via `[data-theme]` custom properties
- `globals.css`: full reset, token set, base typography; flash-free theme init in `layout.tsx`
- Token-migrated all 3 existing CSS modules (zero hardcoded hex values remain)
- Styled home page (`/`) with navigation CTAs
- Visual-only onboarding scaffold (`/onboarding`) — 4-step flow, full program catalog, no API wiring

## Test plan
- [x] `npm run build -w @lifting-logbook/web` — clean
- [x] `npm test -w @lifting-logbook/web` — passing (10/10)
- [ ] DevTools: `document.documentElement.dataset.theme = 'iron'` switches all screens
- [ ] No hardcoded hex values in migrated CSS modules

Closes #148