### PR TITLE
[fix] Remove stale Reps column from Training Max History table

### DIFF
--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/[lift]/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/[lift]/page.tsx
@@ -67,7 +67,6 @@ export default async function LiftDetailPage({
               <tr>
                 <th>Date</th>
                 <th>Weight</th>
-                <th>Reps</th>
                 <th></th>
               </tr>
             </thead>
@@ -81,7 +80,6 @@ export default async function LiftDetailPage({
                     <td>
                       {entry.weight} {entry.unit}
                     </td>
-                    <td>{entry.reps}</td>
                     <td>{entry.isPR && <span className={styles.prBadge}>PR</span>}</td>
                   </tr>
                 ))}


### PR DESCRIPTION
## Summary

Removes the orphaned `Reps` column from the Training Max History table, which caused a TypeScript error blocking `npm run build`:

```
Property 'reps' does not exist on type 'TrainingMaxHistoryEntryResponse'
```

`TrainingMaxHistoryEntryResponse` tracks weight adjustments over time and has no `reps` field — that field belongs to `LiftRecordResponse`/`SetResponse`. The column was scaffolding debris.

## Changes

- Removed `<th>Reps</th>` from the table header
- Removed `<td>{entry.reps}</td>` from the table body

Table now renders: Date | Weight | PR badge (3 columns, matching the type).

## Test plan

- [x] `npm run build -w @lifting-logbook/web` — passes, no TypeScript errors
- [x] `npm test` — no regressions

Closes #195