### PR TITLE
[feat] Strength goals — per-lift targets with progress tracking

### DIFF
--- a/apps/api/prisma/migrations/20260505000002_add_strength_goals/migration.sql
+++ b/apps/api/prisma/migrations/20260505000002_add_strength_goals/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "strength_goal" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "program" TEXT NOT NULL,
+    "lift" TEXT NOT NULL,
+    "target" DOUBLE PRECISION NOT NULL,
+    "unit" TEXT NOT NULL,
+    "ratio" DOUBLE PRECISION,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "strength_goal_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "strength_goal_userId_program_idx" ON "strength_goal"("userId", "program");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "strength_goal_userId_program_lift_key" ON "strength_goal"("userId", "program", "lift");

--- a/apps/api/prisma/migrations/20260505000003_strength_goal_type/migration.sql
+++ b/apps/api/prisma/migrations/20260505000003_strength_goal_type/migration.sql
@@ -1,3 +1,3 @@
--- AlterTable: add goalType column with default "absolute", make target nullable
+-- AlterTable: add goalType column with default "relative", make target nullable
 ALTER TABLE "strength_goal" ADD COLUMN "goalType" TEXT NOT NULL DEFAULT 'relative';
 ALTER TABLE "strength_goal" ALTER COLUMN "target" DROP NOT NULL;

--- a/apps/api/prisma/migrations/20260505000003_strength_goal_type/migration.sql
+++ b/apps/api/prisma/migrations/20260505000003_strength_goal_type/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable: add goalType column with default "absolute", make target nullable
+ALTER TABLE "strength_goal" ADD COLUMN "goalType" TEXT NOT NULL DEFAULT 'relative';
+ALTER TABLE "strength_goal" ALTER COLUMN "target" DROP NOT NULL;

--- a/apps/api/prisma/migrations/20260505000004_strength_goal_unit_check/migration.sql
+++ b/apps/api/prisma/migrations/20260505000004_strength_goal_unit_check/migration.sql
@@ -1,0 +1,3 @@
+-- AddConstraint: enforce valid unit values at the DB layer
+ALTER TABLE "strength_goal"
+  ADD CONSTRAINT "strength_goal_unit_check" CHECK ("unit" IN ('lbs', 'kg'));

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -73,3 +73,18 @@ model TrainingMaxHistory {
   @@index([userId, program, lift])
   @@map("training_max_history")
 }
