### PR TITLE
[docs] Mark integration-tests workstream as shipped in ROADMAP (#181)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -94,6 +94,7 @@ Web and mobile clients functional end-to-end. Key user-facing features implement
 | Manage lifts | Per-workout add/remove/replace overrides stored in `workout_lift_override` table; `GET /workouts/:workoutNum` returns planned lifts for upcoming workouts; manage-lifts and lift-picker web pages | [#178](https://github.com/brownm09/lifting-logbook/issues/178) |
 | Lift metadata | Per-user, per-lift metadata: muscle groups (`string[]`), substitutions (`string[]`), foundational flag (`boolean`); `GET /lifts/:lift/metadata` + `PATCH /lifts/:lift/metadata`; `LiftEditor` component + edit page + Edit link in manage-lifts | [#179](https://github.com/brownm09/lifting-logbook/issues/179) |
 | Onboarding program catalog | Full 13-program catalog with `Purpose`/`Goal` union types, experience + goal filters, "View Full Catalog" cross-tier sub-view, rich detail view (purpose tags, Core Lifts, duration/frequency grid, sample schedule), server-side availability guard, `useTransition` + Server Action wiring → `/cycle/1` | [#180](https://github.com/brownm09/lifting-logbook/issues/180) |
+| Integration tests | Cross-cutting e2e scenarios for strength goals, training max history, rescheduling, manage lifts, and lift metadata; `?isPR=true` filter coverage in DB suite; in-memory adapter wiring audit | [#181](https://github.com/brownm09/lifting-logbook/issues/181) |
 
 ### Proposals
 


### PR DESCRIPTION
Moves issue #181 (integration tests for strength goals, max history, rescheduling, manage lifts, and lift metadata) to the v0.3 Shipped table in ROADMAP.md.

No code changes.