### PR TITLE
[feat] Training max history with PR flags and source tracking

### DIFF
--- a/apps/api/prisma/migrations/20260505000000_add_training_max_history/migration.sql
+++ b/apps/api/prisma/migrations/20260505000000_add_training_max_history/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "training_max_history" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "program" TEXT NOT NULL,
+    "lift" TEXT NOT NULL,
+    "weight" DOUBLE PRECISION NOT NULL,
+    "reps" INTEGER NOT NULL DEFAULT 1,
+    "date" TIMESTAMP(3) NOT NULL,
+    "isPR" BOOLEAN NOT NULL DEFAULT false,
+    "source" TEXT NOT NULL,
+    "goalMet" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "training_max_history_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "training_max_history_userId_program_idx" ON "training_max_history"("userId", "program");
+
+-- CreateIndex
+CREATE INDEX "training_max_history_userId_program_lift_idx" ON "training_max_history"("userId", "program", "lift");

--- a/apps/api/prisma/migrations/20260505000001_add_training_max_source_check/migration.sql
+++ b/apps/api/prisma/migrations/20260505000001_add_training_max_source_check/migration.sql
@@ -1,0 +1,4 @@
+-- AddCheckConstraint
+ALTER TABLE "training_max_history"
+ADD CONSTRAINT "training_max_history_source_check"
+CHECK (source IN ('test', 'program'));

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -55,3 +55,21 @@ model CycleDashboard {
   @@index([userId, program])
   @@map("cycle_dashboard")
 }
+
+model TrainingMaxHistory {
+  id        String   @id @default(cuid())
+  userId    String
+  program   String
+  lift      String
+  weight    Float
+  reps      Int      @default(1)
+  date      DateTime
+  isPR      Boolean  @default(false)
+  source    String
+  goalMet   Boolean  @default(false)
+  createdAt DateTime @default(now())
+
+  @@index([userId, program])
+  @@index([userId, program, lift])
+  @@map("training_max_history")
+}

--- a/apps/api/src/adapters/factory/in-memory-repository-factory.ts
+++ b/apps/api/src/adapters/factory/in-memory-repository-factory.ts
@@ -7,6 +7,7 @@ import { InMemoryLiftingProgramSpecRepository } from '../in-memory/lifting-progr
 import { InMemoryLiftRecordRepository } from '../in-memory/lift-record.adapter';
 import { InMemoryProgramPhilosophyRepository } from '../in-memory/program-philosophy.adapter';
 import { InMemoryTrainingMaxRepository } from '../in-memory/training-max.adapter';
+import { InMemoryTrainingMaxHistoryRepository } from '../in-memory/training-max-history.adapter';
 import { InMemoryWorkoutRepository } from '../in-memory/workout.adapter';
 import { SEED_PROGRAM, seedLiftRecords } from '../in-memory/fixtures';
 
@@ -32,6 +33,7 @@ export class InMemoryRepositoryFactory implements IRepositoryFactory {
         liftRecord: new InMemoryLiftRecordRepository(sharedRecords),
         programPhilosophy: new InMemoryProgramPhilosophyRepository(),
         trainingMax: new InMemoryTrainingMaxRepository(preSeed),
+        trainingMaxHistory: new InMemoryTrainingMaxHistoryRepository(),
         workout: new InMemoryWorkoutRepository(sharedRecords),
       });
     }

--- a/apps/api/src/adapters/factory/system-db-repository-factory.ts
+++ b/apps/api/src/adapters/factory/system-db-repository-factory.ts
@@ -6,6 +6,7 @@ import { AuthUser } from '../../ports/auth';
 import { IRepositoryFactory, RepositoryBundle } from '../../ports/factory';
 import { PrismaLiftRecordRepository } from '../prisma/lift-record.repository';
 import { PrismaTrainingMaxRepository } from '../prisma/training-max.repository';
+import { PrismaTrainingMaxHistoryRepository } from '../prisma/training-max-history.repository';
 import { PrismaCycleDashboardRepository } from '../prisma/cycle-dashboard.repository';
 import { PrismaWorkoutRepository } from '../prisma/workout.repository';
 import { InMemoryCycleDashboardRepository } from '../in-memory/cycle-dashboard.adapter';
@@ -13,6 +14,7 @@ import { InMemoryLiftingProgramSpecRepository } from '../in-memory/lifting-progr
 import { InMemoryLiftRecordRepository } from '../in-memory/lift-record.adapter';
 import { InMemoryProgramPhilosophyRepository } from '../in-memory/program-philosophy.adapter';
 import { InMemoryTrainingMaxRepository } from '../in-memory/training-max.adapter';
+import { InMemoryTrainingMaxHistoryRepository } from '../in-memory/training-max-history.adapter';
 import { InMemoryWorkoutRepository } from '../in-memory/workout.adapter';
 
 interface UserDataSourceRow {
@@ -71,6 +73,7 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
       return {
         liftRecord: new PrismaLiftRecordRepository(prisma, userId),
         trainingMax: new PrismaTrainingMaxRepository(prisma, userId),
+        trainingMaxHistory: new PrismaTrainingMaxHistoryRepository(prisma, userId),
         cycleDashboard: new PrismaCycleDashboardRepository(prisma, userId),
         workout: new PrismaWorkoutRepository(prisma, userId),
         liftingProgramSpec: this.programSpecRepo,
@@ -88,6 +91,7 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
       liftRecord: new InMemoryLiftRecordRepository(sharedRecords),
       programPhilosophy: this.philosophyRepo,
       trainingMax: new InMemoryTrainingMaxRepository(),
+      trainingMaxHistory: new InMemoryTrainingMaxHistoryRepository(),
       workout: new InMemoryWorkoutRepository(sharedRecords),
     };
   }

--- a/apps/api/src/adapters/in-memory/training-max-history.adapter.ts
+++ b/apps/api/src/adapters/in-memory/training-max-history.adapter.ts
@@ -34,8 +34,8 @@ export class InMemoryTrainingMaxHistoryRepository implements ITrainingMaxHistory
     const current = entries[idx] as TrainingMaxHistoryEntry;
     const updated: TrainingMaxHistoryEntry = {
       ...current,
-      isPR: update.isPR ?? current.isPR,
-      goalMet: update.goalMet ?? current.goalMet,
+      ...(update.isPR !== undefined && { isPR: update.isPR }),
+      ...(update.goalMet !== undefined && { goalMet: update.goalMet }),
     };
     const next = [...entries];
     next[idx] = updated;

--- a/apps/api/src/adapters/in-memory/training-max-history.adapter.ts
+++ b/apps/api/src/adapters/in-memory/training-max-history.adapter.ts
@@ -1,0 +1,45 @@
+import { TrainingMaxHistoryEntry } from '@lifting-logbook/core';
+import { ITrainingMaxHistoryRepository, TrainingMaxHistoryFilters } from '../../ports/ITrainingMaxHistoryRepository';
+import { HistoryEntryNotFoundError } from '../../ports/errors';
+
+export class InMemoryTrainingMaxHistoryRepository implements ITrainingMaxHistoryRepository {
+  private entriesByProgram: Map<string, TrainingMaxHistoryEntry[]> = new Map();
+  private nextId = 1;
+
+  async getHistory(program: string, filters?: TrainingMaxHistoryFilters): Promise<TrainingMaxHistoryEntry[]> {
+    let entries = [...(this.entriesByProgram.get(program) ?? [])];
+    if (filters?.lift !== undefined) entries = entries.filter((e) => e.lift === filters.lift);
+    if (filters?.source !== undefined) entries = entries.filter((e) => e.source === filters.source);
+    if (filters?.isPR !== undefined) entries = entries.filter((e) => e.isPR === filters.isPR);
+    return entries.sort((a, b) => b.date.getTime() - a.date.getTime());
+  }
+
+  async appendHistoryEntries(
+    program: string,
+    entries: Omit<TrainingMaxHistoryEntry, 'id'>[],
+  ): Promise<void> {
+    const existing = this.entriesByProgram.get(program) ?? [];
+    const withIds = entries.map((e) => ({ ...e, id: String(this.nextId++) }));
+    this.entriesByProgram.set(program, [...existing, ...withIds]);
+  }
+
+  async updateHistoryEntry(
+    program: string,
+    id: string,
+    update: { isPR?: boolean; goalMet?: boolean },
+  ): Promise<TrainingMaxHistoryEntry> {
+    const entries = this.entriesByProgram.get(program) ?? [];
+    const idx = entries.findIndex((e) => e.id === id);
+    if (idx === -1) throw new HistoryEntryNotFoundError(id);
+    const current = entries[idx] as TrainingMaxHistoryEntry;
+    const updated: TrainingMaxHistoryEntry = {
+      ...current,
+      isPR: update.isPR ?? current.isPR,
+      goalMet: update.goalMet ?? current.goalMet,
+    };
+    const next = [...entries];
+    next[idx] = updated;
+    this.entriesByProgram.set(program, next);
+    return updated;
+  }
+}

