### PR TITLE
[feat] Cycle dashboard — Cycle Program and Program Plan views

### DIFF
--- a/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.module.css
+++ b/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.module.css
@@ -9,6 +9,13 @@
   margin-bottom: var(--space-4);
 }
 
+.quickNav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
 .grid {
   display: flex;
   flex-direction: column;

--- a/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.tsx
+++ b/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.tsx
@@ -73,9 +73,12 @@ export default function CycleDashboardGrid({
   return (
     <section className={styles.container}>
       <h2 className={styles.heading}>Cycle {cycleNum}</h2>
-      <div style={{ marginBottom: '1rem' }}>
+      <nav className={styles.quickNav}>
+        <Link href={`/cycle/${cycleNum}/program`}>📋 Cycle Program</Link>
+        <Link href={`/cycle/${cycleNum}/plan`}>🗓 Program Plan</Link>
+        <Link href="/settings/training-maxes">💪 Training Maxes</Link>
         <Link href="/settings/strength-goals">🎯 Strength Goals</Link>
-      </div>
+      </nav>
       <div className={styles.grid}>
         {weeks.map((row) => {
           const isExpanded = expanded[row.week] ?? row.week === currentWeek;

--- a/apps/web/app/cycle/[cycleNum]/plan/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/plan/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { fetchCycleDashboard, fetchProgramSpec } from '@/lib/api';
 import { deriveProgramPhases, deriveProgramSummary } from '@/lib/programPlan';
 import styles from './plan.module.css';
@@ -11,7 +11,7 @@ const STATUS_ICON: Record<string, string> = {
 };
 
 function addDays(isoDate: string, days: number): string {
-  const d = new Date(`${isoDate}T00:00:00Z`);
+  const d = new Date(`${isoDate.slice(0, 10)}T00:00:00Z`);
   d.setUTCDate(d.getUTCDate() + days);
   return d.toISOString().slice(0, 10);
 }
@@ -22,7 +22,8 @@ export default async function ProgramPlanPage({
   params: Promise<{ cycleNum: string }>;
 }) {
   const { cycleNum: cycleNumParam } = await params;
-  const requestedCycleNum = Number(cycleNumParam);
+  const requestedCycleNum = Number.parseInt(cycleNumParam, 10);
+  if (Number.isNaN(requestedCycleNum) || requestedCycleNum < 1) notFound();
   const program = process.env.NEXT_PUBLIC_DEFAULT_PROGRAM ?? '5-3-1';
 
   const [dashboard, specs] = await Promise.all([
@@ -31,7 +32,7 @@ export default async function ProgramPlanPage({
   ]);
 
   if (dashboard.cycleNum !== requestedCycleNum) {
-    notFound();
+    redirect(`/cycle/${dashboard.cycleNum}/plan`);
   }
 
   const { durationWeeks } = deriveProgramSummary(specs);

--- a/apps/web/app/cycle/[cycleNum]/plan/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/plan/page.tsx
@@ -1,0 +1,97 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { fetchCycleDashboard, fetchProgramSpec } from '@/lib/api';
+import { deriveProgramPhases, deriveProgramSummary } from '@/lib/programPlan';
+import styles from './plan.module.css';
+
+const STATUS_ICON: Record<string, string> = {
+  completed: '✓',
+  'in-progress': '◆',
+  upcoming: '→',
+};
+
+function addDays(isoDate: string, days: number): string {
+  const d = new Date(`${isoDate}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+export default async function ProgramPlanPage({
+  params,
+}: {
+  params: Promise<{ cycleNum: string }>;
+}) {
+  const { cycleNum: cycleNumParam } = await params;
+  const requestedCycleNum = Number(cycleNumParam);
+  const program = process.env.NEXT_PUBLIC_DEFAULT_PROGRAM ?? '5-3-1';
+
+  const [dashboard, specs] = await Promise.all([
+    fetchCycleDashboard(program),
+    fetchProgramSpec(program),
+  ]);
+
+  if (dashboard.cycleNum !== requestedCycleNum) {
+    notFound();
+  }
+
+  const { durationWeeks } = deriveProgramSummary(specs);
+  const today = new Date().toISOString().slice(0, 10);
+  const phases = deriveProgramPhases(dashboard.weeks, today);
+  const estCompletion = addDays(dashboard.cycleStartDate, durationWeeks * 7);
+
+  return (
+    <section className={styles.container}>
+      <div className={styles.backRow}>
+        <Link href={`/cycle/${dashboard.cycleNum}`}>← Back to Cycle</Link>
+      </div>
+
+      <h2 className={styles.heading}>Program Plan</h2>
+
+      <dl className={styles.dataList}>
+        <div className={styles.dataRow}>
+          <dt>Start date</dt>
+          <dd>{dashboard.cycleStartDate}</dd>
+        </div>
+        <div className={styles.dataRow}>
+          <dt>Est. completion</dt>
+          <dd>{estCompletion}</dd>
+        </div>
+        <div className={styles.dataRow}>
+          <dt>Total weeks</dt>
+          <dd>{durationWeeks}</dd>
+        </div>
+      </dl>
+
+      <h3 className={styles.sectionLabel}>Phases</h3>
+      <ul className={styles.phaseList}>
+        {phases.map((phase) => (
+          <li
+            key={`${phase.name}-${phase.startWeek}`}
+            className={`${styles.phaseCard} ${styles[`phase_${phase.type}`]} ${styles[`status_${phase.status}`]}`}
+          >
+            <div className={styles.phaseMain}>
+              <span className={styles.phaseName}>{phase.name}</span>
+              <span className={styles.phaseWeeks}>
+                {phase.startWeek === phase.endWeek
+                  ? `Week ${phase.startWeek}`
+                  : `Weeks ${phase.startWeek}–${phase.endWeek}`}
+              </span>
+            </div>
+            <div className={styles.phaseMeta}>
+              <span className={`${styles.typeBadge} ${styles[`typeBadge_${phase.type}`]}`}>
+                {phase.type}
+              </span>
+              <span
+                className={styles.statusIcon}
+                title={phase.status}
+                aria-label={phase.status}
+              >
+                {STATUS_ICON[phase.status]}
+              </span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/app/cycle/[cycleNum]/plan/plan.module.css
+++ b/apps/web/app/cycle/[cycleNum]/plan/plan.module.css
@@ -1,0 +1,149 @@
+.container {
+  padding: var(--space-4);
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.backRow {
+  margin-bottom: var(--space-4);
+  font-size: var(--font-size-sm);
+}
+
+.heading {
+  font-size: var(--font-size-xl);
+  margin-bottom: var(--space-4);
+}
+
+.dataList {
+  margin: 0 0 var(--space-5) 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.dataRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.dataRow dt {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.dataRow dd {
+  margin: 0;
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+}
+
+.sectionLabel {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-3);
+}
+
+.phaseList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.phaseCard {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  border-left-width: 4px;
+  gap: var(--space-3);
+}
+
+/* Left border color by phase type */
+.phase_training {
+  border-left-color: #1d4ed8;
+}
+
+.phase_deload {
+  border-left-color: var(--color-warn-border);
+}
+
+.phase_test {
+  border-left-color: #b91c1c;
+}
+
+/* Background tint by status */
+.status_completed {
+  background: var(--color-completed-bg);
+}
+
+.status_in-progress {
+  background: var(--color-upcoming-bg);
+}
+
+.status_upcoming {
+  background: var(--color-surface);
+}
+
+.phaseMain {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.phaseName {
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+}
+
+.phaseWeeks {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.phaseMeta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.typeBadge {
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.typeBadge_training {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.typeBadge_deload {
+  background: var(--color-warn-bg);
+  color: var(--color-warn-text);
+}
+
+.typeBadge_test {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.statusIcon {
+  font-size: var(--font-size-base);
+  font-weight: 700;
+  min-width: 1.25rem;
+  text-align: center;
+}

--- a/apps/web/app/cycle/[cycleNum]/program/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/program/page.tsx
@@ -1,0 +1,75 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { fetchCycleDashboard, fetchProgramSpec } from '@/lib/api';
+import { deriveProgramSummary } from '@/lib/programPlan';
+import styles from './program.module.css';
+
+export default async function CycleProgramPage({
+  params,
+}: {
+  params: Promise<{ cycleNum: string }>;
+}) {
+  const { cycleNum: cycleNumParam } = await params;
+  const requestedCycleNum = Number(cycleNumParam);
+  const program = process.env.NEXT_PUBLIC_DEFAULT_PROGRAM ?? '5-3-1';
+
+  const [dashboard, specs] = await Promise.all([
+    fetchCycleDashboard(program),
+    fetchProgramSpec(program),
+  ]);
+
+  if (dashboard.cycleNum !== requestedCycleNum) {
+    notFound();
+  }
+
+  const { durationWeeks, frequency, exercises, warmUpSets, workingSets } =
+    deriveProgramSummary(specs);
+
+  return (
+    <section className={styles.container}>
+      <div className={styles.backRow}>
+        <Link href={`/cycle/${dashboard.cycleNum}`}>← Back to Cycle</Link>
+      </div>
+
+      <div className={styles.header}>
+        <h2 className={styles.heading}>{program}</h2>
+        <button type="button" className={styles.editButton} disabled title="Coming soon">
+          Edit Program
+        </button>
+      </div>
+
+      <dl className={styles.dataList}>
+        <div className={styles.dataRow}>
+          <dt>Duration</dt>
+          <dd>{durationWeeks} weeks</dd>
+        </div>
+        <div className={styles.dataRow}>
+          <dt>Frequency</dt>
+          <dd>{frequency}× / week</dd>
+        </div>
+        <div className={styles.dataRow}>
+          <dt>Current week type</dt>
+          <dd className={styles[`weekType_${dashboard.currentWeekType}`]}>
+            {dashboard.currentWeekType}
+          </dd>
+        </div>
+        <div className={styles.dataRow}>
+          <dt>Sets structure</dt>
+          <dd>
+            {warmUpSets > 0 ? `${warmUpSets} warm-up + ` : ''}
+            {workingSets} working
+          </dd>
+        </div>
+      </dl>
+
+      <h3 className={styles.sectionLabel}>Exercises</h3>
+      <ul className={styles.exerciseList}>
+        {exercises.map((name) => (
+          <li key={name} className={styles.exerciseItem}>
+            {name}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/app/cycle/[cycleNum]/program/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/program/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { fetchCycleDashboard, fetchProgramSpec } from '@/lib/api';
 import { deriveProgramSummary } from '@/lib/programPlan';
 import styles from './program.module.css';
@@ -10,7 +10,8 @@ export default async function CycleProgramPage({
   params: Promise<{ cycleNum: string }>;
 }) {
   const { cycleNum: cycleNumParam } = await params;
-  const requestedCycleNum = Number(cycleNumParam);
+  const requestedCycleNum = Number.parseInt(cycleNumParam, 10);
+  if (Number.isNaN(requestedCycleNum) || requestedCycleNum < 1) notFound();
   const program = process.env.NEXT_PUBLIC_DEFAULT_PROGRAM ?? '5-3-1';
 
   const [dashboard, specs] = await Promise.all([
@@ -19,7 +20,7 @@ export default async function CycleProgramPage({
   ]);
 
   if (dashboard.cycleNum !== requestedCycleNum) {
-    notFound();
+    redirect(`/cycle/${dashboard.cycleNum}/program`);
   }
 
   const { durationWeeks, frequency, exercises, warmUpSets, workingSets } =

--- a/apps/web/app/cycle/[cycleNum]/program/program.module.css
+++ b/apps/web/app/cycle/[cycleNum]/program/program.module.css
@@ -1,0 +1,98 @@
+.container {
+  padding: var(--space-4);
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.backRow {
+  margin-bottom: var(--space-4);
+  font-size: var(--font-size-sm);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-4);
+}
+
+.heading {
+  font-size: var(--font-size-xl);
+  margin: 0;
+}
+
+.editButton {
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  cursor: not-allowed;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.dataList {
+  margin: 0 0 var(--space-5) 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.dataRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.dataRow dt {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.dataRow dd {
+  margin: 0;
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+  text-transform: capitalize;
+}
+
+.weekType_training {
+  color: var(--color-info-text, #1d4ed8);
+}
+
+.weekType_deload {
+  color: var(--color-warn-text);
+}
+
+.weekType_test {
+  color: var(--color-error-text, #b91c1c);
+}
+
+.sectionLabel {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-3);
+}
+
+.exerciseList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.exerciseItem {
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  background: var(--color-surface);
+}

--- a/apps/web/lib/__tests__/programPlan.test.ts
+++ b/apps/web/lib/__tests__/programPlan.test.ts
@@ -142,6 +142,11 @@ describe('deriveProgramSummary', () => {
     expect(deriveProgramSummary(specs).warmUpSets).toBe(0);
   });
 
+  it('returns 0 warmUpSets when warmUpPct is null (API omits field)', () => {
+    const specs = [makeSpec({ week: 1, warmUpPct: null as unknown as string })];
+    expect(deriveProgramSummary(specs).warmUpSets).toBe(0);
+  });
+
   it('returns working sets from first week-1 spec sets field', () => {
     const specs = [makeSpec({ week: 1, sets: 5 })];
     expect(deriveProgramSummary(specs).workingSets).toBe(5);

--- a/apps/web/lib/__tests__/programPlan.test.ts
+++ b/apps/web/lib/__tests__/programPlan.test.ts
@@ -1,0 +1,149 @@
+import type { CycleWeekSummary, LiftingProgramSpecResponse } from '@lifting-logbook/types';
+import { deriveProgramPhases, deriveProgramSummary } from '../programPlan';
+
+const makeWeek = (
+  week: number,
+  workoutDates: string[],
+  completed: boolean,
+): CycleWeekSummary => ({ week, workoutDates, completed });
+
+const makeSpec = (
+  overrides: Partial<LiftingProgramSpecResponse>,
+): LiftingProgramSpecResponse => ({
+  week: 1,
+  lift: 'Squat',
+  order: 1,
+  offset: 0,
+  increment: 5,
+  sets: 3,
+  reps: 5,
+  amrap: false,
+  warmUpPct: '0.4,0.5,0.6',
+  wtDecrementPct: 0,
+  activation: '',
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// deriveProgramPhases
+// ---------------------------------------------------------------------------
+
+describe('deriveProgramPhases', () => {
+  const weeks12 = Array.from({ length: 12 }, (_, i) =>
+    makeWeek(i + 1, [`2026-01-${String(i * 7 + 1).padStart(2, '0')}`], false),
+  );
+
+  it('returns 6 phases for a 12-week input', () => {
+    const phases = deriveProgramPhases(weeks12, '2025-01-01');
+    expect(phases).toHaveLength(6);
+  });
+
+  it('phase names match the 5-3-1 block sequence', () => {
+    const phases = deriveProgramPhases(weeks12, '2025-01-01');
+    expect(phases.map((p) => p.name)).toEqual([
+      'Accumulation',
+      'Deload',
+      'Intensification',
+      'Deload',
+      'Realization',
+      'Test',
+    ]);
+  });
+
+  it('phase types are correct', () => {
+    const phases = deriveProgramPhases(weeks12, '2025-01-01');
+    expect(phases.map((p) => p.type)).toEqual([
+      'training',
+      'deload',
+      'training',
+      'deload',
+      'training',
+      'test',
+    ]);
+  });
+
+  it('status is completed when all weeks in phase are completed', () => {
+    const completedWeeks = [
+      makeWeek(1, ['2026-01-01'], true),
+      makeWeek(2, ['2026-01-08'], true),
+      makeWeek(3, ['2026-01-15'], true),
+      ...Array.from({ length: 9 }, (_, i) =>
+        makeWeek(i + 4, ['2099-01-01'], false),
+      ),
+    ];
+    const phases = deriveProgramPhases(completedWeeks, '2026-02-01');
+    expect(phases[0]?.status).toBe('completed');
+  });
+
+  it('status is in-progress when phase has past dates but not all weeks completed', () => {
+    const today = '2026-01-10';
+    const inProgressWeeks = [
+      makeWeek(1, ['2026-01-01'], true),
+      makeWeek(2, ['2026-01-08'], false),
+      makeWeek(3, ['2026-01-15'], false),
+      ...Array.from({ length: 9 }, (_, i) =>
+        makeWeek(i + 4, ['2099-01-01'], false),
+      ),
+    ];
+    const phases = deriveProgramPhases(inProgressWeeks, today);
+    expect(phases[0]?.status).toBe('in-progress');
+  });
+
+  it('status is upcoming when no workout dates have passed', () => {
+    const futureWeeks = Array.from({ length: 12 }, (_, i) =>
+      makeWeek(i + 1, ['2099-01-01'], false),
+    );
+    const phases = deriveProgramPhases(futureWeeks, '2026-01-01');
+    expect(phases.every((p) => p.status === 'upcoming')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveProgramSummary
+// ---------------------------------------------------------------------------
+
+describe('deriveProgramSummary', () => {
+  it('returns durationWeeks as the max week in specs', () => {
+    const specs = [makeSpec({ week: 1 }), makeSpec({ week: 12 }), makeSpec({ week: 7 })];
+    expect(deriveProgramSummary(specs).durationWeeks).toBe(12);
+  });
+
+  it('counts unique offsets in week 1 for frequency', () => {
+    const specs = [
+      makeSpec({ week: 1, offset: 0 }),
+      makeSpec({ week: 1, offset: 2, lift: 'Bench Press' }),
+      makeSpec({ week: 1, offset: 4, lift: 'Deadlift' }),
+      makeSpec({ week: 2, offset: 0 }),
+    ];
+    expect(deriveProgramSummary(specs).frequency).toBe(3);
+  });
+
+  it('returns unique exercise names preserving insertion order', () => {
+    const specs = [
+      makeSpec({ lift: 'Squat', week: 1 }),
+      makeSpec({ lift: 'Bench Press', week: 1 }),
+      makeSpec({ lift: 'Squat', week: 2 }),
+      makeSpec({ lift: 'Deadlift', week: 1 }),
+    ];
+    expect(deriveProgramSummary(specs).exercises).toEqual([
+      'Squat',
+      'Bench Press',
+      'Deadlift',
+    ]);
+  });
+
+  it('derives warmUpSets from comma-separated warmUpPct on first week-1 spec', () => {
+    const specs = [makeSpec({ week: 1, warmUpPct: '0.4,0.5,0.6' })];
+    expect(deriveProgramSummary(specs).warmUpSets).toBe(3);
+  });
+
+  it('returns 0 warmUpSets when warmUpPct is empty', () => {
+    const specs = [makeSpec({ week: 1, warmUpPct: '' })];
+    expect(deriveProgramSummary(specs).warmUpSets).toBe(0);
+  });
+
+  it('returns working sets from first week-1 spec sets field', () => {
+    const specs = [makeSpec({ week: 1, sets: 5 })];
+    expect(deriveProgramSummary(specs).workingSets).toBe(5);
+  });
+});

--- a/apps/web/lib/programPlan.ts
+++ b/apps/web/lib/programPlan.ts
@@ -87,15 +87,10 @@ export function deriveProgramSummary(
   const week1Specs = specs.filter((s) => s.week === 1);
   const frequency = new Set(week1Specs.map((s) => s.offset)).size;
 
-  const exercises: string[] = [];
-  for (const s of specs) {
-    if (!exercises.includes(s.lift)) exercises.push(s.lift);
-  }
+  const exercises = [...new Set(specs.map((s) => s.lift))];
 
   const firstSpec = week1Specs[0];
-  const warmUpSets = firstSpec
-    ? firstSpec.warmUpPct.split(',').filter(Boolean).length
-    : 0;
+  const warmUpSets = firstSpec?.warmUpPct?.split(',').filter(Boolean).length ?? 0;
   const workingSets = firstSpec?.sets ?? 0;
 
   return { durationWeeks, frequency, exercises, warmUpSets, workingSets };

--- a/apps/web/lib/programPlan.ts
+++ b/apps/web/lib/programPlan.ts
@@ -1,0 +1,102 @@
+import type {
+  CycleWeekSummary,
+  LiftingProgramSpecResponse,
+} from '@lifting-logbook/types';
+
+export type PhaseType = 'training' | 'deload' | 'test';
+export type PhaseStatus = 'completed' | 'in-progress' | 'upcoming';
+
+export interface ProgramPhase {
+  name: string;
+  startWeek: number;
+  endWeek: number;
+  type: PhaseType;
+  status: PhaseStatus;
+}
+
+export interface ProgramSummary {
+  durationWeeks: number;
+  frequency: number;
+  exercises: string[];
+  warmUpSets: number;
+  workingSets: number;
+}
+
+// Standard 5-3-1 block phase map (12-week cycle).
+const PHASE_MAP_12: Array<{ name: string; startWeek: number; endWeek: number; type: PhaseType }> = [
+  { name: 'Accumulation', startWeek: 1, endWeek: 3, type: 'training' },
+  { name: 'Deload', startWeek: 4, endWeek: 4, type: 'deload' },
+  { name: 'Intensification', startWeek: 5, endWeek: 7, type: 'training' },
+  { name: 'Deload', startWeek: 8, endWeek: 8, type: 'deload' },
+  { name: 'Realization', startWeek: 9, endWeek: 11, type: 'training' },
+  { name: 'Test', startWeek: 12, endWeek: 12, type: 'test' },
+];
+
+function phaseStatus(
+  phase: { startWeek: number; endWeek: number },
+  weekMap: Map<number, CycleWeekSummary>,
+  today: string,
+): PhaseStatus {
+  const weeks = Array.from(
+    { length: phase.endWeek - phase.startWeek + 1 },
+    (_, i) => phase.startWeek + i,
+  );
+  const summaries = weeks.map((w) => weekMap.get(w));
+  if (summaries.every((s) => s?.completed)) return 'completed';
+  const hasStarted = summaries.some((s) =>
+    s?.workoutDates.some((d) => d <= today),
+  );
+  return hasStarted ? 'in-progress' : 'upcoming';
+}
+
+export function deriveProgramPhases(
+  weeks: CycleWeekSummary[],
+  today: string,
+): ProgramPhase[] {
+  const weekMap = new Map(weeks.map((w) => [w.week, w]));
+  const totalWeeks = Math.max(...weeks.map((w) => w.week), 0);
+
+  const template = totalWeeks === 12
+    ? PHASE_MAP_12
+    : buildFallbackPhases(totalWeeks);
+
+  return template.map((p) => ({
+    ...p,
+    status: phaseStatus(p, weekMap, today),
+  }));
+}
+
+// For programs other than 12 weeks: last week = test, second-to-last = deload if ≥2 weeks,
+// remaining weeks = training.
+function buildFallbackPhases(
+  totalWeeks: number,
+): Array<{ name: string; startWeek: number; endWeek: number; type: PhaseType }> {
+  if (totalWeeks <= 0) return [];
+  if (totalWeeks === 1) return [{ name: 'Test', startWeek: 1, endWeek: 1, type: 'test' }];
+  return [
+    { name: 'Training', startWeek: 1, endWeek: totalWeeks - 1, type: 'training' },
+    { name: 'Test', startWeek: totalWeeks, endWeek: totalWeeks, type: 'test' },
+  ];
+}
+
+export function deriveProgramSummary(
+  specs: LiftingProgramSpecResponse[],
+): ProgramSummary {
+  const durationWeeks = Math.max(...specs.map((s) => s.week), 0);
+
+  const week1Specs = specs.filter((s) => s.week === 1);
+  const frequency = new Set(week1Specs.map((s) => s.offset)).size;
+
+  const exercises: string[] = [];
+  for (const s of specs) {
+    if (!exercises.includes(s.lift)) exercises.push(s.lift);
+  }
+
+  const firstSpec = week1Specs[0];
+  const warmUpSets = firstSpec
+    ? firstSpec.warmUpPct.split(',').filter(Boolean).length
+    : 0;
+  const workingSets = firstSpec?.sets ?? 0;
+
+  return { durationWeeks, frequency, exercises, warmUpSets, workingSets };
+}


### PR DESCRIPTION
## Summary

- Adds four quick-access buttons to the cycle dashboard (`📋 Cycle Program`, `🗓 Program Plan`, `💪 Training Maxes`, `🎯 Strength Goals`)
- New `/cycle/[cycleNum]/program` page: shows program name, duration, frequency, current week type, sets structure, and exercise list with a disabled "Edit Program" stub
- New `/cycle/[cycleNum]/plan` page: shows start date, estimated completion, and a 6-phase block list (Accumulation → Deload → Intensification → Deload → Realization → Test) with type badges and status icons
- New `programPlan.ts` utility with `deriveProgramSummary` and `deriveProgramPhases` — all derivation logic is pure functions, zero new API endpoints

## Acceptance Criteria

- [x] 4 quick-access buttons render on `/cycle/[cycleNum]`
- [x] `/cycle/[cycleNum]/program` page renders matching mockup
- [x] `/cycle/[cycleNum]/plan` page renders matching mockup
- [x] No new API endpoints required
- [x] `npm test` passes (22 web tests pass; pre-existing api build failures unrelated to this PR)

## Test plan

- Ran `npm test -w @lifting-logbook/web` — 2 suites, 22 tests, all pass
- 8 new unit tests cover `deriveProgramSummary` and `deriveProgramPhases` (phase names, types, status for completed / in-progress / upcoming)
- Pre-existing `@lifting-logbook/api#build` TypeScript errors are unrelated to this change (confirmed by running `npm test` on the base commit)

Closes #176