### PR TITLE
[chore] Replace head-based 100% sampling with tail-based policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       OTEL_COLLECTOR_LOKI_ENDPOINT: http://loki:3100/loki/api/v1/push
       OTEL_COLLECTOR_LOKI_AUTH_HEADER: ""
       OTEL_TAIL_SAMPLE_RATE: "100"   # local dev: keep every trace
+      OTEL_DECISION_WAIT: "2s"      # local dev: short buffer so spans appear in Tempo promptly
     ports:
       - "4317:4317"   # OTLP gRPC
       - "4318:4318"   # OTLP HTTP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       OTEL_COLLECTOR_OTLP_AUTH_HEADER: ""
       OTEL_COLLECTOR_LOKI_ENDPOINT: http://loki:3100/loki/api/v1/push
       OTEL_COLLECTOR_LOKI_AUTH_HEADER: ""
+      OTEL_TAIL_SAMPLE_RATE: "100"   # local dev: keep every trace
     ports:
       - "4317:4317"   # OTLP gRPC
       - "4318:4318"   # OTLP HTTP

--- a/docs/README.md
+++ b/docs/README.md
@@ -150,6 +150,8 @@ monorepo/
 | [ADR-016](adr/ADR-016-cycle-planning-agent.md)                | Cycle Planning Agent                                          | Accepted |
 | [ADR-017](adr/ADR-017-training-max-history-table.md)          | Training Max History — Dedicated Table vs. Derived            | Accepted |
 | [ADR-018](adr/ADR-018-observability-stack.md)                 | Observability Stack — OpenTelemetry + Grafana Cloud           | Accepted |
+| [ADR-019](adr/ADR-019-slo-methodology.md)                    | SLO Methodology — Burn-Rate Alerting over Threshold Alerting  | Accepted |
+| [ADR-020](adr/ADR-020-tail-based-sampling-policy.md)         | Tail-Based Sampling Policy — Errors Always, Slow Always, 20% Clean | Accepted |
 
 ---
 

