### PR TITLE
[feat] Lift metadata — muscle groups, substitutions, foundational lift

### DIFF
--- a/apps/api/prisma/migrations/20260507000001_add_lift_metadata/migration.sql
+++ b/apps/api/prisma/migrations/20260507000001_add_lift_metadata/migration.sql
@@ -5,7 +5,7 @@ CREATE TABLE "lift_metadata" (
     "lift" TEXT NOT NULL,
     "muscleGroups" TEXT[],
     "substitutions" TEXT[],
-    "foundational" TEXT NOT NULL DEFAULT '',
+    "foundational" BOOLEAN NOT NULL DEFAULT false,
 
     CONSTRAINT "lift_metadata_pkey" PRIMARY KEY ("id")
 );

--- a/apps/api/prisma/migrations/20260507000001_add_lift_metadata/migration.sql
+++ b/apps/api/prisma/migrations/20260507000001_add_lift_metadata/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "lift_metadata" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "lift" TEXT NOT NULL,
+    "muscleGroups" TEXT[],
+    "substitutions" TEXT[],
+    "foundational" TEXT NOT NULL DEFAULT '',
+
+    CONSTRAINT "lift_metadata_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "lift_metadata_userId_idx" ON "lift_metadata"("userId");
+
+-- CreateUniqueIndex
+CREATE UNIQUE INDEX "lift_metadata_userId_lift_key" ON "lift_metadata"("userId", "lift");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -119,3 +119,16 @@ model WorkoutLiftOverride {
   @@index([userId, program, cycleNum, workoutNum])
   @@map("workout_lift_override")
 }
