### PR TITLE
[fix] Pass shared store to in-memory adapters in SystemDbRepositoryFactory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,6 @@ jobs:
           DATABASE_URL: postgresql://lifting:lifting@localhost:5432/lifting_test
 
       - name: DB Integration Tests
-        run: npx turbo run test --filter=@lifting-logbook/api -- --testPathPattern=db\\.e2e
+        run: npx turbo run test --filter=@lifting-logbook/api -- --testPathPatterns=db\\.e2e
         env:
           DATABASE_URL: postgresql://lifting:lifting@localhost:5432/lifting_test

--- a/apps/api/src/adapters/factory/system-db-repository-factory.ts
+++ b/apps/api/src/adapters/factory/system-db-repository-factory.ts
@@ -1,6 +1,7 @@
 import { Injectable, OnModuleDestroy } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
 import { Pool } from 'pg';
+import { LiftRecord } from '@lifting-logbook/core';
 import { AuthUser } from '../../ports/auth';
 import { IRepositoryFactory, RepositoryBundle } from '../../ports/factory';
 import { PrismaLiftRecordRepository } from '../prisma/lift-record.repository';
@@ -77,13 +78,17 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
       };
     }
 
+    // liftRecord and workout share one backing store so POSTed records are
+    // immediately visible via GET /workouts/:workoutNum (mirrors Prisma behavior
+    // and matches InMemoryRepositoryFactory).
+    const sharedRecords: Map<string, LiftRecord[]> = new Map();
     return {
       cycleDashboard: new InMemoryCycleDashboardRepository(),
       liftingProgramSpec: this.programSpecRepo,
-      liftRecord: new InMemoryLiftRecordRepository(),
+      liftRecord: new InMemoryLiftRecordRepository(sharedRecords),
       programPhilosophy: this.philosophyRepo,
       trainingMax: new InMemoryTrainingMaxRepository(),
-      workout: new InMemoryWorkoutRepository(),
+      workout: new InMemoryWorkoutRepository(sharedRecords),
     };
   }
 


### PR DESCRIPTION
## Summary

`InMemoryLiftRecordRepository` and `InMemoryWorkoutRepository` both require a `Map<string, LiftRecord[]>` backing store, but the in-memory fallback path in `SystemDbRepositoryFactory.makeBundle()` instantiated them with no constructor args. This produced 2 `TS2554` errors that broke `npm run build -w @lifting-logbook/api` on `main`:

```
src/adapters/factory/system-db-repository-factory.ts:83:19 - error TS2554: Expected 1 arguments, but got 0.
src/adapters/factory/system-db-repository-factory.ts:86:16 - error TS2554: Expected 1 arguments, but got 0.
```

The fix mirrors `InMemoryRepositoryFactory.forUser()` — both adapters share a single backing store so POSTed lift records remain immediately visible via `GET /workouts/:workoutNum` (matches Prisma behavior).

## Why this slipped through

`SystemDbRepositoryFactory` was added by #153 alongside the Prisma adapter. The CI workflow that exercises `npm run build` only runs on `pull_request` against `main` — there is no equivalent run on push to `main` itself. So the broken state slipped past once the original PR merged, and only resurfaced when PR #165 became the next PR to attempt to merge.

A separate follow-up worth considering: add a `push: { branches: [main] }` trigger to `.github/workflows/ci.yml` so this class of post-merge breakage is caught immediately.

## Testing

Per project `## Testing`: `npm test` from repo root.

Local verification of this specific change is awkward because the worktree's `node_modules/@lifting-logbook/core` is symlinked to the **main** working tree (where I cannot freely rebuild dist), so I am relying on CI for the canonical answer. The change is mechanical — pass a shared `Map<string, LiftRecord[]>` to both adapters — and matches the established pattern in `in-memory-repository-factory.ts:26-35`.

## Test plan

- [ ] CI `Lint & Test` and `DB Integration Tests` both pass.

Closes #167