### PR TITLE
[test] Multi-cycle progression e2e (issue #142)

### DIFF
--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -350,6 +350,10 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
   // -------------------------------------------------------------------------
 
   describe('multi-cycle progression scenario (issue #142)', () => {
+    // Tests in this block are order-dependent — do not reorder. Each `it`
+    // mutates adapter state (cycleNum, training maxes, dateUpdated) that the
+    // next one reads. Reordering will silently break expected-weight assertions
+    // because the TM/dateUpdated gates in updateMaxes depend on prior state.
     it('advances cycle 3 → 4 to clear prior-scenario state; TMs unchanged', async () => {
       // Existing cycle-3 records were all flagged → updateMaxes leaves TMs at
       // 315/225/405/145. Advancing now just bumps cycleNum.

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -329,6 +329,173 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // Multi-cycle progression scenario — issue #142.
+  //
+  // Order-sensitive, continues from the state left by the multi-workout
+  // scenario above:
+  //   cycleNum:   3
+  //   TMs:        Squat 315, Bench 225, Deadlift 405, Overhead Press 145
+  //               (all dateUpdated 2026-04-13 — none updated by prior recalc)
+  //   records:    cycle-3 set-1 entries for all 4 lifts (none updated TMs)
+  //
+  // Goal: drive at least one lift through a genuine TM increase across two
+  // cycle-advance boundaries and assert the updated maxes persist into the
+  // next cycle (the carry-forward chain that makes new-cycle planned
+  // weights derive from prior-cycle outcomes).
+  //
+  // Logged set-1 weights are engineered at-or-near current TMs (not realistic
+  // 5/3/1 loading) so the progression branch fires deterministically:
+  //   record.reps >= spec.reps AND record.weight + spec.increment > current TM.
+  // -------------------------------------------------------------------------
+
+  describe('multi-cycle progression scenario (issue #142)', () => {
+    it('advances cycle 3 → 4 to clear prior-scenario state; TMs unchanged', async () => {
+      // Existing cycle-3 records were all flagged → updateMaxes leaves TMs at
+      // 315/225/405/145. Advancing now just bumps cycleNum.
+      const advanceRes = await post(`/programs/${SEED_PROGRAM}/cycles`);
+      expect(advanceRes.statusCode).toBe(201);
+      expect(advanceRes.json().cycleNum).toBe(4);
+
+      const tmRes = await get(`/programs/${SEED_PROGRAM}/training-maxes`);
+      expect(tmRes.statusCode).toBe(200);
+      const findTm = (lift: string) =>
+        tmRes.json().find((m: { lift: string }) => m.lift === lift)!;
+      expect(findTm('Squat').weight).toBe(315);
+      expect(findTm('Bench Press').weight).toBe(225);
+      expect(findTm('Deadlift').weight).toBe(405);
+      expect(findTm('Overhead Press').weight).toBe(145);
+    });
+
+    it('cycle 4: logs records that drive Squat + Bench progression, leaves DL + OHP unchanged', async () => {
+      // Date 2026-08-03 > all current TMs' dateUpdated (2026-04-13) → gate passes on date.
+      // Squat: 315 + 5 = 320 > current TM 315 → applies (TM → 320).
+      const squat = await postJson(`/programs/${SEED_PROGRAM}/lift-records`, {
+        cycleNum: 4, workoutNum: 1, date: '2026-08-03',
+        lift: 'Squat', setNum: 1, weight: 315, reps: 5, notes: '',
+      });
+      expect(squat.statusCode).toBe(201);
+
+      // Bench: 225 + 5 = 230 > current TM 225 → applies (TM → 230).
+      const bench = await postJson(`/programs/${SEED_PROGRAM}/lift-records`, {
+        cycleNum: 4, workoutNum: 1, date: '2026-08-03',
+        lift: 'Bench Press', setNum: 1, weight: 225, reps: 5, notes: '',
+      });
+      expect(bench.statusCode).toBe(201);
+
+      // Deadlift: reps 3 < spec.reps 5 → gate fails (TM unchanged at 405).
+      const dl = await postJson(`/programs/${SEED_PROGRAM}/lift-records`, {
+        cycleNum: 4, workoutNum: 1, date: '2026-08-03',
+        lift: 'Deadlift', setNum: 1, weight: 300, reps: 3, notes: '',
+      });
+      expect(dl.statusCode).toBe(201);
+
+      // OHP: reps 2 < spec.reps 5 → gate fails (TM unchanged at 145).
+      const ohp = await postJson(`/programs/${SEED_PROGRAM}/lift-records`, {
+        cycleNum: 4, workoutNum: 1, date: '2026-08-03',
+        lift: 'Overhead Press', setNum: 1, weight: 100, reps: 2, notes: '',
+      });
+      expect(ohp.statusCode).toBe(201);
+    });
+
+    it('cycle 4 → 5: recalculate applies Squat + Bench increases with no flags', async () => {
+      const res = await post(`/programs/${SEED_PROGRAM}/training-maxes/recalculate`);
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as {
+        maxes: Array<{ lift: string; weight: number }>;
+        flagged: Array<{ lift: string }>;
+      };
+      const findMax = (lift: string) => body.maxes.find((m) => m.lift === lift)!;
+
+      expect(findMax('Squat').weight).toBe(320);          // 315 + 5
+      expect(findMax('Bench Press').weight).toBe(230);    // 225 + 5
+      expect(findMax('Deadlift').weight).toBe(405);       // unchanged
+      expect(findMax('Overhead Press').weight).toBe(145); // unchanged
+      expect(body.flagged).toEqual([]);
+    });
+
+    it('cycle 4 → 5: POST /cycles persists updated maxes into cycle 5 (carry-forward)', async () => {
+      const advanceRes = await post(`/programs/${SEED_PROGRAM}/cycles`);
+      expect(advanceRes.statusCode).toBe(201);
+      expect(advanceRes.json().cycleNum).toBe(5);
+
+      // Carry-forward assertion: the maxes that downstream cycle-5 planned
+      // weights will be computed from must reflect cycle-4 outcomes.
+      const tmRes = await get(`/programs/${SEED_PROGRAM}/training-maxes`);
+      expect(tmRes.statusCode).toBe(200);
+      const findTm = (lift: string) =>
+        tmRes.json().find((m: { lift: string }) => m.lift === lift)!;
+      expect(findTm('Squat').weight).toBe(320);
+      expect(findTm('Bench Press').weight).toBe(230);
+      expect(findTm('Deadlift').weight).toBe(405);
+      expect(findTm('Overhead Press').weight).toBe(145);
+    });
+
+    it('cycle 5: logs records with different per-lift outcomes than cycle 4', async () => {
+      // Date 2026-09-07 > all current TMs' dateUpdated (Squat/Bench: 2026-08-03;
+      // DL/OHP: 2026-04-13) → gate passes on date for every lift.
+
+      // Squat: reps 3 < 5 → gate fails (TM unchanged at 320).
+      const squat = await postJson(`/programs/${SEED_PROGRAM}/lift-records`, {
+        cycleNum: 5, workoutNum: 1, date: '2026-09-07',
+        lift: 'Squat', setNum: 1, weight: 322, reps: 3, notes: '',
+      });
+      expect(squat.statusCode).toBe(201);
+
+      // Bench: 232 + 5 = 237 > current TM 230 → applies (TM → 237).
+      const bench = await postJson(`/programs/${SEED_PROGRAM}/lift-records`, {
+        cycleNum: 5, workoutNum: 1, date: '2026-09-07',
+        lift: 'Bench Press', setNum: 1, weight: 232, reps: 5, notes: '',
+      });
+      expect(bench.statusCode).toBe(201);
+
+      // Deadlift: 410 + 10 = 420 > current TM 405 → applies (TM → 420).
+      const dl = await postJson(`/programs/${SEED_PROGRAM}/lift-records`, {
+        cycleNum: 5, workoutNum: 1, date: '2026-09-07',
+        lift: 'Deadlift', setNum: 1, weight: 410, reps: 5, notes: '',
+      });
+      expect(dl.statusCode).toBe(201);
+
+      // OHP: 145 + 5 = 150 > current TM 145 → applies (TM → 150).
+      const ohp = await postJson(`/programs/${SEED_PROGRAM}/lift-records`, {
+        cycleNum: 5, workoutNum: 1, date: '2026-09-07',
+        lift: 'Overhead Press', setNum: 1, weight: 145, reps: 5, notes: '',
+      });
+      expect(ohp.statusCode).toBe(201);
+    });
+
+    it('cycle 5 → 6: recalculate composes correctly across the second boundary', async () => {
+      const res = await post(`/programs/${SEED_PROGRAM}/training-maxes/recalculate`);
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as {
+        maxes: Array<{ lift: string; weight: number }>;
+        flagged: Array<{ lift: string }>;
+      };
+      const findMax = (lift: string) => body.maxes.find((m) => m.lift === lift)!;
+
+      expect(findMax('Squat').weight).toBe(320);          // unchanged (reps<5)
+      expect(findMax('Bench Press').weight).toBe(237);    // 232 + 5
+      expect(findMax('Deadlift').weight).toBe(420);       // 410 + 10
+      expect(findMax('Overhead Press').weight).toBe(150); // 145 + 5
+      expect(body.flagged).toEqual([]);
+    });
+
+    it('cycle 5 → 6: POST /cycles persists final composed maxes into cycle 6', async () => {
+      const advanceRes = await post(`/programs/${SEED_PROGRAM}/cycles`);
+      expect(advanceRes.statusCode).toBe(201);
+      expect(advanceRes.json().cycleNum).toBe(6);
+
+      const tmRes = await get(`/programs/${SEED_PROGRAM}/training-maxes`);
+      expect(tmRes.statusCode).toBe(200);
+      const findTm = (lift: string) =>
+        tmRes.json().find((m: { lift: string }) => m.lift === lift)!;
+      expect(findTm('Squat').weight).toBe(320);
+      expect(findTm('Bench Press').weight).toBe(237);
+      expect(findTm('Deadlift').weight).toBe(420);
+      expect(findTm('Overhead Press').weight).toBe(150);
+    });
+  });
+
   it('isolates adapter state between users', async () => {
     const injectRaw = app.getHttpAdapter().getInstance().inject.bind(
       app.getHttpAdapter().getInstance(),


### PR DESCRIPTION
## Summary

Adds an order-sensitive `multi-cycle progression scenario` block to `apps/api/src/programs/programs.e2e.spec.ts` that walks two full cycle-advance boundaries (4→5, 5→6) and asserts the carry-forward chain — log → recalculate → advance cycle — actually persists updated training maxes into the next cycle. The existing multi-workout scenario only exercises the *flagged* branch (everything logged at 65 % loading is below current TM); this one exercises the *applied* branch.

Engineered set-1 weights at-or-near current TMs deterministically fire the genuine-progression gate (`record.weight + spec.increment > current TM` AND `record.reps >= spec.reps` AND `record.date > max.dateUpdated`). Inline comments document every arithmetic step.

## Per-cycle outcomes

**Cycle 4 → 5** (Squat + Bench progress; DL + OHP unchanged):

| Lift | Logged set 1 | Outcome |
|---|---|---|
| Squat | 315 × 5 reps | TM 315 → 320 |
| Bench Press | 225 × 5 reps | TM 225 → 230 |
| Deadlift | 300 × 3 reps | unchanged (reps < 5) |
| Overhead Press | 100 × 2 reps | unchanged (reps < 5) |

**Cycle 5 → 6** (different lifts progress; confirms composition):

| Lift | Logged set 1 | Outcome |
|---|---|---|
| Squat | 322 × 3 reps | unchanged (reps < 5) |
| Bench Press | 232 × 5 reps | TM 230 → 237 |
| Deadlift | 410 × 5 reps | TM 405 → 420 |
| Overhead Press | 145 × 5 reps | TM 145 → 150 |

## Acceptance criteria

- [x] Cycle 1 (here cycle 4) produces ≥1 max increase and ≥1 unchanged max, calls `POST /training-maxes/recalculate` and `POST /cycles` to advance.
- [x] Cycle 2 (here cycle 5) carry-forward asserted via `GET /training-maxes` after advancement — see scope note below.
- [x] Second advancement (cycle 5 → 6) with different per-lift outcomes confirms composition.
- [x] All assertions deterministic from hardcoded fixture inputs.

### Scope note on AC bullet 2

The original AC asks for cycle 2 *planned weights* via `GET /workouts/:workoutNum`. That endpoint currently returns only logged records — there is no planned-weight projection wired into `workouts.controller.ts` (confirmed in `toWorkoutResponse` in `apps/api/src/programs/mappers.ts`). The carry-forward is therefore asserted via `GET /training-maxes` instead — that's the same data downstream planned-weight derivation would consume, and the percentage-rounding arithmetic itself has unit-test coverage in `packages/core`.

Follow-up tracked in **#166** — wires planned-set projection into `GET /workouts/:n` and adds the corresponding controller-level assertion.

## Testing

Per project `## Testing`: `npm test` is the full-repo command. It currently fails on `main` for unrelated reasons (tracked in **#167**):
- 15 TypeScript build errors in `apps/api` (missing exports `RecalculateMaxesResponse` / `MaxReductionFlag` / `CyclePlanResponse` and Prisma type issues).
- 2 pre-existing failures in `apps/api/src/adapters/prisma/lift-record.repository.spec.ts`.

Both reproduce on a clean `git stash` checkout and are not introduced by this PR. Verified:

```bash
npm test -w @lifting-logbook/api -- --testPathPatterns=programs.e2e.spec
# → 28/28 passed (21 existing + 7 new in multi-cycle progression scenario)
```

```bash
npm test -w @lifting-logbook/api
# → 88 passed (was 81 on main), 2 pre-existing prisma failures unchanged
```

## Test plan

- [x] Reviewer confirms the engineered-weight comments correctly trace `record.weight + spec.increment` vs current TM for every assertion.
- [x] Reviewer confirms scope note on AC bullet 2 is acceptable — follow-up filed as #166.
- [x] Pre-existing breakage tracked as #167.

Closes #142