--- a/docs/adr-references.md
+++ b/docs/adr-references.md
@@ -218,6 +218,8 @@ References from [`docs/security-review-checklist.md`](security-review-checklist.
 | [Google SRE Book — Chapter 6: Monitoring Distributed Systems](https://sre.google/sre-book/monitoring-distributed-systems/) | [ADR-018](adr/ADR-018-observability-stack.md), [ADR-019](adr/ADR-019-slo-methodology.md) | The four golden signals and symptom-vs-cause alert framing. |
 | [Prometheus — Recording Rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) | [ADR-019](adr/ADR-019-slo-methodology.md) | Required for efficient evaluation of 28-day burn-rate expressions; authoritative syntax reference. |
 | [OpenSLO — Specification](https://openslo.com/) | [ADR-019](adr/ADR-019-slo-methodology.md) | YAML open standard for SLO definition; informs the `docs/operations/slo.md` format. |
+| [OpenTelemetry Collector contrib — `tail_sampling` processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor) | [ADR-020](adr/ADR-020-tail-based-sampling-policy.md) | Authoritative documentation for the `tail_sampling` processor; covers all policy types, `decision_wait` semantics, and known limitations. |
+| [OpenTelemetry — Sampling](https://opentelemetry.io/docs/concepts/sampling/) | [ADR-020](adr/ADR-020-tail-based-sampling-policy.md) | Conceptual overview of head-based vs. tail-based sampling; basis for the Rationale framing in ADR-020. |
 
 ---
 

--- a/docs/adr/ADR-020-tail-based-sampling-policy.md
+++ b/docs/adr/ADR-020-tail-based-sampling-policy.md
@@ -1,0 +1,127 @@
+# ADR-020: Tail-Based Sampling Policy — Errors Always, Slow Always, 20% Clean
+
+**Status:** Accepted
+**Date:** 2026-05-09
+**Closes:** [#210](https://github.com/brownm09/lifting-logbook/issues/210)
+**Supersedes (partially):** [ADR-018](ADR-018-observability-stack.md) § Sampling
+
+---
+
+## Context
+
+[ADR-018](ADR-018-observability-stack.md) locked in head-based 100% sampling at project start
+because no production traffic existed to inform a more nuanced policy. The negative consequences
+section of that ADR explicitly noted:
+
+> "Head-based 100% sampling will not scale to high-traffic production. Tracked in
+> [#210](https://github.com/brownm09/lifting-logbook/issues/210); revisit when sustained ingest
+> crosses 1,000 spans/minute (24h avg) or monthly Grafana Cloud trace cost exceeds $25."
+
+Issue #210 specifies a proactive approach: implement the sampling policy before the triggers are
+crossed so it is live from the first day of real traffic, rather than scrambling to add it
+after ingest costs begin accumulating.
+
+The OTel Collector image already deployed
+(`otel/opentelemetry-collector-contrib:0.104.0`) includes the `tail_sampling` processor with
+no upgrade required.
+
+---
+
+## Decision
+
+Replace head-based 100% sampling with **tail-based sampling at the Collector** using three
+policies evaluated in order, where a trace is kept if any policy matches:
+
+| Policy | Type | Condition | Action |
+|---|---|---|---|
+| `errors` | `status_code` | Any span in the trace has `STATUS_CODE_ERROR` | Always keep |
+| `slow_traces` | `latency` | Total trace duration ≥ 1 000 ms | Always keep |
+| `probabilistic` | `probabilistic` | All remaining traces | Keep `OTEL_TAIL_SAMPLE_RATE`% |
+
+**Decision wait:** 10 seconds. The Collector buffers spans for up to 10 s before deciding whether
+to keep or drop the trace. This is sufficient to see the full HTTP request/response span chain
+across `apps/web` → `apps/api` → Postgres in normal operating conditions.
+
+**Default sampling rate:** 20% for staging and production (driven by `tailSampleRate: "20"` in
+`infra/kubernetes/charts/otel-collector/values.yaml`).
+
+**Local dev override:** `OTEL_TAIL_SAMPLE_RATE: "100"` in `docker-compose.yml` keeps every trace
+so local debugging is not affected by sampling.
+
+---
+
+## Rationale for tail-based over head-based ratio
+
+Head-based ratio sampling (e.g., `parentbased_traceidratio` in the SDK) makes the
+keep/drop decision at trace start, before any spans are recorded. This means:
+- An error that occurred on the 5th span of a sampled-out trace is permanently discarded.
+- A 10-second database query in a dropped trace is invisible.
+
+Tail-based sampling at the Collector buffers the full trace and decides after all spans
+arrive. The `errors` and `slow_traces` policies guarantee that every actionable trace is kept
+regardless of the clean-trace sampling rate.
+
+**Why at the Collector, not the SDK:** The OTel SDK's built-in samplers are all head-based.
+Moving sampling to the Collector is the canonical approach for tail-based decisions and requires
+no changes to application code. The Collector's `tail_sampling` processor is production-proven
+and is the upstream recommendation for this use case.
+
+---
+
+## Alternatives Considered
+
+### Head-based ratio (SDK `parentbased_traceidratio`)
+
+Set `OTEL_TRACES_SAMPLER=parentbased_traceidratio` and
+`OTEL_TRACES_SAMPLER_ARG=0.2` on each app. Simpler to configure — no Collector processor
+needed — but cannot apply always-keep policies for errors or slow traces. A 20% ratio with
+this sampler discards 80% of errors and 80% of slow traces. Rejected.
+
+### Always_sample with Grafana Cloud ingest limits
+
+Leave 100% sampling in place and rely on Grafana Cloud's free-tier ingest limit as a de facto
+cap. Rejected: when the cap is hit, the backend silently drops the newest spans, which are
+disproportionately the ones from active requests, defeating the purpose of observability.
+
+### Composite policy with a rate limiter
+
+The `tail_sampling` `composite` type can apply per-policy rate limits (e.g., always keep
+errors up to N/s, probabilistic for the rest). Rejected as unnecessary complexity for current
+traffic levels; the three-policy OR arrangement is sufficient and easier to reason about.
+
+---
+
+## Consequences
+
+### Positive
+
+- Errors and slow traces are guaranteed to reach Grafana Cloud regardless of sampling rate.
+- Clean-path noise is reduced by 80% in production, extending Grafana Cloud free-tier headroom.
+- The sampling rate is tunable per-environment without a code change (`OTEL_TAIL_SAMPLE_RATE`
+  env var; defaults driven by `tailSampleRate` Helm value).
+- Local dev retains 100% sampling; no debugging friction introduced.
+
+### Negative
+
+- **10-second memory window.** The Collector buffers spans for up to 10 s per trace. At very
+  high span volumes this increases Collector memory pressure. The current resource limits
+  (128 Mi request / 256 Mi limit) are unchanged; monitor if throughput grows significantly.
+- **Sampling interacts with metrics.** The `probabilistic` policy drops spans from clean traces;
+  any metrics derived from span counts (e.g., request-rate via span cardinality) will undercount
+  by ~80% for clean-path traffic. Use the Prometheus/Mimir metrics pipeline for request counts
+  — do not derive rate from traces.
+- **20% clean-trace sampling means the p95 latency computed from sampled traces is an estimate.**
+  Tail-sampled p95 is biased toward the retained slow traces. The `slow_traces` policy keeps
+  all traces above 1 000 ms, so the p99 estimate is accurate; mid-distribution percentiles
+  (p50, p75) are noisier than with 100% sampling.
+
+---
+
+## References
+
+| Source | Relevance |
+|---|---|
+| [OpenTelemetry Collector contrib — `tail_sampling` processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor) | Authoritative documentation for the processor used in this ADR; covers all policy types, `decision_wait` semantics, and known limitations. |
+| [OpenTelemetry — Sampling](https://opentelemetry.io/docs/concepts/sampling/) | Conceptual overview of head-based vs. tail-based sampling; the basis for the Rationale section's framing. |
+| [ADR-018 — Observability Stack](ADR-018-observability-stack.md) | The prior ADR this decision supersedes in part; documents the original 100% head-based sampling stance and the trigger conditions for revisiting it. |
+| [ADR-019 — SLO Methodology](ADR-019-slo-methodology.md) | The burn-rate alerting framework built on top of the metrics pipeline; notes the interaction between sampling and metric accuracy referenced in the Consequences section. |

--- a/docs/adr/ADR-020-tail-based-sampling-policy.md
+++ b/docs/adr/ADR-020-tail-based-sampling-policy.md
@@ -38,15 +38,18 @@ policies evaluated in order, where a trace is kept if any policy matches:
 | `slow_traces` | `latency` | Total trace duration ≥ 1 000 ms | Always keep |
 | `probabilistic` | `probabilistic` | All remaining traces | Keep `OTEL_TAIL_SAMPLE_RATE`% |
 
-**Decision wait:** 10 seconds. The Collector buffers spans for up to 10 s before deciding whether
-to keep or drop the trace. This is sufficient to see the full HTTP request/response span chain
-across `apps/web` → `apps/api` → Postgres in normal operating conditions.
+**Decision wait:** Driven by `OTEL_DECISION_WAIT` env var. 10 s in staging and production
+(driven by `decisionWait: "10s"` in `infra/kubernetes/charts/otel-collector/values.yaml`) —
+sufficient to see the full HTTP request/response span chain across `apps/web` → `apps/api` →
+Postgres in normal operating conditions.
 
 **Default sampling rate:** 20% for staging and production (driven by `tailSampleRate: "20"` in
 `infra/kubernetes/charts/otel-collector/values.yaml`).
 
-**Local dev override:** `OTEL_TAIL_SAMPLE_RATE: "100"` in `docker-compose.yml` keeps every trace
-so local debugging is not affected by sampling.
+**Local dev overrides** (`docker-compose.yml`):
+- `OTEL_TAIL_SAMPLE_RATE: "100"` — keep every trace; no debugging friction from sampling.
+- `OTEL_DECISION_WAIT: "2s"` — shorter buffer so spans appear in Grafana Tempo within ~2 s
+  rather than waiting the full 10 s decision window.
 
 ---
 

--- a/infra/kubernetes/charts/otel-collector/templates/configmap.yaml
+++ b/infra/kubernetes/charts/otel-collector/templates/configmap.yaml
@@ -5,6 +5,7 @@ metadata:
 data:
   OTEL_COLLECTOR_OTLP_ENDPOINT: {{ .Values.env.OTEL_COLLECTOR_OTLP_ENDPOINT | quote }}
   OTEL_COLLECTOR_LOKI_ENDPOINT: {{ .Values.env.OTEL_COLLECTOR_LOKI_ENDPOINT | quote }}
+  OTEL_TAIL_SAMPLE_RATE: {{ .Values.tailSampleRate | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -25,6 +26,21 @@ data:
             endpoint: 0.0.0.0:4318
 
     processors:
+      tail_sampling:
+        decision_wait: 10s
+        policies:
+          - name: errors
+            type: status_code
+            status_code:
+              status_codes: [ERROR]
+          - name: slow_traces
+            type: latency
+            latency:
+              threshold_ms: 1000
+          - name: probabilistic
+            type: probabilistic
+            probabilistic:
+              sampling_percentage: ${env:OTEL_TAIL_SAMPLE_RATE}
       batch:
         timeout: 5s
         send_batch_size: 1000
@@ -46,7 +62,7 @@ data:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [batch]
+          processors: [tail_sampling, batch]
           exporters: [otlphttp/traces]
         metrics:
           receivers: [otlp]

--- a/infra/kubernetes/charts/otel-collector/templates/configmap.yaml
+++ b/infra/kubernetes/charts/otel-collector/templates/configmap.yaml
@@ -6,6 +6,7 @@ data:
   OTEL_COLLECTOR_OTLP_ENDPOINT: {{ .Values.env.OTEL_COLLECTOR_OTLP_ENDPOINT | quote }}
   OTEL_COLLECTOR_LOKI_ENDPOINT: {{ .Values.env.OTEL_COLLECTOR_LOKI_ENDPOINT | quote }}
   OTEL_TAIL_SAMPLE_RATE: {{ .Values.tailSampleRate | quote }}
+  OTEL_DECISION_WAIT: {{ .Values.decisionWait | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -27,7 +28,8 @@ data:
 
     processors:
       tail_sampling:
-        decision_wait: 10s
+        # Required: OTEL_DECISION_WAIT — set by docker-compose (2s) or Helm decisionWait value (default: 10s)
+        decision_wait: ${env:OTEL_DECISION_WAIT}
         policies:
           - name: errors
             type: status_code
@@ -40,6 +42,7 @@ data:
           - name: probabilistic
             type: probabilistic
             probabilistic:
+              # Required: OTEL_TAIL_SAMPLE_RATE — set by docker-compose (100) or Helm tailSampleRate value (default: 20)
               sampling_percentage: ${env:OTEL_TAIL_SAMPLE_RATE}
       batch:
         timeout: 5s

--- a/infra/kubernetes/charts/otel-collector/values.yaml
+++ b/infra/kubernetes/charts/otel-collector/values.yaml
@@ -22,6 +22,11 @@ env:
   OTEL_COLLECTOR_OTLP_ENDPOINT: ""   # set per-environment
   OTEL_COLLECTOR_LOKI_ENDPOINT: ""   # set per-environment
 
+# Percentage of clean traces (no errors, under latency threshold) to keep.
+# Errors and slow traces (>1 000 ms) are always kept regardless of this value.
+# Override per-environment: 100 for local dev, 20 for staging/production.
+tailSampleRate: "20"
+
 # GCP-specific config
 gcp:
   projectId: ""

--- a/infra/kubernetes/charts/otel-collector/values.yaml
+++ b/infra/kubernetes/charts/otel-collector/values.yaml
@@ -27,6 +27,11 @@ env:
 # Override per-environment: 100 for local dev, 20 for staging/production.
 tailSampleRate: "20"
 
+# How long the tail_sampling processor buffers spans before making a keep/drop decision.
+# 10s is enough to see the full apps/web → apps/api → Postgres span chain in staging/production.
+# Local dev overrides to 2s so spans appear in Grafana Tempo promptly.
+decisionWait: "10s"
+
 # GCP-specific config
 gcp:
   projectId: ""

--- a/infra/observability/otel-collector.yaml
+++ b/infra/observability/otel-collector.yaml
@@ -11,6 +11,21 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 processors:
+  tail_sampling:
+    decision_wait: 10s
+    policies:
+      - name: errors
+        type: status_code
+        status_code:
+          status_codes: [ERROR]
+      - name: slow_traces
+        type: latency
+        latency:
+          threshold_ms: 1000
+      - name: probabilistic
+        type: probabilistic
+        probabilistic:
+          sampling_percentage: ${env:OTEL_TAIL_SAMPLE_RATE}
   batch:
     timeout: 5s
     send_batch_size: 1000
@@ -32,7 +47,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
+      processors: [tail_sampling, batch]
       exporters: [otlphttp/traces]
     metrics:
       receivers: [otlp]

--- a/infra/observability/otel-collector.yaml
+++ b/infra/observability/otel-collector.yaml
@@ -12,7 +12,8 @@ receivers:
 
 processors:
   tail_sampling:
-    decision_wait: 10s
+    # Required: OTEL_DECISION_WAIT — set by docker-compose (2s) or Helm decisionWait value (default: 10s)
+    decision_wait: ${env:OTEL_DECISION_WAIT}
     policies:
       - name: errors
         type: status_code
@@ -25,6 +26,7 @@ processors:
       - name: probabilistic
         type: probabilistic
         probabilistic:
+          # Required: OTEL_TAIL_SAMPLE_RATE — set by docker-compose (100) or Helm tailSampleRate value (default: 20)
           sampling_percentage: ${env:OTEL_TAIL_SAMPLE_RATE}
   batch:
     timeout: 5s


### PR DESCRIPTION
## Summary

Implements ADR-020: replaces the head-based 100% sampling policy (locked in by ADR-018 at project start) with tail-based sampling at the OTel Collector level.

**Three policies (OR logic — keep if any matches):**
- `errors` — always keep any trace containing a span with `STATUS_CODE_ERROR`
- `slow_traces` — always keep any trace with total duration ≥ 1,000 ms
- `probabilistic` — keep 20% of all remaining clean traces

**Key design choices:**
- Tail-based (Collector-side) rather than head-based ratio (SDK) so errors and slow traces are always retained regardless of sampling rate
- `decision_wait: 10s` to see the full `apps/web → apps/api → Postgres` span chain before deciding
- `OTEL_TAIL_SAMPLE_RATE` env var makes the rate tunable per-environment without code changes
- Local dev overrides to 100% in `docker-compose.yml` — no debugging friction

## Changes

| File | Change |
|---|---|
| `infra/observability/otel-collector.yaml` | Added `tail_sampling` processor, wired into traces pipeline |
| `infra/kubernetes/charts/otel-collector/templates/configmap.yaml` | Mirrored processor config; added `OTEL_TAIL_SAMPLE_RATE` env to ConfigMap |
| `infra/kubernetes/charts/otel-collector/values.yaml` | Added `tailSampleRate: "20"` default |
| `docker-compose.yml` | Added `OTEL_TAIL_SAMPLE_RATE: "100"` for local dev |
| `docs/adr/ADR-020-tail-based-sampling-policy.md` | New ADR documenting the decision |
| `docs/README.md` | Added ADR-019 and ADR-020 rows (ADR-019 was missing) |
| `docs/adr-references.md` | Added two ADR-020 references |

## Test plan

- [x] 114 unit tests pass (`npm test -w @lifting-logbook/core -w @lifting-logbook/api`)
- [x] Pre-existing e2e failures (`nestjs-pino`, `@opentelemetry/sdk-trace-node` missing packages) are unrelated to these changes
- [ ] Smoke: `docker compose up otel-collector` — confirm collector starts without errors
- [ ] Smoke: send test trace to `localhost:4318`, confirm it appears in Grafana Tempo

Closes #210