### PR TITLE
[docs] Mark manage-lifts workstream as shipped in ROADMAP.md

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -91,6 +91,7 @@ Web and mobile clients functional end-to-end. Key user-facing features implement
 | Training max history | `training_max_history` table, GET/PATCH endpoints with date and PR filters, MaxHistory component on settings page, ADR-017 documented | [#174](https://github.com/brownm09/lifting-logbook/issues/174) |
 | Strength goal CRUD | `strength_goal` DB model, CRUD endpoints, `/settings/strength-goals` page with progress bars and quick-access dashboard button | [#175](https://github.com/brownm09/lifting-logbook/issues/175) |
 | Cycle Program and Plan views | Four quick-access buttons on cycle dashboard; `/cycle/:cycleNum/program` and `/cycle/:cycleNum/plan` pages for program spec and 6-phase plan overview | [#176](https://github.com/brownm09/lifting-logbook/issues/176) |
+| Manage lifts | Per-workout add/remove/replace overrides stored in `workout_lift_override` table; `GET /workouts/:workoutNum` returns planned lifts for upcoming workouts; manage-lifts and lift-picker web pages | [#178](https://github.com/brownm09/lifting-logbook/issues/178) |
 
 ### Proposals
 


### PR DESCRIPTION
Adds the manage-lifts row to the v0.3 Shipped table following merge of PR #186.

Closes #178