### PR TITLE
[feat] apps/web OpenTelemetry instrumentation and trace propagation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,8 @@ dist/
 # GAS / clasp (retained from source repo — remove when GAS migration is complete)
 .clasptoken*
 
+# Next.js generated — rebuilt on every dev/build run; tracking causes spurious diffs
+next-env.d.ts
+
 # Claude Code local overrides (machine-specific permissions, not for team sharing)
 .claude/settings.local.json

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -12,3 +12,8 @@ NEXT_PUBLIC_DEFAULT_PROGRAM=5-3-1
 # Bearer token as the user ID. Set these to match DEV_USER_ID in apps/api/.env.
 DEV_AUTH_TOKEN=dev-user
 NEXT_PUBLIC_DEV_AUTH_TOKEN=dev-user
+
+# ── OpenTelemetry ─────────────────────────────────────────────────────────────
+# OTLP endpoint for trace export. Local dev: point to the otel-collector from
+# issue #207's docker-compose stack. Grafana Cloud: set per ADR-018.
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318

--- a/apps/web/app/onboarding/actions.ts
+++ b/apps/web/app/onboarding/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { redirect } from 'next/navigation';
-import { isRedirectError } from 'next/dist/client/components/redirect';
+import { isRedirectError } from 'next/dist/client/components/redirect-error';
 import { createCycle } from '@/lib/api';
 import { PROGRAMS } from './programs';
 

--- a/apps/web/app/onboarding/actions.ts
+++ b/apps/web/app/onboarding/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { redirect } from 'next/navigation';
+// next/dist internal path — not a public API; validate on Next.js upgrades
 import { isRedirectError } from 'next/dist/client/components/redirect-error';
 import { createCycle } from '@/lib/api';
 import { PROGRAMS } from './programs';

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,0 +1,5 @@
+import { registerOTel } from '@vercel/otel';
+
+export function register() {
+  registerOTel({ serviceName: 'lifting-logbook-web' });
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@lifting-logbook/core": "*",
     "@lifting-logbook/types": "*",
+    "@vercel/otel": "^1.0.0",
     "google-auth-library": "^9.0.0",
     "next": "16.2.4",
     "react": "19.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -157,6 +157,7 @@
       "dependencies": {
         "@lifting-logbook/core": "*",
         "@lifting-logbook/types": "*",
+        "@vercel/otel": "^1.0.0",
         "google-auth-library": "^9.0.0",
         "next": "16.2.4",
         "react": "19.2.4",
@@ -295,6 +296,128 @@
         "node": ">= 10"
       }
     },
+    "apps/web/node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "apps/web/node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "apps/web/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+      "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "apps/web/node_modules/@opentelemetry/resources": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "apps/web/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.2.tgz",
+      "integrity": "sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==",
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "apps/web/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
+      "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "apps/web/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "apps/web/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "apps/web/node_modules/@testing-library/react": {
       "version": "16.3.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
@@ -347,6 +470,41 @@
       "dev": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "apps/web/node_modules/@vercel/otel": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@vercel/otel/-/otel-1.14.1.tgz",
+      "integrity": "sha512-8L6aZoOFkjmXR4lT96OR0ntf95idTPWSS0UAYdAmKoW8xmX9H7WOe8b9j+6srFkvauVLIKkXBdk6FI7pS0a7cA==",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.7.0 <2.0.0",
+        "@opentelemetry/api-logs": ">=0.46.0 <0.200.0",
+        "@opentelemetry/instrumentation": ">=0.46.0 <0.200.0",
+        "@opentelemetry/resources": ">=1.19.0 <2.0.0",
+        "@opentelemetry/sdk-logs": ">=0.46.0 <0.200.0",
+        "@opentelemetry/sdk-metrics": ">=1.19.0 <2.0.0",
+        "@opentelemetry/sdk-trace-base": ">=1.19.0 <2.0.0"
+      }
+    },
+    "apps/web/node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "peer": true
+    },
+    "apps/web/node_modules/import-in-the-middle": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+      "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+      "peer": true,
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
       }
     },
     "apps/web/node_modules/next": {
@@ -445,6 +603,20 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "apps/web/node_modules/require-in-the-middle": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
       }
     },
     "apps/web/node_modules/scheduler": {
@@ -8131,6 +8303,12 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/shimmer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+      "peer": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -17871,6 +18049,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+      "peer": true
     },
     "node_modules/side-channel": {
       "version": "1.1.0",


### PR DESCRIPTION
## Summary

- Installs `@vercel/otel@1.14.1` in `apps/web` — Next.js's officially-recommended OTel wrapper
- Creates `apps/web/instrumentation.ts` registering the SDK via the Next.js instrumentation hook; service name `lifting-logbook-web`; OTLP endpoint reads `OTEL_EXPORTER_OTLP_ENDPOINT`
- W3C `traceparent` propagation is enabled by default: `fetch()` from Server Components to `apps/api` carries the header, enabling distributed trace correlation (web + api under one `trace_id` in Tempo)
- Documents `OTEL_EXPORTER_OTLP_ENDPOINT` in `apps/web/.env.example`
- Fixes pre-existing build failure: `isRedirectError` moved from `next/dist/client/components/redirect` → `redirect-error` in Next.js 16

## Acceptance Criteria

- [x] `@vercel/otel` installed in `apps/web`
- [x] `apps/web/instrumentation.ts` registers the SDK per the Next.js instrumentation API
- [x] OTLP exporter endpoint reads `OTEL_EXPORTER_OTLP_ENDPOINT`; service name `lifting-logbook-web`
- [ ] Manual local verification via docker-compose stack (blocked on #207 — Child D)
- [x] `npm test -w @lifting-logbook/web` passes (28/28)
- [x] `npm run build` passes

## Test Results

```
npm test -w @lifting-logbook/web
Tests: 28 passed, 28 total

npm run build -w @lifting-logbook/web
✓ Compiled successfully; TypeScript clean; 7 routes generated
```

Closes #206