### PR TITLE
[infra] OTel Collector config, local docker-compose stack, dashboards, and alert rules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,5 +15,77 @@ services:
       timeout: 5s
       retries: 6
 
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.104.0
+    command: ["--config=/etc/otelcol/config.yaml"]
+    volumes:
+      - ./infra/observability/otel-collector.yaml:/etc/otelcol/config.yaml:ro
+    environment:
+      OTEL_COLLECTOR_OTLP_ENDPOINT: http://tempo:4318
+      OTEL_COLLECTOR_OTLP_AUTH_HEADER: ""
+      OTEL_COLLECTOR_LOKI_ENDPOINT: http://loki:3100/loki/api/v1/push
+      OTEL_COLLECTOR_LOKI_AUTH_HEADER: ""
+    ports:
+      - "4317:4317"   # OTLP gRPC
+      - "4318:4318"   # OTLP HTTP
+      - "8889:8889"   # Prometheus exporter
+    depends_on:
+      - tempo
+      - loki
+
+  tempo:
+    image: grafana/tempo:2.5.0
+    command: ["-config.file=/etc/tempo/config.yaml"]
+    volumes:
+      - ./infra/observability/tempo-local.yml:/etc/tempo/config.yaml:ro
+      - tempo_data:/var/tempo
+    ports:
+      - "3200:3200"   # Tempo query API
+
+  loki:
+    image: grafana/loki:3.1.0
+    command: ["-config.file=/etc/loki/config.yaml"]
+    volumes:
+      - ./infra/observability/loki-local.yml:/etc/loki/config.yaml:ro
+      - loki_data:/loki
+    ports:
+      - "3100:3100"
+
+  prometheus:
+    image: prom/prometheus:v2.53.0
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
+    volumes:
+      - ./infra/observability/prometheus-local.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    ports:
+      - "9090:9090"
+    depends_on:
+      - otel-collector
+
+  grafana:
+    image: grafana/grafana:11.1.0
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+    volumes:
+      - ./infra/observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./infra/observability/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    ports:
+      - "3030:3000"
+    depends_on:
+      - prometheus
+      - tempo
+      - loki
+
 volumes:
   postgres_data:
+  tempo_data:
+  loki_data:
+  prometheus_data:
+  grafana_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,9 +29,16 @@ services:
       - "4317:4317"   # OTLP gRPC
       - "4318:4318"   # OTLP HTTP
       - "8889:8889"   # Prometheus exporter
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:13133/"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
     depends_on:
-      - tempo
-      - loki
+      tempo:
+        condition: service_healthy
+      loki:
+        condition: service_healthy
 
   tempo:
     image: grafana/tempo:2.5.0
@@ -41,6 +48,11 @@ services:
       - tempo_data:/var/tempo
     ports:
       - "3200:3200"   # Tempo query API
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3200/ready"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
 
   loki:
     image: grafana/loki:3.1.0
@@ -50,6 +62,11 @@ services:
       - loki_data:/loki
     ports:
       - "3100:3100"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3100/ready"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
 
   prometheus:
     image: prom/prometheus:v2.53.0
@@ -63,9 +80,16 @@ services:
       - prometheus_data:/prometheus
     ports:
       - "9090:9090"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9090/-/ready"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
     depends_on:
-      - otel-collector
+      otel-collector:
+        condition: service_healthy
 
+  # DEV ONLY — anonymous Admin access, never copy this auth config to staging/prod
   grafana:
     image: grafana/grafana:11.1.0
     environment:
@@ -77,11 +101,14 @@ services:
       - ./infra/observability/dashboards:/var/lib/grafana/dashboards:ro
       - grafana_data:/var/lib/grafana
     ports:
-      - "3030:3000"
+      - "127.0.0.1:3030:3000"
     depends_on:
-      - prometheus
-      - tempo
-      - loki
+      prometheus:
+        condition: service_healthy
+      tempo:
+        condition: service_healthy
+      loki:
+        condition: service_healthy
 
 volumes:
   postgres_data:

