### PR TITLE
[chore] Move Design System & Styling to Shipped in v0.4 ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -107,7 +107,6 @@ First deployable version. Styled web app running against a real database, deploy
 
 | Work stream | Description | Issues |
 |---|---|---|
-| Design system and styling | Global CSS reset, design tokens, and styled screens informed by Claude Design mockups | [#148](https://github.com/brownm09/lifting-logbook/issues/148) |
 | Deployment infrastructure | Cloud Run or GKE manifests, Terraform shared infra, CI/CD deploy on merge | [#149](https://github.com/brownm09/lifting-logbook/issues/149) |
 | Real database adapter | Prisma schema, `SystemDbRepositoryFactory` implementations, migration runner | [#150](https://github.com/brownm09/lifting-logbook/issues/150) |
 | Database integration tests | E2e suite against real Postgres; covers PATCH endpoint gap and row-level isolation | [#151](https://github.com/brownm09/lifting-logbook/issues/151) |
@@ -116,7 +115,7 @@ First deployable version. Styled web app running against a real database, deploy
 
 | Work stream | Description | Issues |
 |---|---|---|
-| *(none yet)* | | |
+| Design system and styling | Global CSS reset, design tokens, and styled screens informed by Claude Design mockups | [#148](https://github.com/brownm09/lifting-logbook/issues/148) |
 
 ### Proposals
 


### PR DESCRIPTION
## Summary
- PR [#160](https://github.com/brownm09/lifting-logbook/pull/160) (issue #148) merged at commit `17c78aa`
- Move "Design system and styling" row from v0.4 Active Work to Shipped
- Removes the `*(none yet)*` placeholder in v0.4 Shipped

## Test plan
- [x] No code changes (docs-only edit to ROADMAP.md)