### PR TITLE
[feat] Workout detail page and rescheduling

### DIFF
--- a/apps/api/prisma/migrations/20260506000000_add_workout_date_override/migration.sql
+++ b/apps/api/prisma/migrations/20260506000000_add_workout_date_override/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "workout_date_override" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "program" TEXT NOT NULL,
+    "cycleNum" INTEGER NOT NULL,
+    "workoutNum" INTEGER NOT NULL,
+    "newDate" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "workout_date_override_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "workout_date_override_userId_program_cycleNum_idx" ON "workout_date_override"("userId", "program", "cycleNum");
+
+-- CreateUniqueIndex
+CREATE UNIQUE INDEX "workout_date_override_userId_program_cycleNum_workoutNum_key" ON "workout_date_override"("userId", "program", "cycleNum", "workoutNum");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -89,3 +89,17 @@ model StrengthGoal {
   @@index([userId, program])
   @@map("strength_goal")
 }
+
+model WorkoutDateOverride {
+  id         String   @id @default(cuid())
+  userId     String
+  program    String
+  cycleNum   Int
+  workoutNum Int
+  newDate    DateTime
+  createdAt  DateTime @default(now())
+
+  @@unique([userId, program, cycleNum, workoutNum])
+  @@index([userId, program, cycleNum])
+  @@map("workout_date_override")
+}

--- a/apps/api/src/adapters/factory/in-memory-repository-factory.ts
+++ b/apps/api/src/adapters/factory/in-memory-repository-factory.ts
@@ -9,6 +9,7 @@ import { InMemoryProgramPhilosophyRepository } from '../in-memory/program-philos
 import { InMemoryStrengthGoalRepository } from '../in-memory/strength-goal.adapter';
 import { InMemoryTrainingMaxRepository } from '../in-memory/training-max.adapter';
 import { InMemoryTrainingMaxHistoryRepository } from '../in-memory/training-max-history.adapter';
+import { InMemoryWorkoutDateOverrideRepository } from '../in-memory/workout-date-override.adapter';
 import { InMemoryWorkoutRepository } from '../in-memory/workout.adapter';
 import { SEED_PROGRAM, seedLiftRecords } from '../in-memory/fixtures';
 
@@ -37,6 +38,7 @@ export class InMemoryRepositoryFactory implements IRepositoryFactory {
         trainingMax: new InMemoryTrainingMaxRepository(preSeed),
         trainingMaxHistory: new InMemoryTrainingMaxHistoryRepository(),
         workout: new InMemoryWorkoutRepository(sharedRecords),
+        workoutDateOverride: new InMemoryWorkoutDateOverrideRepository(),
       });
     }
     return this.bundles.get(user.id)!;

--- a/apps/api/src/adapters/factory/system-db-repository-factory.ts
+++ b/apps/api/src/adapters/factory/system-db-repository-factory.ts
@@ -9,6 +9,7 @@ import { PrismaStrengthGoalRepository } from '../prisma/strength-goal.repository
 import { PrismaTrainingMaxRepository } from '../prisma/training-max.repository';
 import { PrismaTrainingMaxHistoryRepository } from '../prisma/training-max-history.repository';
 import { PrismaCycleDashboardRepository } from '../prisma/cycle-dashboard.repository';
+import { PrismaWorkoutDateOverrideRepository } from '../prisma/workout-date-override.repository';
 import { PrismaWorkoutRepository } from '../prisma/workout.repository';
 import { InMemoryCycleDashboardRepository } from '../in-memory/cycle-dashboard.adapter';
 import { InMemoryLiftingProgramSpecRepository } from '../in-memory/lifting-program-spec.adapter';
@@ -17,6 +18,7 @@ import { InMemoryProgramPhilosophyRepository } from '../in-memory/program-philos
 import { InMemoryStrengthGoalRepository } from '../in-memory/strength-goal.adapter';
 import { InMemoryTrainingMaxRepository } from '../in-memory/training-max.adapter';
 import { InMemoryTrainingMaxHistoryRepository } from '../in-memory/training-max-history.adapter';
+import { InMemoryWorkoutDateOverrideRepository } from '../in-memory/workout-date-override.adapter';
 import { InMemoryWorkoutRepository } from '../in-memory/workout.adapter';
 
 interface UserDataSourceRow {
@@ -79,6 +81,7 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
         trainingMaxHistory: new PrismaTrainingMaxHistoryRepository(prisma, userId),
         cycleDashboard: new PrismaCycleDashboardRepository(prisma, userId),
         workout: new PrismaWorkoutRepository(prisma, userId),
+        workoutDateOverride: new PrismaWorkoutDateOverrideRepository(prisma, userId),
         liftingProgramSpec: this.programSpecRepo,
         programPhilosophy: this.philosophyRepo,
       };
@@ -97,6 +100,7 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
       trainingMax: new InMemoryTrainingMaxRepository(),
       trainingMaxHistory: new InMemoryTrainingMaxHistoryRepository(),
       workout: new InMemoryWorkoutRepository(sharedRecords),
+      workoutDateOverride: new InMemoryWorkoutDateOverrideRepository(),
     };
   }
 

--- a/apps/api/src/adapters/in-memory/workout-date-override.adapter.ts
+++ b/apps/api/src/adapters/in-memory/workout-date-override.adapter.ts
@@ -1,0 +1,28 @@
+import { IWorkoutDateOverrideRepository } from '../../ports/IWorkoutDateOverrideRepository';
+
+export class InMemoryWorkoutDateOverrideRepository
+  implements IWorkoutDateOverrideRepository
+{
+  private readonly store = new Map<string, Date>();
+
+  private key(program: string, cycleNum: number, workoutNum: number): string {
+    return `${program}-${cycleNum}-${workoutNum}`;
+  }
+
+  async getOverride(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+  ): Promise<Date | null> {
+    return this.store.get(this.key(program, cycleNum, workoutNum)) ?? null;
+  }
+
+  async upsertOverride(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+    newDate: Date,
+  ): Promise<void> {
+    this.store.set(this.key(program, cycleNum, workoutNum), newDate);
+  }
+}