--- a/infra/cloud-run/otel-collector-sidecar.yaml
+++ b/infra/cloud-run/otel-collector-sidecar.yaml
@@ -1,0 +1,91 @@
+# OTel Collector sidecar for Cloud Run (template — not yet deployed).
+# Inject alongside the api container as a second container in the same revision.
+# See ADR-018 for the decision to use a DaemonSet on GKE as the primary topology;
+# this sidecar template is provided for Cloud Run parity when GKE is unavailable.
+#
+# Template variables (substituted by CI/CD):
+#   $PROJECT_ID   — GCP project ID
+#   $REGION       — GCP region (us-central1)
+#   $IMAGE_TAG    — Git SHA of the deployed api image
+#   $ENVIRONMENT  — staging | production
+
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: lifting-logbook-api
+  labels:
+    cloud.googleapis.com/location: us-central1
+  annotations:
+    run.googleapis.com/ingress: all
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "10"
+        run.googleapis.com/vpc-access-connector: projects/$PROJECT_ID/locations/$REGION/connectors/prod-connector
+        run.googleapis.com/vpc-access-egress: private-ranges-only
+    spec:
+      serviceAccountName: lifting-logbook-prod-api-wi@$PROJECT_ID.iam.gserviceaccount.com
+      containerConcurrency: 80
+      containers:
+        - name: api
+          image: us-central1-docker.pkg.dev/$PROJECT_ID/lifting-logbook/api:$IMAGE_TAG
+          ports:
+            - containerPort: 3000
+          resources:
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          env:
+            - name: NODE_ENV
+              value: $ENVIRONMENT
+            - name: PORT
+              value: "3000"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://localhost:4318
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: lifting-logbook-prod-database-url
+                  key: latest
+            - name: SYSTEM_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: lifting-logbook-prod-system-database-url
+                  key: latest
+            - name: CLERK_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: lifting-logbook-prod-clerk-secret-key
+                  key: latest
+
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:0.104.0
+          args: ["--config=/etc/otelcol/config.yaml"]
+          resources:
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          env:
+            - name: OTEL_COLLECTOR_OTLP_ENDPOINT
+              value: https://otlp-gateway-prod-us-central1.grafana.net/otlp
+            - name: OTEL_COLLECTOR_LOKI_ENDPOINT
+              value: https://logs-prod-021.grafana.net/loki/api/v1/push
+            - name: OTEL_COLLECTOR_OTLP_AUTH_HEADER
+              valueFrom:
+                secretKeyRef:
+                  name: lifting-logbook-prod-otel-otlp-auth-header
+                  key: latest
+            - name: OTEL_COLLECTOR_LOKI_AUTH_HEADER
+              valueFrom:
+                secretKeyRef:
+                  name: lifting-logbook-prod-otel-loki-auth-header
+                  key: latest
+          volumeMounts:
+            - name: otelconfig
+              mountPath: /etc/otelcol
+      volumes:
+        - name: otelconfig
+          configMap:
+            name: otel-collector-config

--- a/infra/cloud-run/otel-collector-sidecar.yaml
+++ b/infra/cloud-run/otel-collector-sidecar.yaml
@@ -4,10 +4,12 @@
 # this sidecar template is provided for Cloud Run parity when GKE is unavailable.
 #
 # Template variables (substituted by CI/CD):
-#   $PROJECT_ID   — GCP project ID
-#   $REGION       — GCP region (us-central1)
-#   $IMAGE_TAG    — Git SHA of the deployed api image
-#   $ENVIRONMENT  — staging | production
+#   $PROJECT_ID                    — GCP project ID
+#   $REGION                        — GCP region (us-central1)
+#   $IMAGE_TAG                     — Git SHA of the deployed api image
+#   $ENVIRONMENT                   — staging | production
+#   $OTEL_COLLECTOR_CONFIG_SECRET  — Secret Manager secret name holding the otel-collector config.yaml
+#                                    (Cloud Run supports secret volumes, not ConfigMap volumes)
 
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -87,5 +89,5 @@ spec:
               mountPath: /etc/otelcol
       volumes:
         - name: otelconfig
-          configMap:
-            name: otel-collector-config
+          secret:
+            secretName: $OTEL_COLLECTOR_CONFIG_SECRET

