### PR TITLE
[fix] Restore npm test — import PrismaClientKnownRequestError from runtime/library

### DIFF
--- a/apps/api/src/adapters/prisma/lift-record.repository.spec.ts
+++ b/apps/api/src/adapters/prisma/lift-record.repository.spec.ts
@@ -1,4 +1,5 @@
-import { Prisma, PrismaClient } from '@prisma/client';
+import { PrismaClient } from '@prisma/client';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { PrismaLiftRecordRepository } from './lift-record.repository';
 
 const BASE_ROW = {
@@ -104,7 +105,7 @@ describe('PrismaLiftRecordRepository', () => {
 
     it('returns null when the record does not exist in the DB (P2025)', async () => {
       const prisma = makePrisma();
-      const p2025 = new Prisma.PrismaClientKnownRequestError('Record not found', {
+      const p2025 = new PrismaClientKnownRequestError('Record not found', {
         code: 'P2025',
         clientVersion: '5.0.0',
       });
@@ -118,7 +119,7 @@ describe('PrismaLiftRecordRepository', () => {
 
     it('re-throws non-P2025 Prisma errors', async () => {
       const prisma = makePrisma();
-      const dbError = new Prisma.PrismaClientKnownRequestError('Connection error', {
+      const dbError = new PrismaClientKnownRequestError('Connection error', {
         code: 'P1001',
         clientVersion: '5.0.0',
       });

--- a/apps/api/src/adapters/prisma/lift-record.repository.spec.ts
+++ b/apps/api/src/adapters/prisma/lift-record.repository.spec.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+// Prisma 5.x — error classes moved off the Prisma namespace
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { PrismaLiftRecordRepository } from './lift-record.repository';
 

--- a/apps/api/src/adapters/prisma/lift-record.repository.ts
+++ b/apps/api/src/adapters/prisma/lift-record.repository.ts
@@ -1,4 +1,5 @@
-import { Prisma, PrismaClient } from '@prisma/client';
+import { PrismaClient } from '@prisma/client';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { LiftRecord } from '@lifting-logbook/core';
 import { ILiftRecordRepository } from '../../ports/ILiftRecordRepository';
 
@@ -58,7 +59,7 @@ export class PrismaLiftRecordRepository implements ILiftRecordRepository {
       });
       return rowToLiftRecord(updated);
     } catch (e) {
-      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025') {
+      if (e instanceof PrismaClientKnownRequestError && e.code === 'P2025') {
         return null;
       }
       throw e;

--- a/apps/api/src/adapters/prisma/lift-record.repository.ts
+++ b/apps/api/src/adapters/prisma/lift-record.repository.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+// Prisma 5.x — error classes moved off the Prisma namespace
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { LiftRecord } from '@lifting-logbook/core';
 import { ILiftRecordRepository } from '../../ports/ILiftRecordRepository';


### PR DESCRIPTION
## Summary

- Fixes `TypeError: Prisma.PrismaClientKnownRequestError is not a constructor` in `lift-record.repository.spec.ts`
- Root cause: Prisma 5.x does not expose `PrismaClientKnownRequestError` on the `Prisma` namespace at runtime; the class must be imported directly from `@prisma/client/runtime/library`
- Updates both the implementation and its spec to use the direct import

## Files changed

- `apps/api/src/adapters/prisma/lift-record.repository.ts` — import fix + `instanceof` guard
- `apps/api/src/adapters/prisma/lift-record.repository.spec.ts` — import fix + two `new PrismaClientKnownRequestError(...)` constructor calls

## Test plan

- [x] `npm test -w @lifting-logbook/api` — 13 suites pass, 90 tests pass, 0 failures (1 suite skipped: DB e2e, requires `DATABASE_URL`)
- [x] Targeted spec `lift-record.repository.spec.ts` — all 6 tests pass including the two previously failing P2025/P1001 cases

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)