--- a/apps/api/src/adapters/prisma/prisma-repository-factory.ts
+++ b/apps/api/src/adapters/prisma/prisma-repository-factory.ts
@@ -4,6 +4,7 @@ import { IRepositoryFactory, RepositoryBundle } from '../../ports/factory';
 import { PrismaService } from './prisma.service';
 import { PrismaLiftRecordRepository } from './lift-record.repository';
 import { PrismaTrainingMaxRepository } from './training-max.repository';
+import { PrismaTrainingMaxHistoryRepository } from './training-max-history.repository';
 import { PrismaCycleDashboardRepository } from './cycle-dashboard.repository';
 import { PrismaWorkoutRepository } from './workout.repository';
 import { InMemoryLiftingProgramSpecRepository } from '../in-memory/lifting-program-spec.adapter';
@@ -21,6 +22,7 @@ export class PrismaRepositoryFactory implements IRepositoryFactory {
     return {
       liftRecord: new PrismaLiftRecordRepository(this.prisma, user.id),
       trainingMax: new PrismaTrainingMaxRepository(this.prisma, user.id),
+      trainingMaxHistory: new PrismaTrainingMaxHistoryRepository(this.prisma, user.id),
       cycleDashboard: new PrismaCycleDashboardRepository(this.prisma, user.id),
       workout: new PrismaWorkoutRepository(this.prisma, user.id),
       liftingProgramSpec: this.programSpecRepo,

--- a/apps/api/src/adapters/prisma/training-max-history.repository.ts
+++ b/apps/api/src/adapters/prisma/training-max-history.repository.ts
@@ -1,0 +1,86 @@
+import { PrismaClient } from '@prisma/client';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
+import { TrainingMaxHistoryEntry } from '@lifting-logbook/core';
+import { ITrainingMaxHistoryRepository, TrainingMaxHistoryFilters } from '../../ports/ITrainingMaxHistoryRepository';
+import { HistoryEntryNotFoundError } from '../../ports/errors';
+
+export class PrismaTrainingMaxHistoryRepository implements ITrainingMaxHistoryRepository {
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly userId: string,
+  ) {}
+
+  async getHistory(program: string, filters?: TrainingMaxHistoryFilters): Promise<TrainingMaxHistoryEntry[]> {
+    const rows = await this.prisma.trainingMaxHistory.findMany({
+      where: {
+        userId: this.userId,
+        program,
+        ...(filters?.lift !== undefined && { lift: filters.lift }),
+        ...(filters?.source !== undefined && { source: filters.source }),
+        ...(filters?.isPR !== undefined && { isPR: filters.isPR }),
+      },
+      orderBy: { date: 'desc' },
+    });
+    return rows.map((r) => ({
+      id: r.id,
+      lift: r.lift,
+      weight: r.weight,
+      reps: r.reps,
+      date: r.date,
+      isPR: r.isPR,
+      source: r.source as 'test' | 'program',
+      goalMet: r.goalMet,
+    }));
+  }
+
+  async appendHistoryEntries(
+    program: string,
+    entries: Omit<TrainingMaxHistoryEntry, 'id'>[],
+  ): Promise<void> {
+    if (entries.length === 0) return;
+    await this.prisma.trainingMaxHistory.createMany({
+      data: entries.map((e) => ({
+        userId: this.userId,
+        program,
+        lift: e.lift,
+        weight: e.weight,
+        reps: e.reps,
+        date: e.date,
+        isPR: e.isPR,
+        source: e.source,
+        goalMet: e.goalMet,
+      })),
+    });
+  }
+
+  async updateHistoryEntry(
+    program: string,
+    id: string,
+    update: { isPR?: boolean; goalMet?: boolean },
+  ): Promise<TrainingMaxHistoryEntry> {
+    try {
+      const row = await this.prisma.trainingMaxHistory.update({
+        where: { id, userId: this.userId, program },
+        data: {
+          ...(update.isPR !== undefined && { isPR: update.isPR }),
+          ...(update.goalMet !== undefined && { goalMet: update.goalMet }),
+        },
+      });
+      return {
+        id: row.id,
+        lift: row.lift,
+        weight: row.weight,
+        reps: row.reps,
+        date: row.date,
+        isPR: row.isPR,
+        source: row.source as 'test' | 'program',
+        goalMet: row.goalMet,
+      };
+    } catch (e) {
+      if (e instanceof PrismaClientKnownRequestError && e.code === 'P2025') {
+        throw new HistoryEntryNotFoundError(id);
+      }
+      throw e;
+    }
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
     new FastifyAdapter(),
   );
   app.useGlobalFilters(new DomainNotFoundFilter());
-  app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }));
   const port = parseInt(process.env.PORT ?? '3004', 10);
   await app.listen(port, '0.0.0.0');
 }

--- a/apps/api/src/ports/ITrainingMaxHistoryRepository.ts
+++ b/apps/api/src/ports/ITrainingMaxHistoryRepository.ts
@@ -1,0 +1,17 @@
+import { TrainingMaxHistoryEntry } from '@lifting-logbook/core';
+
+export interface TrainingMaxHistoryFilters {
+  lift?: string;
+  source?: 'test' | 'program';
+  isPR?: boolean;
+}
+
+export interface ITrainingMaxHistoryRepository {
+  getHistory(program: string, filters?: TrainingMaxHistoryFilters): Promise<TrainingMaxHistoryEntry[]>;
+  appendHistoryEntries(program: string, entries: Omit<TrainingMaxHistoryEntry, 'id'>[]): Promise<void>;
+  updateHistoryEntry(
+    program: string,
+    id: string,
+    update: { isPR?: boolean; goalMet?: boolean },
+  ): Promise<TrainingMaxHistoryEntry>;
+}

--- a/apps/api/src/ports/errors.ts
+++ b/apps/api/src/ports/errors.ts
@@ -24,3 +24,10 @@ export class WorkoutNotFoundError extends Error {
     this.name = 'WorkoutNotFoundError';
   }
 }
+
+export class HistoryEntryNotFoundError extends Error {
+  constructor(public readonly id: string) {
+    super(`History entry '${id}' not found`);
+    this.name = 'HistoryEntryNotFoundError';
+  }
+}

--- a/apps/api/src/ports/factory.ts
+++ b/apps/api/src/ports/factory.ts
@@ -3,6 +3,7 @@ import { ICycleDashboardRepository } from './ICycleDashboardRepository';
 import { ILiftingProgramSpecRepository } from './ILiftingProgramSpecRepository';
 import { ILiftRecordRepository } from './ILiftRecordRepository';
 import { IProgramPhilosophyRepository } from './IProgramPhilosophyRepository';
+import { ITrainingMaxHistoryRepository } from './ITrainingMaxHistoryRepository';
 import { ITrainingMaxRepository } from './ITrainingMaxRepository';
 import { IWorkoutRepository } from './IWorkoutRepository';
 
@@ -12,6 +13,7 @@ export interface RepositoryBundle {
   liftRecord: ILiftRecordRepository;
   programPhilosophy: IProgramPhilosophyRepository;
   trainingMax: ITrainingMaxRepository;
+  trainingMaxHistory: ITrainingMaxHistoryRepository;
   workout: IWorkoutRepository;
 }
 

--- a/apps/api/src/ports/index.ts
+++ b/apps/api/src/ports/index.ts
@@ -8,5 +8,6 @@ export * from './ICyclePlanningAgent';
 export * from './ILiftingProgramSpecRepository';
 export * from './ILiftRecordRepository';
 export * from './IProgramPhilosophyRepository';
+export * from './ITrainingMaxHistoryRepository';
 export * from './ITrainingMaxRepository';
 export * from './IWorkoutRepository';

--- a/apps/api/src/ports/ports.compile-test.ts
+++ b/apps/api/src/ports/ports.compile-test.ts
@@ -5,7 +5,7 @@
  * If the mock is missing a required method or uses an incompatible signature,
  * the TypeScript compiler will error here — no runtime needed.
  */
-import { CycleDashboard, LiftRecord, LiftingProgramSpec, TrainingMax } from '@lifting-logbook/core';
+import { CycleDashboard, LiftRecord, LiftingProgramSpec, TrainingMax, TrainingMaxHistoryEntry } from '@lifting-logbook/core';
 import { BodyWeightEntry } from '@lifting-logbook/types';
 import { AuthUser, IAuthProvider } from './auth';
 import { IBodyWeightRepository } from './IBodyWeightRepository';
@@ -15,6 +15,7 @@ import { ILiftingProgramSpecRepository } from './ILiftingProgramSpecRepository';
 import { ILiftRecordRepository } from './ILiftRecordRepository';
 import { IProgramPhilosophyRepository } from './IProgramPhilosophyRepository';
 import { ITrainingMaxRepository } from './ITrainingMaxRepository';