--- a/infra/kubernetes/charts/otel-collector/Chart.yaml
+++ b/infra/kubernetes/charts/otel-collector/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: otel-collector
+description: Helm chart for the OTel Collector DaemonSet on GKE
+type: application
+version: 0.1.0
+appVersion: "0.104.0"

--- a/infra/kubernetes/charts/otel-collector/templates/NOTES.txt
+++ b/infra/kubernetes/charts/otel-collector/templates/NOTES.txt
@@ -1,0 +1,20 @@
+OTel Collector DaemonSet deployed as: {{ include "otel-collector.fullname" . }}
+
+REQUIRED: Create the auth-header Secret before running helm install.
+The chart does NOT create this Secret — it must exist in the namespace first.
+
+  kubectl create secret generic {{ .Values.existingSecret }} \
+    --from-literal=otlp-auth-header="Basic <base64(instanceId:apiKey)>" \
+    --from-literal=loki-auth-header="Basic <base64(instanceId:apiKey)>"
+
+Recommended production pattern: External Secrets Operator pulling from
+GCP Secret Manager via Workload Identity (configure existingSecret to match
+the ExternalSecret's target.name).
+
+Endpoints (ClusterIP):
+  OTLP gRPC:  {{ include "otel-collector.fullname" . }}:4317
+  OTLP HTTP:  {{ include "otel-collector.fullname" . }}:4318
+  Prometheus: {{ include "otel-collector.fullname" . }}:8889
+
+Configure your apps to export to:
+  OTEL_EXPORTER_OTLP_ENDPOINT=http://{{ include "otel-collector.fullname" . }}:4318

--- a/infra/kubernetes/charts/otel-collector/templates/_helpers.tpl
+++ b/infra/kubernetes/charts/otel-collector/templates/_helpers.tpl
@@ -1,0 +1,18 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "otel-collector.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "otel-collector.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}

--- a/infra/kubernetes/charts/otel-collector/templates/configmap.yaml
+++ b/infra/kubernetes/charts/otel-collector/templates/configmap.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "otel-collector.fullname" . }}-config
+data:
+  OTEL_COLLECTOR_OTLP_ENDPOINT: {{ .Values.env.OTEL_COLLECTOR_OTLP_ENDPOINT | quote }}
+  OTEL_COLLECTOR_LOKI_ENDPOINT: {{ .Values.env.OTEL_COLLECTOR_LOKI_ENDPOINT | quote }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "otel-collector.fullname" . }}-otelconfig
+data:
+  config.yaml: |
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+    processors:
+      batch:
+        timeout: 5s
+        send_batch_size: 1000
+
+    exporters:
+      otlphttp/traces:
+        endpoint: ${env:OTEL_COLLECTOR_OTLP_ENDPOINT}
+        headers:
+          authorization: ${env:OTEL_COLLECTOR_OTLP_AUTH_HEADER}
+      prometheus:
+        endpoint: "0.0.0.0:8889"
+      loki:
+        endpoint: ${env:OTEL_COLLECTOR_LOKI_ENDPOINT}
+        headers:
+          authorization: ${env:OTEL_COLLECTOR_LOKI_AUTH_HEADER}
+
+    service:
+      extensions: [health_check]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [otlphttp/traces]
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [prometheus]
+        logs:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [loki]

--- a/infra/kubernetes/charts/otel-collector/templates/daemonset.yaml
+++ b/infra/kubernetes/charts/otel-collector/templates/daemonset.yaml
@@ -37,12 +37,12 @@ spec:
             - name: OTEL_COLLECTOR_OTLP_AUTH_HEADER
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "otel-collector.fullname" . }}-secrets
+                  name: {{ .Values.existingSecret }}
                   key: otlp-auth-header
             - name: OTEL_COLLECTOR_LOKI_AUTH_HEADER
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "otel-collector.fullname" . }}-secrets
+                  name: {{ .Values.existingSecret }}
                   key: loki-auth-header
           volumeMounts:
             - name: otelconfig

