### PR TITLE
[feat] Manage lifts — add/remove/replace within a workout

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,6 +88,9 @@ Web and mobile clients functional end-to-end. Key user-facing features implement
 | A/B comparison documentation | Exit criteria and CI event taxonomy enforcement for Express/NestJS comparison | [#41](https://github.com/brownm09/lifting-logbook/issues/41) |
 | Per-user repository factory | `IRepositoryFactory` port with `forUser(AuthUser)`, `InMemoryRepositoryFactory` (per-user isolated bundles), `SystemDbRepositoryFactory` (adapter-type dispatch + single-flight cache); all 8 controllers threaded through factory; auth guard isolation E2E test | [#144](https://github.com/brownm09/lifting-logbook/issues/144) |
 | Workout detail and rescheduling | Per-workout detail screen (date, week, status, planned lifts with set counts, lift history drilldown); per-workout date override with `PATCH .../reschedule` endpoint; cycle dashboard cards now link to detail | [#177](https://github.com/brownm09/lifting-logbook/issues/177) |
+| Training max history | `training_max_history` table, GET/PATCH endpoints with date and PR filters, MaxHistory component on settings page, ADR-017 documented | [#174](https://github.com/brownm09/lifting-logbook/issues/174) |
+| Strength goal CRUD | `strength_goal` DB model, CRUD endpoints, `/settings/strength-goals` page with progress bars and quick-access dashboard button | [#175](https://github.com/brownm09/lifting-logbook/issues/175) |
+| Cycle Program and Plan views | Four quick-access buttons on cycle dashboard; `/cycle/:cycleNum/program` and `/cycle/:cycleNum/plan` pages for program spec and 6-phase plan overview | [#176](https://github.com/brownm09/lifting-logbook/issues/176) |
 
 ### Proposals
 

--- a/apps/api/prisma/migrations/20260507000000_add_workout_lift_override/migration.sql
+++ b/apps/api/prisma/migrations/20260507000000_add_workout_lift_override/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "workout_lift_override" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "program" TEXT NOT NULL,
+    "cycleNum" INTEGER NOT NULL,
+    "workoutNum" INTEGER NOT NULL,
+    "lift" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "replacedBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "workout_lift_override_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "workout_lift_override_userId_program_cycleNum_workoutNum_idx" ON "workout_lift_override"("userId", "program", "cycleNum", "workoutNum");
+
+-- CreateUniqueIndex
+CREATE UNIQUE INDEX "workout_lift_override_userId_program_cycleNum_workoutNum_lift_key" ON "workout_lift_override"("userId", "program", "cycleNum", "workoutNum", "lift");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -103,3 +103,19 @@ model WorkoutDateOverride {
   @@index([userId, program, cycleNum])
   @@map("workout_date_override")
 }
+
+model WorkoutLiftOverride {
+  id         String   @id @default(cuid())
+  userId     String
+  program    String
+  cycleNum   Int
+  workoutNum Int
+  lift       String
+  action     String
+  replacedBy String?
+  createdAt  DateTime @default(now())
+
+  @@unique([userId, program, cycleNum, workoutNum, lift])
+  @@index([userId, program, cycleNum, workoutNum])
+  @@map("workout_lift_override")
+}

--- a/apps/api/src/adapters/factory/in-memory-repository-factory.ts
+++ b/apps/api/src/adapters/factory/in-memory-repository-factory.ts
@@ -10,6 +10,7 @@ import { InMemoryStrengthGoalRepository } from '../in-memory/strength-goal.adapt
 import { InMemoryTrainingMaxRepository } from '../in-memory/training-max.adapter';
 import { InMemoryTrainingMaxHistoryRepository } from '../in-memory/training-max-history.adapter';
 import { InMemoryWorkoutDateOverrideRepository } from '../in-memory/workout-date-override.adapter';
+import { InMemoryWorkoutLiftOverrideRepository } from '../in-memory/workout-lift-override.adapter';
 import { InMemoryWorkoutRepository } from '../in-memory/workout.adapter';
 import { SEED_PROGRAM, seedLiftRecords } from '../in-memory/fixtures';
 
@@ -39,6 +40,7 @@ export class InMemoryRepositoryFactory implements IRepositoryFactory {
         trainingMaxHistory: new InMemoryTrainingMaxHistoryRepository(),
         workout: new InMemoryWorkoutRepository(sharedRecords),
         workoutDateOverride: new InMemoryWorkoutDateOverrideRepository(),
+        workoutLiftOverride: new InMemoryWorkoutLiftOverrideRepository(),
       });
     }
     return this.bundles.get(user.id)!;

--- a/apps/api/src/adapters/in-memory/lifting-program-spec.adapter.ts
+++ b/apps/api/src/adapters/in-memory/lifting-program-spec.adapter.ts
@@ -7,10 +7,9 @@ export class InMemoryLiftingProgramSpecRepository
 {
   private specByProgram: Map<string, LiftingProgramSpec[]>;
 
-  constructor(preSeed = false) {
-    this.specByProgram = preSeed
-      ? new Map([[SEED_PROGRAM, seedProgramSpec()]])
-      : new Map();
+  constructor(_preSeed = false) {
+    // Program specs are global (not per-user), so always seed them.
+    this.specByProgram = new Map([[SEED_PROGRAM, seedProgramSpec()]]);
   }
 
   async getProgramSpec(program: string): Promise<LiftingProgramSpec[]> {

--- a/apps/api/src/adapters/in-memory/workout-lift-override.adapter.ts
+++ b/apps/api/src/adapters/in-memory/workout-lift-override.adapter.ts
@@ -1,0 +1,51 @@
+import { LiftOverride, IWorkoutLiftOverrideRepository } from '../../ports/IWorkoutLiftOverrideRepository';
+
+export class InMemoryWorkoutLiftOverrideRepository
+  implements IWorkoutLiftOverrideRepository
+{
+  private readonly store = new Map<string, LiftOverride[]>();
+
+  private key(program: string, cycleNum: number, workoutNum: number): string {
+    // Null byte delimiter — program slugs cannot contain \0, unambiguous even for slugs like "5-3-1".
+    return `${program}\0${cycleNum}\0${workoutNum}`;
+  }
+
+  async getOverrides(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+  ): Promise<LiftOverride[]> {
+    return this.store.get(this.key(program, cycleNum, workoutNum)) ?? [];
+  }
+
+  async upsertOverride(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+    override: LiftOverride,
+  ): Promise<void> {
+    const k = this.key(program, cycleNum, workoutNum);
+    const existing = this.store.get(k) ?? [];
+    const idx = existing.findIndex((o) => o.lift === override.lift);
+    if (idx >= 0) {
+      existing[idx] = override;
+    } else {
+      existing.push(override);
+    }
+    this.store.set(k, existing);
+  }
+
+  async deleteOverride(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+    lift: string,
+  ): Promise<void> {
+    const k = this.key(program, cycleNum, workoutNum);
+    const existing = this.store.get(k) ?? [];
+    this.store.set(
+      k,
+      existing.filter((o) => o.lift !== lift),
+    );
+  }
+}

--- a/apps/api/src/adapters/prisma/prisma-repository-factory.ts
+++ b/apps/api/src/adapters/prisma/prisma-repository-factory.ts
@@ -8,6 +8,7 @@ import { PrismaTrainingMaxRepository } from './training-max.repository';
 import { PrismaTrainingMaxHistoryRepository } from './training-max-history.repository';
 import { PrismaCycleDashboardRepository } from './cycle-dashboard.repository';
 import { PrismaWorkoutDateOverrideRepository } from './workout-date-override.repository';
+import { PrismaWorkoutLiftOverrideRepository } from './workout-lift-override.repository';
 import { PrismaWorkoutRepository } from './workout.repository';
 import { InMemoryLiftingProgramSpecRepository } from '../in-memory/lifting-program-spec.adapter';
 import { InMemoryProgramPhilosophyRepository } from '../in-memory/program-philosophy.adapter';
@@ -29,6 +30,7 @@ export class PrismaRepositoryFactory implements IRepositoryFactory {
       cycleDashboard: new PrismaCycleDashboardRepository(this.prisma, user.id),
       workout: new PrismaWorkoutRepository(this.prisma, user.id),
       workoutDateOverride: new PrismaWorkoutDateOverrideRepository(this.prisma, user.id),
+      workoutLiftOverride: new PrismaWorkoutLiftOverrideRepository(this.prisma, user.id),
       liftingProgramSpec: this.programSpecRepo,
       programPhilosophy: this.philosophyRepo,
     };

--- a/apps/api/src/adapters/prisma/workout-lift-override.repository.ts
+++ b/apps/api/src/adapters/prisma/workout-lift-override.repository.ts
@@ -1,0 +1,69 @@
+import { PrismaClient } from '@prisma/client';
+import { LiftOverride, IWorkoutLiftOverrideRepository } from '../../ports/IWorkoutLiftOverrideRepository';
+
+export class PrismaWorkoutLiftOverrideRepository
+  implements IWorkoutLiftOverrideRepository
+{
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly userId: string,
+  ) {}
+
+  async getOverrides(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+  ): Promise<LiftOverride[]> {
+    const rows = await this.prisma.workoutLiftOverride.findMany({
+      where: { userId: this.userId, program, cycleNum, workoutNum },
+    });
+    return rows.map((r) => ({
+      lift: r.lift,
+      action: r.action as LiftOverride['action'],
+      ...(r.replacedBy !== null && { replacedBy: r.replacedBy }),
+    }));
+  }
+
+  async upsertOverride(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+    override: LiftOverride,
+  ): Promise<void> {
+    await this.prisma.workoutLiftOverride.upsert({
+      where: {
+        userId_program_cycleNum_workoutNum_lift: {
+          userId: this.userId,
+          program,
+          cycleNum,
+          workoutNum,
+          lift: override.lift,
+        },
+      },
+      create: {
+        userId: this.userId,
+        program,
+        cycleNum,
+        workoutNum,
+        lift: override.lift,
+        action: override.action,
+        replacedBy: override.replacedBy ?? null,
+      },
+      update: {
+        action: override.action,
+        replacedBy: override.replacedBy ?? null,
+      },
+    });
+  }
+
+  async deleteOverride(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+    lift: string,
+  ): Promise<void> {
+    await this.prisma.workoutLiftOverride.deleteMany({
+      where: { userId: this.userId, program, cycleNum, workoutNum, lift },
+    });
+  }
+}

--- a/apps/api/src/ports/IWorkoutLiftOverrideRepository.ts
+++ b/apps/api/src/ports/IWorkoutLiftOverrideRepository.ts
@@ -1,0 +1,29 @@
+import { LiftOverrideAction } from '@lifting-logbook/types';
+
+export interface LiftOverride {
+  lift: string;
+  action: LiftOverrideAction;
+  replacedBy?: string;
+}
+
+export interface IWorkoutLiftOverrideRepository {
+  getOverrides(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+  ): Promise<LiftOverride[]>;
+
+  upsertOverride(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+    override: LiftOverride,
+  ): Promise<void>;
+
+  deleteOverride(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+    lift: string,
+  ): Promise<void>;
+}

--- a/apps/api/src/ports/factory.ts
+++ b/apps/api/src/ports/factory.ts
@@ -7,6 +7,7 @@ import { IStrengthGoalRepository } from './IStrengthGoalRepository';
 import { ITrainingMaxHistoryRepository } from './ITrainingMaxHistoryRepository';
 import { ITrainingMaxRepository } from './ITrainingMaxRepository';
 import { IWorkoutDateOverrideRepository } from './IWorkoutDateOverrideRepository';
+import { IWorkoutLiftOverrideRepository } from './IWorkoutLiftOverrideRepository';
 import { IWorkoutRepository } from './IWorkoutRepository';
 
 export interface RepositoryBundle {
@@ -19,6 +20,7 @@ export interface RepositoryBundle {
   trainingMaxHistory: ITrainingMaxHistoryRepository;
   workout: IWorkoutRepository;
   workoutDateOverride: IWorkoutDateOverrideRepository;
+  workoutLiftOverride: IWorkoutLiftOverrideRepository;
 }
 
 export interface IRepositoryFactory {

--- a/apps/api/src/programs/lift-override.dto.ts
+++ b/apps/api/src/programs/lift-override.dto.ts
@@ -1,0 +1,15 @@
+import { IsIn, IsString, ValidateIf } from 'class-validator';
+import { LiftOverrideAction } from '@lifting-logbook/types';
+
+export class LiftOverrideDto {
+  @IsIn(['add', 'remove', 'replace'])
+  action!: LiftOverrideAction;
+
+  @IsString()
+  lift!: string;
+
+  /** Required when action is 'replace'. */
+  @ValidateIf((o: LiftOverrideDto) => o.action === 'replace')
+  @IsString()
+  replacedBy?: string;
+}

--- a/apps/api/src/programs/manage-lifts.controller.spec.ts
+++ b/apps/api/src/programs/manage-lifts.controller.spec.ts
@@ -1,0 +1,138 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { LIFT_NAMES } from '@lifting-logbook/types';
+import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
+import { IWorkoutLiftOverrideRepository } from '../ports/IWorkoutLiftOverrideRepository';
+import { IRepositoryFactory } from '../ports/factory';
+import { REPOSITORY_FACTORY } from '../ports/tokens';
+import { ManageLiftsController } from './manage-lifts.controller';
+
+const MOCK_USER_A = { id: 'user-a', email: 'a@example.com', provider: 'dev' };
+
+const STUB_SPEC = [{ lift: 'Squat' }] as unknown as Awaited<
+  ReturnType<ILiftingProgramSpecRepository['getProgramSpec']>
+>;
+
+describe('ManageLiftsController', () => {
+  let controller: ManageLiftsController;
+  let liftOverrideRepoA: jest.Mocked<IWorkoutLiftOverrideRepository>;
+  let liftOverrideRepoB: jest.Mocked<IWorkoutLiftOverrideRepository>;
+  let specRepoA: jest.Mocked<ILiftingProgramSpecRepository>;
+  let specRepoB: jest.Mocked<ILiftingProgramSpecRepository>;
+  let factory: jest.Mocked<IRepositoryFactory>;
+
+  beforeEach(async () => {
+    liftOverrideRepoA = {
+      getOverrides: jest.fn().mockResolvedValue([]),
+      upsertOverride: jest.fn().mockResolvedValue(undefined),
+      deleteOverride: jest.fn().mockResolvedValue(undefined),
+    };
+    liftOverrideRepoB = {
+      getOverrides: jest.fn().mockResolvedValue([]),
+      upsertOverride: jest.fn().mockResolvedValue(undefined),
+      deleteOverride: jest.fn().mockResolvedValue(undefined),
+    };
+    specRepoA = { getProgramSpec: jest.fn().mockResolvedValue(STUB_SPEC) } as jest.Mocked<ILiftingProgramSpecRepository>;
+    specRepoB = { getProgramSpec: jest.fn().mockResolvedValue(STUB_SPEC) } as jest.Mocked<ILiftingProgramSpecRepository>;
+    factory = {
+      forUser: jest.fn().mockImplementation(async (user) =>
+        user.id === MOCK_USER_A.id
+          ? { workoutLiftOverride: liftOverrideRepoA, liftingProgramSpec: specRepoA }
+          : { workoutLiftOverride: liftOverrideRepoB, liftingProgramSpec: specRepoB },
+      ),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ManageLiftsController],
+      providers: [{ provide: REPOSITORY_FACTORY, useValue: factory }],
+    }).compile();
+    controller = module.get(ManageLiftsController);
+  });
+
+  describe('getLifts', () => {
+    it('returns the full LIFT_NAMES catalog', () => {
+      const result = controller.getLifts();
+      expect(result).toEqual([...LIFT_NAMES]);
+      expect(result.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('upsertOverride', () => {
+    it('stores an add override and returns it', async () => {
+      const result = await controller.upsertOverride(
+        '5-3-1', '3', '1',
+        { action: 'add', lift: 'Chin-up' },
+        MOCK_USER_A,
+      );
+
+      expect(liftOverrideRepoA.upsertOverride).toHaveBeenCalledWith(
+        '5-3-1', 3, 1,
+        { lift: 'Chin-up', action: 'add' },
+      );
+      expect(result).toEqual({ action: 'add', lift: 'Chin-up' });
+    });
+
+    it('stores a replace override with replacedBy', async () => {
+      const result = await controller.upsertOverride(
+        '5-3-1', '3', '1',
+        { action: 'replace', lift: 'Squat', replacedBy: 'Front Squat' },
+        MOCK_USER_A,
+      );
+
+      expect(result).toEqual({ action: 'replace', lift: 'Squat', replacedBy: 'Front Squat' });
+    });
+
+    it('throws 400 when action is replace but replacedBy is missing', async () => {
+      await expect(
+        controller.upsertOverride('5-3-1', '3', '1', { action: 'replace', lift: 'Squat' }, MOCK_USER_A),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws 404 when program is not found', async () => {
+      specRepoA.getProgramSpec.mockResolvedValue([]);
+
+      await expect(
+        controller.upsertOverride('unknown', '3', '1', { action: 'add', lift: 'Squat' }, MOCK_USER_A),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('throws 400 for invalid cycleNum', async () => {
+      await expect(
+        controller.upsertOverride('5-3-1', '0', '1', { action: 'add', lift: 'Squat' }, MOCK_USER_A),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('user isolation — user B repo is not touched by user A request', async () => {
+      await controller.upsertOverride('5-3-1', '3', '1', { action: 'add', lift: 'Squat' }, MOCK_USER_A);
+
+      expect(liftOverrideRepoA.upsertOverride).toHaveBeenCalledTimes(1);
+      expect(liftOverrideRepoB.upsertOverride).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteOverride', () => {
+    it('calls deleteOverride on the repo', async () => {
+      await controller.deleteOverride('5-3-1', '3', '1', 'Squat', MOCK_USER_A);
+
+      expect(liftOverrideRepoA.deleteOverride).toHaveBeenCalledWith('5-3-1', 3, 1, 'Squat');
+    });
+
+    it('is idempotent — no error when lift not found', async () => {
+      liftOverrideRepoA.deleteOverride.mockResolvedValue(undefined);
+      await expect(
+        controller.deleteOverride('5-3-1', '3', '1', 'NonExistent', MOCK_USER_A),
+      ).resolves.toBeUndefined();
+    });
+
+    it('decodes URL-encoded lift name', async () => {
+      await controller.deleteOverride('5-3-1', '3', '1', 'Bench%20Press', MOCK_USER_A);
+
+      expect(liftOverrideRepoA.deleteOverride).toHaveBeenCalledWith('5-3-1', 3, 1, 'Bench Press');
+    });
+
+    it('user isolation — user B repo is not touched by user A request', async () => {
+      await controller.deleteOverride('5-3-1', '3', '1', 'Squat', MOCK_USER_A);
+
+      expect(liftOverrideRepoB.deleteOverride).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/programs/manage-lifts.controller.ts
+++ b/apps/api/src/programs/manage-lifts.controller.ts
@@ -1,0 +1,93 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  NotFoundException,
+  Param,
+  Post,
+} from '@nestjs/common';
+import { LIFT_NAMES, LiftOverrideResponse } from '@lifting-logbook/types';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { AuthUser } from '../ports/auth';
+import { IRepositoryFactory } from '../ports/factory';
+import { REPOSITORY_FACTORY } from '../ports/tokens';
+import { toLiftOverrideResponse, isValidWorkoutNum } from './mappers';
+import { LiftOverrideDto } from './lift-override.dto';
+
+@Controller('programs/:program')
+export class ManageLiftsController {
+  constructor(
+    @Inject(REPOSITORY_FACTORY) private readonly factory: IRepositoryFactory,
+  ) {}
+
+  @Get('lifts')
+  getLifts(): string[] {
+    return [...LIFT_NAMES];
+  }
+
+  @Post('cycles/:cycleNum/workouts/:workoutNum/lift-overrides')
+  @HttpCode(HttpStatus.CREATED)
+  async upsertOverride(
+    @Param('program') program: string,
+    @Param('cycleNum') cycleNumParam: string,
+    @Param('workoutNum') workoutNumParam: string,
+    @Body() dto: LiftOverrideDto,
+    @CurrentUser() user: AuthUser,
+  ): Promise<LiftOverrideResponse> {
+    const cycleNum = Number.parseInt(cycleNumParam, 10);
+    const workoutNum = Number.parseInt(workoutNumParam, 10);
+
+    if (!Number.isInteger(cycleNum) || cycleNum < 1) {
+      throw new BadRequestException('cycleNum must be a positive integer');
+    }
+    if (!isValidWorkoutNum(workoutNum)) {
+      throw new BadRequestException('workoutNum must be a positive integer');
+    }
+    if (dto.action === 'replace' && !dto.replacedBy) {
+      throw new BadRequestException("replacedBy is required when action is 'replace'");
+    }
+
+    const { workoutLiftOverride, liftingProgramSpec } = await this.factory.forUser(user);
+
+    const spec = await liftingProgramSpec.getProgramSpec(program);
+    if (spec.length === 0) {
+      throw new NotFoundException(`Program '${program}' not found`);
+    }
+
+    const override = {
+      lift: dto.lift,
+      action: dto.action,
+      ...(dto.replacedBy !== undefined && { replacedBy: dto.replacedBy }),
+    };
+    await workoutLiftOverride.upsertOverride(program, cycleNum, workoutNum, override);
+    return toLiftOverrideResponse(override);
+  }
+
+  @Delete('cycles/:cycleNum/workouts/:workoutNum/lift-overrides/:lift')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteOverride(
+    @Param('program') program: string,
+    @Param('cycleNum') cycleNumParam: string,
+    @Param('workoutNum') workoutNumParam: string,
+    @Param('lift') lift: string,
+    @CurrentUser() user: AuthUser,
+  ): Promise<void> {
+    const cycleNum = Number.parseInt(cycleNumParam, 10);
+    const workoutNum = Number.parseInt(workoutNumParam, 10);
+
+    if (!Number.isInteger(cycleNum) || cycleNum < 1) {
+      throw new BadRequestException('cycleNum must be a positive integer');
+    }
+    if (!isValidWorkoutNum(workoutNum)) {
+      throw new BadRequestException('workoutNum must be a positive integer');
+    }
+
+    const { workoutLiftOverride } = await this.factory.forUser(user);
+    await workoutLiftOverride.deleteOverride(program, cycleNum, workoutNum, decodeURIComponent(lift));
+  }
+}

--- a/apps/api/src/programs/mappers.spec.ts
+++ b/apps/api/src/programs/mappers.spec.ts
@@ -1,5 +1,6 @@
 import { LiftingProgramSpec } from '@lifting-logbook/core';
-import { weekForWorkoutNum } from './mappers';
+import { applyLiftOverrides, toWorkoutResponse, weekForWorkoutNum } from './mappers';
+import { LiftOverride } from '../ports/IWorkoutLiftOverrideRepository';
 
 const baseFields: Omit<LiftingProgramSpec, 'offset' | 'lift' | 'week'> = {
   increment: 5,
@@ -63,5 +64,99 @@ describe('weekForWorkoutNum', () => {
     const s = [spec(0, 'Squat'), spec(7, 'Deadlift')];
     expect(weekForWorkoutNum(s, 1)).toBe(1);
     expect(weekForWorkoutNum(s, 2)).toBe(1);
+  });
+});
+
+describe('applyLiftOverrides', () => {
+  const lifts = ['Squat', 'Bench Press', 'Deadlift'];
+
+  it('returns spec lifts unchanged when no overrides', () => {
+    expect(applyLiftOverrides(lifts, [])).toEqual(lifts);
+  });
+
+  it('remove — drops the target lift', () => {
+    const o: LiftOverride[] = [{ lift: 'Bench Press', action: 'remove' }];
+    expect(applyLiftOverrides(lifts, o)).toEqual(['Squat', 'Deadlift']);
+  });
+
+  it('remove — no-op when lift is not in list', () => {
+    const o: LiftOverride[] = [{ lift: 'Overhead Press', action: 'remove' }];
+    expect(applyLiftOverrides(lifts, o)).toEqual(lifts);
+  });
+
+  it('replace — swaps in-place preserving order', () => {
+    const o: LiftOverride[] = [{ lift: 'Bench Press', action: 'replace', replacedBy: 'Dips' }];
+    expect(applyLiftOverrides(lifts, o)).toEqual(['Squat', 'Dips', 'Deadlift']);
+  });
+
+  it('replace without replacedBy — no-op (invalid but defensively handled)', () => {
+    const o: LiftOverride[] = [{ lift: 'Bench Press', action: 'replace' }];
+    expect(applyLiftOverrides(lifts, o)).toEqual(lifts);
+  });
+
+  it('add — appends new lift', () => {
+    const o: LiftOverride[] = [{ lift: 'Chin-up', action: 'add' }];
+    expect(applyLiftOverrides(lifts, o)).toEqual([...lifts, 'Chin-up']);
+  });
+
+  it('add — no-op when lift already present', () => {
+    const o: LiftOverride[] = [{ lift: 'Squat', action: 'add' }];
+    expect(applyLiftOverrides(lifts, o)).toEqual(lifts);
+  });
+
+  it('combined — remove, replace, add applied in order', () => {
+    const o: LiftOverride[] = [
+      { lift: 'Squat', action: 'remove' },
+      { lift: 'Bench Press', action: 'replace', replacedBy: 'Dips' },
+      { lift: 'Chin-up', action: 'add' },
+    ];
+    expect(applyLiftOverrides(lifts, o)).toEqual(['Dips', 'Deadlift', 'Chin-up']);
+  });
+});
+
+describe('toWorkoutResponse with plannedLifts', () => {
+  const program = '5-3-1';
+  const cycleNum = 1;
+  const workoutNum = 1;
+  const week = 1;
+
+  const record = (lift: string, setNum: number, weight: number) => ({
+    program,
+    cycleNum,
+    workoutNum,
+    date: new Date('2026-05-07T00:00:00Z'),
+    lift,
+    setNum,
+    weight,
+    reps: 5,
+    notes: '',
+  });
+
+  it('marks logged lifts as planned:false', () => {
+    const records = [record('Squat', 1, 200)];
+    const result = toWorkoutResponse(program, cycleNum, workoutNum, week, records, undefined, ['Squat']);
+    expect(result.lifts[0]).toMatchObject({ lift: 'Squat', planned: false });
+    expect(result.lifts[0]?.sets).toHaveLength(1);
+  });
+
+  it('marks unlogged planned lifts as planned:true with empty sets', () => {
+    const result = toWorkoutResponse(program, cycleNum, workoutNum, week, [], undefined, ['Squat', 'Bench Press']);
+    expect(result.lifts).toHaveLength(2);
+    expect(result.lifts[0]).toMatchObject({ lift: 'Squat', sets: [], planned: true });
+    expect(result.lifts[1]).toMatchObject({ lift: 'Bench Press', sets: [], planned: true });
+  });
+
+  it('appends logged lifts not in planned list as planned:false', () => {
+    const records = [record('Squat', 1, 200), record('Chin-up', 1, 0)];
+    const result = toWorkoutResponse(program, cycleNum, workoutNum, week, records, undefined, ['Squat']);
+    expect(result.lifts).toHaveLength(2);
+    expect(result.lifts[0]).toMatchObject({ lift: 'Squat', planned: false });
+    expect(result.lifts[1]).toMatchObject({ lift: 'Chin-up', planned: false });
+  });
+
+  it('without plannedLifts — all logged lifts get planned:false (legacy behaviour)', () => {
+    const records = [record('Squat', 1, 200)];
+    const result = toWorkoutResponse(program, cycleNum, workoutNum, week, records);
+    expect(result.lifts[0]).toMatchObject({ lift: 'Squat', planned: false });
   });
 });

--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -9,6 +9,7 @@ import {
 import {
   CycleDashboardResponse,
   CyclePlanResponse,
+  LiftOverrideResponse,
   LiftRecordResponse,
   LiftingProgramSpecResponse,
   SetResponse,
@@ -20,6 +21,7 @@ import {
   WorkoutResponse,
 } from '@lifting-logbook/types';
 import { CyclePlanResult } from '../ports/ICyclePlanningAgent';
+import { LiftOverride } from '../ports/IWorkoutLiftOverrideRepository';
 
 // All API date fields are emitted as `YYYY-MM-DD` in UTC. Domain `Date`
 // values must be stored as UTC midnight; adapters parsing external sources
@@ -112,6 +114,32 @@ export const toCyclePlanResponse = (r: CyclePlanResult): CyclePlanResponse => ({
   ...(r.partialReason !== undefined && { partialReason: r.partialReason }),
 });
 
+export const toLiftOverrideResponse = (o: LiftOverride): LiftOverrideResponse => ({
+  action: o.action,
+  lift: o.lift,
+  ...(o.replacedBy !== undefined && { replacedBy: o.replacedBy }),
+});
+
+/**
+ * Applies a list of lift overrides to the spec-derived planned lift list.
+ * - 'remove': drops the lift from the list.
+ * - 'replace': swaps the lift in-place, preserving order.
+ * - 'add': appends the lift if not already present.
+ */
+export function applyLiftOverrides(specLifts: string[], overrides: LiftOverride[]): string[] {
+  let lifts = [...specLifts];
+  for (const o of overrides) {
+    if (o.action === 'remove') {
+      lifts = lifts.filter((l) => l !== o.lift);
+    } else if (o.action === 'replace' && o.replacedBy) {
+      lifts = lifts.map((l) => (l === o.lift ? o.replacedBy! : l));
+    } else if (o.action === 'add') {
+      if (!lifts.includes(o.lift)) lifts.push(o.lift);
+    }
+  }
+  return lifts;
+}
+
 export const isValidWorkoutNum = (n: number): boolean =>
   Number.isInteger(n) && n >= 1;
 
@@ -137,6 +165,12 @@ export const weekForWorkoutNum = (
  * Groups a workout's lift records into the WorkoutResponse shape.
  * Caller must validate `workoutNum` with `isValidWorkoutNum` and derive
  * `week` via `weekForWorkoutNum` before invoking.
+ *
+ * When `plannedLifts` is provided (the spec-derived + override list), lifts are
+ * emitted in that order. Planned-but-unlogged lifts appear with `sets: []` and
+ * `planned: true`. Logged lifts not in the planned list are appended with
+ * `planned: false`. When `plannedLifts` is omitted, all logged lifts are emitted
+ * in record order with `planned: false` (preserves pre-override behaviour).
  */
 export const toWorkoutResponse = (
   program: string,
@@ -145,6 +179,7 @@ export const toWorkoutResponse = (
   week: WeekNumber,
   records: LiftRecord[],
   overrideDate?: Date,
+  plannedLifts?: string[],
 ): WorkoutResponse => {
   const liftMap = new Map<string, SetResponse[]>();
   for (const r of records) {
@@ -158,9 +193,29 @@ export const toWorkoutResponse = (
     if (sets) sets.push(set);
     else liftMap.set(r.lift, [set]);
   }
-  const lifts: WorkoutLiftResponse[] = Array.from(liftMap.entries()).map(
-    ([lift, sets]) => ({ lift, sets }),
-  );
+
+  let lifts: WorkoutLiftResponse[];
+  if (plannedLifts) {
+    const emitted = new Set<string>();
+    lifts = plannedLifts.map((lift) => {
+      emitted.add(lift);
+      const sets = liftMap.get(lift) ?? [];
+      return { lift, sets, planned: sets.length === 0 };
+    });
+    // Append any logged lifts not in the planned list (e.g. added ad-hoc during logging).
+    for (const [lift, sets] of liftMap.entries()) {
+      if (!emitted.has(lift)) {
+        lifts.push({ lift, sets, planned: false });
+      }
+    }
+  } else {
+    lifts = Array.from(liftMap.entries()).map(([lift, sets]) => ({
+      lift,
+      sets,
+      planned: false,
+    }));
+  }
+
   const date = records[0] ? isoDate(records[0].date) : isoDate(new Date());
   return {
     program,

--- a/apps/api/src/programs/programs.db.e2e.spec.ts
+++ b/apps/api/src/programs/programs.db.e2e.spec.ts
@@ -31,6 +31,7 @@ async function cleanTestUsers(prisma: PrismaClient): Promise<void> {
   await prisma.trainingMax.deleteMany({ where: { userId: { in: users } } });
   await prisma.trainingMaxHistory.deleteMany({ where: { userId: { in: users } } });
   await prisma.cycleDashboard.deleteMany({ where: { userId: { in: users } } });
+  await prisma.workoutLiftOverride.deleteMany({ where: { userId: { in: users } } });
 }
 
 const describeOrSkip = process.env.DATABASE_URL ? describe : describe.skip;
@@ -389,5 +390,88 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
       where: { userId: USER_BOB, program: SEED_PROGRAM, lift: 'Squat' },
     });
     expect(bobRow).toBeNull();
+  });
+
+  describe('workout lift overrides (DB)', () => {
+    const deleteReq = (url: string) =>
+      app.getHttpAdapter().getInstance().inject({ method: 'DELETE', url, headers: AUTH });
+
+    it('POST override persists to the database', async () => {
+      const dashRes = await get(`/programs/${SEED_PROGRAM}/cycle-dashboard`);
+      const { cycleNum } = dashRes.json() as { cycleNum: number };
+
+      const res = await postJson(
+        `/programs/${SEED_PROGRAM}/cycles/${cycleNum}/workouts/1/lift-overrides`,
+        { action: 'add', lift: 'Dips' },
+      );
+      expect(res.statusCode).toBe(201);
+
+      const row = await prisma.workoutLiftOverride.findFirst({
+        where: { userId: TEST_USER, program: SEED_PROGRAM, cycleNum, workoutNum: 1, lift: 'Dips' },
+      });
+      expect(row).not.toBeNull();
+      expect(row?.action).toBe('add');
+    });
+
+    it('DELETE override removes the row', async () => {
+      const dashRes = await get(`/programs/${SEED_PROGRAM}/cycle-dashboard`);
+      const { cycleNum } = dashRes.json() as { cycleNum: number };
+
+      // Create first
+      await postJson(
+        `/programs/${SEED_PROGRAM}/cycles/${cycleNum}/workouts/1/lift-overrides`,
+        { action: 'remove', lift: 'Squat' },
+      );
+
+      // Then delete
+      const delRes = await deleteReq(
+        `/programs/${SEED_PROGRAM}/cycles/${cycleNum}/workouts/1/lift-overrides/Squat`,
+      );
+      expect(delRes.statusCode).toBe(204);
+
+      const row = await prisma.workoutLiftOverride.findFirst({
+        where: { userId: TEST_USER, program: SEED_PROGRAM, cycleNum, workoutNum: 1, lift: 'Squat' },
+      });
+      expect(row).toBeNull();
+    });
+
+    it('user isolation — lift overrides are scoped to userId', async () => {
+      const injectRaw = app.getHttpAdapter().getInstance().inject.bind(
+        app.getHttpAdapter().getInstance(),
+      );
+      const AS_ALICE = { authorization: `Bearer ${USER_ALICE}` };
+      const AS_BOB = { authorization: `Bearer ${USER_BOB}` };
+
+      const dashAlice = await injectRaw({ method: 'GET', url: `/programs/${SEED_PROGRAM}/cycle-dashboard`, headers: AS_ALICE });
+      const { cycleNum } = dashAlice.json() as { cycleNum: number };
+
+      // Alice adds an override
+      const alicePost = await injectRaw({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/cycles/${cycleNum}/workouts/1/lift-overrides`,
+        headers: { 'content-type': 'application/json', ...AS_ALICE },
+        payload: JSON.stringify({ action: 'add', lift: 'Face Pulls' }),
+      });
+      expect(alicePost.statusCode).toBe(201);
+
+      // Bob GETs the workout — should NOT contain Face Pulls
+      const dashBob = await injectRaw({ method: 'GET', url: `/programs/${SEED_PROGRAM}/cycle-dashboard`, headers: AS_BOB });
+      const { cycleNum: bobCycle } = dashBob.json() as { cycleNum: number };
+      const bobWorkout = await injectRaw({ method: 'GET', url: `/programs/${SEED_PROGRAM}/workouts/1`, headers: AS_BOB });
+      const bobLifts = (bobWorkout.json() as { lifts: { lift: string }[] }).lifts;
+      expect(bobLifts.some((l) => l.lift === 'Face Pulls')).toBe(false);
+      void bobCycle;
+
+      // DB layer — Alice's row exists, Bob's does not
+      const aliceRow = await prisma.workoutLiftOverride.findFirst({
+        where: { userId: USER_ALICE, program: SEED_PROGRAM, lift: 'Face Pulls' },
+      });
+      expect(aliceRow).not.toBeNull();
+
+      const bobRow = await prisma.workoutLiftOverride.findFirst({
+        where: { userId: USER_BOB, program: SEED_PROGRAM, lift: 'Face Pulls' },
+      });
+      expect(bobRow).toBeNull();
+    });
   });
 });

--- a/apps/api/src/programs/programs.db.e2e.spec.ts
+++ b/apps/api/src/programs/programs.db.e2e.spec.ts
@@ -397,7 +397,7 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
       app.getHttpAdapter().getInstance().inject({ method: 'DELETE', url, headers: AUTH });
 
     it('POST override persists to the database', async () => {
-      const dashRes = await get(`/programs/${SEED_PROGRAM}/cycle-dashboard`);
+      const dashRes = await get(`/programs/${SEED_PROGRAM}/cycles/current`);
       const { cycleNum } = dashRes.json() as { cycleNum: number };
 
       const res = await postJson(
@@ -414,7 +414,7 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
     });
 
     it('DELETE override removes the row', async () => {
-      const dashRes = await get(`/programs/${SEED_PROGRAM}/cycle-dashboard`);
+      const dashRes = await get(`/programs/${SEED_PROGRAM}/cycles/current`);
       const { cycleNum } = dashRes.json() as { cycleNum: number };
 
       // Create first
@@ -442,7 +442,7 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
       const AS_ALICE = { authorization: `Bearer ${USER_ALICE}` };
       const AS_BOB = { authorization: `Bearer ${USER_BOB}` };
 
-      const dashAlice = await injectRaw({ method: 'GET', url: `/programs/${SEED_PROGRAM}/cycle-dashboard`, headers: AS_ALICE });
+      const dashAlice = await injectRaw({ method: 'GET', url: `/programs/${SEED_PROGRAM}/cycles/current`, headers: AS_ALICE });
       const { cycleNum } = dashAlice.json() as { cycleNum: number };
 
       // Alice adds an override
@@ -455,12 +455,9 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
       expect(alicePost.statusCode).toBe(201);
 
       // Bob GETs the workout — should NOT contain Face Pulls
-      const dashBob = await injectRaw({ method: 'GET', url: `/programs/${SEED_PROGRAM}/cycle-dashboard`, headers: AS_BOB });
-      const { cycleNum: bobCycle } = dashBob.json() as { cycleNum: number };
       const bobWorkout = await injectRaw({ method: 'GET', url: `/programs/${SEED_PROGRAM}/workouts/1`, headers: AS_BOB });
       const bobLifts = (bobWorkout.json() as { lifts: { lift: string }[] }).lifts;
       expect(bobLifts.some((l) => l.lift === 'Face Pulls')).toBe(false);
-      void bobCycle;
 
       // DB layer — Alice's row exists, Bob's does not
       const aliceRow = await prisma.workoutLiftOverride.findFirst({

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -757,4 +757,100 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
       expect(bobGoals.find((g) => g.lift === 'Bench Press')).toBeUndefined();
     });
   });
+
+  describe('manage lifts overrides', () => {
+    const PROGRAM = SEED_PROGRAM;
+    // Cycle 1, workout 1 is used for override tests. The seed data has records
+    // for the dev user so override operations run against a known baseline.
+    const OVERRIDE_URL = (cycleNum: number, workoutNum: number) =>
+      `/programs/${PROGRAM}/cycles/${cycleNum}/workouts/${workoutNum}/lift-overrides`;
+
+    it('GET /programs/:program/lifts returns the lift catalog', async () => {
+      const res = await get(`/programs/${PROGRAM}/lifts`);
+      expect(res.statusCode).toBe(200);
+      const lifts = res.json() as string[];
+      expect(Array.isArray(lifts)).toBe(true);
+      expect(lifts).toContain('Squat');
+      expect(lifts.length).toBeGreaterThan(0);
+    });
+
+    it('POST add override returns 201 with the override', async () => {
+      const res = await postJson(OVERRIDE_URL(1, 1), { action: 'add', lift: 'Chin-up' });
+      expect(res.statusCode).toBe(201);
+      expect(res.json()).toMatchObject({ action: 'add', lift: 'Chin-up' });
+    });
+
+    it('POST remove override and GET workout — lift absent from response', async () => {
+      // First confirm Squat is present in workout 1
+      const before = await get(`/programs/${PROGRAM}/workouts/1`);
+      expect(before.statusCode).toBe(200);
+      const liftsBefore = (before.json() as { lifts: { lift: string }[] }).lifts;
+      expect(liftsBefore.some((l) => l.lift === 'Squat')).toBe(true);
+
+      // Apply remove override using the current cycleNum from dashboard
+      const dashRes = await get(`/programs/${PROGRAM}/cycles/current`);
+      const { cycleNum } = dashRes.json() as { cycleNum: number };
+      await postJson(OVERRIDE_URL(cycleNum, 1), { action: 'remove', lift: 'Squat' });
+
+      // GET workout — Squat should now be absent
+      const after = await get(`/programs/${PROGRAM}/workouts/1`);
+      expect(after.statusCode).toBe(200);
+      const liftsAfter = (after.json() as { lifts: { lift: string }[] }).lifts;
+      expect(liftsAfter.some((l) => l.lift === 'Squat')).toBe(false);
+
+      // Cleanup: delete the override
+      const dashRes2 = await get(`/programs/${PROGRAM}/cycles/current`);
+      const { cycleNum: cn } = dashRes2.json() as { cycleNum: number };
+      await deleteReq(`${OVERRIDE_URL(cn, 1)}/Squat`);
+    });
+
+    it('POST replace override — old lift absent, new lift present', async () => {
+      const dashRes = await get(`/programs/${PROGRAM}/cycles/current`);
+      const { cycleNum } = dashRes.json() as { cycleNum: number };
+      await postJson(OVERRIDE_URL(cycleNum, 1), { action: 'replace', lift: 'Squat', replacedBy: 'Front Squat' });
+
+      const res = await get(`/programs/${PROGRAM}/workouts/1`);
+      const lifts = (res.json() as { lifts: { lift: string }[] }).lifts;
+      expect(lifts.some((l) => l.lift === 'Squat')).toBe(false);
+      expect(lifts.some((l) => l.lift === 'Front Squat')).toBe(true);
+
+      // Cleanup
+      await deleteReq(`${OVERRIDE_URL(cycleNum, 1)}/Squat`);
+    });
+
+    it('DELETE override is idempotent — returns 204 even when override absent', async () => {
+      const dashRes = await get(`/programs/${PROGRAM}/cycles/current`);
+      const { cycleNum } = dashRes.json() as { cycleNum: number };
+      const res = await deleteReq(`${OVERRIDE_URL(cycleNum, 99)}/NonExistentLift`);
+      expect(res.statusCode).toBe(204);
+    });
+
+    it('POST replace without replacedBy returns 400', async () => {
+      const res = await postJson(OVERRIDE_URL(1, 1), { action: 'replace', lift: 'Squat' });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('isolates lift overrides between users', async () => {
+      const injectRaw = app.getHttpAdapter().getInstance().inject.bind(
+        app.getHttpAdapter().getInstance(),
+      );
+      const AS_ALICE = { authorization: 'Bearer user-alice-lifts' };
+      const AS_BOB   = { authorization: 'Bearer user-bob-lifts' };
+
+      // Alice adds a Cable Curls override for cycle 1, workout 1.
+      // Use cycleNum=1 directly (Alice is a fresh user with no cycle dashboard).
+      await injectRaw({
+        method: 'POST',
+        url: OVERRIDE_URL(1, 1),
+        headers: { 'content-type': 'application/json', ...AS_ALICE },
+        payload: JSON.stringify({ action: 'add', lift: 'Cable Curls' }),
+      });
+
+      // Bob GETs workout 1 — should NOT see Cable Curls (Alice's override is isolated).
+      const bobWorkout = await injectRaw({ method: 'GET', url: `/programs/${PROGRAM}/workouts/1`, headers: AS_BOB });
+      expect(bobWorkout.statusCode).toBe(200);
+      const bobLifts = (bobWorkout.json() as { lifts: { lift: string }[] }).lifts;
+      expect(bobLifts.some((l) => l.lift === 'Cable Curls')).toBe(false);
+    });
+  });
 });

--- a/apps/api/src/programs/programs.module.ts
+++ b/apps/api/src/programs/programs.module.ts
@@ -8,6 +8,7 @@ import { CycleGenerationController } from './cycle-generation.controller';
 import { CycleGenerationService } from './cycle-generation.service';
 import { CyclePlanController } from './cycle-plan.controller';
 import { LiftRecordsController } from './lift-records.controller';
+import { ManageLiftsController } from './manage-lifts.controller';
 import { ProgramSpecController } from './program-spec.controller';
 import { StrengthGoalsController } from './strength-goals.controller';
 import { TrainingMaxesController } from './training-maxes.controller';
@@ -27,6 +28,7 @@ import { WorkoutsController } from './workouts.controller';
     TrainingMaxesController,
     TrainingMaxHistoryController,
     LiftRecordsController,
+    ManageLiftsController,
     ProgramSpecController,
   ],
   providers: [

--- a/apps/api/src/programs/workouts.controller.spec.ts
+++ b/apps/api/src/programs/workouts.controller.spec.ts
@@ -6,7 +6,7 @@ import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepos
 import { IWorkoutDateOverrideRepository } from '../ports/IWorkoutDateOverrideRepository';
 import { IWorkoutLiftOverrideRepository } from '../ports/IWorkoutLiftOverrideRepository';
 import { IWorkoutRepository } from '../ports/IWorkoutRepository';
-import { WorkoutNotFoundError } from '../ports/errors';
+import { ProgramNotFoundError, WorkoutNotFoundError } from '../ports/errors';
 import { IRepositoryFactory } from '../ports/factory';
 import { REPOSITORY_FACTORY } from '../ports/tokens';
 import { WorkoutsController } from './workouts.controller';
@@ -301,6 +301,17 @@ describe('WorkoutsController', () => {
       workoutRepo.getWorkout.mockRejectedValue(new Error('db connection lost'));
 
       await expect(controller.getWorkout('5-3-1', '1', MOCK_USER)).rejects.toThrow('db connection lost');
+    });
+
+    it('falls back to cycleNum 1 when getCycleDashboard throws ProgramNotFoundError', async () => {
+      dashboardRepo.getCycleDashboard.mockRejectedValue(new ProgramNotFoundError('5-3-1'));
+      specRepo.getProgramSpec.mockResolvedValue(twoLiftSpec);
+      workoutRepo.getWorkout.mockRejectedValue(new WorkoutNotFoundError('5-3-1', 1, 1));
+
+      const result = await controller.getWorkout('5-3-1', '1', MOCK_USER);
+
+      expect(result.lifts).toHaveLength(2);
+      expect(result.lifts[0]).toMatchObject({ lift: 'Squat', planned: true });
     });
   });
 });

--- a/apps/api/src/programs/workouts.controller.spec.ts
+++ b/apps/api/src/programs/workouts.controller.spec.ts
@@ -4,7 +4,9 @@ import { Weekday } from '@lifting-logbook/core';
 import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
 import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
 import { IWorkoutDateOverrideRepository } from '../ports/IWorkoutDateOverrideRepository';
+import { IWorkoutLiftOverrideRepository } from '../ports/IWorkoutLiftOverrideRepository';
 import { IWorkoutRepository } from '../ports/IWorkoutRepository';
+import { WorkoutNotFoundError } from '../ports/errors';
 import { IRepositoryFactory } from '../ports/factory';
 import { REPOSITORY_FACTORY } from '../ports/tokens';
 import { WorkoutsController } from './workouts.controller';
@@ -17,6 +19,7 @@ describe('WorkoutsController', () => {
   let dashboardRepo: jest.Mocked<ICycleDashboardRepository>;
   let specRepo: jest.Mocked<ILiftingProgramSpecRepository>;
   let overrideRepo: jest.Mocked<IWorkoutDateOverrideRepository>;
+  let liftOverrideRepo: jest.Mocked<IWorkoutLiftOverrideRepository>;
   let factory: jest.Mocked<IRepositoryFactory>;
 
   beforeEach(async () => {
@@ -30,12 +33,18 @@ describe('WorkoutsController', () => {
       getOverride: jest.fn().mockResolvedValue(null),
       upsertOverride: jest.fn().mockResolvedValue(undefined),
     };
+    liftOverrideRepo = {
+      getOverrides: jest.fn().mockResolvedValue([]),
+      upsertOverride: jest.fn().mockResolvedValue(undefined),
+      deleteOverride: jest.fn().mockResolvedValue(undefined),
+    };
     factory = {
       forUser: jest.fn().mockResolvedValue({
         workout: workoutRepo,
         cycleDashboard: dashboardRepo,
         liftingProgramSpec: specRepo,
         workoutDateOverride: overrideRepo,
+        workoutLiftOverride: liftOverrideRepo,
       }),
     };
     const module: TestingModule = await Test.createTestingModule({
@@ -102,6 +111,7 @@ describe('WorkoutsController', () => {
     expect(result.week).toBe(1);
     expect(result.lifts).toHaveLength(1);
     expect(result.lifts[0]?.lift).toBe('Squat');
+    expect(result.lifts[0]?.planned).toBe(false);
     expect(result.lifts[0]?.sets).toEqual([
       { setNum: 1, weight: 200, reps: 5, amrap: false },
       { setNum: 2, weight: 220, reps: 5, amrap: true },
@@ -233,6 +243,64 @@ describe('WorkoutsController', () => {
       const result = await controller.getWorkout('5-3-1', '1', MOCK_USER);
 
       expect(result.overrideDate).toBeUndefined();
+    });
+  });
+
+  describe('upcoming workouts (no logged records)', () => {
+    const dashboard = {
+      program: '5-3-1',
+      cycleUnit: 'week',
+      cycleNum: 3,
+      cycleDate: new Date('2026-04-20T00:00:00.000Z'),
+      sheetName: '',
+      cycleStartWeekday: Weekday.Monday,
+      currentWeekType: 'training' as const,
+    };
+    const twoLiftSpec = [
+      { week: 1, offset: 0, lift: 'Squat', increment: 5, order: 1, sets: 3, reps: 5, amrap: false, warmUpPct: '', wtDecrementPct: 0, activation: 'compound' },
+      { week: 1, offset: 0, lift: 'Bench Press', increment: 5, order: 2, sets: 3, reps: 5, amrap: false, warmUpPct: '', wtDecrementPct: 0, activation: 'compound' },
+    ];
+
+    it('returns planned lifts with planned:true and empty sets when workout not yet logged', async () => {
+      dashboardRepo.getCycleDashboard.mockResolvedValue(dashboard);
+      specRepo.getProgramSpec.mockResolvedValue(twoLiftSpec);
+      workoutRepo.getWorkout.mockRejectedValue(new WorkoutNotFoundError('5-3-1', 3, 1));
+
+      const result = await controller.getWorkout('5-3-1', '1', MOCK_USER);
+
+      expect(result.lifts).toHaveLength(2);
+      expect(result.lifts[0]).toMatchObject({ lift: 'Squat', sets: [], planned: true });
+      expect(result.lifts[1]).toMatchObject({ lift: 'Bench Press', sets: [], planned: true });
+    });
+
+    it('excludes removed lifts from the planned list', async () => {
+      dashboardRepo.getCycleDashboard.mockResolvedValue(dashboard);
+      specRepo.getProgramSpec.mockResolvedValue(twoLiftSpec);
+      workoutRepo.getWorkout.mockRejectedValue(new WorkoutNotFoundError('5-3-1', 3, 1));
+      liftOverrideRepo.getOverrides.mockResolvedValue([{ lift: 'Squat', action: 'remove' }]);
+
+      const result = await controller.getWorkout('5-3-1', '1', MOCK_USER);
+
+      expect(result.lifts.map((l) => l.lift)).toEqual(['Bench Press']);
+    });
+
+    it('appends added lifts to the planned list', async () => {
+      dashboardRepo.getCycleDashboard.mockResolvedValue(dashboard);
+      specRepo.getProgramSpec.mockResolvedValue(twoLiftSpec);
+      workoutRepo.getWorkout.mockRejectedValue(new WorkoutNotFoundError('5-3-1', 3, 1));
+      liftOverrideRepo.getOverrides.mockResolvedValue([{ lift: 'Deadlift', action: 'add' }]);
+
+      const result = await controller.getWorkout('5-3-1', '1', MOCK_USER);
+
+      expect(result.lifts.map((l) => l.lift)).toEqual(['Squat', 'Bench Press', 'Deadlift']);
+    });
+
+    it('rethrows non-WorkoutNotFoundError errors', async () => {
+      dashboardRepo.getCycleDashboard.mockResolvedValue(dashboard);
+      specRepo.getProgramSpec.mockResolvedValue(twoLiftSpec);
+      workoutRepo.getWorkout.mockRejectedValue(new Error('db connection lost'));
+
+      await expect(controller.getWorkout('5-3-1', '1', MOCK_USER)).rejects.toThrow('db connection lost');
     });
   });
 });

--- a/apps/api/src/programs/workouts.controller.ts
+++ b/apps/api/src/programs/workouts.controller.ts
@@ -5,12 +5,19 @@ import {
   Inject,
   Param,
 } from '@nestjs/common';
+import { LiftRecord } from '@lifting-logbook/core';
 import { WorkoutResponse } from '@lifting-logbook/types';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../ports/auth';
+import { ProgramNotFoundError, WorkoutNotFoundError } from '../ports/errors';
 import { IRepositoryFactory } from '../ports/factory';
 import { REPOSITORY_FACTORY } from '../ports/tokens';
-import { isValidWorkoutNum, toWorkoutResponse, weekForWorkoutNum } from './mappers';
+import {
+  applyLiftOverrides,
+  isValidWorkoutNum,
+  toWorkoutResponse,
+  weekForWorkoutNum,
+} from './mappers';
 
 @Controller('programs/:program')
 export class WorkoutsController {
@@ -28,9 +35,13 @@ export class WorkoutsController {
     if (!isValidWorkoutNum(workoutNum)) {
       throw new BadRequestException('workoutNum must be a positive integer');
     }
-    const { workout, cycleDashboard, liftingProgramSpec, workoutDateOverride } = await this.factory.forUser(user);
+    const { workout, cycleDashboard, liftingProgramSpec, workoutDateOverride, workoutLiftOverride } =
+      await this.factory.forUser(user);
     const [dashboard, spec] = await Promise.all([
-      cycleDashboard.getCycleDashboard(program),
+      cycleDashboard.getCycleDashboard(program).catch((err: unknown) => {
+        if (err instanceof ProgramNotFoundError) return { cycleNum: 1 };
+        throw err;
+      }),
       liftingProgramSpec.getProgramSpec(program),
     ]);
     const week = weekForWorkoutNum(spec, workoutNum);
@@ -39,10 +50,47 @@ export class WorkoutsController {
         `workoutNum ${workoutNum} exceeds program spec (${new Set(spec.map((s) => s.offset)).size} workout days)`,
       );
     }
-    const [records, overrideDate] = await Promise.all([
-      workout.getWorkout(program, dashboard.cycleNum, workoutNum),
+
+    // Spec lifts for this workout's week — used to build the planned lift list.
+    const specLifts = [...new Set(spec.filter((s) => s.week === week).map((s) => s.lift))];
+
+    const [records, overrideDate, liftOverrides] = await Promise.all([
+      workout
+        .getWorkout(program, dashboard.cycleNum, workoutNum)
+        .catch((err: unknown) => {
+          // Upcoming workouts have no logged records yet — treat as empty.
+          if (err instanceof WorkoutNotFoundError) return [] as LiftRecord[];
+          throw err;
+        }),
       workoutDateOverride.getOverride(program, dashboard.cycleNum, workoutNum),
+      workoutLiftOverride.getOverrides(program, dashboard.cycleNum, workoutNum),
     ]);
-    return toWorkoutResponse(program, dashboard.cycleNum, workoutNum, week, records, overrideDate ?? undefined);
+
+    const plannedLifts = applyLiftOverrides(specLifts, liftOverrides);
+
+    // Apply overrides to logged records so removed/replaced lifts don't
+    // re-appear via the "append ad-hoc logged lifts" path in toWorkoutResponse.
+    const replaceMap = new Map(
+      liftOverrides
+        .filter((o): o is (typeof o) & { replacedBy: string } => o.action === 'replace' && !!o.replacedBy)
+        .map((o) => [o.lift, o.replacedBy!]),
+    );
+    const removedLifts = new Set(liftOverrides.filter((o) => o.action === 'remove').map((o) => o.lift));
+    const adjustedRecords = records
+      .filter((r) => !removedLifts.has(r.lift))
+      .map((r) => {
+        const renamed = replaceMap.get(r.lift);
+        return renamed !== undefined ? { ...r, lift: renamed } : r;
+      });
+
+    return toWorkoutResponse(
+      program,
+      dashboard.cycleNum,
+      workoutNum,
+      week,
+      adjustedRecords,
+      overrideDate ?? undefined,
+      plannedLifts,
+    );
   }
 }

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/ManageLiftsActions.module.css
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/ManageLiftsActions.module.css
@@ -72,3 +72,9 @@
   color: var(--color-text-secondary, #666);
   font-size: 0.875rem;
 }
+
+.error {
+  color: #dc2626;
+  font-size: 0.875rem;
+  margin: 0 0 0.75rem;
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/ManageLiftsActions.module.css
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/ManageLiftsActions.module.css
@@ -1,0 +1,74 @@
+.liftList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.liftItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  background: var(--color-surface, #f8f9fa);
+  border-radius: 8px;
+  border: 1px solid var(--color-border, #e5e7eb);
+}
+
+.liftName {
+  font-size: 0.9375rem;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.plannedBadge {
+  font-size: 0.6875rem;
+  font-weight: 400;
+  color: var(--color-text-secondary, #888);
+  background: var(--color-badge, #e5e7eb);
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.btnSecondary {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8125rem;
+  color: var(--color-primary, #0070f3);
+  border: 1px solid var(--color-primary, #0070f3);
+  border-radius: 5px;
+  text-decoration: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.btnSecondary:hover {
+  background: var(--color-primary-light, #e8f0fe);
+}
+
+.btnDanger {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8125rem;
+  color: #dc2626;
+  border: 1px solid #dc2626;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.btnDanger:hover {
+  background: #fef2f2;
+}
+
+.empty {
+  color: var(--color-text-secondary, #666);
+  font-size: 0.875rem;
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/ManageLiftsActions.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/ManageLiftsActions.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { upsertLiftOverride, deleteLiftOverride } from '@/lib/client-api';
+import type { WorkoutLiftResponse } from '@lifting-logbook/types';
+import styles from './ManageLiftsActions.module.css';
+
+interface Props {
+  program: string;
+  cycleNum: number;
+  workoutNum: number;
+  lifts: WorkoutLiftResponse[];
+}
+
+export default function ManageLiftsActions({ program, cycleNum, workoutNum, lifts }: Props) {
+  const router = useRouter();
+
+  async function handleRemove(lift: string) {
+    await upsertLiftOverride(program, cycleNum, workoutNum, { action: 'remove', lift });
+    router.refresh();
+  }
+
+  const replaceUrl = (lift: string) =>
+    `/cycle/${cycleNum}/workout/${workoutNum}/detail/manage-lifts/pick?action=replace&replacing=${encodeURIComponent(lift)}`;
+
+  if (lifts.length === 0) {
+    return <p className={styles.empty}>No lifts planned for this workout.</p>;
+  }
+
+  return (
+    <ul className={styles.liftList}>
+      {lifts.map(({ lift, planned }) => (
+        <li key={lift} className={styles.liftItem}>
+          <span className={styles.liftName}>
+            {lift}
+            {planned && <span className={styles.plannedBadge}>planned</span>}
+          </span>
+          <span className={styles.actions}>
+            <Link href={replaceUrl(lift)} className={styles.btnSecondary}>
+              Replace
+            </Link>
+            <button
+              type="button"
+              className={styles.btnDanger}
+              onClick={() => void handleRemove(lift)}
+            >
+              Remove
+            </button>
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/ManageLiftsActions.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/ManageLiftsActions.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { upsertLiftOverride, deleteLiftOverride } from '@/lib/client-api';
+import { upsertLiftOverride } from '@/lib/client-api';
 import type { WorkoutLiftResponse } from '@lifting-logbook/types';
 import styles from './ManageLiftsActions.module.css';
 
@@ -15,10 +16,21 @@ interface Props {
 
 export default function ManageLiftsActions({ program, cycleNum, workoutNum, lifts }: Props) {
   const router = useRouter();
+  const [pending, setPending] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   async function handleRemove(lift: string) {
-    await upsertLiftOverride(program, cycleNum, workoutNum, { action: 'remove', lift });
-    router.refresh();
+    setPending(lift);
+    setError(null);
+    try {
+      await upsertLiftOverride(program, cycleNum, workoutNum, { action: 'remove', lift });
+      router.refresh();
+    } catch (err) {
+      setError(`Failed to remove ${lift}. Please try again.`);
+      console.error(err);
+    } finally {
+      setPending(null);
+    }
   }
 
   const replaceUrl = (lift: string) =>
@@ -29,27 +41,31 @@ export default function ManageLiftsActions({ program, cycleNum, workoutNum, lift
   }
 
   return (
-    <ul className={styles.liftList}>
-      {lifts.map(({ lift, planned }) => (
-        <li key={lift} className={styles.liftItem}>
-          <span className={styles.liftName}>
-            {lift}
-            {planned && <span className={styles.plannedBadge}>planned</span>}
-          </span>
-          <span className={styles.actions}>
-            <Link href={replaceUrl(lift)} className={styles.btnSecondary}>
-              Replace
-            </Link>
-            <button
-              type="button"
-              className={styles.btnDanger}
-              onClick={() => void handleRemove(lift)}
-            >
-              Remove
-            </button>
-          </span>
-        </li>
-      ))}
-    </ul>
+    <>
+      {error && <p className={styles.error}>{error}</p>}
+      <ul className={styles.liftList}>
+        {lifts.map(({ lift, planned }) => (
+          <li key={lift} className={styles.liftItem}>
+            <span className={styles.liftName}>
+              {lift}
+              {planned && <span className={styles.plannedBadge}>planned</span>}
+            </span>
+            <span className={styles.actions}>
+              <Link href={replaceUrl(lift)} className={styles.btnSecondary}>
+                Replace
+              </Link>
+              <button
+                type="button"
+                className={styles.btnDanger}
+                disabled={pending !== null}
+                onClick={() => void handleRemove(lift)}
+              >
+                {pending === lift ? '…' : 'Remove'}
+              </button>
+            </span>
+          </li>
+        ))}
+      </ul>
+    </>
   );
 }

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/manage-lifts.module.css
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/manage-lifts.module.css
@@ -1,0 +1,61 @@
+.container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem;
+}
+
+.backLink {
+  display: inline-block;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #666);
+  text-decoration: none;
+  margin-bottom: 1.25rem;
+}
+
+.backLink:hover {
+  text-decoration: underline;
+}
+
+.header {
+  margin-bottom: 1.5rem;
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0 0 0.25rem;
+}
+
+.subtitle {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #666);
+  margin: 0;
+}
+
+.liftsSection {
+  margin-bottom: 1.5rem;
+}
+
+.addLift {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.btnPrimary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.5rem 1rem;
+  background: var(--color-primary, #0070f3);
+  color: #fff;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+}
+
+.btnPrimary:hover {
+  opacity: 0.9;
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/page.tsx
@@ -1,0 +1,60 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { fetchWorkout } from '@/lib/api';
+import ManageLiftsActions from './ManageLiftsActions';
+import styles from './manage-lifts.module.css';
+
+export default async function ManageLiftsPage({
+  params,
+}: {
+  params: Promise<{ cycleNum: string; workoutNum: string }>;
+}) {
+  const { cycleNum: cycleNumParam, workoutNum: workoutNumParam } = await params;
+  const cycleNum = Number(cycleNumParam);
+  const workoutNum = Number(workoutNumParam);
+
+  if (!Number.isInteger(cycleNum) || !Number.isInteger(workoutNum) || workoutNum < 1) {
+    notFound();
+  }
+
+  const program = process.env.NEXT_PUBLIC_DEFAULT_PROGRAM ?? '5-3-1';
+  const workout = await fetchWorkout(program, workoutNum);
+
+  if (!workout) {
+    notFound();
+  }
+
+  return (
+    <main className={styles.container}>
+      <Link
+        href={`/cycle/${cycleNum}/workout/${workoutNum}/detail`}
+        className={styles.backLink}
+      >
+        ← Back to Workout
+      </Link>
+
+      <header className={styles.header}>
+        <h1 className={styles.title}>Manage Lifts</h1>
+        <p className={styles.subtitle}>Week {workout.week} — Workout {workoutNum}</p>
+      </header>
+
+      <section className={styles.liftsSection}>
+        <ManageLiftsActions
+          program={program}
+          cycleNum={cycleNum}
+          workoutNum={workoutNum}
+          lifts={workout.lifts}
+        />
+      </section>
+
+      <div className={styles.addLift}>
+        <Link
+          href={`/cycle/${cycleNum}/workout/${workoutNum}/detail/manage-lifts/pick?action=add`}
+          className={styles.btnPrimary}
+        >
+          + Add Lift
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/pick/LiftPicker.module.css
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/pick/LiftPicker.module.css
@@ -1,0 +1,58 @@
+.searchInput {
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  font-size: 0.9375rem;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.searchInput:focus {
+  border-color: var(--color-primary, #0070f3);
+}
+
+.liftList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.liftItem {
+  display: flex;
+}
+
+.liftButton {
+  width: 100%;
+  text-align: left;
+  padding: 0.75rem 1rem;
+  font-size: 0.9375rem;
+  background: var(--color-surface, #f8f9fa);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.liftButton:hover:not(:disabled) {
+  background: var(--color-primary-light, #e8f0fe);
+  border-color: var(--color-primary, #0070f3);
+}
+
+.liftButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.spinner {
+  color: var(--color-text-secondary, #888);
+}
+
+.noResults {
+  padding: 1rem;
+  color: var(--color-text-secondary, #888);
+  font-size: 0.875rem;
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/pick/LiftPicker.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/pick/LiftPicker.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { upsertLiftOverride } from '@/lib/client-api';
+import styles from './LiftPicker.module.css';
+
+interface Props {
+  program: string;
+  cycleNum: number;
+  workoutNum: number;
+  action: 'add' | 'replace';
+  replacing?: string;
+  catalog: string[];
+  backHref: string;
+}
+
+export default function LiftPicker({
+  program,
+  cycleNum,
+  workoutNum,
+  action,
+  replacing,
+  catalog,
+  backHref,
+}: Props) {
+  const router = useRouter();
+  const [query, setQuery] = useState('');
+  const [pending, setPending] = useState<string | null>(null);
+
+  const filtered = catalog.filter((lift) =>
+    lift.toLowerCase().includes(query.toLowerCase()),
+  );
+
+  async function handleSelect(lift: string) {
+    setPending(lift);
+    try {
+      if (action === 'replace' && replacing) {
+        await upsertLiftOverride(program, cycleNum, workoutNum, {
+          action: 'replace',
+          lift: replacing,
+          replacedBy: lift,
+        });
+      } else {
+        await upsertLiftOverride(program, cycleNum, workoutNum, { action: 'add', lift });
+      }
+      router.push(backHref);
+      router.refresh();
+    } finally {
+      setPending(null);
+    }
+  }
+
+  return (
+    <div>
+      <input
+        type="search"
+        placeholder="Search lifts…"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        className={styles.searchInput}
+        autoFocus
+      />
+
+      <ul className={styles.liftList}>
+        {filtered.length === 0 && (
+          <li className={styles.noResults}>No lifts match "{query}"</li>
+        )}
+        {filtered.map((lift) => (
+          <li key={lift} className={styles.liftItem}>
+            <button
+              type="button"
+              className={styles.liftButton}
+              disabled={pending !== null}
+              onClick={() => void handleSelect(lift)}
+            >
+              {lift}
+              {pending === lift && <span className={styles.spinner}> …</span>}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/pick/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/pick/page.tsx
@@ -1,0 +1,52 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { fetchLiftCatalog } from '@/lib/api';
+import LiftPicker from './LiftPicker';
+import styles from './pick.module.css';
+
+export default async function LiftPickerPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ cycleNum: string; workoutNum: string }>;
+  searchParams: Promise<{ action?: string; replacing?: string }>;
+}) {
+  const { cycleNum: cycleNumParam, workoutNum: workoutNumParam } = await params;
+  const { action, replacing } = await searchParams;
+
+  const cycleNum = Number(cycleNumParam);
+  const workoutNum = Number(workoutNumParam);
+
+  if (!Number.isInteger(cycleNum) || !Number.isInteger(workoutNum) || workoutNum < 1) {
+    notFound();
+  }
+
+  const validAction = action === 'replace' ? 'replace' : 'add';
+  const program = process.env.NEXT_PUBLIC_DEFAULT_PROGRAM ?? '5-3-1';
+  const catalog = await fetchLiftCatalog(program);
+
+  const backHref = `/cycle/${cycleNum}/workout/${workoutNum}/detail/manage-lifts`;
+  const title = validAction === 'replace' ? `Replace ${replacing ?? 'lift'}` : 'Add Lift';
+
+  return (
+    <main className={styles.container}>
+      <Link href={backHref} className={styles.backLink}>
+        ← Back to Manage Lifts
+      </Link>
+
+      <header className={styles.header}>
+        <h1 className={styles.title}>{title}</h1>
+      </header>
+
+      <LiftPicker
+        program={program}
+        cycleNum={cycleNum}
+        workoutNum={workoutNum}
+        action={validAction}
+        replacing={replacing}
+        catalog={catalog}
+        backHref={backHref}
+      />
+    </main>
+  );
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/pick/pick.module.css
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/pick/pick.module.css
@@ -1,0 +1,27 @@
+.container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem;
+}
+
+.backLink {
+  display: inline-block;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #666);
+  text-decoration: none;
+  margin-bottom: 1.25rem;
+}
+
+.backLink:hover {
+  text-decoration: underline;
+}
+
+.header {
+  margin-bottom: 1.25rem;
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/page.tsx
@@ -42,7 +42,7 @@ export default async function WorkoutDetailPage({
   }
 
   const effectiveDate = workout.overrideDate ?? workout.date;
-  const hasLogs = workout.lifts.length > 0;
+  const hasLogs = workout.lifts.some((l) => !l.planned);
   const status = workoutStatus(effectiveDate, hasLogs);
   const maxMap = new Map(maxes.map((m) => [m.lift, m.weight]));
 
@@ -100,9 +100,12 @@ export default async function WorkoutDetailPage({
       </section>
 
       <section className={styles.actions}>
-        <button type="button" className={styles.btnSecondary} disabled>
+        <Link
+          href={`/cycle/${cycleNum}/workout/${workoutNum}/detail/manage-lifts`}
+          className={styles.btnSecondary}
+        >
           ✏️ Manage Lifts
-        </button>
+        </Link>
         {status !== 'completed' && (
           <Link
             href={`/cycle/${cycleNum}/workout/${workoutNum}`}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -7,7 +7,6 @@ import type {
   CycleDashboardResponse,
   LiftingProgramSpecResponse,
   LiftRecordResponse,
-  LiftOverrideResponse,
   RecordBodyWeightRequest,
   StrengthGoalResponse,
   UpsertStrengthGoalRequest,
@@ -256,15 +255,3 @@ export async function fetchLiftCatalog(program: string): Promise<string[]> {
   return res.json() as Promise<string[]>;
 }
 
-export async function fetchLiftOverrides(
-  program: string,
-  cycleNum: number,
-  workoutNum: number,
-): Promise<LiftOverrideResponse[]> {
-  const path = `/programs/${encodeURIComponent(program)}/cycles/${cycleNum}/workouts/${workoutNum}/lift-overrides`;
-  const authHeaders = await getAuthHeaders();
-  const res = await fetch(`${API_URL}${path}`, { cache: 'no-store', headers: authHeaders });
-  if (res.status === 404) return [];
-  if (!res.ok) throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
-  return res.json() as Promise<LiftOverrideResponse[]>;
-}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -7,6 +7,7 @@ import type {
   CycleDashboardResponse,
   LiftingProgramSpecResponse,
   LiftRecordResponse,
+  LiftOverrideResponse,
   RecordBodyWeightRequest,
   StrengthGoalResponse,
   UpsertStrengthGoalRequest,
@@ -245,4 +246,25 @@ export async function deleteStrengthGoal(
   if (!res.ok && res.status !== 404) {
     throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
   }
+}
+
+export async function fetchLiftCatalog(program: string): Promise<string[]> {
+  const path = `/programs/${encodeURIComponent(program)}/lifts`;
+  const authHeaders = await getAuthHeaders();
+  const res = await fetch(`${API_URL}${path}`, { cache: 'no-store', headers: authHeaders });
+  if (!res.ok) throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
+  return res.json() as Promise<string[]>;
+}
+
+export async function fetchLiftOverrides(
+  program: string,
+  cycleNum: number,
+  workoutNum: number,
+): Promise<LiftOverrideResponse[]> {
+  const path = `/programs/${encodeURIComponent(program)}/cycles/${cycleNum}/workouts/${workoutNum}/lift-overrides`;
+  const authHeaders = await getAuthHeaders();
+  const res = await fetch(`${API_URL}${path}`, { cache: 'no-store', headers: authHeaders });
+  if (res.status === 404) return [];
+  if (!res.ok) throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
+  return res.json() as Promise<LiftOverrideResponse[]>;
 }

--- a/apps/web/lib/client-api.ts
+++ b/apps/web/lib/client-api.ts
@@ -3,6 +3,8 @@
 // In Cloud Run environments, browser-to-API auth is handled separately (e.g., JWT/Clerk).
 
 import type {
+  CreateLiftOverrideRequest,
+  LiftOverrideResponse,
   CreateLiftRecordRequest,
   LiftRecordResponse,
   RecordBodyWeightRequest,
@@ -81,4 +83,32 @@ export function recordBodyWeight(
       cache: 'no-store',
     },
   );
+}
+
+export function upsertLiftOverride(
+  program: string,
+  cycleNum: number,
+  workoutNum: number,
+  body: CreateLiftOverrideRequest,
+): Promise<LiftOverrideResponse> {
+  return clientFetch(
+    `/programs/${encodeURIComponent(program)}/cycles/${cycleNum}/workouts/${workoutNum}/lift-overrides`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      cache: 'no-store',
+    },
+  );
+}
+
+export async function deleteLiftOverride(
+  program: string,
+  cycleNum: number,
+  workoutNum: number,
+  lift: string,
+): Promise<void> {
+  const path = `/programs/${encodeURIComponent(program)}/cycles/${cycleNum}/workouts/${workoutNum}/lift-overrides/${encodeURIComponent(lift)}`;
+  const res = await fetch(`${API_URL}${path}`, { method: 'DELETE', cache: 'no-store' });
+  if (!res.ok) throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
 }

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -80,6 +80,8 @@ export interface SetResponse {
 export interface WorkoutLiftResponse {
   lift: LiftName;
   sets: SetResponse[];
+  /** True when derived from the program spec with no logged sets yet; false when backed by real records. */
+  planned: boolean;
 }
 
 /** Serialized workout as returned by the API. */
@@ -210,6 +212,31 @@ export interface CyclePlanResponse {
   overallReasoning: string;
   partial: boolean;
   partialReason?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Lifting Program Spec
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Lift Overrides (Manage Lifts)
+// ---------------------------------------------------------------------------
+
+export type LiftOverrideAction = 'add' | 'remove' | 'replace';
+
+/** Request body for POST /programs/:program/cycles/:cycleNum/workouts/:workoutNum/lift-overrides. */
+export interface CreateLiftOverrideRequest {
+  action: LiftOverrideAction;
+  lift: string;
+  /** Required when action is 'replace'. */
+  replacedBy?: string;
+}
+
+/** A single lift override as returned by the API. */
+export interface LiftOverrideResponse {
+  action: LiftOverrideAction;
+  lift: string;
+  replacedBy?: string;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `workout_lift_override` Prisma model (manual migration SQL) with port interface, in-memory adapter, and Prisma adapter — all registered in `RepositoryBundle`
- `GET /programs/:program/workouts/:workoutNum` now works for upcoming (unstarted) workouts: derives planned lift list from the program spec and applies overrides
- `ManageLiftsController`: `GET /lifts` (catalog), `POST /cycles/:cycleNum/workouts/:workoutNum/lift-overrides`, `DELETE /cycles/:cycleNum/workouts/:workoutNum/lift-overrides/:lift`
- Web: manage-lifts page (remove/replace buttons), lift picker page (search + select), detail page "Manage Lifts" now a link
- `applyLiftOverrides` pure function; `toWorkoutResponse` extended with optional `plannedLifts` parameter; override-adjusted records prevent replaced/removed lifts from re-appearing via logged-records path
- `InMemoryLiftingProgramSpecRepository` made non-user-specific (spec is global)

## Acceptance Criteria

- [x] Per-workout add, remove, replace overrides persisted in `workout_lift_override` table
- [x] `GET /workouts/:workoutNum` returns planned lifts for upcoming workouts
- [x] Manage Lifts link on detail page navigates to manage-lifts flow
- [x] Lift picker filters catalog client-side; selection calls upsert and navigates back
- [x] User isolation: Alice's overrides don't appear for Bob

## Test Plan

- All unit, integration, and in-memory E2E tests pass: `npm test -w @lifting-logbook/api` (165 passed, 23 skipped)
- Core and types: `npm test -w @lifting-logbook/core -w @lifting-logbook/types` (124 passed)

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)