### PR TITLE
[chore] Local dev setup: docker-compose Postgres and dev auth wiring

### DIFF
--- a/.claude/hook-config.json
+++ b/.claude/hook-config.json
@@ -16,5 +16,7 @@
     "v0.1 — Foundation",
     "v0.2 — Core API",
     "v0.3 — Client Applications"
-  ]
+  ],
+  "status_field_id": "PVTSSF_lAHOAjEKvM4BTuEFzhA7F7E",
+  "done_option_id": "98236657"
 }

--- a/README.md
+++ b/README.md
@@ -54,12 +54,50 @@ runs only core's tests, with no knowledge of the rest of the monorepo.
 
 - Node.js >= 20.11.1 (use `.nvmrc`: `nvm use`)
 - npm >= 10 (bundled with Node 20)
+- Docker (for local Postgres)
 
-### Install
+### Local Development
 
 ```sh
+# 1. Install dependencies
 npm install
+
+# 2. Start Postgres
+docker compose up db -d
+
+# 3. Create env files from examples
+cp apps/api/.env.example apps/api/.env
+cp apps/web/.env.example apps/web/.env
 ```
+
+Edit `apps/api/.env` and set:
+```
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/lifting_logbook
+SYSTEM_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/lifting_logbook
+# Leave CLERK_SECRET_KEY unset — DevAuthProvider is used automatically
+DEV_USER_ID=dev-user
+DEV_USER_EMAIL=dev@example.com
+```
+
+Edit `apps/web/.env` and set:
+```
+API_URL=http://localhost:3004
+NEXT_PUBLIC_API_URL=http://localhost:3004
+NEXT_PUBLIC_DEFAULT_PROGRAM=5-3-1
+DEV_AUTH_TOKEN=dev-user
+NEXT_PUBLIC_DEV_AUTH_TOKEN=dev-user
+```
+
+```sh
+# 4. Apply database migrations
+cd apps/api && npx prisma migrate dev && cd ../..
+
+# 5. Start all dev servers
+npm run dev
+```
+
+- Web: http://localhost:3000
+- API: http://localhost:3004
 
 ### Common Commands
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ cp apps/web/.env.example apps/web/.env
 Edit `apps/api/.env` and set:
 ```
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/lifting_logbook
-SYSTEM_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/lifting_logbook
 # Leave CLERK_SECRET_KEY unset — DevAuthProvider is used automatically
 DEV_USER_ID=dev-user
 DEV_USER_EMAIL=dev@example.com

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -20,9 +20,10 @@ DEV_USER_EMAIL=dev@example.com
 DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/lifting_logbook
 
 # ── System dispatch database ───────────────────────────────────────
-# Optional. When set (with DATABASE_URL unset), the API consults the
-# user_data_source table to route each user to their configured adapter
-# (supports 'in-memory' and 'postgres').
+# Production only — not needed for local dev.
+# When set (and DATABASE_URL is unset), the API consults the user_data_source
+# table to route each user to their configured adapter ('in-memory' or 'postgres').
+# DATABASE_URL takes precedence over SYSTEM_DATABASE_URL when both are set.
 # See infra/migrations/001_create_user_data_source.sql for schema.
 SYSTEM_DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/lifting_logbook_system
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -4,7 +4,14 @@
 # ─────────────────────────────────────────────────────────────────
 
 # ── Auth (Clerk) ───────────────────────────────────────────────────
+# Leave CLERK_SECRET_KEY unset for local dev — the API will use DevAuthProvider,
+# which accepts any Bearer token as the user ID.
 CLERK_SECRET_KEY=sk_test_...
+
+# ── Local dev auth (only used when CLERK_SECRET_KEY is unset) ──────
+# Fixed user identity. Must match DEV_AUTH_TOKEN / NEXT_PUBLIC_DEV_AUTH_TOKEN in apps/web/.env.
+DEV_USER_ID=dev-user
+DEV_USER_EMAIL=dev@example.com
 
 # ── User data database (Prisma / Cloud SQL Postgres) ──────────────
 # When set, the API persists lift records, training maxes, and cycle

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,5 +1,14 @@
 # URL of the NestJS API server, reachable from the Next.js process (server-side only)
 API_URL=http://localhost:3004
 
+# URL reachable from the browser (used by client-side components)
+NEXT_PUBLIC_API_URL=http://localhost:3004
+
 # Default lifting program identifier — used as the :program path param in all API calls
 NEXT_PUBLIC_DEFAULT_PROGRAM=5-3-1
+
+# ── Local dev auth ────────────────────────────────────────────────────────────
+# When CLERK_SECRET_KEY is unset, the API uses DevAuthProvider which accepts any
+# Bearer token as the user ID. Set these to match DEV_USER_ID in apps/api/.env.
+DEV_AUTH_TOKEN=dev-user
+NEXT_PUBLIC_DEV_AUTH_TOKEN=dev-user

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -24,7 +24,10 @@ const isCloudRun = API_URL.startsWith('https://');
 let _auth: GoogleAuth | undefined;
 
 async function getAuthHeaders(): Promise<Record<string, string>> {
-  if (!isCloudRun) return {};
+  if (!isCloudRun) {
+    const devToken = process.env.DEV_AUTH_TOKEN;
+    return devToken ? { Authorization: `Bearer ${devToken}` } : {};
+  }
   try {
     _auth ??= new GoogleAuth();
     const client = await _auth.getIdTokenClient(API_URL);

--- a/apps/web/lib/client-api.ts
+++ b/apps/web/lib/client-api.ts
@@ -14,9 +14,17 @@ import type {
 } from '@lifting-logbook/types';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+const isCloudRun = API_URL.startsWith('https://');
+const devToken = !isCloudRun ? process.env.NEXT_PUBLIC_DEV_AUTH_TOKEN : undefined;
 
 async function clientFetch<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(`${API_URL}${path}`, init);
+  const devAuthHeaders: Record<string, string> = devToken
+    ? { Authorization: `Bearer ${devToken}` }
+    : {};
+  const res = await fetch(`${API_URL}${path}`, {
+    ...init,
+    headers: { ...devAuthHeaders, ...(init?.headers as Record<string, string> | undefined) },
+  });
   if (!res.ok) {
     throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
   }

--- a/apps/web/lib/client-api.ts
+++ b/apps/web/lib/client-api.ts
@@ -62,22 +62,21 @@ export function updateLiftRecord(
   );
 }
 
-export async function rescheduleWorkout(
+export function rescheduleWorkout(
   program: string,
   cycleNum: number,
   workoutNum: number,
   newDate: string,
 ): Promise<void> {
-  const path = `/programs/${encodeURIComponent(program)}/cycles/${cycleNum}/workouts/${workoutNum}/reschedule`;
-  const res = await fetch(`${API_URL}${path}`, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ newDate }),
-    cache: 'no-store',
-  });
-  if (!res.ok) {
-    throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
-  }
+  return clientFetch<void>(
+    `/programs/${encodeURIComponent(program)}/cycles/${cycleNum}/workouts/${workoutNum}/reschedule`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ newDate }),
+      cache: 'no-store',
+    },
+  );
 }
 
 export function recordBodyWeight(
@@ -127,13 +126,14 @@ export function patchLiftMetadata(
   );
 }
 
-export async function deleteLiftOverride(
+export function deleteLiftOverride(
   program: string,
   cycleNum: number,
   workoutNum: number,
   lift: string,
 ): Promise<void> {
-  const path = `/programs/${encodeURIComponent(program)}/cycles/${cycleNum}/workouts/${workoutNum}/lift-overrides/${encodeURIComponent(lift)}`;
-  const res = await fetch(`${API_URL}${path}`, { method: 'DELETE', cache: 'no-store' });
-  if (!res.ok) throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
+  return clientFetch<void>(
+    `/programs/${encodeURIComponent(program)}/cycles/${cycleNum}/workouts/${workoutNum}/lift-overrides/${encodeURIComponent(lift)}`,
+    { method: 'DELETE', cache: 'no-store' },
+  );
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: lifting_logbook
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 6
 
 volumes:
   postgres_data:

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -58,15 +58,9 @@ if grep -q 'USER:PASSWORD@HOST' apps/api/.env 2>/dev/null; then
     sed -i '' \
       's|DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/lifting_logbook|DATABASE_URL=postgresql://postgres:postgres@localhost:5432/lifting_logbook|' \
       apps/api/.env
-    sed -i '' \
-      's|SYSTEM_DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/lifting_logbook_system|SYSTEM_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/lifting_logbook|' \
-      apps/api/.env
   else
     sed -i \
       's|DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/lifting_logbook|DATABASE_URL=postgresql://postgres:postgres@localhost:5432/lifting_logbook|' \
-      apps/api/.env
-    sed -i \
-      's|SYSTEM_DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/lifting_logbook_system|SYSTEM_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/lifting_logbook|' \
       apps/api/.env
   fi
   ok "DATABASE_URL patched with local postgres credentials"
@@ -94,7 +88,7 @@ done
 
 # ── 5. Run migrations ─────────────────────────────────────────────────────────
 step "Running database migrations"
-(cd apps/api && npx prisma migrate dev --name init 2>&1 | grep -v "^$" || true)
+(cd apps/api && npx prisma migrate dev 2>&1 | grep -v "^$" || true)
 ok "Migrations applied"
 
 # ── Done ──────────────────────────────────────────────────────────────────────

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+# ── Colours ───────────────────────────────────────────────────────────────────
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+ok()   { echo -e "${GREEN}✓${NC} $*"; }
+warn() { echo -e "${YELLOW}!${NC} $*"; }
+die()  { echo -e "${RED}✗${NC} $*" >&2; exit 1; }
+step() { echo -e "\n${GREEN}▶${NC} $*"; }
+
+echo "Lifting Logbook — local dev setup"
+echo "==================================="
+
+# ── 1. Prerequisites ──────────────────────────────────────────────────────────
+step "Checking prerequisites"
+
+node_version=$(node --version 2>/dev/null | sed 's/v//' || echo "0")
+node_major=$(echo "$node_version" | cut -d. -f1)
+[[ "$node_major" -ge 20 ]] || die "Node.js >= 20 required (found v${node_version}). Run: nvm use"
+ok "Node.js v${node_version}"
+
+docker info &>/dev/null || die "Docker is not running. Start Docker Desktop and re-run this script."
+ok "Docker"
+
+docker compose version &>/dev/null || die "docker compose plugin not found."
+ok "docker compose"
+
+# ── 2. npm install ────────────────────────────────────────────────────────────
+step "Installing npm dependencies"
+if [[ ! -d node_modules ]]; then
+  npm install
+else
+  ok "node_modules exists — skipping (run 'npm install' manually if packages changed)"
+fi
+
+# ── 3. Env files ──────────────────────────────────────────────────────────────
+step "Setting up env files"
+
+setup_env() {
+  local src="$1" dst="$2" label="$3"
+  if [[ -f "$dst" ]]; then
+    ok "$label already exists — leaving unchanged"
+  else
+    cp "$src" "$dst"
+    ok "$label created from example"
+  fi
+}
+
+setup_env apps/api/.env.example  apps/api/.env  "apps/api/.env"
+setup_env apps/web/.env.example  apps/web/.env  "apps/web/.env"
+
+# Patch DATABASE_URL in apps/api/.env if it still has the placeholder
+if grep -q 'USER:PASSWORD@HOST' apps/api/.env 2>/dev/null; then
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    sed -i '' \
+      's|DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/lifting_logbook|DATABASE_URL=postgresql://postgres:postgres@localhost:5432/lifting_logbook|' \
+      apps/api/.env
+    sed -i '' \
+      's|SYSTEM_DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/lifting_logbook_system|SYSTEM_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/lifting_logbook|' \
+      apps/api/.env
+  else
+    sed -i \
+      's|DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/lifting_logbook|DATABASE_URL=postgresql://postgres:postgres@localhost:5432/lifting_logbook|' \
+      apps/api/.env
+    sed -i \
+      's|SYSTEM_DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/lifting_logbook_system|SYSTEM_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/lifting_logbook|' \
+      apps/api/.env
+  fi
+  ok "DATABASE_URL patched with local postgres credentials"
+fi
+
+# ── 4. Start Postgres ─────────────────────────────────────────────────────────
+step "Starting Postgres"
+docker compose up db -d
+
+# Wait until Postgres accepts connections (up to 30s)
+echo -n "  Waiting for Postgres to be ready"
+for i in $(seq 1 30); do
+  if docker compose exec -T db pg_isready -U postgres &>/dev/null; then
+    echo ""
+    ok "Postgres is ready"
+    break
+  fi
+  echo -n "."
+  sleep 1
+  if [[ $i -eq 30 ]]; then
+    echo ""
+    die "Postgres did not become ready in 30 seconds."
+  fi
+done
+
+# ── 5. Run migrations ─────────────────────────────────────────────────────────
+step "Running database migrations"
+(cd apps/api && npx prisma migrate dev --name init 2>&1 | grep -v "^$" || true)
+ok "Migrations applied"
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${GREEN}Setup complete.${NC}"
+echo ""
+echo "Start the dev servers:"
+echo "  npm run dev"
+echo ""
+echo "Then open:"
+echo "  Web → http://localhost:3000"
+echo "  API → http://localhost:3004"
+echo ""
+warn "No Clerk account needed — DevAuthProvider handles auth automatically in local dev."


### PR DESCRIPTION
## Summary

- Adds `docker-compose.yml` (postgres:16 on port 5432) so `docker compose up db` works as documented in the `.env.example` files
- Wires `DEV_AUTH_TOKEN` / `NEXT_PUBLIC_DEV_AUTH_TOKEN` into `apps/web/lib/api.ts` and `client-api.ts` so the web sends a Bearer token in local dev, letting the API's `DevAuthProvider` identify the caller without Clerk
- Updates `apps/api/.env.example` and `apps/web/.env.example` to document the new variables and explain the auth fallback

## Root cause

`DevAuthProvider` (selected when `CLERK_SECRET_KEY` is unset) was already wired in the API, but `getAuthHeaders()` returned `{}` for non-Cloud Run URLs so every request arrived unauthenticated → 401.

## Test plan

- [x] 124 API + core unit tests pass (`npm test -w @lifting-logbook/api -w @lifting-logbook/core`)
- [x] `jest-environment-jsdom` failure in `@lifting-logbook/web` is pre-existing on `main` (confirmed by running on `main` before changes)
- [ ] Manual: `docker compose up db`, copy `.env.example` → `.env` in both apps, `npm run dev`, navigate to `http://localhost:3000`

Closes #197