--- a/infra/kubernetes/charts/otel-collector/templates/daemonset.yaml
+++ b/infra/kubernetes/charts/otel-collector/templates/daemonset.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "otel-collector.fullname" . }}
+  labels:
+    app: {{ include "otel-collector.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "otel-collector.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "otel-collector.fullname" . }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "otel-collector.fullname" . }}
+      containers:
+        - name: otel-collector
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["--config=/etc/otelcol/config.yaml"]
+          ports:
+            - containerPort: 4317
+              name: otlp-grpc
+            - containerPort: 4318
+              name: otlp-http
+            - containerPort: 8889
+              name: prometheus
+            - containerPort: 13133
+              name: health
+          envFrom:
+            - configMapRef:
+                name: {{ include "otel-collector.fullname" . }}-config
+          env:
+            - name: OTEL_COLLECTOR_OTLP_AUTH_HEADER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "otel-collector.fullname" . }}-secrets
+                  key: otlp-auth-header
+            - name: OTEL_COLLECTOR_LOKI_AUTH_HEADER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "otel-collector.fullname" . }}-secrets
+                  key: loki-auth-header
+          volumeMounts:
+            - name: otelconfig
+              mountPath: /etc/otelcol
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      volumes:
+        - name: otelconfig
+          configMap:
+            name: {{ include "otel-collector.fullname" . }}-otelconfig

--- a/infra/kubernetes/charts/otel-collector/templates/service.yaml
+++ b/infra/kubernetes/charts/otel-collector/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "otel-collector.fullname" . }}
+  labels:
+    app: {{ include "otel-collector.fullname" . }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ include "otel-collector.fullname" . }}
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+    - name: prometheus
+      port: 8889
+      targetPort: 8889
+      protocol: TCP

--- a/infra/kubernetes/charts/otel-collector/templates/serviceaccount.yaml
+++ b/infra/kubernetes/charts/otel-collector/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "otel-collector.fullname" . }}
+  annotations:
+    iam.gke.io/gcp-service-account: {{ .Values.gcp.serviceAccountEmail | quote }}

--- a/infra/kubernetes/charts/otel-collector/values.yaml
+++ b/infra/kubernetes/charts/otel-collector/values.yaml
@@ -1,0 +1,33 @@
+# Default values — overridden by infra/kubernetes/values/{staging,production}.yaml
+
+image:
+  repository: otel/opentelemetry-collector-contrib
+  tag: "0.104.0"
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: "otel-collector"
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+# Non-secret env vars for the collector config substitution.
+# Auth header secrets are pulled from Secret Manager via workload identity SA.
+env:
+  OTEL_COLLECTOR_OTLP_ENDPOINT: ""   # set per-environment
+  OTEL_COLLECTOR_LOKI_ENDPOINT: ""   # set per-environment
+
+# GCP-specific config
+gcp:
+  projectId: ""
+  serviceAccountEmail: ""   # workload identity SA email
+
+# Secret Manager secret IDs (not the secret values)
+secrets:
+  otlpAuthHeader: ""   # Secret Manager secret ID for OTEL_COLLECTOR_OTLP_AUTH_HEADER
+  lokiAuthHeader: ""   # Secret Manager secret ID for OTEL_COLLECTOR_LOKI_AUTH_HEADER

--- a/infra/kubernetes/charts/otel-collector/values.yaml
+++ b/infra/kubernetes/charts/otel-collector/values.yaml
@@ -27,7 +27,11 @@ gcp:
   projectId: ""
   serviceAccountEmail: ""   # workload identity SA email
 
-# Secret Manager secret IDs (not the secret values)
-secrets:
-  otlpAuthHeader: ""   # Secret Manager secret ID for OTEL_COLLECTOR_OTLP_AUTH_HEADER
-  lokiAuthHeader: ""   # Secret Manager secret ID for OTEL_COLLECTOR_LOKI_AUTH_HEADER
+# Name of the pre-existing Kubernetes Secret containing otlp-auth-header and loki-auth-header keys.
+# Create this Secret before running helm install — the chart does NOT create it.
+# Recommended pattern: External Secrets Operator pulling from GCP Secret Manager via Workload Identity.
+# Example manual creation:
+#   kubectl create secret generic otel-collector-secrets \
+#     --from-literal=otlp-auth-header="Basic <base64(instanceId:apiKey)>" \
+#     --from-literal=loki-auth-header="Basic <base64(instanceId:apiKey)>"
+existingSecret: "otel-collector-secrets"