--- a/apps/api/src/adapters/in-memory/workout-date-override.adapter.ts
+++ b/apps/api/src/adapters/in-memory/workout-date-override.adapter.ts
@@ -6,7 +6,9 @@ export class InMemoryWorkoutDateOverrideRepository
   private readonly store = new Map<string, Date>();
 
   private key(program: string, cycleNum: number, workoutNum: number): string {
-    return `${program}-${cycleNum}-${workoutNum}`;
+    // Use null byte as delimiter — program slugs cannot contain \0, so this is unambiguous
+    // even for slugs like "5-3-1" that contain hyphens.
+    return `${program}\0${cycleNum}\0${workoutNum}`;
   }
 
   async getOverride(

--- a/apps/api/src/adapters/llm/agent-tools.spec.ts
+++ b/apps/api/src/adapters/llm/agent-tools.spec.ts
@@ -32,6 +32,7 @@ const mkRepos = (): RepositoryBundle => ({
     getTrainingMaxes: jest.fn().mockResolvedValue([{ lift: 'Squat', weight: 315 }]),
   } as unknown as RepositoryBundle['trainingMax'],
   workout: {} as RepositoryBundle['workout'],
+  workoutDateOverride: {} as RepositoryBundle['workoutDateOverride'],
 });
 
 describe('agent-tools', () => {

--- a/apps/api/src/adapters/prisma/prisma-repository-factory.ts
+++ b/apps/api/src/adapters/prisma/prisma-repository-factory.ts
@@ -7,6 +7,7 @@ import { PrismaStrengthGoalRepository } from './strength-goal.repository';
 import { PrismaTrainingMaxRepository } from './training-max.repository';
 import { PrismaTrainingMaxHistoryRepository } from './training-max-history.repository';
 import { PrismaCycleDashboardRepository } from './cycle-dashboard.repository';
+import { PrismaWorkoutDateOverrideRepository } from './workout-date-override.repository';
 import { PrismaWorkoutRepository } from './workout.repository';
 import { InMemoryLiftingProgramSpecRepository } from '../in-memory/lifting-program-spec.adapter';
 import { InMemoryProgramPhilosophyRepository } from '../in-memory/program-philosophy.adapter';
@@ -27,6 +28,7 @@ export class PrismaRepositoryFactory implements IRepositoryFactory {
       trainingMaxHistory: new PrismaTrainingMaxHistoryRepository(this.prisma, user.id),
       cycleDashboard: new PrismaCycleDashboardRepository(this.prisma, user.id),
       workout: new PrismaWorkoutRepository(this.prisma, user.id),
+      workoutDateOverride: new PrismaWorkoutDateOverrideRepository(this.prisma, user.id),
       liftingProgramSpec: this.programSpecRepo,
       programPhilosophy: this.philosophyRepo,
     };

--- a/apps/api/src/adapters/prisma/workout-date-override.repository.ts
+++ b/apps/api/src/adapters/prisma/workout-date-override.repository.ts
@@ -1,0 +1,49 @@
+import { PrismaClient } from '@prisma/client';
+import { IWorkoutDateOverrideRepository } from '../../ports/IWorkoutDateOverrideRepository';
+
+export class PrismaWorkoutDateOverrideRepository
+  implements IWorkoutDateOverrideRepository
+{
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly userId: string,
+  ) {}
+
+  async getOverride(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+  ): Promise<Date | null> {
+    const row = await this.prisma.workoutDateOverride.findUnique({
+      where: {
+        userId_program_cycleNum_workoutNum: {
+          userId: this.userId,
+          program,
+          cycleNum,
+          workoutNum,
+        },
+      },
+    });
+    return row?.newDate ?? null;
+  }
+
+  async upsertOverride(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+    newDate: Date,
+  ): Promise<void> {
+    await this.prisma.workoutDateOverride.upsert({
+      where: {
+        userId_program_cycleNum_workoutNum: {
+          userId: this.userId,
+          program,
+          cycleNum,
+          workoutNum,
+        },
+      },
+      create: { userId: this.userId, program, cycleNum, workoutNum, newDate },
+      update: { newDate },
+    });
+  }
+}

--- a/apps/api/src/ports/IWorkoutDateOverrideRepository.ts
+++ b/apps/api/src/ports/IWorkoutDateOverrideRepository.ts
@@ -1,0 +1,14 @@
+export interface IWorkoutDateOverrideRepository {
+  getOverride(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+  ): Promise<Date | null>;
+
+  upsertOverride(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+    newDate: Date,
+  ): Promise<void>;
+}

--- a/apps/api/src/ports/factory.ts
+++ b/apps/api/src/ports/factory.ts
@@ -6,6 +6,7 @@ import { IProgramPhilosophyRepository } from './IProgramPhilosophyRepository';
 import { IStrengthGoalRepository } from './IStrengthGoalRepository';
 import { ITrainingMaxHistoryRepository } from './ITrainingMaxHistoryRepository';
 import { ITrainingMaxRepository } from './ITrainingMaxRepository';
+import { IWorkoutDateOverrideRepository } from './IWorkoutDateOverrideRepository';
 import { IWorkoutRepository } from './IWorkoutRepository';
 
 export interface RepositoryBundle {
@@ -17,6 +18,7 @@ export interface RepositoryBundle {
   trainingMax: ITrainingMaxRepository;
   trainingMaxHistory: ITrainingMaxHistoryRepository;
   workout: IWorkoutRepository;
+  workoutDateOverride: IWorkoutDateOverrideRepository;
 }
 
 export interface IRepositoryFactory {

--- a/apps/api/src/ports/index.ts
+++ b/apps/api/src/ports/index.ts
@@ -11,4 +11,5 @@ export * from './IProgramPhilosophyRepository';
 export * from './ITrainingMaxHistoryRepository';
 export * from './IStrengthGoalRepository';
 export * from './ITrainingMaxRepository';
+export * from './IWorkoutDateOverrideRepository';
 export * from './IWorkoutRepository';

--- a/apps/api/src/ports/ports.compile-test.ts
+++ b/apps/api/src/ports/ports.compile-test.ts
@@ -16,6 +16,7 @@ import { ILiftRecordRepository } from './ILiftRecordRepository';
 import { IProgramPhilosophyRepository } from './IProgramPhilosophyRepository';
 import { ITrainingMaxRepository } from './ITrainingMaxRepository';
 import { ITrainingMaxHistoryRepository } from './ITrainingMaxHistoryRepository';
+import { IWorkoutDateOverrideRepository } from './IWorkoutDateOverrideRepository';
 import { IWorkoutRepository } from './IWorkoutRepository';
 
 // ---------------------------------------------------------------------------
@@ -112,6 +113,11 @@ const _programPhilosophyRepo: IProgramPhilosophyRepository = {
   listPrograms: () => Promise.resolve([]),
 };
 
+const _workoutDateOverrideRepo: IWorkoutDateOverrideRepository = {
+  getOverride: () => Promise.resolve(null),
+  upsertOverride: () => Promise.resolve(),
+};
+
 const _repositoryBundle: RepositoryBundle = {
   cycleDashboard: _cycleDashboardRepo,
   liftingProgramSpec: _programSpecRepo,
@@ -120,6 +126,7 @@ const _repositoryBundle: RepositoryBundle = {
   trainingMax: _trainingMaxRepo,
   trainingMaxHistory: _trainingMaxHistoryRepo,
   workout: _workoutRepo,
+  workoutDateOverride: _workoutDateOverrideRepo,
 };
 
 const _repositoryFactory: IRepositoryFactory = {
@@ -136,5 +143,6 @@ void _liftRecordRepo;
 void _trainingMaxRepo;
 void _trainingMaxHistoryRepo;
 void _workoutRepo;
+void _workoutDateOverrideRepo;
 void _repositoryBundle;
 void _repositoryFactory;

--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -144,6 +144,7 @@ export const toWorkoutResponse = (
   workoutNum: number,
   week: WeekNumber,
   records: LiftRecord[],
+  overrideDate?: Date,
 ): WorkoutResponse => {
   const liftMap = new Map<string, SetResponse[]>();
   for (const r of records) {
@@ -161,5 +162,13 @@ export const toWorkoutResponse = (
     ([lift, sets]) => ({ lift, sets }),
   );
   const date = records[0] ? isoDate(records[0].date) : isoDate(new Date());
-  return { program, cycleNum, workoutNum, week, date, lifts };
+  return {
+    program,
+    cycleNum,
+    workoutNum,
+    week,
+    date,
+    ...(overrideDate !== undefined && { overrideDate: isoDate(overrideDate) }),
+    lifts,
+  };
 };

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -162,6 +162,19 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
       const res = await injectRaw({ method: 'PATCH', url: RESCHEDULE_URL });
       expect(res.statusCode).toBe(401);
     });
+
+    it('PATCH reschedule with unknown program returns 404', async () => {
+      const res = await _patchJson(
+        `/programs/no-such-program/cycles/1/workouts/1/reschedule`,
+        { newDate: '2026-06-01' },
+      );
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('PATCH reschedule with datetime string returns 400', async () => {
+      const res = await _patchJson(RESCHEDULE_URL, { newDate: '2026-06-01T12:00:00Z' });
+      expect(res.statusCode).toBe(400);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -121,6 +121,49 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
     expect(res.statusCode).toBe(404);
   });
 
+  // ---------------------------------------------------------------------------
+  // Workout reschedule (read-compatible: uses seeded cycle 1 data)
+  // Run before write operations so cycleNum is still 1.
+  // ---------------------------------------------------------------------------
+
+  describe('workout reschedule', () => {
+    const RESCHEDULE_URL = `/programs/${SEED_PROGRAM}/cycles/1/workouts/1/reschedule`;
+
+    it('PATCH reschedule returns 204 No Content', async () => {
+      const res = await _patchJson(RESCHEDULE_URL, { newDate: '2026-06-01' });
+      expect(res.statusCode).toBe(204);
+    });
+
+    it('GET workout after reschedule includes overrideDate', async () => {
+      await _patchJson(RESCHEDULE_URL, { newDate: '2026-06-01' });
+      const res = await get(`/programs/${SEED_PROGRAM}/workouts/1`);
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.overrideDate).toBe('2026-06-01');
+    });
+
+    it('PATCH reschedule with invalid date returns 400', async () => {
+      const res = await _patchJson(RESCHEDULE_URL, { newDate: 'not-a-date' });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('PATCH reschedule with invalid workoutNum returns 400', async () => {
+      const res = await _patchJson(
+        `/programs/${SEED_PROGRAM}/cycles/1/workouts/0/reschedule`,
+        { newDate: '2026-06-01' },
+      );
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('PATCH reschedule requires auth', async () => {
+      const injectRaw = app.getHttpAdapter().getInstance().inject.bind(
+        app.getHttpAdapter().getInstance(),
+      );
+      const res = await injectRaw({ method: 'PATCH', url: RESCHEDULE_URL });
+      expect(res.statusCode).toBe(401);
+    });
+  });
+
   // -------------------------------------------------------------------------
   // Write endpoints — order-sensitive; each test mutates singleton adapter
   // state and the next test observes that state. Do not reorder or randomize.

--- a/apps/api/src/programs/programs.module.ts
+++ b/apps/api/src/programs/programs.module.ts
@@ -12,6 +12,7 @@ import { ProgramSpecController } from './program-spec.controller';
 import { StrengthGoalsController } from './strength-goals.controller';
 import { TrainingMaxesController } from './training-maxes.controller';
 import { TrainingMaxHistoryController } from './training-max-history.controller';
+import { RescheduleController } from './reschedule.controller';
 import { WorkoutsController } from './workouts.controller';
 
 @Module({
@@ -20,6 +21,7 @@ import { WorkoutsController } from './workouts.controller';
     CycleDashboardController,
     CycleGenerationController,
     CyclePlanController,
+    RescheduleController,
     WorkoutsController,
     StrengthGoalsController,
     TrainingMaxesController,

--- a/apps/api/src/programs/reschedule.controller.spec.ts
+++ b/apps/api/src/programs/reschedule.controller.spec.ts
@@ -1,0 +1,93 @@
+import { BadRequestException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { IWorkoutDateOverrideRepository } from '../ports/IWorkoutDateOverrideRepository';
+import { IRepositoryFactory } from '../ports/factory';
+import { REPOSITORY_FACTORY } from '../ports/tokens';
+import { RescheduleController } from './reschedule.controller';
+
+const MOCK_USER_A = { id: 'user-a', email: 'a@example.com', provider: 'dev' };
+const _MOCK_USER_B = { id: 'user-b', email: 'b@example.com', provider: 'dev' };
+
+describe('RescheduleController', () => {
+  let controller: RescheduleController;
+  let overrideRepoA: jest.Mocked<IWorkoutDateOverrideRepository>;
+  let overrideRepoB: jest.Mocked<IWorkoutDateOverrideRepository>;
+  let factory: jest.Mocked<IRepositoryFactory>;
+
+  beforeEach(async () => {
+    overrideRepoA = {
+      getOverride: jest.fn().mockResolvedValue(null),
+      upsertOverride: jest.fn().mockResolvedValue(undefined),
+    };
+    overrideRepoB = {
+      getOverride: jest.fn().mockResolvedValue(null),
+      upsertOverride: jest.fn().mockResolvedValue(undefined),
+    };
+    factory = {
+      forUser: jest.fn().mockImplementation(async (user) =>
+        user.id === MOCK_USER_A.id
+          ? { workoutDateOverride: overrideRepoA }
+          : { workoutDateOverride: overrideRepoB },
+      ),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [RescheduleController],
+      providers: [{ provide: REPOSITORY_FACTORY, useValue: factory }],
+    }).compile();
+    controller = module.get(RescheduleController);
+  });
+
+  it('upserts an override for valid inputs', async () => {
+    await controller.reschedule('5-3-1', '3', '2', { newDate: '2026-05-15' }, MOCK_USER_A);
+
+    expect(overrideRepoA.upsertOverride).toHaveBeenCalledWith(
+      '5-3-1',
+      3,
+      2,
+      new Date('2026-05-15'),
+    );
+  });
+
+  it('returns no content (void) on success', async () => {
+    const result = await controller.reschedule(
+      '5-3-1',
+      '3',
+      '2',
+      { newDate: '2026-05-15' },
+      MOCK_USER_A,
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it('rejects non-integer cycleNum', async () => {
+    await expect(
+      controller.reschedule('5-3-1', 'abc', '2', { newDate: '2026-05-15' }, MOCK_USER_A),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(overrideRepoA.upsertOverride).not.toHaveBeenCalled();
+  });
+
+  it('rejects zero cycleNum', async () => {
+    await expect(
+      controller.reschedule('5-3-1', '0', '2', { newDate: '2026-05-15' }, MOCK_USER_A),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects non-integer workoutNum', async () => {
+    await expect(
+      controller.reschedule('5-3-1', '3', 'xyz', { newDate: '2026-05-15' }, MOCK_USER_A),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects workoutNum less than 1', async () => {
+    await expect(
+      controller.reschedule('5-3-1', '3', '0', { newDate: '2026-05-15' }, MOCK_USER_A),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('user A reschedule does not affect user B repo', async () => {
+    await controller.reschedule('5-3-1', '3', '2', { newDate: '2026-05-15' }, MOCK_USER_A);
+
+    expect(overrideRepoA.upsertOverride).toHaveBeenCalledTimes(1);
+    expect(overrideRepoB.upsertOverride).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/programs/reschedule.controller.spec.ts
+++ b/apps/api/src/programs/reschedule.controller.spec.ts
@@ -1,5 +1,6 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
 import { IWorkoutDateOverrideRepository } from '../ports/IWorkoutDateOverrideRepository';
 import { IRepositoryFactory } from '../ports/factory';
 import { REPOSITORY_FACTORY } from '../ports/tokens';
@@ -8,10 +9,14 @@ import { RescheduleController } from './reschedule.controller';
 const MOCK_USER_A = { id: 'user-a', email: 'a@example.com', provider: 'dev' };
 const _MOCK_USER_B = { id: 'user-b', email: 'b@example.com', provider: 'dev' };
 
+const STUB_SPEC = [{ lift: 'Squat' }] as unknown as Awaited<ReturnType<ILiftingProgramSpecRepository['getProgramSpec']>>;
+
 describe('RescheduleController', () => {
   let controller: RescheduleController;
   let overrideRepoA: jest.Mocked<IWorkoutDateOverrideRepository>;
   let overrideRepoB: jest.Mocked<IWorkoutDateOverrideRepository>;
+  let specRepoA: jest.Mocked<ILiftingProgramSpecRepository>;
+  let specRepoB: jest.Mocked<ILiftingProgramSpecRepository>;
   let factory: jest.Mocked<IRepositoryFactory>;
 
   beforeEach(async () => {
@@ -23,11 +28,13 @@ describe('RescheduleController', () => {
       getOverride: jest.fn().mockResolvedValue(null),
       upsertOverride: jest.fn().mockResolvedValue(undefined),
     };
+    specRepoA = { getProgramSpec: jest.fn().mockResolvedValue(STUB_SPEC) } as jest.Mocked<ILiftingProgramSpecRepository>;
+    specRepoB = { getProgramSpec: jest.fn().mockResolvedValue(STUB_SPEC) } as jest.Mocked<ILiftingProgramSpecRepository>;
     factory = {
       forUser: jest.fn().mockImplementation(async (user) =>
         user.id === MOCK_USER_A.id
-          ? { workoutDateOverride: overrideRepoA }
-          : { workoutDateOverride: overrideRepoB },
+          ? { workoutDateOverride: overrideRepoA, liftingProgramSpec: specRepoA }
+          : { workoutDateOverride: overrideRepoB, liftingProgramSpec: specRepoB },
       ),
     };
     const module: TestingModule = await Test.createTestingModule({
@@ -44,7 +51,7 @@ describe('RescheduleController', () => {
       '5-3-1',
       3,
       2,
-      new Date('2026-05-15'),
+      new Date('2026-05-15T00:00:00Z'),
     );
   });
 
@@ -89,5 +96,13 @@ describe('RescheduleController', () => {
 
     expect(overrideRepoA.upsertOverride).toHaveBeenCalledTimes(1);
     expect(overrideRepoB.upsertOverride).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown program with NotFoundException', async () => {
+    specRepoA.getProgramSpec.mockResolvedValue([]);
+    await expect(
+      controller.reschedule('no-such-program', '3', '2', { newDate: '2026-05-15' }, MOCK_USER_A),
+    ).rejects.toBeInstanceOf(NotFoundException);
+    expect(overrideRepoA.upsertOverride).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/programs/reschedule.controller.ts
+++ b/apps/api/src/programs/reschedule.controller.ts
@@ -5,6 +5,7 @@ import {
   HttpCode,
   HttpStatus,
   Inject,
+  NotFoundException,
   Param,
   Patch,
 } from '@nestjs/common';
@@ -40,7 +41,20 @@ export class RescheduleController {
       throw new BadRequestException('workoutNum must be a positive integer');
     }
 
-    const { workoutDateOverride } = await this.factory.forUser(user);
-    await workoutDateOverride.upsertOverride(program, cycleNum, workoutNum, new Date(dto.newDate));
+    const { workoutDateOverride, liftingProgramSpec } = await this.factory.forUser(user);
+
+    const spec = await liftingProgramSpec.getProgramSpec(program);
+    if (spec.length === 0) {
+      throw new NotFoundException(`Program '${program}' not found`);
+    }
+
+    // Append explicit UTC midnight so the YYYY-MM-DD string is stored as the correct calendar day
+    // regardless of the server's local timezone.
+    await workoutDateOverride.upsertOverride(
+      program,
+      cycleNum,
+      workoutNum,
+      new Date(dto.newDate + 'T00:00:00Z'),
+    );
   }
 }

--- a/apps/api/src/programs/reschedule.controller.ts
+++ b/apps/api/src/programs/reschedule.controller.ts
@@ -1,0 +1,46 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  Param,
+  Patch,
+} from '@nestjs/common';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { AuthUser } from '../ports/auth';
+import { IRepositoryFactory } from '../ports/factory';
+import { REPOSITORY_FACTORY } from '../ports/tokens';
+import { isValidWorkoutNum } from './mappers';
+import { RescheduleDto } from './reschedule.dto';
+
+@Controller('programs/:program')
+export class RescheduleController {
+  constructor(
+    @Inject(REPOSITORY_FACTORY) private readonly factory: IRepositoryFactory,
+  ) {}
+
+  @Patch('cycles/:cycleNum/workouts/:workoutNum/reschedule')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async reschedule(
+    @Param('program') program: string,
+    @Param('cycleNum') cycleNumParam: string,
+    @Param('workoutNum') workoutNumParam: string,
+    @Body() dto: RescheduleDto,
+    @CurrentUser() user: AuthUser,
+  ): Promise<void> {
+    const cycleNum = Number.parseInt(cycleNumParam, 10);
+    const workoutNum = Number.parseInt(workoutNumParam, 10);
+
+    if (!Number.isInteger(cycleNum) || cycleNum < 1) {
+      throw new BadRequestException('cycleNum must be a positive integer');
+    }
+    if (!isValidWorkoutNum(workoutNum)) {
+      throw new BadRequestException('workoutNum must be a positive integer');
+    }
+
+    const { workoutDateOverride } = await this.factory.forUser(user);
+    await workoutDateOverride.upsertOverride(program, cycleNum, workoutNum, new Date(dto.newDate));
+  }
+}

--- a/apps/api/src/programs/reschedule.dto.ts
+++ b/apps/api/src/programs/reschedule.dto.ts
@@ -1,6 +1,8 @@
-import { IsDateString } from 'class-validator';
+import { IsString, Matches } from 'class-validator';
 
 export class RescheduleDto {
-  @IsDateString()
+  /** Calendar date in YYYY-MM-DD format. Time and timezone components are not accepted. */
+  @IsString()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'newDate must be a calendar date in YYYY-MM-DD format' })
   newDate!: string;
 }

--- a/apps/api/src/programs/reschedule.dto.ts
+++ b/apps/api/src/programs/reschedule.dto.ts
@@ -1,0 +1,6 @@
+import { IsDateString } from 'class-validator';
+
+export class RescheduleDto {
+  @IsDateString()
+  newDate!: string;
+}

--- a/apps/api/src/programs/workouts.controller.spec.ts
+++ b/apps/api/src/programs/workouts.controller.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { Weekday } from '@lifting-logbook/core';
 import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
 import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
+import { IWorkoutDateOverrideRepository } from '../ports/IWorkoutDateOverrideRepository';
 import { IWorkoutRepository } from '../ports/IWorkoutRepository';
 import { IRepositoryFactory } from '../ports/factory';
 import { REPOSITORY_FACTORY } from '../ports/tokens';
@@ -15,6 +16,7 @@ describe('WorkoutsController', () => {
   let workoutRepo: jest.Mocked<IWorkoutRepository>;
   let dashboardRepo: jest.Mocked<ICycleDashboardRepository>;
   let specRepo: jest.Mocked<ILiftingProgramSpecRepository>;
+  let overrideRepo: jest.Mocked<IWorkoutDateOverrideRepository>;
   let factory: jest.Mocked<IRepositoryFactory>;
 
   beforeEach(async () => {
@@ -24,11 +26,16 @@ describe('WorkoutsController', () => {
       saveCycleDashboard: jest.fn(),
     };
     specRepo = { getProgramSpec: jest.fn() };
+    overrideRepo = {
+      getOverride: jest.fn().mockResolvedValue(null),
+      upsertOverride: jest.fn().mockResolvedValue(undefined),
+    };
     factory = {
       forUser: jest.fn().mockResolvedValue({
         workout: workoutRepo,
         cycleDashboard: dashboardRepo,
         liftingProgramSpec: specRepo,
+        workoutDateOverride: overrideRepo,
       }),
     };
     const module: TestingModule = await Test.createTestingModule({
@@ -167,5 +174,65 @@ describe('WorkoutsController', () => {
     await expect(controller.getWorkout('5-3-1', '2', MOCK_USER)).rejects.toBeInstanceOf(
       BadRequestException,
     );
+  });
+
+  describe('overrideDate', () => {
+    const baseDashboard = {
+      program: '5-3-1',
+      cycleUnit: 'week',
+      cycleNum: 3,
+      cycleDate: new Date('2026-04-20T00:00:00.000Z'),
+      sheetName: '',
+      cycleStartWeekday: Weekday.Monday,
+      currentWeekType: 'training' as const,
+    };
+    const baseSpec = [
+      {
+        week: 1,
+        offset: 0,
+        lift: 'Squat',
+        increment: 5,
+        order: 1,
+        sets: 3,
+        reps: 5,
+        amrap: false,
+        warmUpPct: '',
+        wtDecrementPct: 0,
+        activation: 'compound',
+      },
+    ];
+    const baseRecord = {
+      program: '5-3-1',
+      cycleNum: 3,
+      workoutNum: 1,
+      date: new Date('2026-04-20T00:00:00.000Z'),
+      lift: 'Squat',
+      setNum: 1,
+      weight: 200,
+      reps: 5,
+      notes: '',
+    };
+
+    it('includes overrideDate in response when an override exists', async () => {
+      dashboardRepo.getCycleDashboard.mockResolvedValue(baseDashboard);
+      specRepo.getProgramSpec.mockResolvedValue(baseSpec);
+      workoutRepo.getWorkout.mockResolvedValue([baseRecord]);
+      overrideRepo.getOverride.mockResolvedValue(new Date('2026-05-01T00:00:00.000Z'));
+
+      const result = await controller.getWorkout('5-3-1', '1', MOCK_USER);
+
+      expect(result.overrideDate).toBe('2026-05-01');
+    });
+
+    it('omits overrideDate when no override exists', async () => {
+      dashboardRepo.getCycleDashboard.mockResolvedValue(baseDashboard);
+      specRepo.getProgramSpec.mockResolvedValue(baseSpec);
+      workoutRepo.getWorkout.mockResolvedValue([baseRecord]);
+      overrideRepo.getOverride.mockResolvedValue(null);
+
+      const result = await controller.getWorkout('5-3-1', '1', MOCK_USER);
+
+      expect(result.overrideDate).toBeUndefined();
+    });
   });
 });

--- a/apps/api/src/programs/workouts.controller.ts
+++ b/apps/api/src/programs/workouts.controller.ts
@@ -28,7 +28,7 @@ export class WorkoutsController {
     if (!isValidWorkoutNum(workoutNum)) {
       throw new BadRequestException('workoutNum must be a positive integer');
     }
-    const { workout, cycleDashboard, liftingProgramSpec } = await this.factory.forUser(user);
+    const { workout, cycleDashboard, liftingProgramSpec, workoutDateOverride } = await this.factory.forUser(user);
     const [dashboard, spec] = await Promise.all([
       cycleDashboard.getCycleDashboard(program),
       liftingProgramSpec.getProgramSpec(program),
@@ -39,7 +39,10 @@ export class WorkoutsController {
         `workoutNum ${workoutNum} exceeds program spec (${new Set(spec.map((s) => s.offset)).size} workout days)`,
       );
     }
-    const records = await workout.getWorkout(program, dashboard.cycleNum, workoutNum);
-    return toWorkoutResponse(program, dashboard.cycleNum, workoutNum, week, records);
+    const [records, overrideDate] = await Promise.all([
+      workout.getWorkout(program, dashboard.cycleNum, workoutNum),
+      workoutDateOverride.getOverride(program, dashboard.cycleNum, workoutNum),
+    ]);
+    return toWorkoutResponse(program, dashboard.cycleNum, workoutNum, week, records, overrideDate ?? undefined);
   }
 }

--- a/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.module.css
+++ b/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.module.css
@@ -60,10 +60,19 @@
 }
 
 .workoutCard {
+  display: block;
   padding: var(--space-4);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   min-width: 0;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  transition: box-shadow var(--transition-fast);
+}
+
+.workoutCard:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
 .card_completed {

--- a/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.tsx
+++ b/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.tsx
@@ -28,9 +28,18 @@ function StatusBadge({ status }: { status: WorkoutCell['status'] }) {
   );
 }
 
-function WorkoutCard({ cell }: { cell: WorkoutCell }) {
+function WorkoutCard({
+  cell,
+  cycleNum,
+}: {
+  cell: WorkoutCell;
+  cycleNum: number;
+}) {
   return (
-    <div className={`${styles.workoutCard} ${styles[`card_${cell.status}`]}`}>
+    <Link
+      href={`/cycle/${cycleNum}/workout/${cell.workoutNum}/detail`}
+      className={`${styles.workoutCard} ${styles[`card_${cell.status}`]}`}
+    >
       <div className={styles.cardHeader}>
         <time dateTime={cell.date}>{cell.date}</time>
         <StatusBadge status={cell.status} />
@@ -49,7 +58,7 @@ function WorkoutCard({ cell }: { cell: WorkoutCell }) {
           </li>
         ))}
       </ul>
-    </div>
+    </Link>
   );
 }
 
@@ -106,7 +115,7 @@ export default function CycleDashboardGrid({
               {isExpanded && (
                 <div className={styles.workouts}>
                   {row.workouts.map((cell) => (
-                    <WorkoutCard key={cell.workoutNum} cell={cell} />
+                    <WorkoutCard key={cell.workoutNum} cell={cell} cycleNum={cycleNum} />
                   ))}
                 </div>
               )}

--- a/apps/web/app/cycle/[cycleNum]/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/page.tsx
@@ -52,14 +52,17 @@ export default async function CycleDashboardPage({
       .map((w): WorkoutCell => {
         const response = workoutResponseMap.get(w.workoutNum);
         const logged = response != null && response.lifts.length > 0;
+        // Prefer the user's overridden date when one exists; fall back to the computed schedule date.
+        // Status comparison uses UTC date strings (ISO YYYY-MM-DD) consistently across dashboard and detail page.
+        const effectiveDate = response?.overrideDate ?? w.date;
         const status: WorkoutCell['status'] = logged
           ? 'completed'
-          : w.date < today
+          : effectiveDate < today
             ? 'missed'
             : 'upcoming';
         return {
           workoutNum: w.workoutNum,
-          date: w.date,
+          date: effectiveDate,
           status,
           lifts: w.lifts.map((spec) => ({
             name: spec.lift,

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/RescheduleForm.module.css
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/RescheduleForm.module.css
@@ -1,0 +1,115 @@
+.trigger {
+  padding: var(--space-2) var(--space-4);
+  background: transparent;
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.trigger:hover {
+  background: var(--color-surface-alt);
+}
+
+.form {
+  width: 100%;
+  padding: var(--space-4);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.infoBox {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.label {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+.input,
+.inputReadOnly {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  background: var(--color-surface);
+  color: var(--color-text);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.inputReadOnly {
+  background: var(--color-surface-alt);
+  color: var(--color-text-muted);
+  cursor: default;
+}
+
+.error {
+  font-size: var(--font-size-sm);
+  color: var(--color-error-text, red);
+  margin: 0;
+}
+
+.buttons {
+  display: flex;
+  gap: var(--space-3);
+  justify-content: flex-end;
+}
+
+.cancel {
+  padding: var(--space-2) var(--space-4);
+  background: transparent;
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.cancel:not(:disabled):hover {
+  background: var(--color-surface-alt);
+}
+
+.cancel:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.move {
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-accent);
+  color: var(--color-accent-text);
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.move:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.move:not(:disabled):hover {
+  opacity: 0.88;
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/RescheduleForm.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/RescheduleForm.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { rescheduleWorkout } from '@/lib/client-api';
+import styles from './RescheduleForm.module.css';
+
+interface Props {
+  program: string;
+  cycleNum: number;
+  workoutNum: number;
+  currentDate: string;
+}
+
+export default function RescheduleForm({ program, cycleNum, workoutNum, currentDate }: Props) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [newDate, setNewDate] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleMove() {
+    if (!newDate) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await rescheduleWorkout(program, cycleNum, workoutNum, newDate);
+      setOpen(false);
+      router.refresh();
+    } catch {
+      setError('Failed to reschedule. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button type="button" className={styles.trigger} onClick={() => setOpen(true)}>
+        📅 Reschedule
+      </button>
+    );
+  }
+
+  return (
+    <div className={styles.form}>
+      <p className={styles.infoBox}>
+        Move this workout to a different day. Lifts stay the same.
+      </p>
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="current-date">
+          Current date
+        </label>
+        <input
+          id="current-date"
+          type="text"
+          value={currentDate}
+          readOnly
+          className={styles.inputReadOnly}
+        />
+      </div>
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="new-date">
+          New date
+        </label>
+        <input
+          id="new-date"
+          type="date"
+          value={newDate}
+          onChange={(e) => setNewDate(e.target.value)}
+          className={styles.input}
+          aria-describedby={error ? 'reschedule-error' : undefined}
+        />
+      </div>
+      {error && (
+        <p id="reschedule-error" className={styles.error}>
+          {error}
+        </p>
+      )}
+      <div className={styles.buttons}>
+        <button
+          type="button"
+          className={styles.cancel}
+          onClick={() => {
+            setOpen(false);
+            setNewDate('');
+            setError(null);
+          }}
+          disabled={loading}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className={styles.move}
+          onClick={handleMove}
+          disabled={!newDate || loading}
+        >
+          {loading ? 'Moving…' : 'Move'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/[lift]/LiftHistoryFilters.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/[lift]/LiftHistoryFilters.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useState } from 'react';
+import type { LiftRecordResponse } from '@lifting-logbook/types';
+import styles from './lift.module.css';
+
+interface Props {
+  records: LiftRecordResponse[];
+}
+
+export default function LiftHistoryFilters({ records }: Props) {
+  const [minWeight, setMinWeight] = useState('');
+  const [dateFilter, setDateFilter] = useState('');
+
+  const filtered = records.filter((r) => {
+    if (minWeight !== '' && r.weight < Number(minWeight)) return false;
+    if (dateFilter !== '' && !r.date.includes(dateFilter)) return false;
+    return true;
+  });
+
+  return (
+    <div>
+      <div className={styles.filters}>
+        <label className={styles.filterLabel}>
+          Min weight
+          <input
+            type="number"
+            min={0}
+            value={minWeight}
+            onChange={(e) => setMinWeight(e.target.value)}
+            className={styles.filterInput}
+            placeholder="e.g. 135"
+          />
+        </label>
+        <label className={styles.filterLabel}>
+          Date contains
+          <input
+            type="text"
+            value={dateFilter}
+            onChange={(e) => setDateFilter(e.target.value)}
+            className={styles.filterInput}
+            placeholder="e.g. 2026-04"
+          />
+        </label>
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className={styles.empty}>No sets match the current filters.</p>
+      ) : (
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Workout</th>
+              <th>Set</th>
+              <th>Weight</th>
+              <th>Reps</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((r) => (
+              <tr key={r.id}>
+                <td>{r.date}</td>
+                <td>{r.workoutNum}</td>
+                <td>{r.setNum}</td>
+                <td>{r.weight} lbs</td>
+                <td>{r.reps}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/[lift]/lift.module.css
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/[lift]/lift.module.css
@@ -1,0 +1,103 @@
+.container {
+  padding: var(--space-4);
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.backLink {
+  display: inline-block;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  text-decoration: none;
+  margin-bottom: var(--space-4);
+}
+
+.backLink:hover {
+  color: var(--color-text);
+}
+
+.heading {
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+  margin-bottom: var(--space-6);
+}
+
+.section {
+  margin-bottom: var(--space-6);
+}
+
+.sectionHeading {
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  margin-bottom: var(--space-3);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.currentMax {
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+}
+
+.empty {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.prBadge {
+  display: inline-block;
+  padding: 1px var(--space-2);
+  background: var(--color-success-bg);
+  color: var(--color-success-text);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-sm);
+}
+
+.table th {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 2px solid var(--color-border-strong);
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.table td {
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.table tr:last-child td {
+  border-bottom: none;
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.filterLabel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+.filterInput {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  background: var(--color-surface);
+  color: var(--color-text);
+  min-width: 120px;
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/[lift]/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/[lift]/page.tsx
@@ -32,6 +32,11 @@ export default async function LiftDetailPage({
     .filter((r) => r.lift === lift)
     .sort((a, b) => b.date.localeCompare(a.date));
 
+  // Unknown lift: no TM, no history, no sets — the URL is invalid or stale.
+  if (!currentMax && tmHistory.length === 0 && setHistory.length === 0) {
+    notFound();
+  }
+
   return (
     <main className={styles.container}>
       <Link

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/[lift]/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/[lift]/page.tsx
@@ -1,0 +1,98 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { fetchTrainingMaxes, fetchTrainingMaxHistory, fetchLiftRecords } from '@/lib/api';
+import LiftHistoryFilters from './LiftHistoryFilters';
+import styles from './lift.module.css';
+
+export default async function LiftDetailPage({
+  params,
+}: {
+  params: Promise<{ cycleNum: string; workoutNum: string; lift: string }>;
+}) {
+  const { cycleNum: cycleNumParam, workoutNum: workoutNumParam, lift: liftParam } = await params;
+  const cycleNum = Number(cycleNumParam);
+  const workoutNum = Number(workoutNumParam);
+  const lift = decodeURIComponent(liftParam);
+
+  if (!Number.isInteger(cycleNum) || !Number.isInteger(workoutNum) || workoutNum < 1) {
+    notFound();
+  }
+
+  const program = process.env.NEXT_PUBLIC_DEFAULT_PROGRAM ?? '5-3-1';
+
+  const [maxes, history, allRecords] = await Promise.all([
+    fetchTrainingMaxes(program),
+    fetchTrainingMaxHistory(program),
+    fetchLiftRecords(program),
+  ]);
+
+  const currentMax = maxes.find((m) => m.lift === lift);
+  const tmHistory = history.entries.filter((e) => e.lift === lift);
+  const setHistory = allRecords
+    .filter((r) => r.lift === lift)
+    .sort((a, b) => b.date.localeCompare(a.date));
+
+  return (
+    <main className={styles.container}>
+      <Link
+        href={`/cycle/${cycleNum}/workout/${workoutNum}/detail`}
+        className={styles.backLink}
+      >
+        ← Back to Workout
+      </Link>
+
+      <h1 className={styles.heading}>{lift}</h1>
+
+      <section className={styles.section}>
+        <h2 className={styles.sectionHeading}>Current Training Max</h2>
+        {currentMax ? (
+          <p className={styles.currentMax}>
+            {currentMax.weight} {currentMax.unit}
+          </p>
+        ) : (
+          <p className={styles.empty}>No training max set.</p>
+        )}
+      </section>
+
+      {tmHistory.length > 0 && (
+        <section className={styles.section}>
+          <h2 className={styles.sectionHeading}>Training Max History</h2>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Weight</th>
+                <th>Reps</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {tmHistory
+                .slice()
+                .sort((a, b) => b.date.localeCompare(a.date))
+                .map((entry) => (
+                  <tr key={entry.id}>
+                    <td>{entry.date}</td>
+                    <td>
+                      {entry.weight} {entry.unit}
+                    </td>
+                    <td>{entry.reps}</td>
+                    <td>{entry.isPR && <span className={styles.prBadge}>PR</span>}</td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </section>
+      )}
+
+      <section className={styles.section}>
+        <h2 className={styles.sectionHeading}>Set History</h2>
+        {setHistory.length === 0 ? (
+          <p className={styles.empty}>No sets logged yet.</p>
+        ) : (
+          <LiftHistoryFilters records={setHistory} />
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/detail.module.css
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/detail.module.css
@@ -1,0 +1,168 @@
+.container {
+  padding: var(--space-4);
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.backLink {
+  display: inline-block;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  text-decoration: none;
+  margin-bottom: var(--space-4);
+}
+
+.backLink:hover {
+  color: var(--color-text);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: var(--space-6);
+  gap: var(--space-3);
+}
+
+.headerMeta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.date {
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+}
+
+.rescheduled {
+  font-weight: 400;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.weekLabel {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.badge {
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.badge_completed {
+  background: var(--color-success-bg);
+  color: var(--color-success-text);
+}
+
+.badge_upcoming {
+  background: var(--color-warn-bg);
+  color: var(--color-warn-text);
+}
+
+.badge_missed {
+  background: var(--color-missed-bg);
+  color: var(--color-upcoming-text);
+}
+
+.sectionHeading {
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  margin-bottom: var(--space-3);
+}
+
+.liftsSection {
+  margin-bottom: var(--space-6);
+}
+
+.liftList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.liftItem + .liftItem {
+  border-top: 1px solid var(--color-border);
+}
+
+.liftLink {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  text-decoration: none;
+  color: inherit;
+  transition: background var(--transition-fast);
+}
+
+.liftLink:hover {
+  background: var(--color-surface-alt);
+}
+
+.liftName {
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+  flex: 1;
+}
+
+.liftSummary {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.liftArrow {
+  font-size: var(--font-size-base);
+  color: var(--color-text-muted);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.btnPrimary {
+  display: inline-block;
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-accent);
+  color: var(--color-accent-text);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.btnPrimary:hover {
+  opacity: 0.88;
+}
+
+.btnSecondary {
+  padding: var(--space-2) var(--space-4);
+  background: transparent;
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.btnSecondary:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.btnSecondary:not(:disabled):hover {
+  background: var(--color-surface-alt);
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/page.tsx
@@ -1,0 +1,123 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { fetchWorkout, fetchProgramSpec, fetchTrainingMaxes } from '@/lib/api';
+import { computePlannedSets } from '@/lib/workoutPlan';
+import RescheduleForm from './RescheduleForm';
+import styles from './detail.module.css';
+
+function workoutStatus(
+  date: string,
+  hasLogs: boolean,
+): 'completed' | 'upcoming' | 'missed' {
+  const today = new Date().toISOString().slice(0, 10);
+  if (hasLogs) return 'completed';
+  if (date < today) return 'missed';
+  return 'upcoming';
+}
+
+export default async function WorkoutDetailPage({
+  params,
+}: {
+  params: Promise<{ cycleNum: string; workoutNum: string }>;
+}) {
+  const { cycleNum: cycleNumParam, workoutNum: workoutNumParam } = await params;
+  const cycleNum = Number(cycleNumParam);
+  const workoutNum = Number(workoutNumParam);
+
+  if (!Number.isInteger(cycleNum) || !Number.isInteger(workoutNum) || workoutNum < 1) {
+    notFound();
+  }
+
+  const program = process.env.NEXT_PUBLIC_DEFAULT_PROGRAM ?? '5-3-1';
+
+  const [workout, specs, maxes] = await Promise.all([
+    fetchWorkout(program, workoutNum),
+    fetchProgramSpec(program),
+    fetchTrainingMaxes(program),
+  ]);
+
+  if (!workout) {
+    notFound();
+    return null;
+  }
+
+  const effectiveDate = workout.overrideDate ?? workout.date;
+  const hasLogs = workout.lifts.length > 0;
+  const status = workoutStatus(effectiveDate, hasLogs);
+  const maxMap = new Map(maxes.map((m) => [m.lift, m.weight]));
+
+  // For each lift, compute warm-up and work set counts from spec
+  const liftDetails = workout.lifts.map((wl) => {
+    const spec = specs.find((s) => s.week === workout.week && s.lift === wl.lift);
+    const plannedSets = spec ? computePlannedSets(spec, maxMap.get(wl.lift) ?? 0) : [];
+    const warmUpCount = plannedSets.filter((s) => s.setLabel.startsWith('Warm-up')).length;
+    const workCount = plannedSets.filter((s) => s.setLabel.startsWith('Set')).length;
+    return { lift: wl.lift, warmUpCount, workCount };
+  });
+
+  const statusLabel =
+    status === 'completed' ? '✓ Done' : status === 'upcoming' ? 'Upcoming' : 'Missed';
+
+  return (
+    <main className={styles.container}>
+      <Link href={`/cycle/${cycleNum}`} className={styles.backLink}>
+        ← Back to Cycle
+      </Link>
+
+      <header className={styles.header}>
+        <div className={styles.headerMeta}>
+          <time dateTime={effectiveDate} className={styles.date}>
+            {effectiveDate}
+            {workout.overrideDate && (
+              <span className={styles.rescheduled}> (rescheduled)</span>
+            )}
+          </time>
+          <span className={styles.weekLabel}>Week {workout.week}</span>
+        </div>
+        <span className={`${styles.badge} ${styles[`badge_${status}`]}`}>
+          {statusLabel}
+        </span>
+      </header>
+
+      <section className={styles.liftsSection}>
+        <h2 className={styles.sectionHeading}>Planned Lifts</h2>
+        <ul className={styles.liftList}>
+          {liftDetails.map(({ lift, warmUpCount, workCount }) => (
+            <li key={lift} className={styles.liftItem}>
+              <Link
+                href={`/cycle/${cycleNum}/workout/${workoutNum}/detail/${encodeURIComponent(lift)}`}
+                className={styles.liftLink}
+              >
+                <span className={styles.liftName}>{lift}</span>
+                <span className={styles.liftSummary}>
+                  {warmUpCount} warm-up • {workCount} working
+                </span>
+                <span className={styles.liftArrow} aria-hidden="true">›</span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className={styles.actions}>
+        <button type="button" className={styles.btnSecondary} disabled>
+          ✏️ Manage Lifts
+        </button>
+        {status !== 'completed' && (
+          <Link
+            href={`/cycle/${cycleNum}/workout/${workoutNum}`}
+            className={styles.btnPrimary}
+          >
+            Start Logging
+          </Link>
+        )}
+        <RescheduleForm
+          program={program}
+          cycleNum={cycleNum}
+          workoutNum={workoutNum}
+          currentDate={effectiveDate}
+        />
+      </section>
+    </main>
+  );
+}

--- a/apps/web/lib/client-api.ts
+++ b/apps/web/lib/client-api.ts
@@ -50,6 +50,24 @@ export function updateLiftRecord(
   );
 }
 
+export async function rescheduleWorkout(
+  program: string,
+  cycleNum: number,
+  workoutNum: number,
+  newDate: string,
+): Promise<void> {
+  const path = `/programs/${encodeURIComponent(program)}/cycles/${cycleNum}/workouts/${workoutNum}/reschedule`;
+  const res = await fetch(`${API_URL}${path}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ newDate }),
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
+  }
+}
+
 export function recordBodyWeight(
   program: string,
   body: RecordBodyWeightRequest,

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -89,6 +89,7 @@ export interface WorkoutResponse {
   workoutNum: number;
   week: WeekNumber;
   date: string; // ISO 8601 date string
+  overrideDate?: string; // ISO 8601 date string; present when the user has rescheduled
   lifts: WorkoutLiftResponse[];
   bodyWeightEntry?: Pick<BodyWeightEntry, 'weight' | 'unit'>;
 }


### PR DESCRIPTION
## Summary

- Adds a workout detail screen between the cycle dashboard and the logger, matching the mockup in `docs/mockups/user-journeys.html`
- Introduces per-workout date overrides: users can reschedule any workout to a different day without changing its lifts
- Cycle dashboard cards now link to `/detail` instead of being static divs

## Changes

**Database**
- New `WorkoutDateOverride` model + migration `20260506000000_add_workout_date_override`

**API**
- `IWorkoutDateOverrideRepository` port with in-memory and Prisma adapters
- `PATCH /programs/:program/cycles/:cycleNum/workouts/:workoutNum/reschedule` — upserts override, returns 204
- `WorkoutResponse.overrideDate?: string` — present when workout has been rescheduled
- All three factory implementations updated (`InMemoryRepositoryFactory`, `PrismaRepositoryFactory`, `SystemDbRepositoryFactory`)

**Web**
- `apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/page.tsx` — server component showing date, week, status, planned lifts, and action buttons
- `RescheduleForm.tsx` — inline client component; toggles a date picker, calls PATCH, then `router.refresh()`
- `apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/[lift]/page.tsx` — lift history with current TM, TM history table, filterable set history
- `CycleDashboardGrid.tsx` — workout cards wrapped in `<Link href="…/detail">` and styled with hover state

## Acceptance Criteria

- [x] `workout_date_override` model + migration
- [x] PATCH reschedule endpoint
- [x] `WorkoutResponse` includes `overrideDate` when set
- [x] Detail page + lift history page render and match mockup
- [x] Cycle dashboard links to detail (not logger)
- [x] All new tests pass

## Testing

```
npm test -w @lifting-logbook/api   # 128 passed, 20 skipped (DB e2e, requires live DB)
npm test -w @lifting-logbook/web   # 23 passed
```

New test coverage:
- `reschedule.controller.spec.ts` — 7 unit cases (happy path, validation, isolation)
- `workouts.controller.spec.ts` — 2 new cases for `overrideDate` presence/absence
- `programs.e2e.spec.ts` — 5 new e2e cases (204, GET with overrideDate, 400 invalid date, 400 invalid workoutNum, 401 no auth)

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)