+import { ITrainingMaxHistoryRepository } from './ITrainingMaxHistoryRepository';
 import { IWorkoutRepository } from './IWorkoutRepository';
 
 // ---------------------------------------------------------------------------
@@ -82,6 +83,16 @@ const _trainingMaxRepo: ITrainingMaxRepository = {
 };
 
 // ---------------------------------------------------------------------------
+// ITrainingMaxHistoryRepository
+// ---------------------------------------------------------------------------
+
+const _trainingMaxHistoryRepo: ITrainingMaxHistoryRepository = {
+  getHistory: (): Promise<TrainingMaxHistoryEntry[]> => Promise.resolve([]),
+  appendHistoryEntries: (): Promise<void> => Promise.resolve(),
+  updateHistoryEntry: (): Promise<TrainingMaxHistoryEntry> =>
+    Promise.resolve({ id: '', lift: '', weight: 0, reps: 1, date: new Date(), isPR: false, source: 'program', goalMet: false }),
+};
+
 // IWorkoutRepository
 // ---------------------------------------------------------------------------
 
@@ -107,6 +118,7 @@ const _repositoryBundle: RepositoryBundle = {
   liftRecord: _liftRecordRepo,
   programPhilosophy: _programPhilosophyRepo,
   trainingMax: _trainingMaxRepo,
+  trainingMaxHistory: _trainingMaxHistoryRepo,
   workout: _workoutRepo,
 };
 
@@ -122,6 +134,7 @@ void _cycleDashboardRepo;
 void _programSpecRepo;
 void _liftRecordRepo;
 void _trainingMaxRepo;
+void _trainingMaxHistoryRepo;
 void _workoutRepo;
 void _repositoryBundle;
 void _repositoryFactory;

--- a/apps/api/src/programs/cycle-generation.service.spec.ts
+++ b/apps/api/src/programs/cycle-generation.service.spec.ts
@@ -4,6 +4,7 @@ import {
   ICycleDashboardRepository,
   ILiftRecordRepository,
   ILiftingProgramSpecRepository,
+  ITrainingMaxHistoryRepository,
   ITrainingMaxRepository,
 } from '../ports';
 import { CycleGenerationService } from './cycle-generation.service';