--- a/infra/observability/alerts/api.yaml
+++ b/infra/observability/alerts/api.yaml
@@ -28,7 +28,7 @@ groups:
 
       - alert: APINoRequests
         expr: |
-          sum(increase(http_server_request_duration_seconds_count[10m])) == 0
+          (sum(increase(http_server_request_duration_seconds_count[10m])) or vector(0)) == 0
         for: 10m
         labels:
           severity: info

--- a/infra/observability/alerts/api.yaml
+++ b/infra/observability/alerts/api.yaml
@@ -1,0 +1,37 @@
+groups:
+  - name: api
+    rules:
+      - alert: APIHighErrorRate
+        expr: |
+          sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[5m]))
+          / sum(rate(http_server_request_duration_seconds_count[5m]))
+          > 0.01
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "API error rate > 1%"
+          description: "{{ $value | humanizePercentage }} of requests are returning 5xx"
+
+      - alert: APIHighP95Latency
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le)
+          ) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "API p95 latency > 1s"
+          description: "p95 latency is {{ $value | humanizeDuration }}"
+
+      - alert: APINoRequests
+        expr: |
+          sum(increase(http_server_request_duration_seconds_count[10m])) == 0
+        for: 10m
+        labels:
+          severity: info
+        annotations:
+          summary: "API received no requests in 10 minutes"
+          description: "No traffic seen. May fire spuriously outside business hours."

--- a/infra/observability/dashboards/api-red.json
+++ b/infra/observability/dashboards/api-red.json
@@ -1,0 +1,123 @@
+{
+  "id": null,
+  "uid": "api-red",
+  "title": "API RED",
+  "tags": ["observability", "api"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "label": "Datasource",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "options": [],
+        "refresh": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Request Rate",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_request_duration_seconds_count[5m]))",
+          "legendFormat": "req/s",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "color": { "mode": "palette-classic" } },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "single" } }
+    },
+    {
+      "id": 2,
+      "title": "Error Rate",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~\"5..\"}[5m])) / sum(rate(http_server_request_duration_seconds_count[5m])) * 100",
+          "legendFormat": "error %",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "percent", "color": { "mode": "fixed", "fixedColor": "red" } },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "single" } }
+    },
+    {
+      "id": 3,
+      "title": "Duration p50",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 8, "w": 8, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "single" } }
+    },
+    {
+      "id": 4,
+      "title": "Duration p95",
+      "type": "timeseries",
+      "gridPos": { "x": 8, "y": 8, "w": 8, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "single" } }
+    },
+    {
+      "id": 5,
+      "title": "Duration p99",
+      "type": "timeseries",
+      "gridPos": { "x": 16, "y": 8, "w": 8, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      },
+      "options": { "tooltip": { "mode": "single" } }
+    }
+  ]
+}

--- a/infra/observability/grafana/provisioning/dashboards/local.yml
+++ b/infra/observability/grafana/provisioning/dashboards/local.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards

--- a/infra/observability/grafana/provisioning/datasources/local.yml
+++ b/infra/observability/grafana/provisioning/datasources/local.yml
@@ -1,0 +1,39 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    uid: prometheus
+
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    uid: tempo
+    jsonData:
+      tracesToLogsV2:
+        datasourceUid: loki
+        tags:
+          - key: service.name
+            value: service_name
+      lokiSearch:
+        datasourceUid: loki
+      serviceMap:
+        datasourceUid: prometheus
+      nodeGraph:
+        enabled: true
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    uid: loki
+    jsonData:
+      derivedFields:
+        - matcherRegex: '"trace_id":"(\w+)"'
+          name: TraceID
+          url: "$${__value.raw}"
+          datasourceUid: tempo

--- a/infra/observability/loki-local.yml
+++ b/infra/observability/loki-local.yml
@@ -1,0 +1,30 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  log_level: warn
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h

