### PR TITLE
[docs] Mark on-call readiness as shipped in ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,7 +105,7 @@ Web and mobile clients functional end-to-end. Key user-facing features implement
 | [Training Max Management Screen](docs/proposals/2026-04-29-training-max-management.md) | View and edit per-lift 1RMs at `/settings/training-maxes`; drives all working set calculations | [#108](https://github.com/brownm09/lifting-logbook/issues/108) | shipped |
 | [Strength Goal Tracking](docs/proposals/2026-04-29-strength-goal-tracking.md) | Per-lift, per-tier strength standards (intermediate/advanced/elite) with target and observed dates | [#111](https://github.com/brownm09/lifting-logbook/issues/111) | shipped |
 | [Initial Training Max Discovery](docs/proposals/2026-04-30-initial-training-max-discovery.md) | Estimation utility (Brzycki) and test-week cycle phase for users with no existing training maxes | [#129](https://github.com/brownm09/lifting-logbook/issues/129) | shipped |
-| [On-Call Readiness](docs/proposals/2026-05-08-on-call-readiness.md) | Runbooks, SLOs, incident response guide, and severity/escalation framework; sequences after #199 | [#201](https://github.com/brownm09/lifting-logbook/issues/201) | draft |
+| [On-Call Readiness](docs/proposals/2026-05-08-on-call-readiness.md) | Runbooks, SLOs, incident response guide, and severity/escalation framework; sequences after #199 | [#201](https://github.com/brownm09/lifting-logbook/issues/201) | shipped |
 
 ---
 

--- a/docs/adr-references.md
+++ b/docs/adr-references.md
@@ -213,6 +213,11 @@ References from [`docs/security-review-checklist.md`](security-review-checklist.
 | [Google SRE Book — Monitoring Distributed Systems](https://sre.google/sre-book/monitoring-distributed-systems/) | [ADR-018](adr/ADR-018-observability-stack.md) | The RED/USE framing the initial alert rules are built on. |
 | [Prometheus — Alerting Rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) | [ADR-018](adr/ADR-018-observability-stack.md) | The alert rule syntax used in `infra/observability/alerts/api.yaml`. |
 | [CNCF — OpenTelemetry project page](https://www.cncf.io/projects/opentelemetry/) | [ADR-018](adr/ADR-018-observability-stack.md) | Supports the "de facto standard" framing of the OTel decision. |
+| [Google SRE Workbook — Chapter 5: Alerting on SLOs](https://sre.google/workbook/alerting-on-slos/) | [ADR-019](adr/ADR-019-slo-methodology.md) | Canonical burn-rate alerting methodology; defines the burn-rate concept, two-window strategy, and the 14×/6×/3× rate thresholds. |
+| [Google SRE Book — Chapter 4: Service Level Objectives](https://sre.google/sre-book/service-level-objectives/) | [ADR-019](adr/ADR-019-slo-methodology.md) | Foundational SLO framing: SLI → SLO → error budget chain, measurement window semantics, and conservative target rationale. |
+| [Google SRE Book — Chapter 6: Monitoring Distributed Systems](https://sre.google/sre-book/monitoring-distributed-systems/) | [ADR-018](adr/ADR-018-observability-stack.md), [ADR-019](adr/ADR-019-slo-methodology.md) | The four golden signals and symptom-vs-cause alert framing. |
+| [Prometheus — Recording Rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) | [ADR-019](adr/ADR-019-slo-methodology.md) | Required for efficient evaluation of 28-day burn-rate expressions; authoritative syntax reference. |
+| [OpenSLO — Specification](https://openslo.com/) | [ADR-019](adr/ADR-019-slo-methodology.md) | YAML open standard for SLO definition; informs the `docs/operations/slo.md` format. |
 
 ---
 

--- a/docs/adr/ADR-019-slo-methodology.md
+++ b/docs/adr/ADR-019-slo-methodology.md
@@ -1,0 +1,156 @@
+# ADR-019: SLO Methodology — Burn-Rate Alerting over Threshold Alerting
+
+**Status:** Accepted
+**Date:** 2026-05-09
+**Closes:** [#201](https://github.com/brownm09/lifting-logbook/issues/201)
+
+---
+
+## Context
+
+The observability stack ([ADR-018](ADR-018-observability-stack.md)) ships three RED-style
+Prometheus alert rules (`APIHighErrorRate`, `APIHighP95Latency`, `APINoRequests`). These rules
+use simple threshold conditions — when a metric crosses a fixed boundary for a sustained window,
+an alert fires. That is sufficient for a pre-traffic service with no SLOs, but it is not a
+durable model: threshold alerts decouple from the user-visible reliability promise, they fire
+at the same cadence regardless of how much of the monthly budget has been consumed, and they
+can't express "this burn rate will exhaust our budget in four hours."
+
+Before this can be an on-call-ready service, two decisions need to be locked in:
+
+1. **What are the SLO targets?** Availability and latency SLOs define what "reliable" means and
+   what the error budget is. Without them there is no way to know whether an alert is actionable
+   or noise.
+2. **How should alerting relate to SLO compliance?** The choice is between threshold alerting
+   (current state) and burn-rate alerting (the methodology described in the Google SRE Workbook,
+   chapter 5). Both approaches can coexist; this ADR decides which is the primary on-call signal.
+
+---
+
+## Decision
+
+### SLO targets
+
+Adopt two SLOs for `apps/api`, measured over a 28-day rolling window:
+
+| SLO | Target | Measurement |
+|---|---|---|
+| Availability | 99.5% | `1 − (5xx responses / total responses)` using `http_server_request_duration_seconds_count` from the OTel instrumentation |
+| p95 latency | < 1 s | `histogram_quantile(0.95, ...)` using `http_server_request_duration_seconds_bucket` |
+
+These targets are deliberately conservative for a pre-traffic service. They can be tightened
+after 90 days of production data.
+
+Error budget per window:
+
+| Window | Availability budget | Notes |
+|---|---|---|
+| 28 days (672 h) | 3.36 h of 5xx responses | 0.5% × 672 h |
+| 30 days (720 h) | 3.60 h of 5xx responses | Reference for monthly reviews |
+
+### Alerting methodology: burn-rate alerting
+
+Use burn-rate alerting as the primary on-call signal rather than simple threshold alerting.
+A burn rate of 1× means the service is consuming error budget at exactly the sustainable rate
+(would exhaust it precisely at the end of the 28-day window). Rates above 1× exhaust the budget
+faster; rates below 1× are within SLO.
+
+The Workbook's recommended two-window alerting strategy:
+
+| Burn rate | Alert window | Look-back | Exhaustion at this rate | Action |
+|---|---|---|---|---|
+| > 14× | 5 m fast | 1 h slow | ~2 h | Page immediately (SEV1 candidate) |
+| > 6× | 30 m fast | 6 h slow | ~4 h | Page (SEV2) |
+| > 3× | 2 h fast | 1 d slow | ~9 h | Ticket (SEV3, next business day) |
+
+The two-window check (short window ∧ long window both above threshold) suppresses spurious
+alerts from transient spikes while catching sustained degradation quickly enough to act before
+the budget is exhausted.
+
+The existing threshold alerts (`APIHighErrorRate`, `APIHighP95Latency`, `APINoRequests`) are
+preserved as leading indicators — they fire faster than burn-rate alerts and help surface the
+nature of a degradation. Burn-rate alerts are the signal that SLO compliance is at risk.
+
+Burn-rate alert rules are not implemented in this ADR; they will be added in a follow-up
+issue once sustained traffic data establishes a realistic baseline request rate (the PromQL
+expressions require it).
+
+---
+
+## Alternatives Considered
+
+### Simple threshold alerting only (status quo)
+
+The three existing rules fire when a metric crosses a fixed boundary. This is sufficient as an
+early-warning system but has three weaknesses: (1) a 2% error rate for 10 minutes is treated
+identically whether it happens on the first day of the month or the last, (2) low-traffic
+periods can cause the alert to fire on a single failed request, and (3) it cannot express
+"at this rate, we run out of budget in four hours." Retained as a secondary layer, not as the
+primary SLO-compliance signal.
+
+### Multi-window multi-burn-rate (full Workbook implementation)
+
+The Workbook describes six alert rules covering three burn rates at two windows each, with
+separate paging and ticket thresholds. This is the correct end state but is disproportionate for
+a service that has no real traffic yet. The exact burn-rate numbers need to be calibrated against
+actual request volume. Deferred until the service has 30+ days of production data.
+
+### Error-budget-based alerting in Grafana SLO product
+
+Grafana Cloud includes an SLO product that generates burn-rate alerts automatically from an SLO
+definition. Ruled out for now because it introduces a Grafana-proprietary layer on top of the
+Prometheus-compatible alert rules already established in [ADR-018](ADR-018-observability-stack.md).
+Reconsider if the team grows and alert management overhead increases.
+
+---
+
+## Consequences
+
+### Positive
+
+- **SLOs tie on-call decisions to user experience.** An alert that fires because 0.3% of budget
+  remains in the last hour of the month is more useful than an alert that fires because a counter
+  crossed an arbitrary threshold.
+- **Error budget enables risk conversations.** When a deploy regression burns 30% of the monthly
+  budget in 20 minutes, the team has a shared vocabulary for the severity rather than debating
+  whether a 3% error rate "feels bad."
+- **Existing alerts are preserved.** The three threshold alerts continue to fire and can point
+  an on-call engineer at the RED dashboard within minutes. Burn-rate alerts will layer on top,
+  not replace them.
+
+### Negative
+
+- **Burn-rate alert rules require a request rate baseline.** The PromQL expressions divide by
+  total request count; on a service with near-zero traffic, any error produces a 100% error
+  rate and an infinite burn rate. Implementation is deferred until there is enough traffic to
+  make the numbers meaningful.
+- **Two-window alerting is harder to explain.** New on-call engineers need to understand both
+  the burn rate concept and why two windows are required. The on-call guide and runbooks must
+  document this clearly.
+- **28-day rolling windows cannot be queried from a Prometheus scrape longer than its retention.**
+  If Prometheus retention is set below 28 days, the window expression will silently use partial
+  data. Grafana Cloud Metrics (Mimir) has configurable retention; ensure it is set to ≥ 30 days.
+
+---
+
+## Implementation outline
+
+| Step | Owner | Notes |
+|---|---|---|
+| SLO doc (`docs/operations/slo.md`) | This PR | Defines the targets and error budget policy |
+| On-call guide (`docs/operations/on-call.md`) | This PR | Severity mapping, escalation, postmortem |
+| Runbooks (`docs/runbooks/`) | This PR | Four failure-mode runbooks |
+| Alert rule annotations | This PR | Add `runbook_url` to existing threshold alerts |
+| Burn-rate alert rules | Follow-up issue | After 30 days of production traffic |
+
+---
+
+## References
+
+| Source | Relevance |
+|---|---|
+| [Google SRE Workbook — Chapter 5: Alerting on SLOs](https://sre.google/workbook/alerting-on-slos/) | Canonical source for burn-rate alerting methodology; defines the burn-rate concept, the two-window strategy, and the specific rate thresholds (14×, 6×, 3×) used above. |
+| [Google SRE Book — Chapter 4: Service Level Objectives](https://sre.google/sre-book/service-level-objectives/) | Foundational SLO framing: SLI → SLO → error budget chain, measurement window semantics, and the rationale for choosing 99.5% availability over higher targets for early-stage services. |
+| [Google SRE Book — Chapter 6: Monitoring Distributed Systems](https://sre.google/sre-book/monitoring-distributed-systems/) | The four golden signals (latency, traffic, errors, saturation); the two SLOs above correspond to the errors and latency signals. Also introduces the symptom-vs-cause alert framing. |
+| [Prometheus — Recording Rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) | Recording rules are required to evaluate burn-rate expressions efficiently at 28-day windows; the two-window strategy generates six pre-computed rates. Authoritative syntax reference. |
+| [OpenSLO — Specification](https://openslo.com/) | YAML-based open standard for SLO definition across observability backends; the `docs/operations/slo.md` format is informed by OpenSLO's SLO object shape. |

--- a/docs/operations/on-call.md
+++ b/docs/operations/on-call.md
@@ -1,0 +1,139 @@
+# On-Call Guide
+
+Covers severity levels, escalation paths, incident response process, and the postmortem
+template. SLO targets and error budget policy are in [`docs/operations/slo.md`](slo.md).
+Runbooks for specific failure modes are in [`docs/runbooks/`](../runbooks/README.md).
+
+---
+
+## Severity Levels
+
+| Severity | Definition | Response target |
+|---|---|---|
+| **SEV1** | Full service outage, data loss risk, or security incident. No users can complete core workflows. | Acknowledge within 15 minutes. Sync call immediately. |
+| **SEV2** | Partial degradation or confirmed SLO breach. A subset of users is affected or the error budget is burning faster than sustainable. | Acknowledge within 30 minutes. Async investigation; escalate to SEV1 if not improving. |
+| **SEV3** | Minor degradation with no measurable user impact. Spurious alert, known false positive, or cosmetic issue. | Next business day. No paging. |
+
+When in doubt, declare a higher severity and downgrade later — it is safer to over-respond than
+to under-respond.
+
+---
+
+## Alert → Severity Mapping
+
+| Alert | Default severity | Escalate to SEV1 if |
+|---|---|---|
+| `APIHighErrorRate` | SEV2 | Error rate sustained above 10% for > 5 minutes |
+| `APIHighP95Latency` | SEV3 | Latency sustained above 3 s for > 15 minutes, or accompanied by `APIHighErrorRate` |
+| `APINoRequests` | SEV3 | Known false-positive risk (see [ADR-018](../adr/ADR-018-observability-stack.md)); confirm in Grafana before acting |
+
+A burn-rate alert (when implemented — see [ADR-019](../adr/ADR-019-slo-methodology.md)) at
+the 14× rate maps to SEV1; at 6× to SEV2; at 3× to SEV3.
+
+---
+
+## Escalation Paths
+
+### SEV1
+
+1. Page the on-call engineer immediately.
+2. If unacknowledged after 15 minutes, page the secondary on-call.
+3. If unresolved after 30 minutes, loop in the engineering lead.
+4. Open a real-time incident channel (e.g., `#incident-YYYY-MM-DD`).
+5. Post a status update every 30 minutes until resolved.
+
+### SEV2
+
+1. Notify the on-call engineer via direct message.
+2. Open an incident ticket and link the relevant alert.
+3. If not improving after 60 minutes, escalate to SEV1.
+
+### SEV3
+
+1. Create a GitHub issue with the `bug` label.
+2. Link the alert that fired and note why it was downgraded.
+3. Assign to the next sprint.
+
+---
+
+## Incident Response Checklist
+
+Work through this checklist in order. Skip steps that clearly do not apply.
+
+- [ ] **Acknowledge the alert** in Grafana Alerting or silence it with a comment if it is a known false positive.
+- [ ] **Assess severity** using the table above. Declare a severity level immediately — even if you are not sure yet, choose the higher one.
+- [ ] **Open an incident channel** for SEV1/SEV2 (`#incident-YYYY-MM-DD`). Post the alert text and your initial assessment.
+- [ ] **Check the dashboard.** Open Grafana → Lifting Logbook → API RED. Note the error rate, p95 latency, and request rate panels.
+- [ ] **Identify the failure mode.** Use the runbook index at [`docs/runbooks/README.md`](../runbooks/README.md) to find the matching runbook.
+- [ ] **Follow the runbook.** Work through symptom → diagnosis → remediation in order.
+- [ ] **Communicate status.** Post an update to the incident channel every 30 minutes for SEV1, every 60 minutes for SEV2.
+- [ ] **Resolve and verify.** Confirm the error rate drops and stays below the alert threshold for at least 10 minutes before declaring resolution.
+- [ ] **Post-incident.** For SEV1 and SEV2, write a postmortem within 48 hours using the template below.
+
+---
+
+## Postmortem Template
+
+Copy and fill in. Postmortems are blameless — focus on systemic causes, not individual errors.
+
+```markdown
+# Postmortem: <brief title>
+
+**Date:** YYYY-MM-DD
+**Severity:** SEV1 / SEV2
+**Duration:** HH:MM (from first symptom to resolution)
+**On-call:** <name>
+**Reviewers:** <names>
+
+---
+
+## Timeline
+
+| Time (UTC) | Event |
+|---|---|
+| HH:MM | Alert fired / first symptom observed |
+| HH:MM | Incident declared; <name> acknowledged |
+| HH:MM | Root cause identified |
+| HH:MM | Remediation applied |
+| HH:MM | Service restored; alert resolved |
+
+## Impact
+
+- **Users affected:** <number or percentage>
+- **Error budget consumed:** approximately X minutes out of Y.YY hours remaining in the current 28-day window
+- **Customer-facing impact:** <description of what users experienced>
+
+## Root Cause
+
+<Explain the technical root cause in detail. What failed, why it failed, and why it was not caught earlier.>
+
+## What Went Well
+
+- <thing that worked>
+- <thing that worked>
+
+## What Could Be Improved
+
+- <gap or failure>
+- <gap or failure>
+
+## Action Items
+
+| Action | Owner | Due date |
+|---|---|---|
+| <specific remediation or prevention step> | <name> | YYYY-MM-DD |
+| <runbook update or alert improvement> | <name> | YYYY-MM-DD |
+
+## Lessons Learned
+
+<One paragraph summarising what the team learned from this incident that applies broadly.>
+```
+
+---
+
+## References
+
+- [`docs/operations/slo.md`](slo.md) — SLO targets and error budget policy
+- [`docs/runbooks/README.md`](../runbooks/README.md) — Runbook index
+- [Google SRE Book — Being On-Call](https://sre.google/sre-book/being-on-call/) — on-call structure and severity framing
+- [Atlassian Incident Handbook](https://www.atlassian.com/incident-management/handbook) — incident response at small org scale

--- a/docs/operations/slo.md
+++ b/docs/operations/slo.md
@@ -30,6 +30,9 @@ PromQL expression:
 )
 ```
 
+> **Note:** 28-day range vectors are expensive to evaluate ad-hoc. In production, pre-compute
+> these via Prometheus recording rules — see [ADR-019](../adr/ADR-019-slo-methodology.md).
+
 ### Latency definition
 
 The p95 of all request durations, measured end-to-end from the first byte received by Fastify
@@ -44,6 +47,9 @@ histogram_quantile(
   sum(rate(http_server_request_duration_seconds_bucket[28d])) by (le)
 )
 ```
+
+> **Note:** 28-day range vectors are expensive to evaluate ad-hoc. In production, pre-compute
+> these via Prometheus recording rules — see [ADR-019](../adr/ADR-019-slo-methodology.md).
 
 ---
 

--- a/docs/operations/slo.md
+++ b/docs/operations/slo.md
@@ -1,0 +1,136 @@
+# Service Level Objectives — `apps/api`
+
+Defines the availability and latency SLOs for the Lifting Logbook API, the error budget
+policy, and how compliance is measured. Methodology rationale is in
+[ADR-019](../adr/ADR-019-slo-methodology.md).
+
+---
+
+## SLO Targets
+
+| SLO | Target | Measurement window |
+|---|---|---|
+| Availability | 99.5% | 28-day rolling |
+| p95 latency | < 1 s | 28-day rolling |
+
+### Availability definition
+
+A request is **good** if the API returns a non-5xx HTTP response. A request is **bad** if it
+returns a 5xx response or the API fails to respond (connection reset, timeout at the load
+balancer). Client-side 4xx responses (malformed input, auth rejection) are **not** counted as
+bad — they represent expected user-error handling, not service failures.
+
+PromQL expression:
+
+```promql
+1 - (
+  sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[28d]))
+  /
+  sum(rate(http_server_request_duration_seconds_count[28d]))
+)
+```
+
+### Latency definition
+
+The p95 of all request durations, measured end-to-end from the first byte received by Fastify
+to the last byte of the response body written. Excludes TLS handshake time and load-balancer
+overhead.
+
+PromQL expression:
+
+```promql
+histogram_quantile(
+  0.95,
+  sum(rate(http_server_request_duration_seconds_bucket[28d])) by (le)
+)
+```
+
+---
+
+## Error Budget
+
+Error budget = (1 − SLO target) × window duration.
+
+| Window | Availability budget | Latency budget |
+|---|---|---|
+| 28 days (672 h) | **3.36 h** of bad responses | Not directly time-based; see burn-rate policy below |
+| 30 days (720 h) | **3.60 h** of bad responses | — |
+
+Availability budget is consumed any time the error rate is above zero. At a sustained 100%
+error rate, the entire 28-day budget is exhausted in 3.36 hours.
+
+---
+
+## Error Budget Policy
+
+### Burn-rate thresholds
+
+| Burn rate | Estimated time to budget exhaustion | Response |
+|---|---|---|
+| > 14× | ~2 h | Page on-call immediately; treat as SEV1 candidate |
+| > 6× | ~4 h | Page on-call; treat as SEV2 |
+| > 3× | ~9 h | Create ticket; treat as SEV3 |
+| ≤ 1× | Budget not at risk | No action required |
+
+Burn rates are measured using a two-window strategy (short detection window ∧ long confidence
+window) to suppress transient spikes. Burn-rate alert rules will be implemented once the
+service receives enough sustained production traffic to calibrate the PromQL expressions.
+Until then, the existing threshold alerts in `infra/observability/alerts/api.yaml` serve
+as the primary on-call signal.
+
+### Budget reset
+
+The 28-day rolling window advances continuously — consuming budget today affects the window for
+the next 28 days, not just the current calendar month. This means a severe incident early in
+the month may make it difficult to deploy risky changes for several weeks.
+
+### Monthly review
+
+On the first business day of each month, the on-call engineer reviews:
+
+1. How much error budget was consumed in the previous 30 days.
+2. Whether any alerts fired that should not have (false positives).
+3. Whether any real degradations went unalerted (gaps in coverage).
+4. Whether the targets remain appropriately conservative or should be tightened.
+
+Targets are reviewed and, if warranted, adjusted after the first 90 days of production traffic.
+
+---
+
+## Exclusions
+
+The following are excluded from SLO measurement and do not count against the error budget:
+
+- **Planned maintenance windows** — maintenance must be announced in the incident channel at
+  least 24 hours in advance and marked as a silence in Grafana Alerting.
+- **Clerk auth provider outages** — 5xx responses caused by Clerk's own service degradation
+  (confirmed via [status.clerk.com](https://status.clerk.com)) are excluded. The on-call
+  engineer must document the exclusion in the incident record.
+- **GCP infrastructure incidents** — outages attributable to GKE, Cloud Run, Cloud SQL, or
+  other GCP-managed services that are beyond the application's control. Document with the GCP
+  incident number.
+
+Exclusions must be recorded in the incident postmortem so they can be audited during the
+monthly review.
+
+---
+
+## Measurement Infrastructure
+
+SLO compliance is derived from the Prometheus metrics emitted by the OpenTelemetry SDK in
+`apps/api` and collected by the OTel Collector:
+
+- **Local dev:** Prometheus runs at `http://localhost:9090`; Grafana at `http://localhost:3030`
+- **Production:** Grafana Cloud Metrics (Mimir); alert rules in
+  `infra/observability/alerts/api.yaml` are applied to the Grafana Cloud stack
+
+Ensure Mimir retention is set to **≥ 30 days** so 28-day window expressions have complete
+data. Contact the Grafana Cloud portal (Stack → Settings → Data retention) to verify.
+
+---
+
+## References
+
+- [ADR-019 — SLO Methodology](../adr/ADR-019-slo-methodology.md)
+- [Google SRE Workbook — Chapter 5: Alerting on SLOs](https://sre.google/workbook/alerting-on-slos/)
+- [Google SRE Book — Chapter 4: Service Level Objectives](https://sre.google/sre-book/service-level-objectives/)

--- a/docs/proposals/2026-05-08-on-call-readiness.md
+++ b/docs/proposals/2026-05-08-on-call-readiness.md
@@ -1,6 +1,6 @@
 # Proposal: On-Call Readiness — Runbooks, SLOs, and Incident Response
 
-**Status:** `draft`
+**Status:** `shipped`
 **Date:** 2026-05-08
 **Issue:** [#201](https://github.com/brownm09/lifting-logbook/issues/201)
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,56 @@
+# Runbooks
+
+Runbooks for known failure modes. Each file follows a fixed template:
+**Symptom → Likely causes → Diagnosis → Remediation → Escalation.**
+
+For severity levels, escalation paths, and the incident response checklist, see
+[`docs/operations/on-call.md`](../operations/on-call.md).
+
+---
+
+## Index
+
+| Runbook | Trigger | Default severity |
+|---|---|---|
+| [Observability stack](observability.md) | Local dev / Grafana access reference | N/A |
+| [API 5xx surge](api-5xx-surge.md) | `APIHighErrorRate` alert | SEV2 |
+| [Database unreachable](database-unreachable.md) | DB connection errors in structured logs | SEV1 |
+| [Auth provider outage](auth-provider-outage.md) | 401/403 surge + Clerk status incident | SEV2 |
+| [Deploy regression rollback](deploy-regression-rollback.md) | Error rate spike correlated with recent deploy | SEV2 |
+
+---
+
+## Runbook template
+
+When adding a new runbook, use this structure:
+
+```markdown
+# Runbook: <Title>
+
+**Triggers:** <alert name or log pattern>
+**Default severity:** SEV1 / SEV2 / SEV3
+**Dashboard:** <Grafana path>
+
+---
+
+## Symptom
+<What the on-call engineer sees: alert text, dashboard state, error messages>
+
+## Likely causes
+<Ordered by probability — most common first>
+1.
+2.
+3.
+
+## Diagnosis
+<Concrete steps: Grafana panels to check, LogQL/TraceQL queries, kubectl commands>
+
+## Remediation
+<Ordered action list — stop when the symptom resolves>
+1.
+2.
+3.
+
+## Escalation
+<Who to loop in if the runbook does not resolve the issue>
+```

--- a/docs/runbooks/api-5xx-surge.md
+++ b/docs/runbooks/api-5xx-surge.md
@@ -1,0 +1,107 @@
+# Runbook: API 5xx Surge
+
+**Triggers:** `APIHighErrorRate` alert (5xx rate > 1% for 5 minutes)
+**Default severity:** SEV2 — escalate to SEV1 if error rate exceeds 10% for > 5 minutes
+**Dashboard:** Grafana → Lifting Logbook → API RED → Error Rate panel
+
+---
+
+## Symptom
+
+- `APIHighErrorRate` alert fires in Grafana Alerting
+- The Error Rate panel in the API RED dashboard shows a spike above the 1% threshold
+- Users report errors or the application appears broken
+
+---
+
+## Likely causes
+
+1. **Code regression from a recent deploy** — a bad deployment introduced a bug that causes
+   requests to fail. Check whether a deploy happened in the last 30–60 minutes.
+2. **Database connectivity failure** — Prisma cannot reach Postgres; all DB-backed endpoints
+   return 500. See [database-unreachable.md](database-unreachable.md).
+3. **Auth provider degradation** — Clerk is returning errors, causing request validation to
+   fail. Check [auth-provider-outage.md](auth-provider-outage.md).
+4. **Memory or resource exhaustion** — the API pod is OOMKilled or hitting CPU limits,
+   causing intermittent 503s from Kubernetes.
+5. **Misconfigured environment variable** — a missing or invalid env var causes
+   initialisation to fail on a particular code path.
+
+---
+
+## Diagnosis
+
+### 1. Check the dashboard
+
+Open Grafana → Lifting Logbook → API RED. Note:
+- Is the error rate rising, stable, or recovering?
+- Is the request rate also changing (a traffic spike can amplify a latent bug)?
+- Did the error rate start abruptly (deploy) or gradually (resource exhaustion)?
+
+### 2. Find error traces
+
+In Grafana Explore → Tempo, run a TraceQL query to find 5xx spans:
+
+```
+{ .http.status_code >= 500 }
+```
+
+Open a span and read the `exception.message` and `exception.stacktrace` attributes.
+
+### 3. Tail error logs
+
+In Grafana Explore → Loki:
+
+```logql
+{service_name="lifting-logbook-api"} |= "error" | json
+```
+
+Look for a repeated error message, stack trace, or status code that identifies the
+failing code path.
+
+### 4. Check for a recent deploy
+
+```sh
+kubectl rollout history deployment/api
+```
+
+If a deploy happened in the last 60 minutes and the error started around the same time,
+follow [deploy-regression-rollback.md](deploy-regression-rollback.md).
+
+### 5. Check pod health
+
+```sh
+kubectl get pods -l app=api
+kubectl describe pod <pod-name>
+```
+
+Look for `OOMKilled`, `CrashLoopBackOff`, or failed readiness probes.
+
+---
+
+## Remediation
+
+1. **If a recent deploy is the cause:** roll back immediately using
+   [deploy-regression-rollback.md](deploy-regression-rollback.md).
+2. **If the database is unreachable:** follow [database-unreachable.md](database-unreachable.md).
+3. **If the auth provider is failing:** follow [auth-provider-outage.md](auth-provider-outage.md).
+4. **If the pod is OOMKilled:** temporarily increase the memory limit in the Helm values file
+   (`infra/kubernetes/charts/api/values.yaml`) and redeploy. Open a GitHub issue to
+   investigate root cause.
+5. **If the cause is unclear and the error rate is still rising:** restart the API deployment
+   as a last resort. This may resolve transient issues and buys time to diagnose:
+   ```sh
+   kubectl rollout restart deployment/api
+   ```
+   Confirm the error rate drops within 2 minutes of the restart completing.
+
+---
+
+## Escalation
+
+If the error rate does not improve after working through this runbook:
+
+1. Escalate to SEV1 and loop in the engineering lead.
+2. Capture the failing TraceQL and LogQL queries and the error messages you found.
+3. Check GCP Status (status.cloud.google.com) and Clerk Status (status.clerk.com) for
+   ongoing incidents before assuming the issue is internal.

--- a/docs/runbooks/api-5xx-surge.md
+++ b/docs/runbooks/api-5xx-surge.md
@@ -1,8 +1,9 @@
 # Runbook: API 5xx Surge
 
-**Triggers:** `APIHighErrorRate` alert (5xx rate > 1% for 5 minutes)
+**Triggers:** `APIHighErrorRate` alert (5xx rate > 1% for 5 minutes); also the starting
+point for `APIHighP95Latency` — check the Latency panel alongside the Error Rate panel
 **Default severity:** SEV2 — escalate to SEV1 if error rate exceeds 10% for > 5 minutes
-**Dashboard:** Grafana → Lifting Logbook → API RED → Error Rate panel
+**Dashboard:** Grafana → Lifting Logbook → API RED → Error Rate panel and Latency panel
 
 ---
 

--- a/docs/runbooks/auth-provider-outage.md
+++ b/docs/runbooks/auth-provider-outage.md
@@ -103,11 +103,9 @@ issue from inside the cluster.
    ```
 
 3. **Invalid API key:** generate a new key in the Clerk dashboard and update the
-   Kubernetes secret, then restart the API pods:
+   `CLERK_SECRET_KEY` key in the Kubernetes secret, then restart the API pods:
    ```sh
-   kubectl create secret generic api-env \
-     --from-literal=CLERK_SECRET_KEY="<new-key>" \
-     --dry-run=client -o yaml | kubectl apply -f -
+   kubectl patch secret api-env -p '{"stringData":{"CLERK_SECRET_KEY":"<new-key>"}}'
    kubectl rollout restart deployment/api
    ```
 

--- a/docs/runbooks/auth-provider-outage.md
+++ b/docs/runbooks/auth-provider-outage.md
@@ -1,0 +1,133 @@
+# Runbook: Auth Provider Outage
+
+**Triggers:** Surge in 401/403 responses in Grafana; Clerk status incident confirmed at
+[status.clerk.com](https://status.clerk.com); JWT verification errors in structured logs
+**Default severity:** SEV2 — authenticated users cannot access the application
+**Dashboard:** Grafana → Lifting Logbook → API RED → Error Rate panel (filter by 4xx)
+
+---
+
+## Symptom
+
+- Users report being logged out or unable to log in
+- API logs contain JWT verification errors:
+  ```
+  JsonWebTokenError: invalid signature
+  ClerkApiError: unauthenticated
+  ```
+- Grafana Explore → Loki shows a surge in 401 or 403 responses
+- The API RED dashboard shows an elevated error rate from auth-gated endpoints
+
+---
+
+## Likely causes
+
+1. **Clerk service outage** — Clerk's authentication service is degraded or down.
+   Confirmed via [status.clerk.com](https://status.clerk.com).
+2. **JWT signing key rotation** — Clerk has rotated its JWKS (JSON Web Key Set) and
+   the API is still validating against a cached old key.
+3. **`CLERK_SECRET_KEY` or `CLERK_PUBLISHABLE_KEY` expired or revoked** — the API key
+   configured in the Kubernetes secret is no longer valid.
+4. **Webhook delivery failure** — Clerk webhooks (user creation, session events) are
+   failing silently, causing user-sync inconsistencies.
+5. **Network timeout to Clerk JWKS endpoint** — the API pod cannot reach
+   `https://api.clerk.com` to fetch the current signing keys, causing all JWT
+   verifications to fail.
+
+---
+
+## Diagnosis
+
+### 1. Check Clerk status
+
+Go to [status.clerk.com](https://status.clerk.com). If Clerk has an active incident,
+the outage is external. No remediation is possible until Clerk resolves it — communicate
+status to users and monitor for recovery.
+
+### 2. Find auth errors in logs
+
+In Grafana Explore → Loki:
+
+```logql
+{service_name="lifting-logbook-api"} |= "unauthenticated" | json
+```
+
+```logql
+{service_name="lifting-logbook-api"} |= "401" | json
+```
+
+Look for the specific error message and which endpoint is failing.
+
+### 3. Check for JWKS-related errors
+
+```logql
+{service_name="lifting-logbook-api"} |= "jwks" | json
+```
+
+If the API is unable to fetch JWKS, it typically logs a network error or timeout
+pointing at `api.clerk.com`. This indicates a network policy or DNS issue, not a
+Clerk outage.
+
+### 4. Verify the Clerk API key
+
+```sh
+kubectl get secret api-env -o jsonpath='{.data.CLERK_SECRET_KEY}' | base64 -d
+```
+
+Take the key value and verify it is valid in the Clerk dashboard:
+Dashboard → API Keys → verify the key exists and is not marked as revoked.
+
+### 5. Test JWKS reachability from a pod
+
+```sh
+kubectl exec -it <api-pod-name> -- sh
+curl -s https://api.clerk.com/.well-known/jwks.json | head -c 200
+```
+
+A successful response returns JSON. A timeout or connection error indicates a network
+issue from inside the cluster.
+
+---
+
+## Remediation
+
+1. **Clerk service outage:** wait for Clerk to resolve the incident. Post a status update
+   in the incident channel. If the outage is prolonged (> 2 hours), consider whether
+   a maintenance page is appropriate.
+
+2. **JWKS cache stale after key rotation:** restart the API pods to force a fresh JWKS
+   fetch. Clerk's `@clerk/backend` SDK caches JWKS in memory; a pod restart clears
+   the cache:
+   ```sh
+   kubectl rollout restart deployment/api
+   ```
+
+3. **Invalid API key:** generate a new key in the Clerk dashboard and update the
+   Kubernetes secret, then restart the API pods:
+   ```sh
+   kubectl create secret generic api-env \
+     --from-literal=CLERK_SECRET_KEY="<new-key>" \
+     --dry-run=client -o yaml | kubectl apply -f -
+   kubectl rollout restart deployment/api
+   ```
+
+4. **Network timeout to Clerk:** check the GKE network policy and egress rules. Clerk's
+   JWKS endpoint must be reachable from the API pod on port 443. If a recent network
+   policy change blocked egress, revert it:
+   ```sh
+   kubectl get networkpolicies
+   kubectl describe networkpolicy <policy-name>
+   ```
+
+---
+
+## Escalation
+
+If the issue is not resolved after working through this runbook:
+
+1. Confirm whether it is a Clerk incident (check status page) or an internal issue
+   (network, misconfiguration).
+2. For a Clerk incident: there is nothing to escalate internally — monitor the status
+   page and communicate timeline to users.
+3. For an internal issue: escalate to the engineering lead with the specific error
+   message and the kubectl/Loki output gathered above.

--- a/docs/runbooks/database-unreachable.md
+++ b/docs/runbooks/database-unreachable.md
@@ -116,10 +116,10 @@ If usage is at or near 100%, the database is at risk of data-loss-causing crashe
    If this recurs, open a GitHub issue to increase the pool size in `schema.prisma`
    (`connection_limit`) or add a connection pooler (PgBouncer).
 
-4. **Wrong credentials:** update the Kubernetes secret with the correct `DATABASE_URL`
+4. **Wrong credentials:** update the `DATABASE_URL` key in the Kubernetes secret
    and restart the API pods to pick up the change:
    ```sh
-   kubectl create secret generic api-env --from-literal=DATABASE_URL="<correct-url>" --dry-run=client -o yaml | kubectl apply -f -
+   kubectl patch secret api-env -p '{"stringData":{"DATABASE_URL":"<correct-url>"}}'
    kubectl rollout restart deployment/api
    ```
 

--- a/docs/runbooks/database-unreachable.md
+++ b/docs/runbooks/database-unreachable.md
@@ -1,0 +1,142 @@
+# Runbook: Database Unreachable
+
+**Triggers:** DB connection errors in structured logs; `APIHighErrorRate` accompanied by
+`"database"` and `"error"` in log lines; Prisma connection exceptions in traces
+**Default severity:** SEV1 — all DB-backed endpoints fail when Postgres is unreachable
+**Dashboard:** Grafana → Lifting Logbook → API RED → Error Rate panel
+
+---
+
+## Symptom
+
+- API returns 500 on all endpoints that read or write data
+- Structured logs contain Prisma connection errors:
+  ```
+  PrismaClientInitializationError: Can't reach database server
+  ```
+  or connection pool exhaustion:
+  ```
+  Timed out fetching a new connection from the connection pool
+  ```
+- In Grafana Explore → Tempo, spans show `db.system = postgresql` with error status
+- The `APIHighErrorRate` alert has fired or is close to threshold
+
+---
+
+## Likely causes
+
+1. **Postgres pod crashed or is restarting** — the pod is in `CrashLoopBackOff` or
+   `OOMKilled`.
+2. **Network policy blocking API → Postgres traffic** — a recent Kubernetes network
+   policy change is preventing the connection.
+3. **Connection pool exhausted** — traffic spike or connection leak has saturated
+   Prisma's connection pool, causing new requests to time out.
+4. **Wrong or rotated credentials** — the `DATABASE_URL` secret was updated but the
+   API pods have not been restarted to pick up the new value.
+5. **Postgres storage full** — the PVC backing Postgres has run out of space and the
+   database has gone read-only or crashed.
+
+---
+
+## Diagnosis
+
+### 1. Check Postgres pod status
+
+```sh
+kubectl get pods -l app=postgres
+kubectl describe pod <postgres-pod-name>
+```
+
+Look for `CrashLoopBackOff`, `OOMKilled`, or failed readiness probes. Check the pod
+logs for crash output:
+
+```sh
+kubectl logs <postgres-pod-name> --previous
+```
+
+### 2. Check the connection from the API pod
+
+```sh
+kubectl exec -it <api-pod-name> -- sh
+# Inside the pod:
+nc -zv <postgres-service-name> 5432
+```
+
+If the connection is refused, the network path is broken (network policy or pod down).
+If it hangs, the pool may be exhausted.
+
+### 3. Check for connection pool errors
+
+In Grafana Explore → Loki:
+
+```logql
+{service_name="lifting-logbook-api"} |= "connection pool" | json
+```
+
+A high rate of "Timed out fetching" messages indicates pool exhaustion rather than a
+connectivity failure.
+
+### 4. Verify the DATABASE_URL secret
+
+```sh
+kubectl get secret api-env -o jsonpath='{.data.DATABASE_URL}' | base64 -d
+```
+
+Confirm the hostname, port, user, and database name are correct.
+
+### 5. Check Postgres storage
+
+```sh
+kubectl exec -it <postgres-pod-name> -- df -h /var/lib/postgresql/data
+```
+
+If usage is at or near 100%, the database is at risk of data-loss-causing crashes.
+
+---
+
+## Remediation
+
+1. **Pod crashed:** restart the Postgres pod:
+   ```sh
+   kubectl rollout restart deployment/postgres   # or statefulset, depending on config
+   ```
+   Wait for the pod to reach `Running` with passing readiness probes before continuing.
+
+2. **Network policy issue:** check recently applied network policies and revert if a
+   new policy blocks port 5432:
+   ```sh
+   kubectl get networkpolicies
+   kubectl describe networkpolicy <policy-name>
+   ```
+
+3. **Connection pool exhausted:** restart the API deployment to flush stale connections:
+   ```sh
+   kubectl rollout restart deployment/api
+   ```
+   If this recurs, open a GitHub issue to increase the pool size in `schema.prisma`
+   (`connection_limit`) or add a connection pooler (PgBouncer).
+
+4. **Wrong credentials:** update the Kubernetes secret with the correct `DATABASE_URL`
+   and restart the API pods to pick up the change:
+   ```sh
+   kubectl create secret generic api-env --from-literal=DATABASE_URL="<correct-url>" --dry-run=client -o yaml | kubectl apply -f -
+   kubectl rollout restart deployment/api
+   ```
+
+5. **Storage full:** this requires immediate action to avoid data corruption. Expand the
+   PVC or delete old data under supervision. Escalate to the engineering lead immediately.
+
+---
+
+## Escalation
+
+If Postgres does not recover after restart, or if there is any risk of data loss:
+
+1. Escalate to SEV1 and loop in the engineering lead immediately.
+2. Do not attempt to delete Postgres data or expand storage without guidance — risk of
+   making data loss worse.
+3. If storage is full, take the API offline (scale replicas to 0) to prevent partial
+   writes that could corrupt data:
+   ```sh
+   kubectl scale deployment/api --replicas=0
+   ```

--- a/docs/runbooks/deploy-regression-rollback.md
+++ b/docs/runbooks/deploy-regression-rollback.md
@@ -1,0 +1,134 @@
+# Runbook: Deploy Regression Rollback
+
+**Triggers:** Error rate spike in Grafana that starts immediately after a recent deployment;
+`APIHighErrorRate` alert correlated with a `kubectl rollout history` entry in the last 60 minutes
+**Default severity:** SEV2 — escalate to SEV1 if error rate exceeds 10% or if data integrity
+is at risk
+**Dashboard:** Grafana → Lifting Logbook → API RED → Error Rate panel
+
+---
+
+## Symptom
+
+- `APIHighErrorRate` alert fires shortly after a deploy
+- The Error Rate panel in API RED shows a sharp step-change (not a gradual drift) at a
+  time that matches a recent `kubectl rollout` event
+- New errors appear in structured logs that were not present before the deploy
+- Traces show failures in code paths touched by the recent change
+
+---
+
+## Likely causes
+
+1. **Code bug introduced by the deploy** — a regression in the new image causes requests
+   to fail on a code path that was not covered by tests.
+2. **Missing or changed environment variable** — the new version expects an env var that
+   is not set, or an existing var was renamed.
+3. **Schema migration applied incorrectly** — a Prisma migration ran against the database
+   and is incompatible with the running application version.
+4. **Dependency version conflict** — a new `node_modules` dependency has a breaking change
+   or is incompatible with an existing package.
+
+---
+
+## Diagnosis
+
+### 1. Confirm the deploy timing
+
+```sh
+kubectl rollout history deployment/api
+```
+
+Find the most recent revision number and the timestamp. Compare to when the error rate
+spiked in Grafana.
+
+### 2. Check what changed
+
+```sh
+kubectl rollout history deployment/api --revision=<latest-revision>
+```
+
+Note the image tag. In the GitHub repository, find the commit corresponding to that tag.
+
+### 3. Identify the failing code path
+
+In Grafana Explore → Tempo:
+
+```
+{ .http.status_code >= 500 }
+```
+
+Open a failing trace and read `exception.message` and `exception.stacktrace` to identify
+which function is throwing.
+
+In Grafana Explore → Loki:
+
+```logql
+{service_name="lifting-logbook-api"} |= "error" | json
+```
+
+### 4. Verify there are no pending migrations
+
+A migration that already ran cannot be rolled back by reverting the deployment alone —
+the schema change is in the database. Check whether the deploy included a migration:
+
+```sh
+git log <previous-tag>..<current-tag> -- apps/api/prisma/migrations/
+```
+
+If migrations were included, proceed with caution and escalate before rolling back.
+
+---
+
+## Remediation
+
+### Fast path: rollback the deployment
+
+If no schema migrations were included and the root cause is a code bug, roll back
+immediately:
+
+```sh
+kubectl rollout undo deployment/api
+```
+
+Wait for the rollback to complete:
+
+```sh
+kubectl rollout status deployment/api
+```
+
+Verify the error rate drops in Grafana within 2 minutes of the rollback completing. If
+it does not drop, the rollback did not revert the cause — investigate further.
+
+### If migrations were applied
+
+Do not roll back the deployment until the impact of the migration is understood:
+
+1. Escalate to the engineering lead immediately.
+2. Check whether the previous application version is compatible with the current schema
+   (i.e., is the migration additive-only, or did it drop or alter columns?).
+3. If the migration is additive-only (new table or new nullable column), rolling back
+   the deployment is safe — the old code will ignore the new schema.
+4. If the migration altered or dropped columns, do not roll back without first writing a
+   compensating migration. Rolling back the code without rolling back the schema will
+   cause the old code to fail against the new schema.
+
+### If the rollback resolves the issue
+
+1. Verify the error rate is below the alert threshold for at least 10 minutes.
+2. Resolve the alert in Grafana.
+3. Open a GitHub issue on the specific regression with the failing trace attached.
+4. Do not re-deploy the broken version. Fix the regression in a new branch and re-deploy.
+
+---
+
+## Escalation
+
+If the rollback does not resolve the error rate, or if the deploy included migrations:
+
+1. Escalate to SEV1 and loop in the engineering lead.
+2. Share:
+   - The diff between the previous and current image tag (`git log`)
+   - The failing trace from Grafana Tempo
+   - Whether migrations were applied
+3. Do not attempt to manually edit the database without explicit guidance.

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -205,13 +205,11 @@ Credentials are wired via Cloud Run Secret Manager volumes — see the file for 
 ## On-call escalation
 
 Severity levels, escalation paths, SLO targets, and incident response procedures are
-tracked in the On-Call Readiness epic:
+documented in:
 
-- Proposal: [`docs/proposals/2026-05-08-on-call-readiness.md`](../proposals/2026-05-08-on-call-readiness.md)
-- Issue: [#201](https://github.com/brownm09/lifting-logbook/issues/201)
-
-Until that work lands, treat any `warning`-severity alert as requiring acknowledgment
-within 30 minutes during business hours.
+- [`docs/operations/on-call.md`](../operations/on-call.md) — severity levels, escalation paths, postmortem template
+- [`docs/operations/slo.md`](../operations/slo.md) — SLO targets and error budget policy
+- [`docs/runbooks/README.md`](README.md) — index of all failure-mode runbooks
 
 ---
 

--- a/infra/observability/alerts/api.yaml
+++ b/infra/observability/alerts/api.yaml
@@ -37,4 +37,4 @@ groups:
         annotations:
           summary: "API received no requests in 10 minutes"
           description: "No traffic seen. May fire spuriously outside business hours."
-          runbook_url: "https://github.com/brownm09/lifting-logbook/blob/main/docs/runbooks/deploy-regression-rollback.md"
+          runbook_url: "https://github.com/brownm09/lifting-logbook/blob/main/docs/runbooks/api-5xx-surge.md"

--- a/infra/observability/alerts/api.yaml
+++ b/infra/observability/alerts/api.yaml
@@ -12,6 +12,7 @@ groups:
         annotations:
           summary: "API error rate > 1%"
           description: "{{ $value | humanizePercentage }} of requests are returning 5xx"
+          runbook_url: "https://github.com/brownm09/lifting-logbook/blob/main/docs/runbooks/api-5xx-surge.md"
 
       - alert: APIHighP95Latency
         expr: |
@@ -25,6 +26,7 @@ groups:
         annotations:
           summary: "API p95 latency > 1s"
           description: "p95 latency is {{ $value | humanizeDuration }}"
+          runbook_url: "https://github.com/brownm09/lifting-logbook/blob/main/docs/runbooks/api-5xx-surge.md"
 
       - alert: APINoRequests
         expr: |
@@ -35,3 +37,4 @@ groups:
         annotations:
           summary: "API received no requests in 10 minutes"
           description: "No traffic seen. May fire spuriously outside business hours."
+          runbook_url: "https://github.com/brownm09/lifting-logbook/blob/main/docs/runbooks/deploy-regression-rollback.md"


### PR DESCRIPTION
Marks the On-Call Readiness proposal (issue #201) as `shipped` in ROADMAP.md.
Missed in the squash merge of #215 — the commit landed on the branch after the merge completed.

Closes #201 (status already closed by #215; this just syncs the roadmap).