+
+model StrengthGoal {
+  id        String   @id @default(cuid())
+  userId    String
+  program   String
+  lift      String
+  target    Float
+  unit      String
+  ratio     Float?
+  updatedAt DateTime @updatedAt
+
+  @@unique([userId, program, lift])
+  @@index([userId, program])
+  @@map("strength_goal")
+}

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -79,7 +79,8 @@ model StrengthGoal {
   userId    String
   program   String
   lift      String
-  target    Float
+  goalType  String   @default("relative")
+  target    Float?
   unit      String
   ratio     Float?
   updatedAt DateTime @updatedAt

--- a/apps/api/src/adapters/factory/in-memory-repository-factory.ts
+++ b/apps/api/src/adapters/factory/in-memory-repository-factory.ts
@@ -6,6 +6,7 @@ import { InMemoryCycleDashboardRepository } from '../in-memory/cycle-dashboard.a
 import { InMemoryLiftingProgramSpecRepository } from '../in-memory/lifting-program-spec.adapter';
 import { InMemoryLiftRecordRepository } from '../in-memory/lift-record.adapter';
 import { InMemoryProgramPhilosophyRepository } from '../in-memory/program-philosophy.adapter';
+import { InMemoryStrengthGoalRepository } from '../in-memory/strength-goal.adapter';
 import { InMemoryTrainingMaxRepository } from '../in-memory/training-max.adapter';
 import { InMemoryTrainingMaxHistoryRepository } from '../in-memory/training-max-history.adapter';
 import { InMemoryWorkoutRepository } from '../in-memory/workout.adapter';
@@ -32,6 +33,7 @@ export class InMemoryRepositoryFactory implements IRepositoryFactory {
         liftingProgramSpec: new InMemoryLiftingProgramSpecRepository(preSeed),
         liftRecord: new InMemoryLiftRecordRepository(sharedRecords),
         programPhilosophy: new InMemoryProgramPhilosophyRepository(),
+        strengthGoal: new InMemoryStrengthGoalRepository(),
         trainingMax: new InMemoryTrainingMaxRepository(preSeed),
         trainingMaxHistory: new InMemoryTrainingMaxHistoryRepository(),
         workout: new InMemoryWorkoutRepository(sharedRecords),

--- a/apps/api/src/adapters/factory/system-db-repository-factory.ts
+++ b/apps/api/src/adapters/factory/system-db-repository-factory.ts
@@ -5,6 +5,7 @@ import { LiftRecord } from '@lifting-logbook/core';
 import { AuthUser } from '../../ports/auth';
 import { IRepositoryFactory, RepositoryBundle } from '../../ports/factory';
 import { PrismaLiftRecordRepository } from '../prisma/lift-record.repository';
+import { PrismaStrengthGoalRepository } from '../prisma/strength-goal.repository';
 import { PrismaTrainingMaxRepository } from '../prisma/training-max.repository';
 import { PrismaTrainingMaxHistoryRepository } from '../prisma/training-max-history.repository';
 import { PrismaCycleDashboardRepository } from '../prisma/cycle-dashboard.repository';
@@ -13,6 +14,7 @@ import { InMemoryCycleDashboardRepository } from '../in-memory/cycle-dashboard.a
 import { InMemoryLiftingProgramSpecRepository } from '../in-memory/lifting-program-spec.adapter';
 import { InMemoryLiftRecordRepository } from '../in-memory/lift-record.adapter';
 import { InMemoryProgramPhilosophyRepository } from '../in-memory/program-philosophy.adapter';
+import { InMemoryStrengthGoalRepository } from '../in-memory/strength-goal.adapter';
 import { InMemoryTrainingMaxRepository } from '../in-memory/training-max.adapter';
 import { InMemoryTrainingMaxHistoryRepository } from '../in-memory/training-max-history.adapter';
 import { InMemoryWorkoutRepository } from '../in-memory/workout.adapter';
@@ -72,6 +74,7 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
       const prisma = this.getOrCreatePrisma();
       return {
         liftRecord: new PrismaLiftRecordRepository(prisma, userId),
+        strengthGoal: new PrismaStrengthGoalRepository(prisma, userId),
         trainingMax: new PrismaTrainingMaxRepository(prisma, userId),
         trainingMaxHistory: new PrismaTrainingMaxHistoryRepository(prisma, userId),
         cycleDashboard: new PrismaCycleDashboardRepository(prisma, userId),
@@ -90,6 +93,7 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
       liftingProgramSpec: this.programSpecRepo,
       liftRecord: new InMemoryLiftRecordRepository(sharedRecords),
       programPhilosophy: this.philosophyRepo,
+      strengthGoal: new InMemoryStrengthGoalRepository(),
       trainingMax: new InMemoryTrainingMaxRepository(),
       trainingMaxHistory: new InMemoryTrainingMaxHistoryRepository(),
       workout: new InMemoryWorkoutRepository(sharedRecords),

--- a/apps/api/src/adapters/in-memory/strength-goal.adapter.ts
+++ b/apps/api/src/adapters/in-memory/strength-goal.adapter.ts
@@ -1,0 +1,31 @@
+import { StrengthGoalEntry } from '@lifting-logbook/core';
+import { IStrengthGoalRepository } from '../../ports/IStrengthGoalRepository';
+import { StrengthGoalNotFoundError } from '../../ports/errors';
+
+export class InMemoryStrengthGoalRepository implements IStrengthGoalRepository {
+  private readonly store = new Map<string, Map<string, StrengthGoalEntry>>();
+
+  private programMap(program: string): Map<string, StrengthGoalEntry> {
+    let m = this.store.get(program);
+    if (!m) {
+      m = new Map();
+      this.store.set(program, m);
+    }
+    return m;
+  }
+
+  async getGoals(program: string): Promise<StrengthGoalEntry[]> {
+    return Array.from(this.programMap(program).values());
+  }
+
+  async upsertGoal(program: string, goal: StrengthGoalEntry): Promise<StrengthGoalEntry> {
+    this.programMap(program).set(goal.lift, goal);
+    return goal;
+  }
+
+  async deleteGoal(program: string, lift: string): Promise<void> {
+    const m = this.programMap(program);
+    if (!m.has(lift)) throw new StrengthGoalNotFoundError(lift);
+    m.delete(lift);
+  }
+}

--- a/apps/api/src/adapters/prisma/prisma-repository-factory.ts
+++ b/apps/api/src/adapters/prisma/prisma-repository-factory.ts
@@ -3,6 +3,7 @@ import { AuthUser } from '../../ports/auth';
 import { IRepositoryFactory, RepositoryBundle } from '../../ports/factory';
 import { PrismaService } from './prisma.service';
 import { PrismaLiftRecordRepository } from './lift-record.repository';
+import { PrismaStrengthGoalRepository } from './strength-goal.repository';
 import { PrismaTrainingMaxRepository } from './training-max.repository';
 import { PrismaTrainingMaxHistoryRepository } from './training-max-history.repository';
 import { PrismaCycleDashboardRepository } from './cycle-dashboard.repository';
@@ -21,6 +22,7 @@ export class PrismaRepositoryFactory implements IRepositoryFactory {
   async forUser(user: AuthUser): Promise<RepositoryBundle> {
     return {
       liftRecord: new PrismaLiftRecordRepository(this.prisma, user.id),
+      strengthGoal: new PrismaStrengthGoalRepository(this.prisma, user.id),
       trainingMax: new PrismaTrainingMaxRepository(this.prisma, user.id),
       trainingMaxHistory: new PrismaTrainingMaxHistoryRepository(this.prisma, user.id),
       cycleDashboard: new PrismaCycleDashboardRepository(this.prisma, user.id),

--- a/apps/api/src/adapters/prisma/strength-goal.repository.ts
+++ b/apps/api/src/adapters/prisma/strength-goal.repository.ts
@@ -17,7 +17,8 @@ export class PrismaStrengthGoalRepository implements IStrengthGoalRepository {
     });
     return rows.map((r) => ({
       lift: r.lift,
-      target: r.target,
+      goalType: r.goalType as 'absolute' | 'relative',
+      target: r.target ?? undefined,
       unit: r.unit as 'lbs' | 'kg',
       ratio: r.ratio ?? undefined,
       updatedAt: r.updatedAt,
@@ -27,19 +28,21 @@ export class PrismaStrengthGoalRepository implements IStrengthGoalRepository {
   async upsertGoal(program: string, goal: StrengthGoalEntry): Promise<StrengthGoalEntry> {
     const row = await this.prisma.strengthGoal.upsert({
       where: { userId_program_lift: { userId: this.userId, program, lift: goal.lift } },
-      update: { target: goal.target, unit: goal.unit, ratio: goal.ratio ?? null },
+      update: { goalType: goal.goalType, target: goal.target ?? null, unit: goal.unit, ratio: goal.ratio ?? null },
       create: {
         userId: this.userId,
         program,
         lift: goal.lift,
-        target: goal.target,
+        goalType: goal.goalType,
+        target: goal.target ?? null,
         unit: goal.unit,
         ratio: goal.ratio ?? null,
       },
     });
     return {
       lift: row.lift,
-      target: row.target,
+      goalType: row.goalType as 'absolute' | 'relative',
+      target: row.target ?? undefined,
       unit: row.unit as 'lbs' | 'kg',
       ratio: row.ratio ?? undefined,
       updatedAt: row.updatedAt,

--- a/apps/api/src/adapters/prisma/strength-goal.repository.ts
+++ b/apps/api/src/adapters/prisma/strength-goal.repository.ts
@@ -1,0 +1,61 @@
+import { PrismaClient } from '@prisma/client';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
+import { StrengthGoalEntry } from '@lifting-logbook/core';
+import { IStrengthGoalRepository } from '../../ports/IStrengthGoalRepository';
+import { StrengthGoalNotFoundError } from '../../ports/errors';
+
+export class PrismaStrengthGoalRepository implements IStrengthGoalRepository {
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly userId: string,
+  ) {}
+
+  async getGoals(program: string): Promise<StrengthGoalEntry[]> {
+    const rows = await this.prisma.strengthGoal.findMany({
+      where: { userId: this.userId, program },
+      orderBy: { lift: 'asc' },
+    });
+    return rows.map((r) => ({
+      lift: r.lift,
+      target: r.target,
+      unit: r.unit as 'lbs' | 'kg',
+      ratio: r.ratio ?? undefined,
+      updatedAt: r.updatedAt,
+    }));
+  }
+
+  async upsertGoal(program: string, goal: StrengthGoalEntry): Promise<StrengthGoalEntry> {
+    const row = await this.prisma.strengthGoal.upsert({
+      where: { userId_program_lift: { userId: this.userId, program, lift: goal.lift } },
+      update: { target: goal.target, unit: goal.unit, ratio: goal.ratio ?? null },
+      create: {
+        userId: this.userId,
+        program,
+        lift: goal.lift,
+        target: goal.target,
+        unit: goal.unit,
+        ratio: goal.ratio ?? null,
+      },
+    });
+    return {
+      lift: row.lift,
+      target: row.target,
+      unit: row.unit as 'lbs' | 'kg',
+      ratio: row.ratio ?? undefined,
+      updatedAt: row.updatedAt,
+    };
+  }
+
+  async deleteGoal(program: string, lift: string): Promise<void> {
+    try {
+      await this.prisma.strengthGoal.delete({
+        where: { userId_program_lift: { userId: this.userId, program, lift } },
+      });
+    } catch (e) {
+      if (e instanceof PrismaClientKnownRequestError && e.code === 'P2025') {
+        throw new StrengthGoalNotFoundError(lift);
+      }
+      throw e;
+    }
+  }
+}

--- a/apps/api/src/ports/IStrengthGoalRepository.ts
+++ b/apps/api/src/ports/IStrengthGoalRepository.ts
@@ -1,0 +1,7 @@
+import { StrengthGoalEntry } from '@lifting-logbook/core';
+
+export interface IStrengthGoalRepository {
+  getGoals(program: string): Promise<StrengthGoalEntry[]>;
+  upsertGoal(program: string, goal: StrengthGoalEntry): Promise<StrengthGoalEntry>;
+  deleteGoal(program: string, lift: string): Promise<void>;
+}

--- a/apps/api/src/ports/errors.ts
+++ b/apps/api/src/ports/errors.ts
@@ -31,3 +31,10 @@ export class HistoryEntryNotFoundError extends Error {
     this.name = 'HistoryEntryNotFoundError';
   }
 }
+
+export class StrengthGoalNotFoundError extends Error {
+  constructor(public readonly lift: string) {
+    super(`Strength goal for lift '${lift}' not found`);
+    this.name = 'StrengthGoalNotFoundError';
+  }
+}

--- a/apps/api/src/ports/factory.ts
+++ b/apps/api/src/ports/factory.ts
@@ -3,6 +3,7 @@ import { ICycleDashboardRepository } from './ICycleDashboardRepository';
 import { ILiftingProgramSpecRepository } from './ILiftingProgramSpecRepository';
 import { ILiftRecordRepository } from './ILiftRecordRepository';
 import { IProgramPhilosophyRepository } from './IProgramPhilosophyRepository';
+import { IStrengthGoalRepository } from './IStrengthGoalRepository';
 import { ITrainingMaxHistoryRepository } from './ITrainingMaxHistoryRepository';
 import { ITrainingMaxRepository } from './ITrainingMaxRepository';
 import { IWorkoutRepository } from './IWorkoutRepository';
@@ -12,6 +13,7 @@ export interface RepositoryBundle {
   liftingProgramSpec: ILiftingProgramSpecRepository;
   liftRecord: ILiftRecordRepository;
   programPhilosophy: IProgramPhilosophyRepository;
+  strengthGoal: IStrengthGoalRepository;
   trainingMax: ITrainingMaxRepository;
   trainingMaxHistory: ITrainingMaxHistoryRepository;
   workout: IWorkoutRepository;

--- a/apps/api/src/ports/index.ts
+++ b/apps/api/src/ports/index.ts
@@ -9,5 +9,6 @@ export * from './ILiftingProgramSpecRepository';
 export * from './ILiftRecordRepository';
 export * from './IProgramPhilosophyRepository';
 export * from './ITrainingMaxHistoryRepository';
+export * from './IStrengthGoalRepository';
 export * from './ITrainingMaxRepository';
 export * from './IWorkoutRepository';

--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -2,6 +2,7 @@ import {
   CycleDashboard,
   LiftRecord,
   LiftingProgramSpec,
+  StrengthGoalEntry,
   TrainingMax,
   TrainingMaxHistoryEntry,
 } from '@lifting-logbook/core';
@@ -11,6 +12,7 @@ import {
   LiftRecordResponse,
   LiftingProgramSpecResponse,
   SetResponse,
+  StrengthGoalResponse,
   TrainingMaxHistoryEntryResponse,
   TrainingMaxResponse,
   WeekNumber,
@@ -23,6 +25,14 @@ import { CyclePlanResult } from '../ports/ICyclePlanningAgent';
 // values must be stored as UTC midnight; adapters parsing external sources
 // (e.g. Sheets) are responsible for normalizing before the mapper runs.
 const isoDate = (d: Date): string => d.toISOString().slice(0, 10);
+
+export const toStrengthGoalResponse = (g: StrengthGoalEntry): StrengthGoalResponse => ({
+  lift: g.lift,
+  target: g.target,
+  unit: g.unit,
+  ...(g.ratio !== undefined && { ratio: g.ratio }),
+  updatedAt: isoDate(g.updatedAt),
+});
 
 export const toTrainingMaxResponse = (m: TrainingMax): TrainingMaxResponse => ({
   lift: m.lift,

--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -28,7 +28,8 @@ const isoDate = (d: Date): string => d.toISOString().slice(0, 10);
 
 export const toStrengthGoalResponse = (g: StrengthGoalEntry): StrengthGoalResponse => ({
   lift: g.lift,
-  target: g.target,
+  goalType: g.goalType,
+  ...(g.target !== undefined && { target: g.target }),
   unit: g.unit,
   ...(g.ratio !== undefined && { ratio: g.ratio }),
   updatedAt: isoDate(g.updatedAt),

--- a/apps/api/src/programs/not-found.filter.ts
+++ b/apps/api/src/programs/not-found.filter.ts
@@ -8,17 +8,22 @@ import { FastifyReply } from 'fastify';
 import {
   HistoryEntryNotFoundError,
   ProgramNotFoundError,
+  StrengthGoalNotFoundError,
   WorkoutNotFoundError,
 } from '../ports/errors';
 
-type DomainNotFound = ProgramNotFoundError | WorkoutNotFoundError | HistoryEntryNotFoundError;
+type DomainNotFound =
+  | ProgramNotFoundError
+  | WorkoutNotFoundError
+  | HistoryEntryNotFoundError
+  | StrengthGoalNotFoundError;
 
 /**
  * Translates framework-agnostic domain "not found" errors raised by port
  * adapters into HTTP 404 responses. Keeps adapters free of `@nestjs/common`
  * HTTP dependencies so they can be reused by non-HTTP callers.
  */
-@Catch(ProgramNotFoundError, WorkoutNotFoundError, HistoryEntryNotFoundError)
+@Catch(ProgramNotFoundError, WorkoutNotFoundError, HistoryEntryNotFoundError, StrengthGoalNotFoundError)
 export class DomainNotFoundFilter implements ExceptionFilter {
   catch(err: DomainNotFound, host: ArgumentsHost): void {
     const res = host.switchToHttp().getResponse<FastifyReply>();

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -620,21 +620,21 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
   describe('strength-goals write operations', () => {
     const GOAL_URL = `/programs/${SEED_PROGRAM}/strength-goals`;
 
-    it('PUT → GET → DELETE lifecycle', async () => {
-      // PUT creates the goal
-      const putRes = await putJson(`${GOAL_URL}/Squat`, { target: 315, unit: 'lbs', ratio: 1.75 });
+    it('PUT → GET → DELETE lifecycle (relative goal)', async () => {
+      // PUT creates a relative goal
+      const putRes = await putJson(`${GOAL_URL}/Squat`, { goalType: 'relative', ratio: 1.75, unit: 'lbs' });
       expect(putRes.statusCode).toBe(200);
       const created = putRes.json();
       expect(created.lift).toBe('Squat');
-      expect(created.target).toBe(315);
-      expect(created.unit).toBe('lbs');
+      expect(created.goalType).toBe('relative');
       expect(created.ratio).toBe(1.75);
+      expect(created.unit).toBe('lbs');
 
       // GET returns the goal
       const getRes = await get(GOAL_URL);
       expect(getRes.statusCode).toBe(200);
       expect(getRes.json()).toEqual(expect.arrayContaining([
-        expect.objectContaining({ lift: 'Squat', target: 315 }),
+        expect.objectContaining({ lift: 'Squat', goalType: 'relative', ratio: 1.75 }),
       ]));
 
       // DELETE removes the goal
@@ -647,9 +647,17 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
       expect(remaining.find((g) => g.lift === 'Squat')).toBeUndefined();
     });
 
+    it('PUT absolute goal stores target', async () => {
+      const putRes = await putJson(`${GOAL_URL}/Bench Press`, { goalType: 'absolute', target: 225, unit: 'lbs' });
+      expect(putRes.statusCode).toBe(200);
+      const created = putRes.json();
+      expect(created.goalType).toBe('absolute');
+      expect(created.target).toBe(225);
+    });
+
     it('PUT same lift twice — only latest persists (idempotency)', async () => {
-      await putJson(`${GOAL_URL}/Deadlift`, { target: 400, unit: 'lbs' });
-      const secondPut = await putJson(`${GOAL_URL}/Deadlift`, { target: 450, unit: 'lbs' });
+      await putJson(`${GOAL_URL}/Deadlift`, { goalType: 'absolute', target: 400, unit: 'lbs' });
+      const secondPut = await putJson(`${GOAL_URL}/Deadlift`, { goalType: 'absolute', target: 450, unit: 'lbs' });
       expect(secondPut.statusCode).toBe(200);
       expect(secondPut.json().target).toBe(450);
 
@@ -678,7 +686,7 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
         method: 'PUT',
         url: `${GOAL_URL}/Bench Press`,
         headers: { 'content-type': 'application/json', ...AS_ALICE },
-        payload: JSON.stringify({ target: 200, unit: 'lbs' }),
+        payload: JSON.stringify({ goalType: 'absolute', target: 200, unit: 'lbs' }),
       });
       expect(alicePut.statusCode).toBe(200);
 

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -52,6 +52,17 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
       payload: JSON.stringify(body),
     });
 
+  const putJson = (url: string, body: unknown) =>
+    app.getHttpAdapter().getInstance().inject({
+      method: 'PUT',
+      url,
+      headers: { 'content-type': 'application/json', ...AUTH },
+      payload: JSON.stringify(body),
+    });
+
+  const deleteReq = (url: string) =>
+    app.getHttpAdapter().getInstance().inject({ method: 'DELETE', url, headers: AUTH });
+
   it('GET /health returns ok without auth', async () => {
     const res = await app
       .getHttpAdapter()
@@ -604,5 +615,82 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
     expect(bobRes.statusCode).toBe(200);
     const bobSquat = bobRes.json().find((m: { lift: string }) => m.lift === 'Squat');
     expect(bobSquat).toBeUndefined();
+  });
+
+  describe('strength-goals write operations', () => {
+    const GOAL_URL = `/programs/${SEED_PROGRAM}/strength-goals`;
+
+    it('PUT → GET → DELETE lifecycle', async () => {
+      // PUT creates the goal
+      const putRes = await putJson(`${GOAL_URL}/Squat`, { target: 315, unit: 'lbs', ratio: 1.75 });
+      expect(putRes.statusCode).toBe(200);
+      const created = putRes.json();
+      expect(created.lift).toBe('Squat');
+      expect(created.target).toBe(315);
+      expect(created.unit).toBe('lbs');
+      expect(created.ratio).toBe(1.75);
+
+      // GET returns the goal
+      const getRes = await get(GOAL_URL);
+      expect(getRes.statusCode).toBe(200);
+      expect(getRes.json()).toEqual(expect.arrayContaining([
+        expect.objectContaining({ lift: 'Squat', target: 315 }),
+      ]));
+
+      // DELETE removes the goal
+      const delRes = await deleteReq(`${GOAL_URL}/Squat`);
+      expect(delRes.statusCode).toBe(204);
+
+      // GET after DELETE returns empty
+      const getAfterDel = await get(GOAL_URL);
+      const remaining = getAfterDel.json() as { lift: string }[];
+      expect(remaining.find((g) => g.lift === 'Squat')).toBeUndefined();
+    });
+
+    it('PUT same lift twice — only latest persists (idempotency)', async () => {
+      await putJson(`${GOAL_URL}/Deadlift`, { target: 400, unit: 'lbs' });
+      const secondPut = await putJson(`${GOAL_URL}/Deadlift`, { target: 450, unit: 'lbs' });
+      expect(secondPut.statusCode).toBe(200);
+      expect(secondPut.json().target).toBe(450);
+
+      const getRes = await get(GOAL_URL);
+      const goals = getRes.json() as { lift: string; target: number }[];
+      const deadlifts = goals.filter((g) => g.lift === 'Deadlift');
+      expect(deadlifts).toHaveLength(1);
+      expect(deadlifts[0].target).toBe(450);
+    });
+
+    it('DELETE unknown lift returns 404', async () => {
+      const res = await deleteReq(`${GOAL_URL}/UnknownLift`);
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('isolates strength goals between users', async () => {
+      const injectRaw = app.getHttpAdapter().getInstance().inject.bind(
+        app.getHttpAdapter().getInstance(),
+      );
+
+      const AS_ALICE = { authorization: 'Bearer user-alice-goals' };
+      const AS_BOB   = { authorization: 'Bearer user-bob-goals' };
+
+      // Alice writes a strength goal
+      const alicePut = await injectRaw({
+        method: 'PUT',
+        url: `${GOAL_URL}/Bench Press`,
+        headers: { 'content-type': 'application/json', ...AS_ALICE },
+        payload: JSON.stringify({ target: 200, unit: 'lbs' }),
+      });
+      expect(alicePut.statusCode).toBe(200);
+
+      // Bob reads — must not see Alice's goal
+      const bobGet = await injectRaw({
+        method: 'GET',
+        url: GOAL_URL,
+        headers: AS_BOB,
+      });
+      expect(bobGet.statusCode).toBe(200);
+      const bobGoals = bobGet.json() as { lift: string }[];
+      expect(bobGoals.find((g) => g.lift === 'Bench Press')).toBeUndefined();
+    });
   });
 });

--- a/apps/api/src/programs/programs.module.ts
+++ b/apps/api/src/programs/programs.module.ts
@@ -9,6 +9,7 @@ import { CycleGenerationService } from './cycle-generation.service';
 import { CyclePlanController } from './cycle-plan.controller';
 import { LiftRecordsController } from './lift-records.controller';
 import { ProgramSpecController } from './program-spec.controller';
+import { StrengthGoalsController } from './strength-goals.controller';
 import { TrainingMaxesController } from './training-maxes.controller';
 import { TrainingMaxHistoryController } from './training-max-history.controller';
 import { WorkoutsController } from './workouts.controller';
@@ -20,6 +21,7 @@ import { WorkoutsController } from './workouts.controller';
     CycleGenerationController,
     CyclePlanController,
     WorkoutsController,
+    StrengthGoalsController,
     TrainingMaxesController,
     TrainingMaxHistoryController,
     LiftRecordsController,

--- a/apps/api/src/programs/strength-goals.controller.spec.ts
+++ b/apps/api/src/programs/strength-goals.controller.spec.ts
@@ -30,9 +30,9 @@ describe('StrengthGoalsController', () => {
   });
 
   describe('getGoals', () => {
-    it('returns mapped goals', async () => {
+    it('returns mapped relative goal', async () => {
       repo.getGoals.mockResolvedValue([
-        { lift: 'Squat', target: 315, unit: 'lbs', ratio: 1.75, updatedAt: new Date('2026-05-01T00:00:00.000Z') },
+        { lift: 'Squat', goalType: 'relative', ratio: 1.75, unit: 'lbs', updatedAt: new Date('2026-05-01T00:00:00.000Z') },
       ]);
 
       const result = await controller.getGoals(PROGRAM, MOCK_USER);
@@ -40,17 +40,18 @@ describe('StrengthGoalsController', () => {
       expect(factory.forUser).toHaveBeenCalledWith(MOCK_USER);
       expect(repo.getGoals).toHaveBeenCalledWith(PROGRAM);
       expect(result).toEqual([
-        { lift: 'Squat', target: 315, unit: 'lbs', ratio: 1.75, updatedAt: '2026-05-01' },
+        { lift: 'Squat', goalType: 'relative', ratio: 1.75, unit: 'lbs', updatedAt: '2026-05-01' },
       ]);
     });
 
-    it('omits ratio when undefined', async () => {
+    it('returns mapped absolute goal', async () => {
       repo.getGoals.mockResolvedValue([
-        { lift: 'Bench Press', target: 225, unit: 'lbs', updatedAt: new Date('2026-05-01T00:00:00.000Z') },
+        { lift: 'Bench Press', goalType: 'absolute', target: 225, unit: 'lbs', updatedAt: new Date('2026-05-01T00:00:00.000Z') },
       ]);
 
       const result = await controller.getGoals(PROGRAM, MOCK_USER);
 
+      expect(result[0]).toEqual({ lift: 'Bench Press', goalType: 'absolute', target: 225, unit: 'lbs', updatedAt: '2026-05-01' });
       expect(result[0]).not.toHaveProperty('ratio');
     });
 
@@ -62,17 +63,27 @@ describe('StrengthGoalsController', () => {
   });
 
   describe('upsertGoal', () => {
-    it('saves and returns the mapped goal', async () => {
-      const saved = { lift: 'Squat', target: 320, unit: 'lbs' as const, ratio: 1.8, updatedAt: new Date('2026-05-02T00:00:00.000Z') };
+    it('saves and returns a relative goal', async () => {
+      const saved = { lift: 'Squat', goalType: 'relative' as const, ratio: 1.8, unit: 'lbs' as const, updatedAt: new Date('2026-05-02T00:00:00.000Z') };
       repo.upsertGoal.mockResolvedValue(saved);
 
-      const result = await controller.upsertGoal(PROGRAM, 'Squat', { target: 320, unit: 'lbs', ratio: 1.8 }, MOCK_USER);
+      const result = await controller.upsertGoal(PROGRAM, 'Squat', { goalType: 'relative', ratio: 1.8, unit: 'lbs' }, MOCK_USER);
 
       expect(repo.upsertGoal).toHaveBeenCalledWith(
         PROGRAM,
-        expect.objectContaining({ lift: 'Squat', target: 320, unit: 'lbs', ratio: 1.8 }),
+        expect.objectContaining({ lift: 'Squat', goalType: 'relative', ratio: 1.8, unit: 'lbs' }),
       );
-      expect(result).toEqual({ lift: 'Squat', target: 320, unit: 'lbs', ratio: 1.8, updatedAt: '2026-05-02' });
+      expect(result).toEqual({ lift: 'Squat', goalType: 'relative', ratio: 1.8, unit: 'lbs', updatedAt: '2026-05-02' });
+    });
+
+    it('saves and returns an absolute goal', async () => {
+      const saved = { lift: 'Deadlift', goalType: 'absolute' as const, target: 495, unit: 'lbs' as const, updatedAt: new Date('2026-05-02T00:00:00.000Z') };
+      repo.upsertGoal.mockResolvedValue(saved);
+
+      const result = await controller.upsertGoal(PROGRAM, 'Deadlift', { goalType: 'absolute', target: 495, unit: 'lbs' }, MOCK_USER);
+
+      expect(result).toEqual({ lift: 'Deadlift', goalType: 'absolute', target: 495, unit: 'lbs', updatedAt: '2026-05-02' });
+      expect(result).not.toHaveProperty('ratio');
     });
   });
 

--- a/apps/api/src/programs/strength-goals.controller.spec.ts
+++ b/apps/api/src/programs/strength-goals.controller.spec.ts
@@ -1,0 +1,91 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { IStrengthGoalRepository } from '../ports/IStrengthGoalRepository';
+import { IRepositoryFactory } from '../ports/factory';
+import { StrengthGoalNotFoundError } from '../ports/errors';
+import { REPOSITORY_FACTORY } from '../ports/tokens';
+import { StrengthGoalsController } from './strength-goals.controller';
+
+const MOCK_USER = { id: 'test-user', email: 'test@example.com', provider: 'dev' };
+const PROGRAM = '5-3-1';
+
+describe('StrengthGoalsController', () => {
+  let controller: StrengthGoalsController;
+  let repo: jest.Mocked<IStrengthGoalRepository>;
+  let factory: jest.Mocked<IRepositoryFactory>;
+
+  beforeEach(async () => {
+    repo = {
+      getGoals: jest.fn(),
+      upsertGoal: jest.fn(),
+      deleteGoal: jest.fn(),
+    };
+    factory = { forUser: jest.fn().mockResolvedValue({ strengthGoal: repo }) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [StrengthGoalsController],
+      providers: [{ provide: REPOSITORY_FACTORY, useValue: factory }],
+    }).compile();
+
+    controller = module.get(StrengthGoalsController);
+  });
+
+  describe('getGoals', () => {
+    it('returns mapped goals', async () => {
+      repo.getGoals.mockResolvedValue([
+        { lift: 'Squat', target: 315, unit: 'lbs', ratio: 1.75, updatedAt: new Date('2026-05-01T00:00:00.000Z') },
+      ]);
+
+      const result = await controller.getGoals(PROGRAM, MOCK_USER);
+
+      expect(factory.forUser).toHaveBeenCalledWith(MOCK_USER);
+      expect(repo.getGoals).toHaveBeenCalledWith(PROGRAM);
+      expect(result).toEqual([
+        { lift: 'Squat', target: 315, unit: 'lbs', ratio: 1.75, updatedAt: '2026-05-01' },
+      ]);
+    });
+
+    it('omits ratio when undefined', async () => {
+      repo.getGoals.mockResolvedValue([
+        { lift: 'Bench Press', target: 225, unit: 'lbs', updatedAt: new Date('2026-05-01T00:00:00.000Z') },
+      ]);
+
+      const result = await controller.getGoals(PROGRAM, MOCK_USER);
+
+      expect(result[0]).not.toHaveProperty('ratio');
+    });
+
+    it('returns empty array when no goals', async () => {
+      repo.getGoals.mockResolvedValue([]);
+      const result = await controller.getGoals(PROGRAM, MOCK_USER);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('upsertGoal', () => {
+    it('saves and returns the mapped goal', async () => {
+      const saved = { lift: 'Squat', target: 320, unit: 'lbs' as const, ratio: 1.8, updatedAt: new Date('2026-05-02T00:00:00.000Z') };
+      repo.upsertGoal.mockResolvedValue(saved);
+
+      const result = await controller.upsertGoal(PROGRAM, 'Squat', { target: 320, unit: 'lbs', ratio: 1.8 }, MOCK_USER);
+
+      expect(repo.upsertGoal).toHaveBeenCalledWith(
+        PROGRAM,
+        expect.objectContaining({ lift: 'Squat', target: 320, unit: 'lbs', ratio: 1.8 }),
+      );
+      expect(result).toEqual({ lift: 'Squat', target: 320, unit: 'lbs', ratio: 1.8, updatedAt: '2026-05-02' });
+    });
+  });
+
+  describe('deleteGoal', () => {
+    it('resolves without error on success', async () => {
+      repo.deleteGoal.mockResolvedValue(undefined);
+      await expect(controller.deleteGoal(PROGRAM, 'Squat', MOCK_USER)).resolves.toBeUndefined();
+      expect(repo.deleteGoal).toHaveBeenCalledWith(PROGRAM, 'Squat');
+    });
+
+    it('propagates StrengthGoalNotFoundError', async () => {
+      repo.deleteGoal.mockRejectedValue(new StrengthGoalNotFoundError('Squat'));
+      await expect(controller.deleteGoal(PROGRAM, 'Squat', MOCK_USER)).rejects.toBeInstanceOf(StrengthGoalNotFoundError);
+    });
+  });
+});

--- a/apps/api/src/programs/strength-goals.controller.ts
+++ b/apps/api/src/programs/strength-goals.controller.ts
@@ -1,0 +1,64 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  Param,
+  Put,
+} from '@nestjs/common';
+import { StrengthGoalResponse } from '@lifting-logbook/types';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { AuthUser } from '../ports/auth';
+import { IRepositoryFactory } from '../ports/factory';
+import { REPOSITORY_FACTORY } from '../ports/tokens';
+import { toStrengthGoalResponse } from './mappers';
+import { UpsertStrengthGoalDto } from './upsert-strength-goal.dto';
+
+@Controller('programs/:program')
+export class StrengthGoalsController {
+  constructor(
+    @Inject(REPOSITORY_FACTORY) private readonly factory: IRepositoryFactory,
+  ) {}
+
+  @Get('strength-goals')
+  async getGoals(
+    @Param('program') program: string,
+    @CurrentUser() user: AuthUser,
+  ): Promise<StrengthGoalResponse[]> {
+    const { strengthGoal } = await this.factory.forUser(user);
+    const goals = await strengthGoal.getGoals(program);
+    return goals.map(toStrengthGoalResponse);
+  }
+
+  @Put('strength-goals/:lift')
+  async upsertGoal(
+    @Param('program') program: string,
+    @Param('lift') lift: string,
+    @Body() body: UpsertStrengthGoalDto,
+    @CurrentUser() user: AuthUser,
+  ): Promise<StrengthGoalResponse> {
+    const { strengthGoal } = await this.factory.forUser(user);
+    const saved = await strengthGoal.upsertGoal(program, {
+      lift,
+      target: body.target,
+      unit: body.unit,
+      ratio: body.ratio,
+      updatedAt: new Date(),
+    });
+    return toStrengthGoalResponse(saved);
+  }
+
+  @Delete('strength-goals/:lift')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteGoal(
+    @Param('program') program: string,
+    @Param('lift') lift: string,
+    @CurrentUser() user: AuthUser,
+  ): Promise<void> {
+    const { strengthGoal } = await this.factory.forUser(user);
+    await strengthGoal.deleteGoal(program, lift);
+  }
+}

--- a/apps/api/src/programs/strength-goals.controller.ts
+++ b/apps/api/src/programs/strength-goals.controller.ts
@@ -43,6 +43,7 @@ export class StrengthGoalsController {
     const { strengthGoal } = await this.factory.forUser(user);
     const saved = await strengthGoal.upsertGoal(program, {
       lift,
+      goalType: body.goalType,
       target: body.target,
       unit: body.unit,
       ratio: body.ratio,

--- a/apps/api/src/programs/upsert-strength-goal.dto.ts
+++ b/apps/api/src/programs/upsert-strength-goal.dto.ts
@@ -1,8 +1,13 @@
 import { IsIn, IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class UpsertStrengthGoalDto {
+  @IsString()
+  @IsIn(['absolute', 'relative'])
+  goalType: 'absolute' | 'relative';
+
   @IsNumber()
-  target: number;
+  @IsOptional()
+  target?: number;
 
   @IsString()
   @IsIn(['lbs', 'kg'])

--- a/apps/api/src/programs/upsert-strength-goal.dto.ts
+++ b/apps/api/src/programs/upsert-strength-goal.dto.ts
@@ -1,0 +1,14 @@
+import { IsIn, IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class UpsertStrengthGoalDto {
+  @IsNumber()
+  target: number;
+
+  @IsString()
+  @IsIn(['lbs', 'kg'])
+  unit: 'lbs' | 'kg';
+
+  @IsNumber()
+  @IsOptional()
+  ratio?: number;
+}

--- a/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.tsx
+++ b/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useState } from 'react';
 import type { WeekRow, WorkoutCell } from '@/lib/workoutPlan';
 import styles from './CycleDashboardGrid.module.css';
@@ -72,6 +73,9 @@ export default function CycleDashboardGrid({
   return (
     <section className={styles.container}>
       <h2 className={styles.heading}>Cycle {cycleNum}</h2>
+      <div style={{ marginBottom: '1rem' }}>
+        <Link href="/settings/strength-goals">🎯 Strength Goals</Link>
+      </div>
       <div className={styles.grid}>
         {weeks.map((row) => {
           const isExpanded = expanded[row.week] ?? row.week === currentWeek;

--- a/apps/web/app/settings/strength-goals/StrengthGoalsForm.tsx
+++ b/apps/web/app/settings/strength-goals/StrengthGoalsForm.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { useState } from 'react';
+import { evaluateStrengthTier } from '@lifting-logbook/core';
+import type { BodyWeightResponse, StrengthGoalResponse, TrainingMaxResponse } from '@lifting-logbook/types';
+import { saveStrengthGoal, removeStrengthGoal } from './actions';
+
+interface Props {
+  program: string;
+  trainingMaxes: TrainingMaxResponse[];
+  goals: StrengthGoalResponse[];
+  bodyWeight: BodyWeightResponse | null;
+}
+
+interface GoalRowState {
+  target: string;
+  unit: 'lbs' | 'kg';
+  ratio: string;
+  saving: boolean;
+  error: string | null;
+}
+
+export default function StrengthGoalsForm({ program, trainingMaxes, goals, bodyWeight }: Props) {
+  const [bwValue, setBwValue] = useState(String(bodyWeight?.weight ?? ''));
+  const [editingBw, setEditingBw] = useState(false);
+  const [currentBw, setCurrentBw] = useState(bodyWeight?.weight ?? null);
+
+  const initialRows = Object.fromEntries(
+    trainingMaxes.map((m) => {
+      const existing = goals.find((g) => g.lift === m.lift);
+      return [
+        m.lift,
+        {
+          target: String(existing?.target ?? ''),
+          unit: (existing?.unit ?? 'lbs') as 'lbs' | 'kg',
+          ratio: String(existing?.ratio ?? ''),
+          saving: false,
+          error: null,
+        } satisfies GoalRowState,
+      ];
+    }),
+  );
+
+  const [rows, setRows] = useState<Record<string, GoalRowState>>(initialRows);
+  const [savedGoals, setSavedGoals] = useState<Record<string, boolean>>(
+    Object.fromEntries(goals.map((g) => [g.lift, true])),
+  );
+
+  function updateRow(lift: string, patch: Partial<GoalRowState>) {
+    setRows((prev) => ({ ...prev, [lift]: { ...prev[lift], ...patch } }));
+  }
+
+  async function handleSave(lift: string) {
+    const row = rows[lift];
+    const target = parseFloat(row.target);
+    if (isNaN(target) || target <= 0) {
+      updateRow(lift, { error: 'Enter a positive number' });
+      return;
+    }
+    const ratio = row.ratio ? parseFloat(row.ratio) : undefined;
+    updateRow(lift, { saving: true, error: null });
+    try {
+      await saveStrengthGoal(program, lift, { target, unit: row.unit, ratio });
+      setSavedGoals((prev) => ({ ...prev, [lift]: true }));
+    } catch {
+      updateRow(lift, { error: 'Save failed' });
+    } finally {
+      updateRow(lift, { saving: false });
+    }
+  }
+
+  async function handleDelete(lift: string) {
+    updateRow(lift, { saving: true, error: null });
+    try {
+      await removeStrengthGoal(program, lift);
+      setSavedGoals((prev) => ({ ...prev, [lift]: false }));
+      updateRow(lift, { target: '', ratio: '' });
+    } catch {
+      updateRow(lift, { error: 'Delete failed' });
+    } finally {
+      updateRow(lift, { saving: false });
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: 600, margin: '0 auto', padding: '1rem' }}>
+      <h1>Strength Goals</h1>
+
+      {/* Body weight */}
+      <section style={{ marginBottom: '1.5rem' }}>
+        <h2 style={{ fontSize: '1rem', marginBottom: '0.5rem' }}>Body Weight</h2>
+        {editingBw ? (
+          <span style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+            <input
+              type="number"
+              value={bwValue}
+              onChange={(e) => setBwValue(e.target.value)}
+              style={{ width: 80 }}
+              aria-label="Body weight"
+            />
+            <span>lbs</span>
+            <button
+              type="button"
+              onClick={() => {
+                const w = parseFloat(bwValue);
+                if (!isNaN(w) && w > 0) setCurrentBw(w);
+                setEditingBw(false);
+              }}
+            >
+              ✓
+            </button>
+          </span>
+        ) : (
+          <button type="button" onClick={() => setEditingBw(true)}>
+            {currentBw !== null ? `${currentBw} lbs` : 'Set body weight'}
+          </button>
+        )}
+      </section>
+
+      {/* Per-lift goal cards */}
+      <section>
+        <h2 style={{ fontSize: '1rem', marginBottom: '0.75rem' }}>Lift Goals</h2>
+        {trainingMaxes.map((m) => {
+          const row = rows[m.lift];
+          const hasGoal = savedGoals[m.lift];
+          const target = parseFloat(row.target);
+          const progress =
+            currentBw && hasGoal && !isNaN(target) && target > 0
+              ? evaluateStrengthTier(m.weight, currentBw, target / currentBw).progressRatio
+              : null;
+
+          return (
+            <div
+              key={m.lift}
+              style={{
+                border: '1px solid #ddd',
+                borderRadius: 6,
+                padding: '0.75rem',
+                marginBottom: '0.75rem',
+              }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+                <strong>{m.lift}</strong>
+                <span style={{ fontSize: '0.85rem', color: '#666' }}>
+                  Current max: {m.weight} {m.unit}
+                </span>
+              </div>
+
+              {progress !== null && (
+                <div style={{ margin: '0.5rem 0' }}>
+                  <div
+                    style={{
+                      height: 8,
+                      background: '#eee',
+                      borderRadius: 4,
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <div
+                      style={{
+                        height: '100%',
+                        width: `${Math.min(progress * 100, 100)}%`,
+                        background: progress >= 1 ? '#22c55e' : '#3b82f6',
+                        transition: 'width 0.3s',
+                      }}
+                    />
+                  </div>
+                  <span style={{ fontSize: '0.75rem', color: '#666' }}>
+                    {Math.round(progress * 100)}% of goal
+                  </span>
+                </div>
+              )}
+
+              <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', marginTop: '0.5rem', flexWrap: 'wrap' }}>
+                <input
+                  type="number"
+                  placeholder="Target (lbs)"
+                  value={row.target}
+                  onChange={(e) => updateRow(m.lift, { target: e.target.value })}
+                  style={{ width: 110 }}
+                  aria-label={`Target for ${m.lift}`}
+                />
+                <select
+                  value={row.unit}
+                  onChange={(e) => updateRow(m.lift, { unit: e.target.value as 'lbs' | 'kg' })}
+                  aria-label={`Unit for ${m.lift}`}
+                >
+                  <option value="lbs">lbs</option>
+                  <option value="kg">kg</option>
+                </select>
+                <input
+                  type="number"
+                  placeholder="BW ratio (e.g. 1.75)"
+                  value={row.ratio}
+                  onChange={(e) => updateRow(m.lift, { ratio: e.target.value })}
+                  style={{ width: 130 }}
+                  aria-label={`Body weight ratio for ${m.lift}`}
+                />
+                <button type="button" onClick={() => handleSave(m.lift)} disabled={row.saving}>
+                  {row.saving ? '…' : '✓'}
+                </button>
+                {hasGoal && (
+                  <button type="button" onClick={() => handleDelete(m.lift)} disabled={row.saving}>
+                    ✕
+                  </button>
+                )}
+              </div>
+              {row.error && <p style={{ color: 'red', fontSize: '0.8rem', margin: '0.25rem 0 0' }}>{row.error}</p>}
+            </div>
+          );
+        })}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/settings/strength-goals/StrengthGoalsForm.tsx
+++ b/apps/web/app/settings/strength-goals/StrengthGoalsForm.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { evaluateStrengthTier } from '@lifting-logbook/core';
 import type { BodyWeightResponse, StrengthGoalResponse, TrainingMaxResponse } from '@lifting-logbook/types';
-import { saveStrengthGoal, removeStrengthGoal } from './actions';
+import { saveStrengthGoal, removeStrengthGoal, saveBodyWeight } from './actions';
 
 interface Props {
   program: string;
@@ -13,6 +13,7 @@ interface Props {
 }
 
 interface GoalRowState {
+  goalType: 'absolute' | 'relative';
   target: string;
   unit: 'lbs' | 'kg';
   ratio: string;
@@ -20,10 +21,33 @@ interface GoalRowState {
   error: string | null;
 }
 
+function computeProgress(
+  trainingMaxWeight: number,
+  bw: number,
+  goalType: 'absolute' | 'relative',
+  target: string,
+  ratio: string,
+): number | null {
+  if (goalType === 'relative') {
+    const r = parseFloat(ratio);
+    if (!isNaN(r) && r > 0 && bw > 0) {
+      return evaluateStrengthTier(trainingMaxWeight, bw, r).progressRatio;
+    }
+  } else {
+    const t = parseFloat(target);
+    if (!isNaN(t) && t > 0) {
+      return trainingMaxWeight / t;
+    }
+  }
+  return null;
+}
+
 export default function StrengthGoalsForm({ program, trainingMaxes, goals, bodyWeight }: Props) {
-  const [bwValue, setBwValue] = useState(String(bodyWeight?.weight ?? ''));
+  const [currentBw, setCurrentBw] = useState<number | null>(bodyWeight?.weight ?? null);
+  const [bwInput, setBwInput] = useState(String(bodyWeight?.weight ?? ''));
   const [editingBw, setEditingBw] = useState(false);
-  const [currentBw, setCurrentBw] = useState(bodyWeight?.weight ?? null);
+  const [savingBw, setSavingBw] = useState(false);
+  const [bwError, setBwError] = useState<string | null>(null);
 
   const initialRows = Object.fromEntries(
     trainingMaxes.map((m) => {
@@ -31,6 +55,7 @@ export default function StrengthGoalsForm({ program, trainingMaxes, goals, bodyW
       return [
         m.lift,
         {
+          goalType: (existing?.goalType ?? 'relative') as 'absolute' | 'relative',
           target: String(existing?.target ?? ''),
           unit: (existing?.unit ?? 'lbs') as 'lbs' | 'kg',
           ratio: String(existing?.ratio ?? ''),
@@ -50,17 +75,47 @@ export default function StrengthGoalsForm({ program, trainingMaxes, goals, bodyW
     setRows((prev) => ({ ...prev, [lift]: { ...prev[lift], ...patch } }));
   }
 
-  async function handleSave(lift: string) {
-    const row = rows[lift];
-    const target = parseFloat(row.target);
-    if (isNaN(target) || target <= 0) {
-      updateRow(lift, { error: 'Enter a positive number' });
+  async function handleSaveBw() {
+    const w = parseFloat(bwInput);
+    if (isNaN(w) || w <= 0) {
+      setBwError('Enter a positive number');
       return;
     }
-    const ratio = row.ratio ? parseFloat(row.ratio) : undefined;
+    setSavingBw(true);
+    setBwError(null);
+    try {
+      await saveBodyWeight(program, w, 'lbs');
+      setCurrentBw(w);
+      setEditingBw(false);
+    } catch {
+      setBwError('Save failed');
+    } finally {
+      setSavingBw(false);
+    }
+  }
+
+  async function handleSave(lift: string) {
+    const row = rows[lift];
+    if (row.goalType === 'relative') {
+      const ratio = parseFloat(row.ratio);
+      if (isNaN(ratio) || ratio <= 0) {
+        updateRow(lift, { error: 'Enter a positive ratio (e.g. 1.75)' });
+        return;
+      }
+    } else {
+      const target = parseFloat(row.target);
+      if (isNaN(target) || target <= 0) {
+        updateRow(lift, { error: 'Enter a positive target weight' });
+        return;
+      }
+    }
     updateRow(lift, { saving: true, error: null });
     try {
-      await saveStrengthGoal(program, lift, { target, unit: row.unit, ratio });
+      const body =
+        row.goalType === 'relative'
+          ? { goalType: 'relative' as const, ratio: parseFloat(row.ratio), unit: row.unit }
+          : { goalType: 'absolute' as const, target: parseFloat(row.target), unit: row.unit };
+      await saveStrengthGoal(program, lift, body);
       setSavedGoals((prev) => ({ ...prev, [lift]: true }));
     } catch {
       updateRow(lift, { error: 'Save failed' });
@@ -90,30 +145,46 @@ export default function StrengthGoalsForm({ program, trainingMaxes, goals, bodyW
       <section style={{ marginBottom: '1.5rem' }}>
         <h2 style={{ fontSize: '1rem', marginBottom: '0.5rem' }}>Body Weight</h2>
         {editingBw ? (
-          <span style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+          <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
             <input
               type="number"
-              value={bwValue}
-              onChange={(e) => setBwValue(e.target.value)}
+              value={bwInput}
+              onChange={(e) => setBwInput(e.target.value)}
               style={{ width: 80 }}
               aria-label="Body weight"
+              autoFocus
             />
             <span>lbs</span>
-            <button
-              type="button"
-              onClick={() => {
-                const w = parseFloat(bwValue);
-                if (!isNaN(w) && w > 0) setCurrentBw(w);
-                setEditingBw(false);
-              }}
-            >
-              ✓
+            <button type="button" onClick={handleSaveBw} disabled={savingBw}>
+              {savingBw ? '…' : '✓'}
             </button>
-          </span>
+            <button type="button" onClick={() => { setEditingBw(false); setBwError(null); }}>
+              ✕
+            </button>
+            {bwError && <span style={{ color: 'red', fontSize: '0.8rem' }}>{bwError}</span>}
+          </div>
         ) : (
-          <button type="button" onClick={() => setEditingBw(true)}>
-            {currentBw !== null ? `${currentBw} lbs` : 'Set body weight'}
-          </button>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.75rem',
+              padding: '0.5rem 0.75rem',
+              background: '#f8f9fa',
+              borderRadius: 6,
+              border: '1px solid #ecf0f1',
+              cursor: 'pointer',
+              width: 'fit-content',
+            }}
+            onClick={() => { setEditingBw(true); setBwInput(String(currentBw ?? '')); }}
+            role="button"
+            aria-label="Record new body weight"
+          >
+            <span style={{ fontWeight: 600 }}>
+              {currentBw !== null ? `${currentBw} lbs` : 'No weight recorded'}
+            </span>
+            <span style={{ fontSize: '0.8rem', color: '#7f8c8d' }}>✎ Record new weight</span>
+          </div>
         )}
       </section>
 
@@ -123,10 +194,18 @@ export default function StrengthGoalsForm({ program, trainingMaxes, goals, bodyW
         {trainingMaxes.map((m) => {
           const row = rows[m.lift];
           const hasGoal = savedGoals[m.lift];
-          const target = parseFloat(row.target);
-          const progress =
-            currentBw && hasGoal && !isNaN(target) && target > 0
-              ? evaluateStrengthTier(m.weight, currentBw, target / currentBw).progressRatio
+          const progress = currentBw
+            ? computeProgress(m.weight, currentBw, row.goalType, row.target, row.ratio)
+            : null;
+
+          const computedTarget =
+            row.goalType === 'relative' && currentBw && parseFloat(row.ratio) > 0
+              ? Math.round(currentBw * parseFloat(row.ratio))
+              : null;
+
+          const bwPercent =
+            row.goalType === 'absolute' && currentBw && parseFloat(row.target) > 0
+              ? Math.round((parseFloat(row.target) / currentBw) * 100)
               : null;
 
           return (
@@ -139,16 +218,99 @@ export default function StrengthGoalsForm({ program, trainingMaxes, goals, bodyW
                 marginBottom: '0.75rem',
               }}
             >
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: '0.5rem' }}>
                 <strong>{m.lift}</strong>
                 <span style={{ fontSize: '0.85rem', color: '#666' }}>
                   Current max: {m.weight} {m.unit}
                 </span>
               </div>
 
-              {progress !== null && (
+              {/* Goal type toggle */}
+              <div style={{ display: 'flex', gap: '0.25rem', marginBottom: '0.5rem' }}>
+                {(['relative', 'absolute'] as const).map((type) => (
+                  <button
+                    key={type}
+                    type="button"
+                    onClick={() => updateRow(m.lift, { goalType: type })}
+                    style={{
+                      padding: '2px 10px',
+                      fontSize: '0.75rem',
+                      borderRadius: 4,
+                      border: '1px solid #ccc',
+                      background: row.goalType === type ? '#3b82f6' : '#f5f5f5',
+                      color: row.goalType === type ? '#fff' : '#333',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {type === 'relative' ? 'Relative (× BW)' : 'Absolute (lbs/kg)'}
+                  </button>
+                ))}
+              </div>
+
+              {/* Input fields */}
+              {row.goalType === 'relative' ? (
+                <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+                  <input
+                    type="number"
+                    placeholder="BW ratio (e.g. 1.75)"
+                    value={row.ratio}
+                    onChange={(e) => updateRow(m.lift, { ratio: e.target.value })}
+                    style={{ width: 140 }}
+                    aria-label={`Body weight ratio for ${m.lift}`}
+                  />
+                  <span style={{ fontSize: '0.85rem', color: '#555' }}>× BW</span>
+                  {computedTarget !== null && (
+                    <span
+                      style={{ fontSize: '0.8rem', color: '#666' }}
+                      title={`${row.ratio}× BW = ${computedTarget} lbs at current weight`}
+                    >
+                      = {computedTarget} lbs
+                    </span>
+                  )}
+                  <select
+                    value={row.unit}
+                    onChange={(e) => updateRow(m.lift, { unit: e.target.value as 'lbs' | 'kg' })}
+                    aria-label={`Unit for ${m.lift}`}
+                  >
+                    <option value="lbs">lbs</option>
+                    <option value="kg">kg</option>
+                  </select>
+                </div>
+              ) : (
+                <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+                  <input
+                    type="number"
+                    placeholder="Target weight"
+                    value={row.target}
+                    onChange={(e) => updateRow(m.lift, { target: e.target.value })}
+                    style={{ width: 110 }}
+                    aria-label={`Target weight for ${m.lift}`}
+                  />
+                  <select
+                    value={row.unit}
+                    onChange={(e) => updateRow(m.lift, { unit: e.target.value as 'lbs' | 'kg' })}
+                    aria-label={`Unit for ${m.lift}`}
+                  >
+                    <option value="lbs">lbs</option>
+                    <option value="kg">kg</option>
+                  </select>
+                  {bwPercent !== null && (
+                    <span style={{ fontSize: '0.8rem', color: '#666' }}>
+                      = {bwPercent}% of body weight
+                    </span>
+                  )}
+                </div>
+              )}
+
+              {/* Progress bar */}
+              {progress !== null && hasGoal && (
                 <div style={{ margin: '0.5rem 0' }}>
                   <div
+                    title={
+                      row.goalType === 'relative'
+                        ? `Goal: ${row.ratio}× BW`
+                        : `Goal: ${row.target} ${row.unit}`
+                    }
                     style={{
                       height: 8,
                       background: '#eee',
@@ -167,41 +329,21 @@ export default function StrengthGoalsForm({ program, trainingMaxes, goals, bodyW
                   </div>
                   <span style={{ fontSize: '0.75rem', color: '#666' }}>
                     {Math.round(progress * 100)}% of goal
+                    {row.goalType === 'relative' && row.ratio
+                      ? ` (${row.ratio}× BW)`
+                      : ''}
                   </span>
                 </div>
               )}
 
-              <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', marginTop: '0.5rem', flexWrap: 'wrap' }}>
-                <input
-                  type="number"
-                  placeholder="Target (lbs)"
-                  value={row.target}
-                  onChange={(e) => updateRow(m.lift, { target: e.target.value })}
-                  style={{ width: 110 }}
-                  aria-label={`Target for ${m.lift}`}
-                />
-                <select
-                  value={row.unit}
-                  onChange={(e) => updateRow(m.lift, { unit: e.target.value as 'lbs' | 'kg' })}
-                  aria-label={`Unit for ${m.lift}`}
-                >
-                  <option value="lbs">lbs</option>
-                  <option value="kg">kg</option>
-                </select>
-                <input
-                  type="number"
-                  placeholder="BW ratio (e.g. 1.75)"
-                  value={row.ratio}
-                  onChange={(e) => updateRow(m.lift, { ratio: e.target.value })}
-                  style={{ width: 130 }}
-                  aria-label={`Body weight ratio for ${m.lift}`}
-                />
+              {/* Save / delete */}
+              <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem' }}>
                 <button type="button" onClick={() => handleSave(m.lift)} disabled={row.saving}>
-                  {row.saving ? '…' : '✓'}
+                  {row.saving ? '…' : '✓ Save'}
                 </button>
                 {hasGoal && (
                   <button type="button" onClick={() => handleDelete(m.lift)} disabled={row.saving}>
-                    ✕
+                    ✕ Remove
                   </button>
                 )}
               </div>

--- a/apps/web/app/settings/strength-goals/actions.ts
+++ b/apps/web/app/settings/strength-goals/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
-import { deleteStrengthGoal, upsertStrengthGoal } from '@/lib/api';
+import { revalidatePath } from 'next/cache';
+import { deleteStrengthGoal, recordBodyWeight, upsertStrengthGoal } from '@/lib/api';
 import type { StrengthGoalResponse, UpsertStrengthGoalRequest } from '@lifting-logbook/types';
 
 export async function saveStrengthGoal(
@@ -8,12 +9,25 @@ export async function saveStrengthGoal(
   lift: string,
   body: UpsertStrengthGoalRequest,
 ): Promise<StrengthGoalResponse> {
-  return upsertStrengthGoal(program, lift, body);
+  const result = await upsertStrengthGoal(program, lift, body);
+  revalidatePath('/settings/strength-goals');
+  return result;
 }
 
 export async function removeStrengthGoal(
   program: string,
   lift: string,
 ): Promise<void> {
-  return deleteStrengthGoal(program, lift);
+  await deleteStrengthGoal(program, lift);
+  revalidatePath('/settings/strength-goals');
+}
+
+export async function saveBodyWeight(
+  program: string,
+  weight: number,
+  unit: 'lbs' | 'kg',
+): Promise<void> {
+  const today = new Date().toISOString().slice(0, 10);
+  await recordBodyWeight(program, { date: today, weight, unit });
+  revalidatePath('/settings/strength-goals');
 }

--- a/apps/web/app/settings/strength-goals/actions.ts
+++ b/apps/web/app/settings/strength-goals/actions.ts
@@ -1,0 +1,19 @@
+'use server';
+
+import { deleteStrengthGoal, upsertStrengthGoal } from '@/lib/api';
+import type { StrengthGoalResponse, UpsertStrengthGoalRequest } from '@lifting-logbook/types';
+
+export async function saveStrengthGoal(
+  program: string,
+  lift: string,
+  body: UpsertStrengthGoalRequest,
+): Promise<StrengthGoalResponse> {
+  return upsertStrengthGoal(program, lift, body);
+}
+
+export async function removeStrengthGoal(
+  program: string,
+  lift: string,
+): Promise<void> {
+  return deleteStrengthGoal(program, lift);
+}

--- a/apps/web/app/settings/strength-goals/page.tsx
+++ b/apps/web/app/settings/strength-goals/page.tsx
@@ -1,0 +1,20 @@
+import { fetchLatestBodyWeight, fetchStrengthGoals, fetchTrainingMaxes } from '@/lib/api';
+import StrengthGoalsForm from './StrengthGoalsForm';
+
+export default async function StrengthGoalsPage() {
+  const program = process.env.NEXT_PUBLIC_DEFAULT_PROGRAM ?? '5-3-1';
+  const [maxes, goals, bodyWeight] = await Promise.all([
+    fetchTrainingMaxes(program),
+    fetchStrengthGoals(program),
+    fetchLatestBodyWeight(program),
+  ]);
+
+  return (
+    <StrengthGoalsForm
+      program={program}
+      trainingMaxes={maxes}
+      goals={goals}
+      bodyWeight={bodyWeight}
+    />
+  );
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -241,6 +241,7 @@ export async function deleteStrengthGoal(
     cache: 'no-store',
     headers: authHeaders,
   });
+  // 404 is treated as success: the goal is already absent, which is the desired end state.
   if (!res.ok && res.status !== 404) {
     throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
   }

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -8,6 +8,8 @@ import type {
   LiftingProgramSpecResponse,
   LiftRecordResponse,
   RecordBodyWeightRequest,
+  StrengthGoalResponse,
+  UpsertStrengthGoalRequest,
   TrainingMaxHistoryResponse,
   TrainingMaxResponse,
   UpdateLiftRecordRequest,
@@ -196,4 +198,50 @@ export async function fetchLatestBodyWeight(
     throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
   }
   return res.json() as Promise<BodyWeightResponse>;
+}
+
+export async function fetchStrengthGoals(
+  program: string,
+): Promise<StrengthGoalResponse[]> {
+  const path = `/programs/${encodeURIComponent(program)}/strength-goals`;
+  const authHeaders = await getAuthHeaders();
+  const res = await fetch(`${API_URL}${path}`, {
+    cache: 'no-store',
+    headers: authHeaders,
+  });
+  if (!res.ok) throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
+  return res.json() as Promise<StrengthGoalResponse[]>;
+}
+
+export async function upsertStrengthGoal(
+  program: string,
+  lift: string,
+  body: UpsertStrengthGoalRequest,
+): Promise<StrengthGoalResponse> {
+  const path = `/programs/${encodeURIComponent(program)}/strength-goals/${encodeURIComponent(lift)}`;
+  const authHeaders = await getAuthHeaders();
+  const res = await fetch(`${API_URL}${path}`, {
+    method: 'PUT',
+    cache: 'no-store',
+    headers: { 'Content-Type': 'application/json', ...authHeaders },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
+  return res.json() as Promise<StrengthGoalResponse>;
+}
+
+export async function deleteStrengthGoal(
+  program: string,
+  lift: string,
+): Promise<void> {
+  const path = `/programs/${encodeURIComponent(program)}/strength-goals/${encodeURIComponent(lift)}`;
+  const authHeaders = await getAuthHeaders();
+  const res = await fetch(`${API_URL}${path}`, {
+    method: 'DELETE',
+    cache: 'no-store',
+    headers: authHeaders,
+  });
+  if (!res.ok && res.status !== 404) {
+    throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
+  }
 }

--- a/packages/core/src/models/StrengthGoalEntry.ts
+++ b/packages/core/src/models/StrengthGoalEntry.ts
@@ -1,6 +1,7 @@
 export interface StrengthGoalEntry {
   lift: string;
-  target: number;
+  goalType: 'absolute' | 'relative';
+  target?: number;
   unit: 'lbs' | 'kg';
   ratio?: number;
   updatedAt: Date;

--- a/packages/core/src/models/StrengthGoalEntry.ts
+++ b/packages/core/src/models/StrengthGoalEntry.ts
@@ -1,0 +1,7 @@
+export interface StrengthGoalEntry {
+  lift: string;
+  target: number;
+  unit: 'lbs' | 'kg';
+  ratio?: number;
+  updatedAt: Date;
+}

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -1,4 +1,5 @@
 export * from "./CycleDashboard";
+export * from "./StrengthGoalEntry";
 export * from "./LiftingProgramSpec";
 export * from "./LiftRecord";
 export * from "./SpreadsheetCell";

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -156,7 +156,8 @@ export interface BodyWeightResponse {
 /** Serialized strength goal as returned by the API. */
 export interface StrengthGoalResponse {
   lift: string;
-  target: number;
+  goalType: 'absolute' | 'relative';
+  target?: number;
   unit: 'lbs' | 'kg';
   ratio?: number;
   updatedAt: string; // ISO 8601 date string
@@ -164,7 +165,8 @@ export interface StrengthGoalResponse {
 
 /** Request body for PUT /programs/:program/strength-goals/:lift. */
 export interface UpsertStrengthGoalRequest {
-  target: number;
+  goalType: 'absolute' | 'relative';
+  target?: number;
   unit: 'lbs' | 'kg';
   ratio?: number;
 }

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -150,6 +150,26 @@ export interface BodyWeightResponse {
 }
 
 // ---------------------------------------------------------------------------
+// Strength Goals
+// ---------------------------------------------------------------------------
+
+/** Serialized strength goal as returned by the API. */
+export interface StrengthGoalResponse {
+  lift: string;
+  target: number;
+  unit: 'lbs' | 'kg';
+  ratio?: number;
+  updatedAt: string; // ISO 8601 date string
+}
+
+/** Request body for PUT /programs/:program/strength-goals/:lift. */
+export interface UpsertStrengthGoalRequest {
+  target: number;
+  unit: 'lbs' | 'kg';
+  ratio?: number;
+}
+
+// ---------------------------------------------------------------------------
 // Cycle Dashboard
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `strength_goal` DB model with unique constraint on `(userId, program, lift)` and a Prisma migration
- Implements `GET`/`PUT`/`DELETE /programs/:program/strength-goals/:lift` API following the hexagonal port/adapter pattern; `StrengthGoalNotFoundError` maps to HTTP 404 via the existing `DomainNotFoundFilter`
- Wires `InMemoryStrengthGoalRepository` and `PrismaStrengthGoalRepository` into all three factory paths
- Adds `/settings/strength-goals` web page with per-lift goal cards, inline body weight and target editing, progress bars using the existing `evaluateStrengthTier` service, and delete support
- Adds strength goals quick-access link on the cycle dashboard

## Acceptance Criteria

- [x] strength_goal model + migration
- [x] CRUD endpoints + port + adapters (in-memory + Prisma)
- [x] /settings/strength-goals page with goal cards, progress bars, inline edits
- [x] Quick-access button on cycle dashboard
- [x] All new tests pass; npm test green

## Test plan

Ran npm test -w @lifting-logbook/api — 112 tests pass (20 skipped require DATABASE_URL).
Ran npm test -w @lifting-logbook/core — 124 tests pass.
New controller spec covers GET mapping, PUT upsert, DELETE success and 404 propagation.
New e2e tests cover PUT->GET->DELETE lifecycle, idempotency, DELETE unknown -> 404, user isolation.

Closes #175