--- a/infra/observability/otel-collector.yaml
+++ b/infra/observability/otel-collector.yaml
@@ -1,0 +1,44 @@
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 1000
+
+exporters:
+  otlphttp/traces:
+    endpoint: ${env:OTEL_COLLECTOR_OTLP_ENDPOINT}
+    headers:
+      authorization: ${env:OTEL_COLLECTOR_OTLP_AUTH_HEADER}
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+  loki:
+    endpoint: ${env:OTEL_COLLECTOR_LOKI_ENDPOINT}
+    headers:
+      authorization: ${env:OTEL_COLLECTOR_LOKI_AUTH_HEADER}
+
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/traces]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [loki]

--- a/infra/observability/prometheus-local.yml
+++ b/infra/observability/prometheus-local.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: otel-collector
+    static_configs:
+      - targets: ['otel-collector:8889']

--- a/infra/observability/tempo-local.yml
+++ b/infra/observability/tempo-local.yml
@@ -1,0 +1,30 @@
+stream_over_http_enabled: true
+
+server:
+  http_listen_port: 3200
+  log_level: warn
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal
+
+compactor:
+  compaction:
+    block_retention: 1h
+
+query_frontend:
+  search:
+    default_result_limit: 20

--- a/infra/observability/tempo-local.yml
+++ b/infra/observability/tempo-local.yml
@@ -23,7 +23,7 @@ storage:
 
 compactor:
   compaction:
-    block_retention: 1h
+    block_retention: 24h  # keep a full day of traces for local dev debugging sessions
 
 query_frontend:
   search:


### PR DESCRIPTION
## Summary

- **OTel Collector config** (`infra/observability/otel-collector.yaml`): OTLP receiver → batch processor → OTLP/HTTP traces exporter (env-templated for Grafana Cloud), Prometheus metrics exporter, Loki logs exporter. Local dev vs. production differ only in env vars — no code changes required to switch backends.
- **docker-compose stack**: extends existing Postgres compose with `otel-collector:0.104.0`, `tempo:2.5.0`, `loki:3.1.0`, `prometheus:v2.53.0`, `grafana:11.1.0` — all image tags pinned. Grafana datasources (Prometheus, Tempo, Loki with trace↔log correlation) and the API RED dashboard auto-provision on startup.
- **Helm DaemonSet chart** (`infra/kubernetes/charts/otel-collector/`): mirrors `charts/api` structure with DaemonSet instead of Deployment. Auth headers injected via Secret Manager refs. `helm lint` passes.
- **Cloud Run sidecar template** (`infra/cloud-run/otel-collector-sidecar.yaml`): documented but not yet deployed (per ADR-018).
- **RED dashboard** (`infra/observability/dashboards/api-red.json`): Request Rate, Error Rate, p50/p95/p99 Duration panels backed by Prometheus.
- **Alert rules** (`infra/observability/alerts/api.yaml`): API error-rate > 1% (5m), p95 latency > 1s (5m), no requests for 10m. `promtool check rules` passes.

Closes #207

## Acceptance Criteria

- [x] `infra/observability/otel-collector.yaml` — OTLP receiver, batch processor, OTLP/HTTP exporter (env-templated), Prometheus exporter, Loki exporter
- [x] `docker-compose.yml` extended with `tempo`, `loki`, `prometheus`, `grafana`, `otel-collector`; all pinned to specific image tags
- [x] `infra/kubernetes/charts/otel-collector/` — Helm chart (DaemonSet). `helm lint` passes.
- [x] `infra/cloud-run/otel-collector-sidecar.yaml` — sidecar config template (not deployed)
- [x] `infra/observability/dashboards/api-red.json` — Rate, Errors, Duration (p50/p95/p99) panels
- [x] `infra/observability/alerts/api.yaml` — three Prometheus alert rules. `promtool check rules` passes.
- [ ] Manual: `docker compose up`, hit api, see a span in Tempo, a log in Loki with matching `trace_id`, RED panels render in Grafana

## Test Plan

- [x] `helm lint infra/kubernetes/charts/otel-collector` — 1 chart linted, 0 failed
- [x] `promtool check rules infra/observability/alerts/api.yaml` — SUCCESS: 3 rules found
- [x] Pre-existing test failures (`web:test` jsdom, `api:test` e2e DB) are unrelated to this PR (verified by running against main)
- [ ] Manual E2E: `docker compose up -d`, run api with `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318`, `curl http://localhost:3000/health`, check Tempo/Loki/Grafana at localhost:3030