### PR TITLE
[chore] Move v0.4 Active Work items to Shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -99,7 +99,7 @@ Web and mobile clients functional end-to-end. Key user-facing features implement
 
 ---
 
-## v0.4 — Alpha Release `[Current]`
+## v0.4 — Alpha Release `[Shipped]`
 
 First deployable version. Styled web app running against a real database, deployed and accessible to known users. Mobile deferred to v1.0.
 
@@ -107,15 +107,16 @@ First deployable version. Styled web app running against a real database, deploy
 
 | Work stream | Description | Issues |
 |---|---|---|
-| Deployment infrastructure | Cloud Run or GKE manifests, Terraform shared infra, CI/CD deploy on merge | [#149](https://github.com/brownm09/lifting-logbook/issues/149) |
-| Real database adapter | Prisma schema, `SystemDbRepositoryFactory` implementations, migration runner | [#150](https://github.com/brownm09/lifting-logbook/issues/150) |
-| Database integration tests | E2e suite against real Postgres; covers PATCH endpoint gap and row-level isolation | [#151](https://github.com/brownm09/lifting-logbook/issues/151) |
+| *(all shipped)* | | |
 
 ### Shipped
 
 | Work stream | Description | Issues |
 |---|---|---|
 | Design system and styling | Global CSS reset, design tokens, and styled screens informed by Claude Design mockups | [#148](https://github.com/brownm09/lifting-logbook/issues/148) |
+| Deployment infrastructure | Cloud Run or GKE manifests, Terraform shared infra, CI/CD deploy on merge | [#149](https://github.com/brownm09/lifting-logbook/issues/149) |
+| Real database adapter | Prisma schema, `SystemDbRepositoryFactory` implementations, migration runner | [#150](https://github.com/brownm09/lifting-logbook/issues/150) |
+| Database integration tests | E2e suite against real Postgres; covers PATCH endpoint gap and row-level isolation | [#151](https://github.com/brownm09/lifting-logbook/issues/151) |
 
 ### Proposals
 


### PR DESCRIPTION
## Summary

All three v0.4 Active Work items closed while the ROADMAP wasn't updated. This moves them to Shipped and marks the milestone as `[Shipped]`.

- #149 Deployment infrastructure — closed 2026-05-03
- #150 Real database adapter — closed 2026-05-02
- #151 Database integration tests — closed 2026-05-02

## Testing

Docs-only change — no code modified.

Closes #162