@@ -63,11 +64,13 @@ describe('CycleGenerationService', () => {
   let cycleDashboardRepo: jest.Mocked<ICycleDashboardRepository>;
   let programSpecRepo: jest.Mocked<ILiftingProgramSpecRepository>;
   let trainingMaxRepo: jest.Mocked<ITrainingMaxRepository>;
+  let trainingMaxHistoryRepo: jest.Mocked<ITrainingMaxHistoryRepository>;
   let liftRecordRepo: jest.Mocked<ILiftRecordRepository>;
   let repos: {
     cycleDashboard: jest.Mocked<ICycleDashboardRepository>;
     liftingProgramSpec: jest.Mocked<ILiftingProgramSpecRepository>;
     trainingMax: jest.Mocked<ITrainingMaxRepository>;
+    trainingMaxHistory: jest.Mocked<ITrainingMaxHistoryRepository>;
     liftRecord: jest.Mocked<ILiftRecordRepository>;
   };
 
@@ -83,6 +86,11 @@ describe('CycleGenerationService', () => {
       getTrainingMaxes: jest.fn(),
       saveTrainingMaxes: jest.fn().mockResolvedValue(undefined),
     };
+    trainingMaxHistoryRepo = {
+      getHistory: jest.fn().mockResolvedValue([]),
+      appendHistoryEntries: jest.fn().mockResolvedValue(undefined),
+      updateHistoryEntry: jest.fn(),
+    };
     liftRecordRepo = {
       getLiftRecords: jest.fn(),
       appendLiftRecords: jest.fn().mockResolvedValue(undefined),
@@ -91,6 +99,7 @@ describe('CycleGenerationService', () => {
       cycleDashboard: cycleDashboardRepo,
       liftingProgramSpec: programSpecRepo,
       trainingMax: trainingMaxRepo,
+      trainingMaxHistory: trainingMaxHistoryRepo,
       liftRecord: liftRecordRepo,
     };
     service = new CycleGenerationService();

--- a/apps/api/src/programs/cycle-generation.service.ts
+++ b/apps/api/src/programs/cycle-generation.service.ts
@@ -3,6 +3,7 @@ import {
   CycleDashboard,
   MaxReductionFlag,
   TrainingMax,
+  TrainingMaxHistoryEntry,
   updateCycle,
   updateMaxes,
 } from '@lifting-logbook/core';
@@ -11,8 +12,28 @@ import { StartNewCycleDto } from './start-new-cycle.dto';
 
 type CycleRepos = Pick<
   RepositoryBundle,
-  'cycleDashboard' | 'liftingProgramSpec' | 'trainingMax' | 'liftRecord'
+  'cycleDashboard' | 'liftingProgramSpec' | 'trainingMax' | 'trainingMaxHistory' | 'liftRecord'
 >;
+
+function buildHistoryEntries(
+  prevMaxes: TrainingMax[],
+  newMaxes: TrainingMax[],
+  date: Date,
+  source: 'test' | 'program',
+): Omit<TrainingMaxHistoryEntry, 'id'>[] {
+  const prevMap = new Map(prevMaxes.map((m) => [m.lift, m.weight]));
+  return newMaxes
+    .filter((m) => prevMap.get(m.lift) !== m.weight)
+    .map((m) => ({
+      lift: m.lift,
+      weight: m.weight,
+      reps: 1,
+      date,
+      isPR: false,
+      source,
+      goalMet: false,
+    }));
+}
 
 @Injectable()
 export class CycleGenerationService {
@@ -58,6 +79,12 @@ export class CycleGenerationService {
     await repos.trainingMax.saveTrainingMaxes(program, newMaxes);
     await repos.cycleDashboard.saveCycleDashboard(newCycle);
 
+    const source = dashboard.currentWeekType === 'test' ? 'test' : 'program';
+    const historyEntries = buildHistoryEntries(trainingMaxes, newMaxes, newCycle.cycleDate, source);
+    if (historyEntries.length > 0) {
+      await repos.trainingMaxHistory.appendHistoryEntries(program, historyEntries);
+    }
+
     return newCycle;
   }
 
@@ -74,6 +101,11 @@ export class CycleGenerationService {
 
     const result = updateMaxes(programSpec, trainingMaxes, liftRecords);
     await repos.trainingMax.saveTrainingMaxes(program, result.maxes);
+
+    const historyEntries = buildHistoryEntries(trainingMaxes, result.maxes, new Date(), 'program');
+    if (historyEntries.length > 0) {
+      await repos.trainingMaxHistory.appendHistoryEntries(program, historyEntries);
+    }
 
     return result;
   }

--- a/apps/api/src/programs/cycle-generation.service.ts
+++ b/apps/api/src/programs/cycle-generation.service.ts
@@ -15,15 +15,19 @@ type CycleRepos = Pick<
   'cycleDashboard' | 'liftingProgramSpec' | 'trainingMax' | 'trainingMaxHistory' | 'liftRecord'
 >;
 
+function round1dp(w: number): number {
+  return Math.round(w * 10) / 10;
+}
+
 function buildHistoryEntries(
   prevMaxes: TrainingMax[],
   newMaxes: TrainingMax[],
   date: Date,
   source: 'test' | 'program',
 ): Omit<TrainingMaxHistoryEntry, 'id'>[] {
-  const prevMap = new Map(prevMaxes.map((m) => [m.lift, m.weight]));
+  const prevMap = new Map(prevMaxes.map((m) => [m.lift, round1dp(m.weight)]));
   return newMaxes
-    .filter((m) => prevMap.get(m.lift) !== m.weight)
+    .filter((m) => prevMap.get(m.lift) !== round1dp(m.weight))
     .map((m) => ({
       lift: m.lift,
       weight: m.weight,
@@ -102,7 +106,7 @@ export class CycleGenerationService {
     const result = updateMaxes(programSpec, trainingMaxes, liftRecords);
     await repos.trainingMax.saveTrainingMaxes(program, result.maxes);
 
-    const historyEntries = buildHistoryEntries(trainingMaxes, result.maxes, new Date(), 'program');
+    const historyEntries = buildHistoryEntries(trainingMaxes, result.maxes, dashboard.cycleDate, 'program');
     if (historyEntries.length > 0) {
       await repos.trainingMaxHistory.appendHistoryEntries(program, historyEntries);
     }

--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -3,6 +3,7 @@ import {
   LiftRecord,
   LiftingProgramSpec,
   TrainingMax,
+  TrainingMaxHistoryEntry,
 } from '@lifting-logbook/core';
 import {
   CycleDashboardResponse,
@@ -10,6 +11,7 @@ import {
   LiftRecordResponse,
   LiftingProgramSpecResponse,
   SetResponse,
+  TrainingMaxHistoryEntryResponse,
   TrainingMaxResponse,
   WeekNumber,
   WorkoutLiftResponse,
@@ -27,6 +29,19 @@ export const toTrainingMaxResponse = (m: TrainingMax): TrainingMaxResponse => ({
   weight: m.weight,
   unit: 'lbs',
   dateUpdated: isoDate(m.dateUpdated),
+});
+
+export const toTrainingMaxHistoryEntryResponse = (
+  e: TrainingMaxHistoryEntry,
+): TrainingMaxHistoryEntryResponse => ({
+  id: e.id,
+  lift: e.lift,
+  weight: e.weight,
+  unit: 'lbs',
+  date: isoDate(e.date),
+  isPR: e.isPR,
+  source: e.source,
+  goalMet: e.goalMet,
 });
 
 export const toLiftRecordResponse = (r: LiftRecord): LiftRecordResponse => ({

--- a/apps/api/src/programs/not-found.filter.ts
+++ b/apps/api/src/programs/not-found.filter.ts
@@ -6,18 +6,19 @@ import {
 } from '@nestjs/common';
 import { FastifyReply } from 'fastify';
 import {
+  HistoryEntryNotFoundError,
   ProgramNotFoundError,
   WorkoutNotFoundError,
 } from '../ports/errors';
 
-type DomainNotFound = ProgramNotFoundError | WorkoutNotFoundError;
+type DomainNotFound = ProgramNotFoundError | WorkoutNotFoundError | HistoryEntryNotFoundError;
 
 /**
  * Translates framework-agnostic domain "not found" errors raised by port
  * adapters into HTTP 404 responses. Keeps adapters free of `@nestjs/common`
  * HTTP dependencies so they can be reused by non-HTTP callers.
  */
-@Catch(ProgramNotFoundError, WorkoutNotFoundError)
+@Catch(ProgramNotFoundError, WorkoutNotFoundError, HistoryEntryNotFoundError)
 export class DomainNotFoundFilter implements ExceptionFilter {
   catch(err: DomainNotFound, host: ArgumentsHost): void {
     const res = host.switchToHttp().getResponse<FastifyReply>();

--- a/apps/api/src/programs/programs.db.e2e.spec.ts
+++ b/apps/api/src/programs/programs.db.e2e.spec.ts
@@ -29,6 +29,7 @@ async function cleanTestUsers(prisma: PrismaClient): Promise<void> {
   const users = [TEST_USER, USER_ALICE, USER_BOB];
   await prisma.liftRecord.deleteMany({ where: { userId: { in: users } } });
   await prisma.trainingMax.deleteMany({ where: { userId: { in: users } } });
+  await prisma.trainingMaxHistory.deleteMany({ where: { userId: { in: users } } });
   await prisma.cycleDashboard.deleteMany({ where: { userId: { in: users } } });
 }
 
@@ -275,6 +276,70 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
 
     it('POST /programs/unknown/cycles returns 404', async () => {
       const res = await post('/programs/does-not-exist/cycles');
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Training max history — order-sensitive, continues from write operations.
+  // At this point cycle advances have written history rows for changed lifts.
+  // -------------------------------------------------------------------------
+
+  describe('training max history', () => {
+    it('GET /training-maxes/history returns entries after cycle advances', async () => {
+      const res = await get(`/programs/${SEED_PROGRAM}/training-maxes/history`);
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(Array.isArray(body.entries)).toBe(true);
+      for (const e of body.entries) {
+        expect(e).toMatchObject({
+          id: expect.any(String),
+          lift: expect.any(String),
+          weight: expect.any(Number),
+          unit: 'lbs',
+          date: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+          isPR: expect.any(Boolean),
+          source: expect.stringMatching(/^(test|program)$/),
+          goalMet: expect.any(Boolean),
+        });
+      }
+    });
+
+    it('GET /training-maxes/history?lift=Squat filters to that lift', async () => {
+      const res = await get(`/programs/${SEED_PROGRAM}/training-maxes/history?lift=Squat`);
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.entries.every((e: { lift: string }) => e.lift === 'Squat')).toBe(true);
+    });
+
+    it('PATCH /training-maxes/history/:id marks entry as PR and persists to DB', async () => {
+      const listRes = await get(`/programs/${SEED_PROGRAM}/training-maxes/history`);
+      const entries = listRes.json().entries as Array<{ id: string }>;
+      if (entries.length === 0) {
+        // No maxes changed — skip toggle test gracefully
+        return;
+      }
+      const firstId = entries[0].id;
+
+      const patchRes = await patchJson(
+        `/programs/${SEED_PROGRAM}/training-maxes/history/${firstId}`,
+        { isPR: true },
+      );
+      expect(patchRes.statusCode).toBe(200);
+      expect(patchRes.json()).toMatchObject({ id: firstId, isPR: true });
+
+      // DB-level assertion
+      const row = await prisma.trainingMaxHistory.findFirst({
+        where: { id: firstId, userId: TEST_USER },
+      });
+      expect(row?.isPR).toBe(true);
+    });
+
+    it('PATCH /training-maxes/history/:id with unknown id returns 404', async () => {
+      const res = await patchJson(
+        `/programs/${SEED_PROGRAM}/training-maxes/history/nonexistent-id`,
+        { isPR: true },
+      );
       expect(res.statusCode).toBe(404);
     });
   });

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -500,6 +500,76 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // Training max history — order-sensitive, continues from multi-cycle scenario.
+  // At this point cycle advances and recalculates have written history entries.
+  // -------------------------------------------------------------------------
+
+  describe('training max history', () => {
+    it('GET /training-maxes/history returns entries after cycle advances', async () => {
+      const res = await get(`/programs/${SEED_PROGRAM}/training-maxes/history`);
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(Array.isArray(body.entries)).toBe(true);
+      expect(body.entries.length).toBeGreaterThan(0);
+      for (const e of body.entries) {
+        expect(e).toMatchObject({
+          id: expect.any(String),
+          lift: expect.any(String),
+          weight: expect.any(Number),
+          unit: 'lbs',
+          date: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+          isPR: expect.any(Boolean),
+          source: expect.stringMatching(/^(test|program)$/),
+          goalMet: expect.any(Boolean),
+        });
+      }
+    });
+
+    it('GET /training-maxes/history?lift=Bench+Press filters to that lift', async () => {
+      const res = await get(
+        `/programs/${SEED_PROGRAM}/training-maxes/history?lift=${encodeURIComponent('Bench Press')}`,
+      );
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.entries.every((e: { lift: string }) => e.lift === 'Bench Press')).toBe(true);
+    });
+
+    it('GET /training-maxes/history?isPR=true returns empty before any entry is marked', async () => {
+      const res = await get(`/programs/${SEED_PROGRAM}/training-maxes/history?isPR=true`);
+      expect(res.statusCode).toBe(200);
+      expect(res.json().entries).toEqual([]);
+    });
+
+    it('PATCH /training-maxes/history/:id marks an entry as PR', async () => {
+      const listRes = await get(`/programs/${SEED_PROGRAM}/training-maxes/history`);
+      const firstId = listRes.json().entries[0].id as string;
+
+      const patchRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'PATCH',
+        url: `/programs/${SEED_PROGRAM}/training-maxes/history/${firstId}`,
+        headers: { 'content-type': 'application/json', authorization: 'Bearer dev-token' },
+        payload: JSON.stringify({ isPR: true }),
+      });
+      expect(patchRes.statusCode).toBe(200);
+      expect(patchRes.json()).toMatchObject({ id: firstId, isPR: true });
+
+      // Verify persistence: GET ?isPR=true now includes the entry
+      const prRes = await get(`/programs/${SEED_PROGRAM}/training-maxes/history?isPR=true`);
+      expect(prRes.json().entries.some((e: { id: string }) => e.id === firstId)).toBe(true);
+    });
+
+    it('PATCH /training-maxes/history/:id with unknown id returns 404', async () => {
+      const res = await app.getHttpAdapter().getInstance().inject({
+        method: 'PATCH',
+        url: `/programs/${SEED_PROGRAM}/training-maxes/history/nonexistent-id`,
+        headers: { 'content-type': 'application/json', authorization: 'Bearer dev-token' },
+        payload: JSON.stringify({ isPR: true }),
+      });
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
   it('isolates adapter state between users', async () => {
     const injectRaw = app.getHttpAdapter().getInstance().inject.bind(
       app.getHttpAdapter().getInstance(),

--- a/apps/api/src/programs/programs.module.ts
+++ b/apps/api/src/programs/programs.module.ts
@@ -10,6 +10,7 @@ import { CyclePlanController } from './cycle-plan.controller';
 import { LiftRecordsController } from './lift-records.controller';
 import { ProgramSpecController } from './program-spec.controller';
 import { TrainingMaxesController } from './training-maxes.controller';
+import { TrainingMaxHistoryController } from './training-max-history.controller';
 import { WorkoutsController } from './workouts.controller';
 
 @Module({
@@ -20,6 +21,7 @@ import { WorkoutsController } from './workouts.controller';
     CyclePlanController,
     WorkoutsController,
     TrainingMaxesController,
+    TrainingMaxHistoryController,
     LiftRecordsController,
     ProgramSpecController,
   ],

--- a/apps/api/src/programs/training-max-history.controller.spec.ts
+++ b/apps/api/src/programs/training-max-history.controller.spec.ts
@@ -1,0 +1,118 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ITrainingMaxHistoryRepository } from '../ports/ITrainingMaxHistoryRepository';
+import { IRepositoryFactory } from '../ports/factory';
+import { REPOSITORY_FACTORY } from '../ports/tokens';
+import { TrainingMaxHistoryController } from './training-max-history.controller';
+import { HistoryEntryNotFoundError } from '../ports/errors';
+
+const MOCK_USER = { id: 'test-user', email: 'test@example.com', provider: 'dev' };
+
+const ENTRY = {
+  id: 'entry-1',
+  lift: 'Squat',
+  weight: 315,
+  reps: 1,
+  date: new Date('2026-04-20T00:00:00.000Z'),
+  isPR: false,
+  source: 'program' as const,
+  goalMet: false,
+};
+
+describe('TrainingMaxHistoryController', () => {
+  let controller: TrainingMaxHistoryController;
+  let repo: jest.Mocked<ITrainingMaxHistoryRepository>;
+  let factory: jest.Mocked<IRepositoryFactory>;
+
+  beforeEach(async () => {
+    repo = {
+      getHistory: jest.fn(),
+      appendHistoryEntries: jest.fn(),
+      updateHistoryEntry: jest.fn(),
+    };
+    factory = {
+      forUser: jest.fn().mockResolvedValue({ trainingMaxHistory: repo }),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TrainingMaxHistoryController],
+      providers: [{ provide: REPOSITORY_FACTORY, useValue: factory }],
+    }).compile();
+    controller = module.get(TrainingMaxHistoryController);
+  });
+
+  describe('getHistory', () => {
+    it('returns mapped entries with ISO date and unit', async () => {
+      repo.getHistory.mockResolvedValue([ENTRY]);
+
+      const result = await controller.getHistory('5-3-1', undefined, undefined, undefined, MOCK_USER);
+
+      expect(factory.forUser).toHaveBeenCalledWith(MOCK_USER);
+      expect(repo.getHistory).toHaveBeenCalledWith('5-3-1', { lift: undefined, source: undefined, isPR: undefined });
+      expect(result).toEqual({
+        entries: [
+          {
+            id: 'entry-1',
+            lift: 'Squat',
+            weight: 315,
+            unit: 'lbs',
+            date: '2026-04-20',
+            isPR: false,
+            source: 'program',
+            goalMet: false,
+          },
+        ],
+      });
+    });
+
+    it('passes lift filter to repository', async () => {
+      repo.getHistory.mockResolvedValue([]);
+
+      await controller.getHistory('5-3-1', 'Squat', undefined, undefined, MOCK_USER);
+
+      expect(repo.getHistory).toHaveBeenCalledWith('5-3-1', expect.objectContaining({ lift: 'Squat' }));
+    });
+
+    it('parses isPR=true string filter', async () => {
+      repo.getHistory.mockResolvedValue([]);
+
+      await controller.getHistory('5-3-1', undefined, undefined, 'true', MOCK_USER);
+
+      expect(repo.getHistory).toHaveBeenCalledWith('5-3-1', expect.objectContaining({ isPR: true }));
+    });
+
+    it('parses isPR=false string filter', async () => {
+      repo.getHistory.mockResolvedValue([]);
+
+      await controller.getHistory('5-3-1', undefined, undefined, 'false', MOCK_USER);
+
+      expect(repo.getHistory).toHaveBeenCalledWith('5-3-1', expect.objectContaining({ isPR: false }));
+    });
+
+    it('passes source filter to repository', async () => {
+      repo.getHistory.mockResolvedValue([]);
+
+      await controller.getHistory('5-3-1', undefined, 'test', undefined, MOCK_USER);
+
+      expect(repo.getHistory).toHaveBeenCalledWith('5-3-1', expect.objectContaining({ source: 'test' }));
+    });
+  });
+
+  describe('updateEntry', () => {
+    it('returns mapped updated entry', async () => {
+      const updated = { ...ENTRY, isPR: true };
+      repo.updateHistoryEntry.mockResolvedValue(updated);
+
+      const result = await controller.updateEntry('5-3-1', 'entry-1', { isPR: true }, MOCK_USER);
+
+      expect(repo.updateHistoryEntry).toHaveBeenCalledWith('5-3-1', 'entry-1', { isPR: true });
+      expect(result).toEqual(expect.objectContaining({ id: 'entry-1', isPR: true, unit: 'lbs' }));
+    });
+
+    it('propagates HistoryEntryNotFoundError for unknown id', async () => {
+      repo.updateHistoryEntry.mockRejectedValue(new HistoryEntryNotFoundError('bad-id'));
+
+      await expect(
+        controller.updateEntry('5-3-1', 'bad-id', { isPR: true }, MOCK_USER),
+      ).rejects.toBeInstanceOf(HistoryEntryNotFoundError);
+    });
+  });
+});

--- a/apps/api/src/programs/training-max-history.controller.spec.ts
+++ b/apps/api/src/programs/training-max-history.controller.spec.ts
@@ -43,7 +43,7 @@ describe('TrainingMaxHistoryController', () => {
     it('returns mapped entries with ISO date and unit', async () => {
       repo.getHistory.mockResolvedValue([ENTRY]);
 
-      const result = await controller.getHistory('5-3-1', undefined, undefined, undefined, MOCK_USER);
+      const result = await controller.getHistory('5-3-1', MOCK_USER, undefined, undefined, undefined);
 
       expect(factory.forUser).toHaveBeenCalledWith(MOCK_USER);
       expect(repo.getHistory).toHaveBeenCalledWith('5-3-1', { lift: undefined, source: undefined, isPR: undefined });
@@ -66,7 +66,7 @@ describe('TrainingMaxHistoryController', () => {
     it('passes lift filter to repository', async () => {
       repo.getHistory.mockResolvedValue([]);
 
-      await controller.getHistory('5-3-1', 'Squat', undefined, undefined, MOCK_USER);
+      await controller.getHistory('5-3-1', MOCK_USER, 'Squat', undefined, undefined);
 
       expect(repo.getHistory).toHaveBeenCalledWith('5-3-1', expect.objectContaining({ lift: 'Squat' }));
     });
@@ -74,7 +74,7 @@ describe('TrainingMaxHistoryController', () => {
     it('parses isPR=true string filter', async () => {
       repo.getHistory.mockResolvedValue([]);
 
-      await controller.getHistory('5-3-1', undefined, undefined, 'true', MOCK_USER);
+      await controller.getHistory('5-3-1', MOCK_USER, undefined, undefined, 'true');
 
       expect(repo.getHistory).toHaveBeenCalledWith('5-3-1', expect.objectContaining({ isPR: true }));
     });
@@ -82,7 +82,7 @@ describe('TrainingMaxHistoryController', () => {
     it('parses isPR=false string filter', async () => {
       repo.getHistory.mockResolvedValue([]);
 
-      await controller.getHistory('5-3-1', undefined, undefined, 'false', MOCK_USER);
+      await controller.getHistory('5-3-1', MOCK_USER, undefined, undefined, 'false');
 
       expect(repo.getHistory).toHaveBeenCalledWith('5-3-1', expect.objectContaining({ isPR: false }));
     });
@@ -90,7 +90,7 @@ describe('TrainingMaxHistoryController', () => {
     it('passes source filter to repository', async () => {
       repo.getHistory.mockResolvedValue([]);
 
-      await controller.getHistory('5-3-1', undefined, 'test', undefined, MOCK_USER);
+      await controller.getHistory('5-3-1', MOCK_USER, undefined, 'test', undefined);
 
       expect(repo.getHistory).toHaveBeenCalledWith('5-3-1', expect.objectContaining({ source: 'test' }));
     });

--- a/apps/api/src/programs/training-max-history.controller.ts
+++ b/apps/api/src/programs/training-max-history.controller.ts
@@ -1,0 +1,58 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Inject,
+  Param,
+  Patch,
+  Query,
+} from '@nestjs/common';
+import {
+  TrainingMaxHistoryEntryResponse,
+  TrainingMaxHistoryResponse,
+  UpdateTrainingMaxHistoryRequest,
+} from '@lifting-logbook/types';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { AuthUser } from '../ports/auth';
+import { IRepositoryFactory } from '../ports/factory';
+import { REPOSITORY_FACTORY } from '../ports/tokens';
+import { toTrainingMaxHistoryEntryResponse } from './mappers';
+
+@Controller('programs/:program')
+export class TrainingMaxHistoryController {
+  constructor(
+    @Inject(REPOSITORY_FACTORY) private readonly factory: IRepositoryFactory,
+  ) {}
+
+  @Get('training-maxes/history')
+  async getHistory(
+    @Param('program') program: string,
+    @Query('lift') lift?: string,
+    @Query('source') source?: 'test' | 'program',
+    @Query('isPR') isPRStr?: string,
+    @CurrentUser() user?: AuthUser,
+  ): Promise<TrainingMaxHistoryResponse> {
+    const { trainingMaxHistory } = await this.factory.forUser(user!);
+    const isPR =
+      isPRStr === 'true' ? true : isPRStr === 'false' ? false : undefined;
+    const filters = {
+      ...(lift !== undefined && { lift }),
+      ...(source !== undefined && { source }),
+      ...(isPR !== undefined && { isPR }),
+    };
+    const entries = await trainingMaxHistory.getHistory(program, filters);
+    return { entries: entries.map(toTrainingMaxHistoryEntryResponse) };
+  }
+
+  @Patch('training-maxes/history/:id')
+  async updateEntry(
+    @Param('program') program: string,
+    @Param('id') id: string,
+    @Body() body: UpdateTrainingMaxHistoryRequest,
+    @CurrentUser() user?: AuthUser,
+  ): Promise<TrainingMaxHistoryEntryResponse> {
+    const { trainingMaxHistory } = await this.factory.forUser(user!);
+    const updated = await trainingMaxHistory.updateHistoryEntry(program, id, body);
+    return toTrainingMaxHistoryEntryResponse(updated);
+  }
+}

--- a/apps/api/src/programs/training-max-history.controller.ts
+++ b/apps/api/src/programs/training-max-history.controller.ts
@@ -10,8 +10,8 @@ import {
 import {
   TrainingMaxHistoryEntryResponse,
   TrainingMaxHistoryResponse,
-  UpdateTrainingMaxHistoryRequest,
 } from '@lifting-logbook/types';
+import { UpdateTrainingMaxHistoryDto } from './update-training-max-history.dto';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../ports/auth';
 import { IRepositoryFactory } from '../ports/factory';
@@ -27,12 +27,12 @@ export class TrainingMaxHistoryController {
   @Get('training-maxes/history')
   async getHistory(
     @Param('program') program: string,
+    @CurrentUser() user: AuthUser,
     @Query('lift') lift?: string,
     @Query('source') source?: 'test' | 'program',
     @Query('isPR') isPRStr?: string,
-    @CurrentUser() user?: AuthUser,
   ): Promise<TrainingMaxHistoryResponse> {
-    const { trainingMaxHistory } = await this.factory.forUser(user!);
+    const { trainingMaxHistory } = await this.factory.forUser(user);
     const isPR =
       isPRStr === 'true' ? true : isPRStr === 'false' ? false : undefined;
     const filters = {
@@ -48,10 +48,10 @@ export class TrainingMaxHistoryController {
   async updateEntry(
     @Param('program') program: string,
     @Param('id') id: string,
-    @Body() body: UpdateTrainingMaxHistoryRequest,
-    @CurrentUser() user?: AuthUser,
+    @Body() body: UpdateTrainingMaxHistoryDto,
+    @CurrentUser() user: AuthUser,
   ): Promise<TrainingMaxHistoryEntryResponse> {
-    const { trainingMaxHistory } = await this.factory.forUser(user!);
+    const { trainingMaxHistory } = await this.factory.forUser(user);
     const updated = await trainingMaxHistory.updateHistoryEntry(program, id, body);
     return toTrainingMaxHistoryEntryResponse(updated);
   }

--- a/apps/api/src/programs/update-training-max-history.dto.ts
+++ b/apps/api/src/programs/update-training-max-history.dto.ts
@@ -1,0 +1,11 @@
+import { IsBoolean, IsOptional } from 'class-validator';
+
+export class UpdateTrainingMaxHistoryDto {
+  @IsBoolean()
+  @IsOptional()
+  isPR?: boolean;
+
+  @IsBoolean()
+  @IsOptional()
+  goalMet?: boolean;
+}

--- a/apps/web/app/settings/training-maxes/MaxHistory.tsx
+++ b/apps/web/app/settings/training-maxes/MaxHistory.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import type { TrainingMaxHistoryEntryResponse } from '@lifting-logbook/types';
+import { toggleHistoryPR, toggleHistoryGoalMet } from './actions';
+
+type View = 'timeline' | 'list';
+type Filter = 'pr' | 'test' | 'goalMet';
+
+export default function MaxHistory({
+  initialEntries,
+  program,
+}: {
+  initialEntries: TrainingMaxHistoryEntryResponse[];
+  program: string;
+}) {
+  const [entries, setEntries] = useState(initialEntries);
+  const [view, setView] = useState<View>('list');
+  const [filters, setFilters] = useState<Set<Filter>>(new Set());
+  const [liftFilter, setLiftFilter] = useState<string>('');
+  const [pending, setPending] = useState<Set<string>>(new Set());
+
+  const lifts = useMemo(
+    () => Array.from(new Set(entries.map((e) => e.lift))).sort(),
+    [entries],
+  );
+
+  const visible = useMemo(() => {
+    let list = [...entries];
+    if (liftFilter) list = list.filter((e) => e.lift === liftFilter);
+    if (filters.has('pr')) list = list.filter((e) => e.isPR);
+    if (filters.has('test')) list = list.filter((e) => e.source === 'test');
+    if (filters.has('goalMet')) list = list.filter((e) => e.goalMet);
+    return list;
+  }, [entries, filters, liftFilter]);
+
+  function toggleFilter(f: Filter) {
+    setFilters((prev) => {
+      const next = new Set(prev);
+      if (next.has(f)) next.delete(f);
+      else next.add(f);
+      return next;
+    });
+  }
+
+  async function handleTogglePR(entry: TrainingMaxHistoryEntryResponse) {
+    setPending((p) => new Set(p).add(entry.id));
+    try {
+      const updated = await toggleHistoryPR(program, entry.id, !entry.isPR);
+      setEntries((prev) => prev.map((e) => (e.id === updated.id ? updated : e)));
+    } finally {
+      setPending((p) => {
+        const next = new Set(p);
+        next.delete(entry.id);
+        return next;
+      });
+    }
+  }
+
+  async function handleToggleGoalMet(entry: TrainingMaxHistoryEntryResponse) {
+    setPending((p) => new Set(p).add(entry.id));
+    try {
+      const updated = await toggleHistoryGoalMet(program, entry.id, !entry.goalMet);
+      setEntries((prev) => prev.map((e) => (e.id === updated.id ? updated : e)));
+    } finally {
+      setPending((p) => {
+        const next = new Set(p);
+        next.delete(entry.id);
+        return next;
+      });
+    }
+  }
+
+  if (entries.length === 0) {
+    return (
+      <section style={{ marginTop: '2rem' }}>
+        <h2>Training Max History</h2>
+        <p style={{ color: 'var(--color-text-muted, #888)' }}>
+          No history yet. History entries are recorded each time a cycle advances or maxes are recalculated.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section style={{ marginTop: '2rem' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap', marginBottom: '1rem' }}>
+        <h2 style={{ margin: 0 }}>Training Max History</h2>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <button
+            onClick={() => setView('list')}
+            aria-pressed={view === 'list'}
+            style={{ fontWeight: view === 'list' ? 'bold' : 'normal' }}
+          >
+            List
+          </button>
+          <button
+            onClick={() => setView('timeline')}
+            aria-pressed={view === 'timeline'}
+            style={{ fontWeight: view === 'timeline' ? 'bold' : 'normal' }}
+          >
+            Timeline
+          </button>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1rem' }}>
+        <button
+          onClick={() => setFilters(new Set())}
+          aria-pressed={filters.size === 0}
+          style={{ fontWeight: filters.size === 0 ? 'bold' : 'normal' }}
+        >
+          All
+        </button>
+        {(['pr', 'test', 'goalMet'] as Filter[]).map((f) => (
+          <button
+            key={f}
+            onClick={() => toggleFilter(f)}
+            aria-pressed={filters.has(f)}
+            style={{ fontWeight: filters.has(f) ? 'bold' : 'normal' }}
+          >
+            {f === 'pr' ? 'PRs' : f === 'test' ? 'Test Week' : 'Goal Met'}
+          </button>
+        ))}
+        <select
+          value={liftFilter}
+          onChange={(e) => setLiftFilter(e.target.value)}
+          aria-label="Filter by lift"
+        >
+          <option value="">All Lifts</option>
+          {lifts.map((l) => (
+            <option key={l} value={l}>{l}</option>
+          ))}
+        </select>
+      </div>
+
+      {visible.length === 0 ? (
+        <p style={{ color: 'var(--color-text-muted, #888)' }}>No entries match the selected filters.</p>
+      ) : view === 'list' ? (
+        <ListView
+          entries={visible}
+          pending={pending}
+          onTogglePR={handleTogglePR}
+          onToggleGoalMet={handleToggleGoalMet}
+        />
+      ) : (
+        <TimelineView
+          entries={visible}
+          pending={pending}
+          onTogglePR={handleTogglePR}
+          onToggleGoalMet={handleToggleGoalMet}
+        />
+      )}
+    </section>
+  );
+}
+
+type EntryHandlers = {
+  pending: Set<string>;
+  onTogglePR: (e: TrainingMaxHistoryEntryResponse) => void;
+  onToggleGoalMet: (e: TrainingMaxHistoryEntryResponse) => void;
+};
+
+function ListView({
+  entries,
+  ...handlers
+}: { entries: TrainingMaxHistoryEntryResponse[] } & EntryHandlers) {
+  return (
+    <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+      <thead>
+        <tr>
+          <th style={{ textAlign: 'left' }}>Date</th>
+          <th style={{ textAlign: 'left' }}>Lift</th>
+          <th style={{ textAlign: 'right' }}>Weight</th>
+          <th style={{ textAlign: 'center' }}>Source</th>
+          <th style={{ textAlign: 'center' }}>PR</th>
+          <th style={{ textAlign: 'center' }}>Goal Met</th>
+        </tr>
+      </thead>
+      <tbody>
+        {entries.map((e) => (
+          <EntryRow key={e.id} entry={e} {...handlers} />
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function TimelineView({
+  entries,
+  ...handlers
+}: { entries: TrainingMaxHistoryEntryResponse[] } & EntryHandlers) {
+  const byMonth = useMemo(() => {
+    const groups = new Map<string, TrainingMaxHistoryEntryResponse[]>();
+    for (const e of entries) {
+      const key = e.date.slice(0, 7); // YYYY-MM
+      const group = groups.get(key) ?? [];
+      group.push(e);
+      groups.set(key, group);
+    }
+    return Array.from(groups.entries()).sort((a, b) => b[0].localeCompare(a[0]));
+  }, [entries]);
+
+  return (
+    <div>
+      {byMonth.map(([month, monthEntries]) => (
+        <div key={month} style={{ marginBottom: '1.5rem' }}>
+          <h3 style={{ marginBottom: '0.5rem' }}>{month}</h3>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <tbody>
+              {monthEntries.map((e) => (
+                <EntryRow key={e.id} entry={e} {...handlers} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EntryRow({
+  entry,
+  pending,
+  onTogglePR,
+  onToggleGoalMet,
+}: { entry: TrainingMaxHistoryEntryResponse } & EntryHandlers) {
+  const busy = pending.has(entry.id);
+  return (
+    <tr>
+      <td>{entry.date}</td>
+      <td>{entry.lift}</td>
+      <td style={{ textAlign: 'right' }}>{entry.weight} {entry.unit}</td>
+      <td style={{ textAlign: 'center' }}>
+        <span title={entry.source === 'test' ? 'Test week' : 'Program cycle'}>
+          {entry.source === 'test' ? 'Test' : 'Program'}
+        </span>
+      </td>
+      <td style={{ textAlign: 'center' }}>
+        <button
+          disabled={busy}
+          onClick={() => onTogglePR(entry)}
+          aria-label={`${entry.isPR ? 'Remove PR flag from' : 'Mark as PR for'} ${entry.lift} on ${entry.date}`}
+          title={entry.isPR ? 'Remove PR flag' : 'Mark as PR'}
+        >
+          {entry.isPR ? '🏆 PR' : '—'}
+        </button>
+      </td>
+      <td style={{ textAlign: 'center' }}>
+        <button
+          disabled={busy}
+          onClick={() => onToggleGoalMet(entry)}
+          aria-label={`${entry.goalMet ? 'Unmark goal met for' : 'Mark goal met for'} ${entry.lift} on ${entry.date}`}
+          title={entry.goalMet ? 'Unmark goal met' : 'Mark goal met'}
+        >
+          {entry.goalMet ? '✓ Goal' : '—'}
+        </button>
+      </td>
+    </tr>
+  );
+}

--- a/apps/web/app/settings/training-maxes/actions.ts
+++ b/apps/web/app/settings/training-maxes/actions.ts
@@ -1,11 +1,31 @@
 'use server';
 
-import { updateTrainingMaxes } from '@/lib/api';
-import type { TrainingMaxResponse, UpdateTrainingMaxesRequest } from '@lifting-logbook/types';
+import { updateTrainingMaxes, updateTrainingMaxHistoryEntry } from '@/lib/api';
+import type {
+  TrainingMaxHistoryEntryResponse,
+  TrainingMaxResponse,
+  UpdateTrainingMaxesRequest,
+} from '@lifting-logbook/types';
 
 export async function saveTrainingMaxes(
   program: string,
   body: UpdateTrainingMaxesRequest,
 ): Promise<TrainingMaxResponse[]> {
   return updateTrainingMaxes(program, body);
+}
+
+export async function toggleHistoryPR(
+  program: string,
+  id: string,
+  isPR: boolean,
+): Promise<TrainingMaxHistoryEntryResponse> {
+  return updateTrainingMaxHistoryEntry(program, id, { isPR });
+}
+
+export async function toggleHistoryGoalMet(
+  program: string,
+  id: string,
+  goalMet: boolean,
+): Promise<TrainingMaxHistoryEntryResponse> {
+  return updateTrainingMaxHistoryEntry(program, id, { goalMet });
 }

--- a/apps/web/app/settings/training-maxes/page.tsx
+++ b/apps/web/app/settings/training-maxes/page.tsx
@@ -1,10 +1,19 @@
-import { fetchTrainingMaxes } from '@/lib/api';
+import { fetchTrainingMaxes, fetchTrainingMaxHistory } from '@/lib/api';
 import TrainingMaxesForm from './TrainingMaxesForm';
+import MaxHistory from './MaxHistory';
 
 export default async function TrainingMaxesPage() {
   const program = process.env.NEXT_PUBLIC_DEFAULT_PROGRAM ?? '5-3-1';
-  const maxes = await fetchTrainingMaxes(program);
+  const [maxes, history] = await Promise.all([
+    fetchTrainingMaxes(program),
+    fetchTrainingMaxHistory(program),
+  ]);
   const lifts = maxes.map((m) => m.lift);
 
-  return <TrainingMaxesForm program={program} lifts={lifts} maxes={maxes} />;
+  return (
+    <>
+      <TrainingMaxesForm program={program} lifts={lifts} maxes={maxes} />
+      <MaxHistory initialEntries={history.entries} program={program} />
+    </>
+  );
 }

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -8,6 +8,7 @@ import type {
   LiftingProgramSpecResponse,
   LiftRecordResponse,
   RecordBodyWeightRequest,
+  TrainingMaxHistoryResponse,
   TrainingMaxResponse,
   UpdateLiftRecordRequest,
   UpdateTrainingMaxesRequest,
@@ -66,6 +67,31 @@ export function fetchTrainingMaxes(
   return apiFetch(
     `/programs/${encodeURIComponent(program)}/training-maxes`,
     { cache: 'no-store' },
+  );
+}
+
+export function fetchTrainingMaxHistory(
+  program: string,
+): Promise<TrainingMaxHistoryResponse> {
+  return apiFetch(
+    `/programs/${encodeURIComponent(program)}/training-maxes/history`,
+    { cache: 'no-store' },
+  );
+}
+
+export function updateTrainingMaxHistoryEntry(
+  program: string,
+  id: string,
+  body: { isPR?: boolean; goalMet?: boolean },
+): Promise<TrainingMaxHistoryResponse['entries'][number]> {
+  return apiFetch(
+    `/programs/${encodeURIComponent(program)}/training-maxes/history/${encodeURIComponent(id)}`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      cache: 'no-store',
+    },
   );
 }
 

--- a/docs/adr-references.md
+++ b/docs/adr-references.md
@@ -183,6 +183,15 @@ References from [`docs/security-review-checklist.md`](security-review-checklist.
 
 ---
 
+## Data Design
+
+| Source | Cited In | Relevance |
+|---|---|---|
+| [Prisma — `createMany`](https://www.prisma.io/docs/orm/reference/prisma-client-reference#createmany) | [ADR-017](adr/ADR-017-training-max-history-table.md) | Batch insert API used by `PrismaTrainingMaxHistoryRepository.appendHistoryEntries`. |
+| [Martin Fowler — Event Sourcing](https://martinfowler.com/eaaDev/EventSourcing.html) | [ADR-017](adr/ADR-017-training-max-history-table.md) | Background pattern: storing state changes as a sequence of events rather than deriving history post-hoc from current state. The `training_max_history` table is a lightweight application of this principle. |
+
+---
+
 ## Case Studies
 
 Empirical evidence from practitioners. Full case studies are in [`docs/case-studies.md`](case-studies.md).

--- a/docs/adr/ADR-017-training-max-history-table.md
+++ b/docs/adr/ADR-017-training-max-history-table.md
@@ -1,0 +1,98 @@
+# ADR-017: Training Max History — Dedicated Table vs. Derived from lift_record
+
+**Status:** Accepted
+**Date:** 2026-05-05
+**Closes:** [#174](https://github.com/brownm09/lifting-logbook/issues/174)
+
+---
+
+## Context
+
+The `/settings/training-maxes` page mockup (see `docs/mockups/user-journeys.html`, Cycle Dashboard journey → Training Maxes view) shows a history timeline with:
+
+- PR flags per entry (user-toggleable)
+- Source labels: "Test Week" vs. "Program Cycle"
+- "Goal Met" markers (user-toggleable)
+
+The existing `training_max` table holds only the latest max per `(userId, program, lift)`. There is no record of prior values, when they changed, or why.
+
+Two approaches were considered:
+
+1. **Derive from `lift_record`**: Reconstruct history by scanning lift records, inferring max updates heuristically (e.g., best set per session, highest ever logged weight).
+2. **New `training_max_history` table**: Append a row each time a max changes (cycle advance, recalculate, manual edit).
+
+---
+
+## Decision
+
+Use a dedicated **`training_max_history` table** populated on every max-changing write.
+
+---
+
+## Rationale
+
+### Why the derivation approach fails
+
+`lift_record` contains logged set data but lacks the two annotations the mockup requires:
+
+- **Source** (`test` vs. `program`): Heuristically distinguishing a test-week max update from a normal cycle advance is fragile. The `weekType` field lives on `CycleDashboard` at the time of the write, not on the records themselves. Post-hoc inference would require joining cycle metadata that may have changed.
+- **PR / goalMet flags**: These are user judgements, not computable from performance data. A PR flag captures "this was a personal record at the time", which cannot be reliably reconstructed later (the user may have since exceeded it).
+
+A heuristic derivation might cover the 80% case today, but every future schema change or edge case at test-week/deload boundaries would silently corrupt the derived view.
+
+### Why a new table is correct
+
+- **Explicit write path**: `CycleGenerationService` already knows which maxes changed (it diffs `prevMaxes` vs. `newMaxes`). Appending a history row is a one-liner at the call site with zero inference needed.
+- **Source is known at write time**: `dashboard.currentWeekType` is available before the write; storing it then is reliable. Reconstructing it later is not.
+- **User overrides are first-class**: `isPR` and `goalMet` are mutable boolean columns. They cannot live on a derived view.
+- **Query simplicity**: Filtering history by lift, source, or isPR is a straightforward indexed query. A derived approach would require multi-table aggregation on every page load.
+- **Append-only semantics**: History rows are never updated on max changes — each change is a new row. Only `isPR` and `goalMet` are mutable (user corrections). This makes the table easy to reason about and audit.
+
+### Trade-offs accepted
+
+- History rows accumulate over time (one per changed lift per cycle). At typical usage rates (1–2 cycles/month, 4 lifts) this is ~100 rows/year/user — negligible at any scale this application will encounter.
+- Manual `PATCH /training-maxes` calls (direct user edits on the settings page) do **not** currently write a history row. This is intentional: the settings form is a correction tool, not a progression tool. Adding history rows for manual edits is deferred to a future issue if it becomes needed.
+
+---
+
+## Implementation
+
+**Schema** (`apps/api/prisma/schema.prisma`):
+```prisma
+model TrainingMaxHistory {
+  id        String   @id @default(cuid())
+  userId    String
+  program   String
+  lift      String
+  weight    Float
+  reps      Int      @default(1)
+  date      DateTime
+  isPR      Boolean  @default(false)
+  source    String   // "test" | "program"
+  goalMet   Boolean  @default(false)
+  createdAt DateTime @default(now())
+
+  @@index([userId, program])
+  @@index([userId, program, lift])
+  @@map("training_max_history")
+}
+```
+
+**Write path**: `CycleGenerationService.startNewCycle` and `recalculateMaxes` diff old vs. new maxes and call `ITrainingMaxHistoryRepository.appendHistoryEntries` for changed lifts. Source is `'test'` when `dashboard.currentWeekType === 'test'`, otherwise `'program'`.
+
+**Read path**: `GET /programs/:program/training-maxes/history` with optional `?lift=`, `?source=`, `?isPR=` query params.
+
+**Mutation path**: `PATCH /programs/:program/training-maxes/history/:id` accepts `{ isPR?, goalMet? }`.
+
+All three paths are implemented behind `ITrainingMaxHistoryRepository` with a Prisma adapter and an in-memory adapter, following the existing hexagonal adapter pattern ([ADR-002](ADR-002-ports-and-adapters.md), [ADR-004](ADR-004-multi-data-store-adapters.md)).
+
+---
+
+## References
+
+| Source | Relevance |
+|---|---|
+| [Prisma — `createMany`](https://www.prisma.io/docs/orm/reference/prisma-client-reference#createmany) | Batch insert API used by `PrismaTrainingMaxHistoryRepository.appendHistoryEntries`. |
+| [Martin Fowler — Event Sourcing](https://martinfowler.com/eaaDev/EventSourcing.html) | Background pattern: storing state changes as a sequence of events rather than deriving history post-hoc from current state. The `training_max_history` table is a lightweight application of this principle. |
+| [ADR-002 — Ports and Adapters](ADR-002-ports-and-adapters.md) | `ITrainingMaxHistoryRepository` follows the same port/adapter boundary pattern established in ADR-002. |
+| [ADR-013 — Testing Strategy](ADR-013-testing-strategy.md) | History repository has both in-memory and Prisma adapters to satisfy the dual-adapter testing requirement. |

--- a/packages/core/src/models/TrainingMaxHistoryEntry.ts
+++ b/packages/core/src/models/TrainingMaxHistoryEntry.ts
@@ -1,0 +1,10 @@
+export interface TrainingMaxHistoryEntry {
+  id: string;
+  lift: string;
+  weight: number;
+  reps: number;
+  date: Date;
+  isPR: boolean;
+  source: 'test' | 'program';
+  goalMet: boolean;
+}

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -3,4 +3,5 @@ export * from "./LiftingProgramSpec";
 export * from "./LiftRecord";
 export * from "./SpreadsheetCell";
 export * from "./TrainingMax";
+export * from "./TrainingMaxHistoryEntry";
 export * from "./UpdateCycleOverrides";

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -36,6 +36,35 @@ export interface UpdateTrainingMaxesRequest {
 }
 
 // ---------------------------------------------------------------------------
+// Training Max History
+// ---------------------------------------------------------------------------
+
+export type TrainingMaxHistorySource = 'test' | 'program';
+
+/** A single entry in the training max history timeline. */
+export interface TrainingMaxHistoryEntryResponse {
+  id: string;
+  lift: LiftName;
+  weight: number;
+  unit: WeightUnit;
+  date: string; // ISO 8601 date string
+  isPR: boolean;
+  source: TrainingMaxHistorySource;
+  goalMet: boolean;
+}
+
+/** Response from GET /training-maxes/history. */
+export interface TrainingMaxHistoryResponse {
+  entries: TrainingMaxHistoryEntryResponse[];
+}
+
+/** Request body for PATCH /training-maxes/history/:id. */
+export interface UpdateTrainingMaxHistoryRequest {
+  isPR?: boolean;
+  goalMet?: boolean;
+}
+
+// ---------------------------------------------------------------------------
 // Workouts
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds a `training_max_history` table that records a row each time a training max changes (cycle advance or recalculate), capturing the weight, source (`test` | `program`), and user-toggleable `isPR` / `goalMet` flags
- Implements `ITrainingMaxHistoryRepository` port with Prisma and in-memory adapters following the existing hexagonal adapter pattern (ADR-002, ADR-004)
- `CycleGenerationService.startNewCycle` and `recalculateMaxes` diff prev vs. new maxes and append history entries; source is `'test'` when `currentWeekType === 'test'`
- New endpoints: `GET /programs/:program/training-maxes/history` (with `?lift`, `?source`, `?isPR` filters) and `PATCH /programs/:program/training-maxes/history/:id` for toggling flags
- `MaxHistory` client component added to the settings/training-maxes page with timeline/list toggle and filter pills (All / PRs / Test Week / Goal Met)
- ADR-017 documents the new-table-vs-derive decision

## Acceptance Criteria

- [x] History row written on every cycle advance (source = test or program based on weekType)
- [x] History row written on every recalculate (source = program)
- [x] `GET /programs/:program/training-maxes/history` returns entries with lift, weight, unit, date, isPR, source, goalMet
- [x] `?lift=`, `?source=`, `?isPR=` query filters work
- [x] `PATCH /programs/:program/training-maxes/history/:id` toggles isPR / goalMet; returns 404 for unknown id
- [x] MaxHistory component renders below TrainingMaxesForm on the settings page
- [x] Unit tests, in-memory e2e, and DB e2e tests added
- [x] ADR-017 written with References section

## Test Results

`npm test` — 14 suites passed, 1 skipped (DB e2e; requires DATABASE_URL), 102 tests passed, 20 skipped.

Closes #174