+
+model LiftMetadata {
+  id            String   @id @default(uuid())
+  userId        String
+  lift          String
+  muscleGroups  String[]
+  substitutions String[]
+  foundational  String   @default("")
+
+  @@unique([userId, lift])
+  @@index([userId])
+  @@map("lift_metadata")
+}

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -126,7 +126,7 @@ model LiftMetadata {
   lift          String
   muscleGroups  String[]
   substitutions String[]
-  foundational  String   @default("")
+  foundational  Boolean  @default(false)
 
   @@unique([userId, lift])
   @@index([userId])

--- a/apps/api/src/adapters/factory/in-memory-repository-factory.ts
+++ b/apps/api/src/adapters/factory/in-memory-repository-factory.ts
@@ -3,6 +3,7 @@ import { LiftRecord } from '@lifting-logbook/core';
 import { AuthUser } from '../../ports/auth';
 import { IRepositoryFactory, RepositoryBundle } from '../../ports/factory';
 import { InMemoryCycleDashboardRepository } from '../in-memory/cycle-dashboard.adapter';
+import { InMemoryLiftMetadataRepository } from '../in-memory/lift-metadata.adapter';
 import { InMemoryLiftingProgramSpecRepository } from '../in-memory/lifting-program-spec.adapter';
 import { InMemoryLiftRecordRepository } from '../in-memory/lift-record.adapter';
 import { InMemoryProgramPhilosophyRepository } from '../in-memory/program-philosophy.adapter';
@@ -32,6 +33,7 @@ export class InMemoryRepositoryFactory implements IRepositoryFactory {
         : new Map();
       this.bundles.set(user.id, {
         cycleDashboard: new InMemoryCycleDashboardRepository(preSeed),
+        liftMetadata: new InMemoryLiftMetadataRepository(),
         liftingProgramSpec: new InMemoryLiftingProgramSpecRepository(preSeed),
         liftRecord: new InMemoryLiftRecordRepository(sharedRecords),
         programPhilosophy: new InMemoryProgramPhilosophyRepository(),

--- a/apps/api/src/adapters/factory/system-db-repository-factory.ts
+++ b/apps/api/src/adapters/factory/system-db-repository-factory.ts
@@ -9,9 +9,12 @@ import { PrismaStrengthGoalRepository } from '../prisma/strength-goal.repository
 import { PrismaTrainingMaxRepository } from '../prisma/training-max.repository';
 import { PrismaTrainingMaxHistoryRepository } from '../prisma/training-max-history.repository';
 import { PrismaCycleDashboardRepository } from '../prisma/cycle-dashboard.repository';
+import { PrismaLiftMetadataRepository } from '../prisma/lift-metadata.repository';
 import { PrismaWorkoutDateOverrideRepository } from '../prisma/workout-date-override.repository';
+import { PrismaWorkoutLiftOverrideRepository } from '../prisma/workout-lift-override.repository';
 import { PrismaWorkoutRepository } from '../prisma/workout.repository';
 import { InMemoryCycleDashboardRepository } from '../in-memory/cycle-dashboard.adapter';
+import { InMemoryLiftMetadataRepository } from '../in-memory/lift-metadata.adapter';
 import { InMemoryLiftingProgramSpecRepository } from '../in-memory/lifting-program-spec.adapter';
 import { InMemoryLiftRecordRepository } from '../in-memory/lift-record.adapter';
 import { InMemoryProgramPhilosophyRepository } from '../in-memory/program-philosophy.adapter';
@@ -19,6 +22,7 @@ import { InMemoryStrengthGoalRepository } from '../in-memory/strength-goal.adapt
 import { InMemoryTrainingMaxRepository } from '../in-memory/training-max.adapter';
 import { InMemoryTrainingMaxHistoryRepository } from '../in-memory/training-max-history.adapter';
 import { InMemoryWorkoutDateOverrideRepository } from '../in-memory/workout-date-override.adapter';
+import { InMemoryWorkoutLiftOverrideRepository } from '../in-memory/workout-lift-override.adapter';
 import { InMemoryWorkoutRepository } from '../in-memory/workout.adapter';
 
 interface UserDataSourceRow {
@@ -75,6 +79,7 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
     if (adapterType === 'postgres') {
       const prisma = this.getOrCreatePrisma();
       return {
+        liftMetadata: new PrismaLiftMetadataRepository(prisma, userId),
         liftRecord: new PrismaLiftRecordRepository(prisma, userId),
         strengthGoal: new PrismaStrengthGoalRepository(prisma, userId),
         trainingMax: new PrismaTrainingMaxRepository(prisma, userId),
@@ -82,6 +87,7 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
         cycleDashboard: new PrismaCycleDashboardRepository(prisma, userId),
         workout: new PrismaWorkoutRepository(prisma, userId),
         workoutDateOverride: new PrismaWorkoutDateOverrideRepository(prisma, userId),
+        workoutLiftOverride: new PrismaWorkoutLiftOverrideRepository(prisma, userId),
         liftingProgramSpec: this.programSpecRepo,
         programPhilosophy: this.philosophyRepo,
       };
@@ -93,6 +99,7 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
     const sharedRecords: Map<string, LiftRecord[]> = new Map();
     return {
       cycleDashboard: new InMemoryCycleDashboardRepository(),
+      liftMetadata: new InMemoryLiftMetadataRepository(),
       liftingProgramSpec: this.programSpecRepo,
       liftRecord: new InMemoryLiftRecordRepository(sharedRecords),
       programPhilosophy: this.philosophyRepo,
@@ -101,6 +108,7 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
       trainingMaxHistory: new InMemoryTrainingMaxHistoryRepository(),
       workout: new InMemoryWorkoutRepository(sharedRecords),
       workoutDateOverride: new InMemoryWorkoutDateOverrideRepository(),
+      workoutLiftOverride: new InMemoryWorkoutLiftOverrideRepository(),
     };
   }
 

--- a/apps/api/src/adapters/in-memory/lift-metadata.adapter.ts
+++ b/apps/api/src/adapters/in-memory/lift-metadata.adapter.ts
@@ -9,13 +9,13 @@ export class InMemoryLiftMetadataRepository implements ILiftMetadataRepository {
 
   async upsertMetadata(
     lift: string,
-    patch: { muscleGroups?: string[]; substitutions?: string[]; foundational?: string },
+    patch: { muscleGroups?: string[]; substitutions?: string[]; foundational?: boolean },
   ): Promise<LiftMetadata> {
     const existing = this.store.get(lift) ?? {
       lift,
       muscleGroups: [],
       substitutions: [],
-      foundational: '',
+      foundational: false,
     };
     const updated: LiftMetadata = {
       lift,

--- a/apps/api/src/adapters/in-memory/lift-metadata.adapter.ts
+++ b/apps/api/src/adapters/in-memory/lift-metadata.adapter.ts
@@ -1,0 +1,29 @@
+import { ILiftMetadataRepository, LiftMetadata } from '../../ports/ILiftMetadataRepository';
+
+export class InMemoryLiftMetadataRepository implements ILiftMetadataRepository {
+  private readonly store = new Map<string, LiftMetadata>();
+
+  async getMetadata(lift: string): Promise<LiftMetadata | null> {
+    return this.store.get(lift) ?? null;
+  }
+
+  async upsertMetadata(
+    lift: string,
+    patch: { muscleGroups?: string[]; substitutions?: string[]; foundational?: string },
+  ): Promise<LiftMetadata> {
+    const existing = this.store.get(lift) ?? {
+      lift,
+      muscleGroups: [],
+      substitutions: [],
+      foundational: '',
+    };
+    const updated: LiftMetadata = {
+      lift,
+      muscleGroups: patch.muscleGroups ?? existing.muscleGroups,
+      substitutions: patch.substitutions ?? existing.substitutions,
+      foundational: patch.foundational ?? existing.foundational,
+    };
+    this.store.set(lift, updated);
+    return updated;
+  }
+}

--- a/apps/api/src/adapters/llm/agent-tools.spec.ts
+++ b/apps/api/src/adapters/llm/agent-tools.spec.ts
@@ -31,8 +31,12 @@ const mkRepos = (): RepositoryBundle => ({
   trainingMax: {
     getTrainingMaxes: jest.fn().mockResolvedValue([{ lift: 'Squat', weight: 315 }]),
   } as unknown as RepositoryBundle['trainingMax'],
+  liftMetadata: {} as RepositoryBundle['liftMetadata'],
+  strengthGoal: {} as RepositoryBundle['strengthGoal'],
+  trainingMaxHistory: {} as RepositoryBundle['trainingMaxHistory'],
   workout: {} as RepositoryBundle['workout'],
   workoutDateOverride: {} as RepositoryBundle['workoutDateOverride'],
+  workoutLiftOverride: {} as RepositoryBundle['workoutLiftOverride'],
 });
 
 describe('agent-tools', () => {

--- a/apps/api/src/adapters/prisma/lift-metadata.repository.ts
+++ b/apps/api/src/adapters/prisma/lift-metadata.repository.ts
@@ -1,0 +1,45 @@
+import { PrismaClient } from '@prisma/client';
+import { ILiftMetadataRepository, LiftMetadata } from '../../ports/ILiftMetadataRepository';
+
+export class PrismaLiftMetadataRepository implements ILiftMetadataRepository {
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly userId: string,
+  ) {}
+
+  async getMetadata(lift: string): Promise<LiftMetadata | null> {
+    const row = await this.prisma.liftMetadata.findUnique({
+      where: { userId_lift: { userId: this.userId, lift } },
+    });
+    if (!row) return null;
+    return {
+      lift: row.lift,
+      muscleGroups: row.muscleGroups,
+      substitutions: row.substitutions,
+      foundational: row.foundational,
+    };
+  }
+
+  async upsertMetadata(
+    lift: string,
+    patch: { muscleGroups?: string[]; substitutions?: string[]; foundational?: string },
+  ): Promise<LiftMetadata> {
+    const existing = await this.getMetadata(lift);
+    const next = {
+      muscleGroups: patch.muscleGroups ?? existing?.muscleGroups ?? [],
+      substitutions: patch.substitutions ?? existing?.substitutions ?? [],
+      foundational: patch.foundational ?? existing?.foundational ?? '',
+    };
+    const row = await this.prisma.liftMetadata.upsert({
+      where: { userId_lift: { userId: this.userId, lift } },
+      update: next,
+      create: { userId: this.userId, lift, ...next },
+    });
+    return {
+      lift: row.lift,
+      muscleGroups: row.muscleGroups,
+      substitutions: row.substitutions,
+      foundational: row.foundational,
+    };
+  }
+}

--- a/apps/api/src/adapters/prisma/lift-metadata.repository.ts
+++ b/apps/api/src/adapters/prisma/lift-metadata.repository.ts
@@ -22,18 +22,17 @@ export class PrismaLiftMetadataRepository implements ILiftMetadataRepository {
 
   async upsertMetadata(
     lift: string,
-    patch: { muscleGroups?: string[]; substitutions?: string[]; foundational?: string },
+    patch: { muscleGroups?: string[]; substitutions?: string[]; foundational?: boolean },
   ): Promise<LiftMetadata> {
-    const existing = await this.getMetadata(lift);
-    const next = {
-      muscleGroups: patch.muscleGroups ?? existing?.muscleGroups ?? [],
-      substitutions: patch.substitutions ?? existing?.substitutions ?? [],
-      foundational: patch.foundational ?? existing?.foundational ?? '',
+    const update = {
+      ...(patch.muscleGroups !== undefined ? { muscleGroups: patch.muscleGroups } : {}),
+      ...(patch.substitutions !== undefined ? { substitutions: patch.substitutions } : {}),
+      ...(patch.foundational !== undefined ? { foundational: patch.foundational } : {}),
     };
     const row = await this.prisma.liftMetadata.upsert({
       where: { userId_lift: { userId: this.userId, lift } },
-      update: next,
-      create: { userId: this.userId, lift, ...next },
+      update,
+      create: { userId: this.userId, lift, muscleGroups: [], substitutions: [], foundational: false, ...update },
     });
     return {
       lift: row.lift,

--- a/apps/api/src/adapters/prisma/prisma-repository-factory.ts
+++ b/apps/api/src/adapters/prisma/prisma-repository-factory.ts
@@ -8,6 +8,7 @@ import { PrismaTrainingMaxRepository } from './training-max.repository';
 import { PrismaTrainingMaxHistoryRepository } from './training-max-history.repository';
 import { PrismaCycleDashboardRepository } from './cycle-dashboard.repository';
 import { PrismaWorkoutDateOverrideRepository } from './workout-date-override.repository';
+import { PrismaLiftMetadataRepository } from './lift-metadata.repository';
 import { PrismaWorkoutLiftOverrideRepository } from './workout-lift-override.repository';
 import { PrismaWorkoutRepository } from './workout.repository';
 import { InMemoryLiftingProgramSpecRepository } from '../in-memory/lifting-program-spec.adapter';
@@ -23,6 +24,7 @@ export class PrismaRepositoryFactory implements IRepositoryFactory {
 
   async forUser(user: AuthUser): Promise<RepositoryBundle> {
     return {
+      liftMetadata: new PrismaLiftMetadataRepository(this.prisma, user.id),
       liftRecord: new PrismaLiftRecordRepository(this.prisma, user.id),
       strengthGoal: new PrismaStrengthGoalRepository(this.prisma, user.id),
       trainingMax: new PrismaTrainingMaxRepository(this.prisma, user.id),

--- a/apps/api/src/adapters/prisma/strength-goal.repository.ts
+++ b/apps/api/src/adapters/prisma/strength-goal.repository.ts
@@ -18,10 +18,10 @@ export class PrismaStrengthGoalRepository implements IStrengthGoalRepository {
     return rows.map((r) => ({
       lift: r.lift,
       goalType: r.goalType as 'absolute' | 'relative',
-      target: r.target ?? undefined,
       unit: r.unit as 'lbs' | 'kg',
-      ratio: r.ratio ?? undefined,
       updatedAt: r.updatedAt,
+      ...(r.target != null ? { target: r.target } : {}),
+      ...(r.ratio != null ? { ratio: r.ratio } : {}),
     }));
   }
 
@@ -42,10 +42,10 @@ export class PrismaStrengthGoalRepository implements IStrengthGoalRepository {
     return {
       lift: row.lift,
       goalType: row.goalType as 'absolute' | 'relative',
-      target: row.target ?? undefined,
       unit: row.unit as 'lbs' | 'kg',
-      ratio: row.ratio ?? undefined,
       updatedAt: row.updatedAt,
+      ...(row.target != null ? { target: row.target } : {}),
+      ...(row.ratio != null ? { ratio: row.ratio } : {}),
     };
   }
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { RepositoryFactoryModule } from './adapters/factory/repository-factory.module';
 import { AuthModule } from './auth/auth.module';
 import { HealthModule } from './health/health.module';
+import { LiftsModule } from './lifts/lifts.module';
 import { ProgramsModule } from './programs/programs.module';
 
 @Module({
-  imports: [AuthModule, HealthModule, ProgramsModule, RepositoryFactoryModule],
+  imports: [AuthModule, HealthModule, LiftsModule, ProgramsModule, RepositoryFactoryModule],
 })
 export class AppModule {}

--- a/apps/api/src/lifts/lift-metadata.controller.ts
+++ b/apps/api/src/lifts/lift-metadata.controller.ts
@@ -1,0 +1,61 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  Param,
+  Patch,
+} from '@nestjs/common';
+import { LiftMetadataResponse } from '@lifting-logbook/types';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { AuthUser } from '../ports/auth';
+import { IRepositoryFactory } from '../ports/factory';
+import { REPOSITORY_FACTORY } from '../ports/tokens';
+import { PatchLiftMetadataDto } from './patch-lift-metadata.dto';
+
+@Controller('lifts')
+export class LiftMetadataController {
+  constructor(
+    @Inject(REPOSITORY_FACTORY) private readonly factory: IRepositoryFactory,
+  ) {}
+
+  @Get(':lift/metadata')
+  async getMetadata(
+    @Param('lift') lift: string,
+    @CurrentUser() user: AuthUser,
+  ): Promise<LiftMetadataResponse> {
+    const { liftMetadata } = await this.factory.forUser(user);
+    const meta = await liftMetadata.getMetadata(lift);
+    return meta
+      ? {
+          lift: meta.lift,
+          muscleGroups: meta.muscleGroups,
+          substitutions: meta.substitutions,
+          foundational: meta.foundational,
+        }
+      : { lift, muscleGroups: [], substitutions: [], foundational: '' };
+  }
+
+  @Patch(':lift/metadata')
+  @HttpCode(HttpStatus.OK)
+  async patchMetadata(
+    @Param('lift') lift: string,
+    @Body() dto: PatchLiftMetadataDto,
+    @CurrentUser() user: AuthUser,
+  ): Promise<LiftMetadataResponse> {
+    const { liftMetadata } = await this.factory.forUser(user);
+    const patch: { muscleGroups?: string[]; substitutions?: string[]; foundational?: string } = {};
+    if (dto.muscleGroups !== undefined) patch.muscleGroups = dto.muscleGroups;
+    if (dto.substitutions !== undefined) patch.substitutions = dto.substitutions;
+    if (dto.foundational !== undefined) patch.foundational = dto.foundational;
+    const meta = await liftMetadata.upsertMetadata(lift, patch);
+    return {
+      lift: meta.lift,
+      muscleGroups: meta.muscleGroups,
+      substitutions: meta.substitutions,
+      foundational: meta.foundational,
+    };
+  }
+}

--- a/apps/api/src/lifts/lift-metadata.controller.ts
+++ b/apps/api/src/lifts/lift-metadata.controller.ts
@@ -35,7 +35,7 @@ export class LiftMetadataController {
           substitutions: meta.substitutions,
           foundational: meta.foundational,
         }
-      : { lift, muscleGroups: [], substitutions: [], foundational: '' };
+      : { lift, muscleGroups: [], substitutions: [], foundational: false };
   }
 
   @Patch(':lift/metadata')
@@ -46,7 +46,7 @@ export class LiftMetadataController {
     @CurrentUser() user: AuthUser,
   ): Promise<LiftMetadataResponse> {
     const { liftMetadata } = await this.factory.forUser(user);
-    const patch: { muscleGroups?: string[]; substitutions?: string[]; foundational?: string } = {};
+    const patch: { muscleGroups?: string[]; substitutions?: string[]; foundational?: boolean } = {};
     if (dto.muscleGroups !== undefined) patch.muscleGroups = dto.muscleGroups;
     if (dto.substitutions !== undefined) patch.substitutions = dto.substitutions;
     if (dto.foundational !== undefined) patch.foundational = dto.foundational;

--- a/apps/api/src/lifts/lifts.module.ts
+++ b/apps/api/src/lifts/lifts.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { LiftMetadataController } from './lift-metadata.controller';
+
+@Module({
+  controllers: [LiftMetadataController],
+})
+export class LiftsModule {}

--- a/apps/api/src/lifts/patch-lift-metadata.dto.ts
+++ b/apps/api/src/lifts/patch-lift-metadata.dto.ts
@@ -1,17 +1,21 @@
-import { IsArray, IsOptional, IsString } from 'class-validator';
+import { ArrayMaxSize, IsArray, IsBoolean, IsOptional, IsString, MaxLength } from 'class-validator';
 
 export class PatchLiftMetadataDto {
   @IsArray()
+  @ArrayMaxSize(20)
   @IsString({ each: true })
+  @MaxLength(100, { each: true })
   @IsOptional()
   muscleGroups?: string[];
 
   @IsArray()
+  @ArrayMaxSize(20)
   @IsString({ each: true })
+  @MaxLength(100, { each: true })
   @IsOptional()
   substitutions?: string[];
 
-  @IsString()
+  @IsBoolean()
   @IsOptional()
-  foundational?: string;
+  foundational?: boolean;
 }

--- a/apps/api/src/lifts/patch-lift-metadata.dto.ts
+++ b/apps/api/src/lifts/patch-lift-metadata.dto.ts
@@ -1,0 +1,17 @@
+import { IsArray, IsOptional, IsString } from 'class-validator';
+
+export class PatchLiftMetadataDto {
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  muscleGroups?: string[];
+
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  substitutions?: string[];
+
+  @IsString()
+  @IsOptional()
+  foundational?: string;
+}

--- a/apps/api/src/ports/ILiftMetadataRepository.ts
+++ b/apps/api/src/ports/ILiftMetadataRepository.ts
@@ -2,13 +2,13 @@ export interface LiftMetadata {
   lift: string;
   muscleGroups: string[];
   substitutions: string[];
-  foundational: string;
+  foundational: boolean;
 }
 
 export interface ILiftMetadataRepository {
   getMetadata(lift: string): Promise<LiftMetadata | null>;
   upsertMetadata(
     lift: string,
-    patch: { muscleGroups?: string[]; substitutions?: string[]; foundational?: string },
+    patch: { muscleGroups?: string[]; substitutions?: string[]; foundational?: boolean },
   ): Promise<LiftMetadata>;
 }

--- a/apps/api/src/ports/ILiftMetadataRepository.ts
+++ b/apps/api/src/ports/ILiftMetadataRepository.ts
@@ -1,0 +1,14 @@
+export interface LiftMetadata {
+  lift: string;
+  muscleGroups: string[];
+  substitutions: string[];
+  foundational: string;
+}
+
+export interface ILiftMetadataRepository {
+  getMetadata(lift: string): Promise<LiftMetadata | null>;
+  upsertMetadata(
+    lift: string,
+    patch: { muscleGroups?: string[]; substitutions?: string[]; foundational?: string },
+  ): Promise<LiftMetadata>;
+}

--- a/apps/api/src/ports/factory.ts
+++ b/apps/api/src/ports/factory.ts
@@ -1,5 +1,6 @@
 import { AuthUser } from './auth';
 import { ICycleDashboardRepository } from './ICycleDashboardRepository';
+import { ILiftMetadataRepository } from './ILiftMetadataRepository';
 import { ILiftingProgramSpecRepository } from './ILiftingProgramSpecRepository';
 import { ILiftRecordRepository } from './ILiftRecordRepository';
 import { IProgramPhilosophyRepository } from './IProgramPhilosophyRepository';
@@ -12,6 +13,7 @@ import { IWorkoutRepository } from './IWorkoutRepository';
 
 export interface RepositoryBundle {
   cycleDashboard: ICycleDashboardRepository;
+  liftMetadata: ILiftMetadataRepository;
   liftingProgramSpec: ILiftingProgramSpecRepository;
   liftRecord: ILiftRecordRepository;
   programPhilosophy: IProgramPhilosophyRepository;

--- a/apps/api/src/ports/ports.compile-test.ts
+++ b/apps/api/src/ports/ports.compile-test.ts
@@ -124,7 +124,7 @@ const _workoutDateOverrideRepo: IWorkoutDateOverrideRepository = {
 const _liftMetadataRepo: ILiftMetadataRepository = {
   getMetadata: () => Promise.resolve(null),
   upsertMetadata: (_lift, _patch) =>
-    Promise.resolve({ lift: '', muscleGroups: [], substitutions: [], foundational: '' }),
+    Promise.resolve({ lift: '', muscleGroups: [], substitutions: [], foundational: false }),
 };
 
 const _strengthGoalRepo: IStrengthGoalRepository = {

--- a/apps/api/src/ports/ports.compile-test.ts
+++ b/apps/api/src/ports/ports.compile-test.ts
@@ -16,7 +16,10 @@ import { ILiftRecordRepository } from './ILiftRecordRepository';
 import { IProgramPhilosophyRepository } from './IProgramPhilosophyRepository';
 import { ITrainingMaxRepository } from './ITrainingMaxRepository';
 import { ITrainingMaxHistoryRepository } from './ITrainingMaxHistoryRepository';
+import { ILiftMetadataRepository } from './ILiftMetadataRepository';
+import { IStrengthGoalRepository } from './IStrengthGoalRepository';
 import { IWorkoutDateOverrideRepository } from './IWorkoutDateOverrideRepository';
+import { IWorkoutLiftOverrideRepository } from './IWorkoutLiftOverrideRepository';
 import { IWorkoutRepository } from './IWorkoutRepository';
 
 // ---------------------------------------------------------------------------
@@ -118,15 +121,36 @@ const _workoutDateOverrideRepo: IWorkoutDateOverrideRepository = {
   upsertOverride: () => Promise.resolve(),
 };
 
+const _liftMetadataRepo: ILiftMetadataRepository = {
+  getMetadata: () => Promise.resolve(null),
+  upsertMetadata: (_lift, _patch) =>
+    Promise.resolve({ lift: '', muscleGroups: [], substitutions: [], foundational: '' }),
+};
+
+const _strengthGoalRepo: IStrengthGoalRepository = {
+  getGoals: () => Promise.resolve([]),
+  upsertGoal: (_program, goal) => Promise.resolve(goal),
+  deleteGoal: () => Promise.resolve(),
+};
+
+const _workoutLiftOverrideRepo: IWorkoutLiftOverrideRepository = {
+  getOverrides: () => Promise.resolve([]),
+  upsertOverride: () => Promise.resolve(),
+  deleteOverride: () => Promise.resolve(),
+};
+
 const _repositoryBundle: RepositoryBundle = {
   cycleDashboard: _cycleDashboardRepo,
+  liftMetadata: _liftMetadataRepo,
   liftingProgramSpec: _programSpecRepo,
   liftRecord: _liftRecordRepo,
   programPhilosophy: _programPhilosophyRepo,
+  strengthGoal: _strengthGoalRepo,
   trainingMax: _trainingMaxRepo,
   trainingMaxHistory: _trainingMaxHistoryRepo,
   workout: _workoutRepo,
   workoutDateOverride: _workoutDateOverrideRepo,
+  workoutLiftOverride: _workoutLiftOverrideRepo,
 };
 
 const _repositoryFactory: IRepositoryFactory = {
@@ -143,6 +167,9 @@ void _liftRecordRepo;
 void _trainingMaxRepo;
 void _trainingMaxHistoryRepo;
 void _workoutRepo;
+void _liftMetadataRepo;
+void _strengthGoalRepo;
 void _workoutDateOverrideRepo;
+void _workoutLiftOverrideRepo;
 void _repositoryBundle;
 void _repositoryFactory;

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -868,41 +868,41 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
     it('GET /lifts/:lift/metadata returns defaults when no record exists', async () => {
       const res = await get('/lifts/Squat/metadata');
       expect(res.statusCode).toBe(200);
-      const body = res.json() as { lift: string; muscleGroups: string[]; substitutions: string[]; foundational: string };
+      const body = res.json() as { lift: string; muscleGroups: string[]; substitutions: string[]; foundational: boolean };
       expect(body.lift).toBe('Squat');
       expect(body.muscleGroups).toEqual([]);
       expect(body.substitutions).toEqual([]);
-      expect(body.foundational).toBe('');
+      expect(body.foundational).toBe(false);
     });
 
     it('PATCH /lifts/:lift/metadata persists values and GET returns them', async () => {
       const patchRes = await patchJson('/lifts/Squat/metadata', {
         muscleGroups: ['Quads', 'Glutes'],
         substitutions: ['Leg Press'],
-        foundational: 'Squat',
+        foundational: true,
       });
       expect(patchRes.statusCode).toBe(200);
-      const patched = patchRes.json() as { muscleGroups: string[]; substitutions: string[]; foundational: string };
+      const patched = patchRes.json() as { muscleGroups: string[]; substitutions: string[]; foundational: boolean };
       expect(patched.muscleGroups).toEqual(['Quads', 'Glutes']);
       expect(patched.substitutions).toEqual(['Leg Press']);
-      expect(patched.foundational).toBe('Squat');
+      expect(patched.foundational).toBe(true);
 
       const getRes = await get('/lifts/Squat/metadata');
       expect(getRes.statusCode).toBe(200);
       const fetched = getRes.json() as typeof patched;
       expect(fetched.muscleGroups).toEqual(['Quads', 'Glutes']);
       expect(fetched.substitutions).toEqual(['Leg Press']);
-      expect(fetched.foundational).toBe('Squat');
+      expect(fetched.foundational).toBe(true);
     });
 
     it('PATCH /lifts/:lift/metadata is partial — unpatched fields retain prior values', async () => {
       await patchJson('/lifts/Squat/metadata', { substitutions: ['Hack Squat'] });
       const res = await get('/lifts/Squat/metadata');
       expect(res.statusCode).toBe(200);
-      const body = res.json() as { muscleGroups: string[]; substitutions: string[]; foundational: string };
+      const body = res.json() as { muscleGroups: string[]; substitutions: string[]; foundational: boolean };
       expect(body.muscleGroups).toEqual(['Quads', 'Glutes']);
       expect(body.substitutions).toEqual(['Hack Squat']);
-      expect(body.foundational).toBe('Squat');
+      expect(body.foundational).toBe(true);
     });
 
     it('user isolation: User B gets empty defaults when User A has metadata', async () => {
@@ -911,10 +911,10 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
         .getInstance()
         .inject({ method: 'GET', url: '/lifts/Squat/metadata', headers: AS_BOB });
       expect(res.statusCode).toBe(200);
-      const body = res.json() as { muscleGroups: string[]; substitutions: string[]; foundational: string };
+      const body = res.json() as { muscleGroups: string[]; substitutions: string[]; foundational: boolean };
       expect(body.muscleGroups).toEqual([]);
       expect(body.substitutions).toEqual([]);
-      expect(body.foundational).toBe('');
+      expect(body.foundational).toBe(false);
     });
   });
 });

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -44,7 +44,7 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
       payload: JSON.stringify(body),
     });
 
-  const _patchJson = (url: string, body: unknown) =>
+  const patchJson = (url: string, body: unknown) =>
     app.getHttpAdapter().getInstance().inject({
       method: 'PATCH',
       url,
@@ -130,12 +130,12 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
     const RESCHEDULE_URL = `/programs/${SEED_PROGRAM}/cycles/1/workouts/1/reschedule`;
 
     it('PATCH reschedule returns 204 No Content', async () => {
-      const res = await _patchJson(RESCHEDULE_URL, { newDate: '2026-06-01' });
+      const res = await patchJson(RESCHEDULE_URL, { newDate: '2026-06-01' });
       expect(res.statusCode).toBe(204);
     });
 
     it('GET workout after reschedule includes overrideDate', async () => {
-      await _patchJson(RESCHEDULE_URL, { newDate: '2026-06-01' });
+      await patchJson(RESCHEDULE_URL, { newDate: '2026-06-01' });
       const res = await get(`/programs/${SEED_PROGRAM}/workouts/1`);
       expect(res.statusCode).toBe(200);
       const body = res.json();
@@ -143,12 +143,12 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
     });
 
     it('PATCH reschedule with invalid date returns 400', async () => {
-      const res = await _patchJson(RESCHEDULE_URL, { newDate: 'not-a-date' });
+      const res = await patchJson(RESCHEDULE_URL, { newDate: 'not-a-date' });
       expect(res.statusCode).toBe(400);
     });
 
     it('PATCH reschedule with invalid workoutNum returns 400', async () => {
-      const res = await _patchJson(
+      const res = await patchJson(
         `/programs/${SEED_PROGRAM}/cycles/1/workouts/0/reschedule`,
         { newDate: '2026-06-01' },
       );
@@ -164,7 +164,7 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
     });
 
     it('PATCH reschedule with unknown program returns 404', async () => {
-      const res = await _patchJson(
+      const res = await patchJson(
         `/programs/no-such-program/cycles/1/workouts/1/reschedule`,
         { newDate: '2026-06-01' },
       );
@@ -172,7 +172,7 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
     });
 
     it('PATCH reschedule with datetime string returns 400', async () => {
-      const res = await _patchJson(RESCHEDULE_URL, { newDate: '2026-06-01T12:00:00Z' });
+      const res = await patchJson(RESCHEDULE_URL, { newDate: '2026-06-01T12:00:00Z' });
       expect(res.statusCode).toBe(400);
     });
   });
@@ -851,6 +851,70 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
       expect(bobWorkout.statusCode).toBe(200);
       const bobLifts = (bobWorkout.json() as { lifts: { lift: string }[] }).lifts;
       expect(bobLifts.some((l) => l.lift === 'Cable Curls')).toBe(false);
+    });
+  });
+
+  describe('lift metadata', () => {
+    const AS_BOB = { authorization: 'Bearer user-b-token' };
+
+    it('GET /lifts/:lift/metadata requires auth', async () => {
+      const res = await app
+        .getHttpAdapter()
+        .getInstance()
+        .inject({ method: 'GET', url: '/lifts/Squat/metadata' });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('GET /lifts/:lift/metadata returns defaults when no record exists', async () => {
+      const res = await get('/lifts/Squat/metadata');
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { lift: string; muscleGroups: string[]; substitutions: string[]; foundational: string };
+      expect(body.lift).toBe('Squat');
+      expect(body.muscleGroups).toEqual([]);
+      expect(body.substitutions).toEqual([]);
+      expect(body.foundational).toBe('');
+    });
+
+    it('PATCH /lifts/:lift/metadata persists values and GET returns them', async () => {
+      const patchRes = await patchJson('/lifts/Squat/metadata', {
+        muscleGroups: ['Quads', 'Glutes'],
+        substitutions: ['Leg Press'],
+        foundational: 'Squat',
+      });
+      expect(patchRes.statusCode).toBe(200);
+      const patched = patchRes.json() as { muscleGroups: string[]; substitutions: string[]; foundational: string };
+      expect(patched.muscleGroups).toEqual(['Quads', 'Glutes']);
+      expect(patched.substitutions).toEqual(['Leg Press']);
+      expect(patched.foundational).toBe('Squat');
+
+      const getRes = await get('/lifts/Squat/metadata');
+      expect(getRes.statusCode).toBe(200);
+      const fetched = getRes.json() as typeof patched;
+      expect(fetched.muscleGroups).toEqual(['Quads', 'Glutes']);
+      expect(fetched.substitutions).toEqual(['Leg Press']);
+      expect(fetched.foundational).toBe('Squat');
+    });
+
+    it('PATCH /lifts/:lift/metadata is partial — unpatched fields retain prior values', async () => {
+      await patchJson('/lifts/Squat/metadata', { substitutions: ['Hack Squat'] });
+      const res = await get('/lifts/Squat/metadata');
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { muscleGroups: string[]; substitutions: string[]; foundational: string };
+      expect(body.muscleGroups).toEqual(['Quads', 'Glutes']);
+      expect(body.substitutions).toEqual(['Hack Squat']);
+      expect(body.foundational).toBe('Squat');
+    });
+
+    it('user isolation: User B gets empty defaults when User A has metadata', async () => {
+      const res = await app
+        .getHttpAdapter()
+        .getInstance()
+        .inject({ method: 'GET', url: '/lifts/Squat/metadata', headers: AS_BOB });
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { muscleGroups: string[]; substitutions: string[]; foundational: string };
+      expect(body.muscleGroups).toEqual([]);
+      expect(body.substitutions).toEqual([]);
+      expect(body.foundational).toBe('');
     });
   });
 });

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -896,12 +896,17 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
     });
 
     it('PATCH /lifts/:lift/metadata is partial — unpatched fields retain prior values', async () => {
-      await patchJson('/lifts/Squat/metadata', { substitutions: ['Hack Squat'] });
-      const res = await get('/lifts/Squat/metadata');
+      await patchJson('/lifts/Deadlift/metadata', {
+        muscleGroups: ['Hamstrings', 'Glutes'],
+        substitutions: ['Romanian Deadlift'],
+        foundational: true,
+      });
+      await patchJson('/lifts/Deadlift/metadata', { substitutions: ['Trap Bar Deadlift'] });
+      const res = await get('/lifts/Deadlift/metadata');
       expect(res.statusCode).toBe(200);
       const body = res.json() as { muscleGroups: string[]; substitutions: string[]; foundational: boolean };
-      expect(body.muscleGroups).toEqual(['Quads', 'Glutes']);
-      expect(body.substitutions).toEqual(['Hack Squat']);
+      expect(body.muscleGroups).toEqual(['Hamstrings', 'Glutes']);
+      expect(body.substitutions).toEqual(['Trap Bar Deadlift']);
       expect(body.foundational).toBe(true);
     });
 

--- a/apps/api/src/programs/strength-goals.controller.ts
+++ b/apps/api/src/programs/strength-goals.controller.ts
@@ -44,10 +44,10 @@ export class StrengthGoalsController {
     const saved = await strengthGoal.upsertGoal(program, {
       lift,
       goalType: body.goalType,
-      target: body.target,
       unit: body.unit,
-      ratio: body.ratio,
       updatedAt: new Date(),
+      ...(body.target !== undefined ? { target: body.target } : {}),
+      ...(body.ratio !== undefined ? { ratio: body.ratio } : {}),
     });
     return toStrengthGoalResponse(saved);
   }

--- a/apps/api/src/programs/upsert-strength-goal.dto.ts
+++ b/apps/api/src/programs/upsert-strength-goal.dto.ts
@@ -3,7 +3,7 @@ import { IsIn, IsNumber, IsOptional, IsString } from 'class-validator';
 export class UpsertStrengthGoalDto {
   @IsString()
   @IsIn(['absolute', 'relative'])
-  goalType: 'absolute' | 'relative';
+  goalType!: 'absolute' | 'relative';
 
   @IsNumber()
   @IsOptional()
@@ -11,7 +11,7 @@ export class UpsertStrengthGoalDto {
 
   @IsString()
   @IsIn(['lbs', 'kg'])
-  unit: 'lbs' | 'kg';
+  unit!: 'lbs' | 'kg';
 
   @IsNumber()
   @IsOptional()

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/ManageLiftsActions.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/ManageLiftsActions.tsx
@@ -36,6 +36,9 @@ export default function ManageLiftsActions({ program, cycleNum, workoutNum, lift
   const replaceUrl = (lift: string) =>
     `/cycle/${cycleNum}/workout/${workoutNum}/detail/manage-lifts/pick?action=replace&replacing=${encodeURIComponent(lift)}`;
 
+  const editUrl = (lift: string) =>
+    `/cycle/${cycleNum}/workout/${workoutNum}/detail/manage-lifts/edit/${encodeURIComponent(lift)}`;
+
   if (lifts.length === 0) {
     return <p className={styles.empty}>No lifts planned for this workout.</p>;
   }
@@ -51,6 +54,9 @@ export default function ManageLiftsActions({ program, cycleNum, workoutNum, lift
               {planned && <span className={styles.plannedBadge}>planned</span>}
             </span>
             <span className={styles.actions}>
+              <Link href={editUrl(lift)} className={styles.btnSecondary}>
+                Edit
+              </Link>
               <Link href={replaceUrl(lift)} className={styles.btnSecondary}>
                 Replace
               </Link>

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/edit/[lift]/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/edit/[lift]/page.tsx
@@ -16,7 +16,7 @@ export default async function EditLiftPage({
     notFound();
   }
 
-  const lift = decodeURIComponent(liftParam);
+  const lift = liftParam;
   const metadata = await fetchLiftMetadata(lift);
 
   return (

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/edit/[lift]/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/manage-lifts/edit/[lift]/page.tsx
@@ -1,0 +1,42 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { fetchLiftMetadata } from '@/lib/api';
+import LiftEditor from '@/components/LiftEditor';
+
+export default async function EditLiftPage({
+  params,
+}: {
+  params: Promise<{ cycleNum: string; workoutNum: string; lift: string }>;
+}) {
+  const { cycleNum: cycleNumParam, workoutNum: workoutNumParam, lift: liftParam } = await params;
+  const cycleNum = Number(cycleNumParam);
+  const workoutNum = Number(workoutNumParam);
+
+  if (!Number.isInteger(cycleNum) || !Number.isInteger(workoutNum) || workoutNum < 1) {
+    notFound();
+  }
+
+  const lift = decodeURIComponent(liftParam);
+  const metadata = await fetchLiftMetadata(lift);
+
+  return (
+    <main style={{ maxWidth: '600px', margin: '0 auto', padding: '1.5rem 1rem' }}>
+      <Link
+        href={`/cycle/${cycleNum}/workout/${workoutNum}/detail/manage-lifts`}
+        style={{ fontSize: '0.875rem', color: 'var(--color-primary, #0070f3)', textDecoration: 'none' }}
+      >
+        ← Back to Manage Lifts
+      </Link>
+
+      <h1 style={{ marginTop: '1rem', marginBottom: '1.5rem', fontSize: '1.25rem', fontWeight: 600 }}>
+        Edit Lift: {lift}
+      </h1>
+
+      <LiftEditor
+        cycleNum={cycleNum}
+        workoutNum={workoutNum}
+        initialMetadata={metadata}
+      />
+    </main>
+  );
+}

--- a/apps/web/components/LiftEditor.module.css
+++ b/apps/web/components/LiftEditor.module.css
@@ -10,6 +10,12 @@
   gap: 0.25rem;
 }
 
+.checkboxField {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .label {
   font-size: 0.8125rem;
   font-weight: 600;

--- a/apps/web/components/LiftEditor.module.css
+++ b/apps/web/components/LiftEditor.module.css
@@ -1,0 +1,85 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-text-secondary, #666);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.readOnly {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.input {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9375rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 6px;
+  background: var(--color-surface, #f8f9fa);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--color-primary, #0070f3);
+}
+
+.error {
+  color: #dc2626;
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.btnPrimary {
+  padding: 0.625rem 1.25rem;
+  font-size: 0.9375rem;
+  background: var(--color-primary, #0070f3);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  width: 100%;
+}
+
+.btnPrimary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btnSecondary {
+  padding: 0.625rem 1.25rem;
+  font-size: 0.9375rem;
+  color: var(--color-primary, #0070f3);
+  border: 1px solid var(--color-primary, #0070f3);
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  width: 100%;
+}
+
+.btnSecondary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/apps/web/components/LiftEditor.tsx
+++ b/apps/web/components/LiftEditor.tsx
@@ -12,28 +12,29 @@ interface Props {
   initialMetadata: LiftMetadataResponse;
 }
 
+function parseList(value: string): string[] {
+  return value
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
 export default function LiftEditor({ cycleNum, workoutNum, initialMetadata }: Props) {
   const router = useRouter();
-  const [muscleGroups, setMuscleGroups] = useState(initialMetadata.muscleGroups.join(', '));
-  const [substitutions, setSubstitutions] = useState(initialMetadata.substitutions.join(', '));
+  // State is string[] matching the API contract; inputs display as comma-joined for editing.
+  const [muscleGroups, setMuscleGroups] = useState<string[]>(initialMetadata.muscleGroups);
+  const [substitutions, setSubstitutions] = useState<string[]>(initialMetadata.substitutions);
   const [foundational, setFoundational] = useState(initialMetadata.foundational);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  function parseList(value: string): string[] {
-    return value
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean);
-  }
 
   async function handleSave() {
     setSaving(true);
     setError(null);
     try {
       await patchLiftMetadata(initialMetadata.lift, {
-        muscleGroups: parseList(muscleGroups),
-        substitutions: parseList(substitutions),
+        muscleGroups,
+        substitutions,
         foundational,
       });
       router.refresh();
@@ -49,8 +50,8 @@ export default function LiftEditor({ cycleNum, workoutNum, initialMetadata }: Pr
   }
 
   function handleReset() {
-    setMuscleGroups('');
-    setSubstitutions('');
+    setMuscleGroups([]);
+    setSubstitutions([]);
     setFoundational(false);
   }
 
@@ -63,27 +64,29 @@ export default function LiftEditor({ cycleNum, workoutNum, initialMetadata }: Pr
 
       <div className={styles.field}>
         <label className={styles.label} htmlFor="muscleGroups">
-          Muscle Groups (comma-separated)
+          Muscle Groups
         </label>
         <input
           id="muscleGroups"
           type="text"
           className={styles.input}
-          value={muscleGroups}
-          onChange={(e) => setMuscleGroups(e.target.value)}
+          placeholder="e.g. Quads, Glutes, Hamstrings"
+          value={muscleGroups.join(', ')}
+          onChange={(e) => setMuscleGroups(parseList(e.target.value))}
         />
       </div>
 
       <div className={styles.field}>
         <label className={styles.label} htmlFor="substitutions">
-          Substitutions (comma-separated)
+          Substitutions
         </label>
         <input
           id="substitutions"
           type="text"
           className={styles.input}
-          value={substitutions}
-          onChange={(e) => setSubstitutions(e.target.value)}
+          placeholder="e.g. Leg Press, Hack Squat"
+          value={substitutions.join(', ')}
+          onChange={(e) => setSubstitutions(parseList(e.target.value))}
         />
       </div>
 

--- a/apps/web/components/LiftEditor.tsx
+++ b/apps/web/components/LiftEditor.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { patchLiftMetadata } from '@/lib/client-api';
+import type { LiftMetadataResponse } from '@lifting-logbook/types';
+import styles from './LiftEditor.module.css';
+
+interface Props {
+  cycleNum: number;
+  workoutNum: number;
+  initialMetadata: LiftMetadataResponse;
+}
+
+export default function LiftEditor({ cycleNum, workoutNum, initialMetadata }: Props) {
+  const router = useRouter();
+  const [muscleGroups, setMuscleGroups] = useState(initialMetadata.muscleGroups.join(', '));
+  const [substitutions, setSubstitutions] = useState(initialMetadata.substitutions.join(', '));
+  const [foundational, setFoundational] = useState(initialMetadata.foundational);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function parseList(value: string): string[] {
+    return value
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    try {
+      await patchLiftMetadata(initialMetadata.lift, {
+        muscleGroups: parseList(muscleGroups),
+        substitutions: parseList(substitutions),
+        foundational,
+      });
+      router.refresh();
+      router.push(
+        `/cycle/${cycleNum}/workout/${workoutNum}/detail/manage-lifts`,
+      );
+    } catch (err) {
+      setError('Failed to save. Please try again.');
+      console.error(err);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleReset() {
+    setMuscleGroups('');
+    setSubstitutions('');
+    setFoundational('');
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.field}>
+        <span className={styles.label}>Lift</span>
+        <p className={styles.readOnly}>{initialMetadata.lift}</p>
+      </div>
+
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="muscleGroups">
+          Muscle Groups (comma-separated)
+        </label>
+        <input
+          id="muscleGroups"
+          type="text"
+          className={styles.input}
+          value={muscleGroups}
+          onChange={(e) => setMuscleGroups(e.target.value)}
+        />
+      </div>
+
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="substitutions">
+          Substitutions (comma-separated)
+        </label>
+        <input
+          id="substitutions"
+          type="text"
+          className={styles.input}
+          value={substitutions}
+          onChange={(e) => setSubstitutions(e.target.value)}
+        />
+      </div>
+
+      <div className={styles.field}>
+        <label className={styles.label} htmlFor="foundational">
+          Foundational Lift
+        </label>
+        <input
+          id="foundational"
+          type="text"
+          className={styles.input}
+          value={foundational}
+          onChange={(e) => setFoundational(e.target.value)}
+        />
+      </div>
+
+      {error && <p className={styles.error}>{error}</p>}
+
+      <div className={styles.actions}>
+        <button
+          type="button"
+          className={styles.btnPrimary}
+          onClick={() => void handleSave()}
+          disabled={saving}
+        >
+          {saving ? 'Saving…' : 'Save Changes'}
+        </button>
+        <button
+          type="button"
+          className={styles.btnSecondary}
+          onClick={handleReset}
+          disabled={saving}
+        >
+          Reset to Foundational
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/LiftEditor.tsx
+++ b/apps/web/components/LiftEditor.tsx
@@ -51,7 +51,7 @@ export default function LiftEditor({ cycleNum, workoutNum, initialMetadata }: Pr
   function handleReset() {
     setMuscleGroups('');
     setSubstitutions('');
-    setFoundational('');
+    setFoundational(false);
   }
 
   return (
@@ -87,17 +87,17 @@ export default function LiftEditor({ cycleNum, workoutNum, initialMetadata }: Pr
         />
       </div>
 
-      <div className={styles.field}>
-        <label className={styles.label} htmlFor="foundational">
-          Foundational Lift
-        </label>
+      <div className={styles.checkboxField}>
         <input
           id="foundational"
-          type="text"
-          className={styles.input}
-          value={foundational}
-          onChange={(e) => setFoundational(e.target.value)}
+          type="checkbox"
+          checked={foundational}
+          onChange={(e) => setFoundational(e.target.checked)}
+          disabled={saving}
         />
+        <label className={styles.label} htmlFor="foundational">
+          Foundational lift
+        </label>
       </div>
 
       {error && <p className={styles.error}>{error}</p>}
@@ -117,7 +117,7 @@ export default function LiftEditor({ cycleNum, workoutNum, initialMetadata }: Pr
           onClick={handleReset}
           disabled={saving}
         >
-          Reset to Foundational
+          Reset
         </button>
       </div>
     </div>

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   BodyWeightResponse,
   CreateLiftRecordRequest,
   CycleDashboardResponse,
+  LiftMetadataResponse,
   LiftingProgramSpecResponse,
   LiftRecordResponse,
   RecordBodyWeightRequest,
@@ -253,5 +254,12 @@ export async function fetchLiftCatalog(program: string): Promise<string[]> {
   const res = await fetch(`${API_URL}${path}`, { cache: 'no-store', headers: authHeaders });
   if (!res.ok) throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
   return res.json() as Promise<string[]>;
+}
+
+export function fetchLiftMetadata(lift: string): Promise<LiftMetadataResponse> {
+  return apiFetch<LiftMetadataResponse>(
+    `/lifts/${encodeURIComponent(lift)}/metadata`,
+    { cache: 'no-store' },
+  );
 }
 

--- a/apps/web/lib/client-api.ts
+++ b/apps/web/lib/client-api.ts
@@ -4,9 +4,11 @@
 
 import type {
   CreateLiftOverrideRequest,
+  LiftMetadataResponse,
   LiftOverrideResponse,
   CreateLiftRecordRequest,
   LiftRecordResponse,
+  PatchLiftMetadataRequest,
   RecordBodyWeightRequest,
   UpdateLiftRecordRequest,
 } from '@lifting-logbook/types';
@@ -95,6 +97,21 @@ export function upsertLiftOverride(
     `/programs/${encodeURIComponent(program)}/cycles/${cycleNum}/workouts/${workoutNum}/lift-overrides`,
     {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      cache: 'no-store',
+    },
+  );
+}
+
+export function patchLiftMetadata(
+  lift: string,
+  body: PatchLiftMetadataRequest,
+): Promise<LiftMetadataResponse> {
+  return clientFetch<LiftMetadataResponse>(
+    `/lifts/${encodeURIComponent(lift)}/metadata`,
+    {
+      method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
       cache: 'no-store',

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -240,6 +240,25 @@ export interface LiftOverrideResponse {
 }
 
 // ---------------------------------------------------------------------------
+// Lift Metadata
+// ---------------------------------------------------------------------------
+
+/** Per-user lift metadata as returned by GET /lifts/:lift/metadata. */
+export interface LiftMetadataResponse {
+  lift: string;
+  muscleGroups: string[];
+  substitutions: string[];
+  foundational: string;
+}
+
+/** Request body for PATCH /lifts/:lift/metadata. */
+export interface PatchLiftMetadataRequest {
+  muscleGroups?: string[];
+  substitutions?: string[];
+  foundational?: string;
+}
+
+// ---------------------------------------------------------------------------
 // Lifting Program Spec
 // ---------------------------------------------------------------------------
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -248,14 +248,14 @@ export interface LiftMetadataResponse {
   lift: string;
   muscleGroups: string[];
   substitutions: string[];
-  foundational: string;
+  foundational: boolean;
 }
 
 /** Request body for PATCH /lifts/:lift/metadata. */
 export interface PatchLiftMetadataRequest {
   muscleGroups?: string[];
   substitutions?: string[];
-  foundational?: string;
+  foundational?: boolean;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds per-user, per-lift metadata storage: muscle groups, substitutions, and foundational lift designation
- New `lift_metadata` Prisma model with `GET /lifts/:lift/metadata` (returns defaults when no record) and `PATCH /lifts/:lift/metadata` (upserts partial fields)
- Full hexagonal architecture stack: `ILiftMetadataRepository` port → `InMemoryLiftMetadataRepository` adapter → `PrismaLiftMetadataRepository` adapter → registered in all three factory implementations
- New `LiftsModule` NestJS module registered in `AppModule`
- Web: `LiftEditor` client component with comma-separated inputs + Save/Reset; edit page at `manage-lifts/edit/[lift]/`; "Edit" link added per lift row in `ManageLiftsActions`
- Also fixes pre-existing `exactOptionalPropertyTypes` errors in strength-goals code and fills a missing `workoutLiftOverride` gap in `SystemDbRepositoryFactory`

## Acceptance Criteria

- [x] `GET /lifts/:lift/metadata` returns defaults (`muscleGroups: []`, `substitutions: []`, `foundational: ""`) when no record exists
- [x] `PATCH /lifts/:lift/metadata` persists and returns the updated metadata
- [x] Partial PATCH retains unpatched fields
- [x] Unauthenticated requests return 401
- [x] User isolation: User B gets empty defaults when User A has metadata for the same lift
- [x] Edit page accessible from manage-lifts via "Edit" button per lift
- [x] Save → fields persist on returning to edit the same lift
- [x] Reset clears the form fields client-side

## Test Results

All 171 API tests pass including 5 new lift metadata e2e tests:
- `GET /lifts/:lift/metadata without auth returns 401`
- `GET /lifts/:lift/metadata returns defaults when no record exists`
- `PATCH then GET persists all fields`
- `Partial PATCH retains unpatched fields`
- `User isolation: User B gets separate metadata`

Closes #179