### PR TITLE
[docs] Add onboarding guide (clone → first PR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For a guided walkthrough from clone to first PR, see [docs/onboarding.md](docs/o
 
 - Node.js >= 20.11.1 (use `.nvmrc`: `nvm use`)
 - npm >= 10 (bundled with Node 20)
-- Docker (for local Postgres)
+- Docker (for local Postgres and the observability stack)
 
 ### Local Development
 
@@ -64,8 +64,8 @@ For a guided walkthrough from clone to first PR, see [docs/onboarding.md](docs/o
 # 1. Install dependencies
 npm install
 
-# 2. Start Postgres
-docker compose up db -d
+# 2. Start full stack (Postgres + observability)
+docker compose up -d
 
 # 3. Create env files from examples
 cp apps/api/.env.example apps/api/.env
@@ -99,6 +99,7 @@ npm run dev
 
 - Web: http://localhost:3000
 - API: http://localhost:3004
+- Grafana: http://localhost:3030
 
 ### Common Commands
 
@@ -114,13 +115,9 @@ packages affected by your changes.
 
 ### Observability
 
-The full docker-compose stack ships Grafana, Tempo, Loki, and Prometheus alongside
-Postgres. Start everything with `docker compose up -d` and open **http://localhost:3030**
-for the Grafana dashboard.
-
-See [docs/runbooks/observability.md](docs/runbooks/observability.md) for the full
-guide: startup, trace queries, log↔trace correlation, alert silencing, and Grafana
-Cloud credential wiring.
+Grafana is available at **http://localhost:3030** once the stack is running. See
+[docs/runbooks/observability.md](docs/runbooks/observability.md) for the full guide:
+trace queries, log↔trace correlation, alert silencing, and Grafana Cloud credential wiring.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ runs only core's tests, with no knowledge of the rest of the monorepo.
 
 ## Getting Started
 
+For a guided walkthrough from clone to first PR, see [docs/onboarding.md](docs/onboarding.md).
+
 ### Prerequisites
 
 - Node.js >= 20.11.1 (use `.nvmrc`: `nvm use`)

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -34,7 +34,7 @@ nvm use
 # Install all workspace dependencies
 npm install
 
-# Start the full stack (Postgres + observability)
+# Start the full stack: Postgres, OTel Collector, Tempo, Loki, Prometheus, Grafana
 docker compose up -d
 
 # Copy env files and fill in values
@@ -143,6 +143,8 @@ npm test -w @lifting-logbook/core
 npm test -w @lifting-logbook/api
 npm test -w @lifting-logbook/web
 ```
+
+> **Note:** `@lifting-logbook/web` has a pre-existing test environment issue (`jest-environment-jsdom` not installed). That failure is safe to ignore — `core` and `api` are the meaningful signal.
 
 Run `npm run build` first if you have touched compiled output (e.g., API controllers, shared
 types in `packages/types`). Integration tests that hit the database require `DATABASE_URL` to

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,205 @@
+# Developer Onboarding Guide
+
+A guided walkthrough from clone to first PR. This document sequences the existing documentation
+and fills the gaps between them — it does not duplicate content covered elsewhere.
+
+---
+
+## Prerequisites
+
+Before you begin, install:
+
+- **Node.js 20.11.1** — use [nvm](https://github.com/nvm-sh/nvm) (macOS/Linux) or
+  [nvm-windows](https://github.com/coreybutler/nvm-windows) (Windows). The repo ships a
+  `.nvmrc`; run `nvm use` from the repo root and it picks the right version automatically.
+- **npm 10** — bundled with Node 20; no separate install needed.
+- **Docker Desktop** — runs the local Postgres database and the full observability stack
+  (Grafana, Tempo, Loki, Prometheus).
+- **Git**
+
+> **Windows:** Use WSL2 or Git Bash for all terminal commands. PowerShell handles arrays and
+> arithmetic differently and has caused failures in this environment.
+
+---
+
+## Clone & Bootstrap
+
+```sh
+git clone https://github.com/brownm09/lifting-logbook.git
+cd lifting-logbook
+
+# Pick up the correct Node version
+nvm use
+
+# Install all workspace dependencies
+npm install
+
+# Start the full stack (Postgres + observability)
+docker compose up -d
+
+# Copy env files and fill in values
+cp apps/api/.env.example apps/api/.env
+cp apps/web/.env.example apps/web/.env
+```
+
+Edit `apps/api/.env`:
+
+```
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/lifting_logbook
+# Leave CLERK_SECRET_KEY unset — DevAuthProvider is used automatically in local dev
+DEV_USER_ID=dev-user
+DEV_USER_EMAIL=dev@example.com
+```
+
+Edit `apps/web/.env`:
+
+```
+API_URL=http://localhost:3004
+NEXT_PUBLIC_API_URL=http://localhost:3004
+NEXT_PUBLIC_DEFAULT_PROGRAM=5-3-1
+DEV_AUTH_TOKEN=dev-user
+NEXT_PUBLIC_DEV_AUTH_TOKEN=dev-user
+```
+
+```sh
+# Apply database migrations
+cd apps/api && npx prisma migrate dev && cd ../..
+
+# Start all dev servers
+npm run dev
+```
+
+**Running services:**
+
+| Service | URL |
+|---------|-----|
+| Web | http://localhost:3000 |
+| API | http://localhost:3004 |
+| Grafana | http://localhost:3030 (no login required locally) |
+
+For the full Getting Started reference — including common commands and the Turborepo pipeline —
+see [README.md](../README.md).
+
+---
+
+## Architecture Mental Model
+
+The codebase follows **hexagonal architecture (Ports & Adapters)**. Domain logic in
+`packages/core` has zero infrastructure dependencies; all external concerns (data stores,
+auth providers, HTTP transport) are accessed through defined interfaces and implemented as
+swappable adapters. Understanding this pattern is the most important thing you can do before
+writing your first line of code here.
+
+For the full narrative, technology choices, and diagram index see [docs/README.md](README.md).
+
+### Recommended ADR Reading Order
+
+Read these five ADRs before touching code. Each is short and self-contained:
+
+1. [ADR-001 — Monorepo Structure with Turborepo](adr/ADR-001-monorepo-structure.md) — explains
+   the workspace layout and why packages are split the way they are
+2. [ADR-002 — Hexagonal Architecture (Ports and Adapters)](adr/ADR-002-ports-and-adapters.md) —
+   the core design pattern; everything else depends on understanding this
+3. [ADR-003 — Per-User Data Store Configuration](adr/ADR-003-per-user-data-store-config.md) —
+   explains how the correct adapter is resolved per request
+4. [ADR-004 — Multi-Data-Store Adapter Strategy](adr/ADR-004-multi-data-store-adapters.md) —
+   explains why both Google Sheets and Postgres coexist as backends
+5. [ADR-013 — Testing Strategy](adr/ADR-013-testing-strategy.md) — explains how tests are
+   organized and what the coverage expectations are
+
+If you are working on the API layer, also read:
+
+- [ADR-005 — Authentication Strategy](adr/ADR-005-authentication-strategy.md) — how Clerk,
+  Auth0, and the local `DevAuthProvider` relate to each other
+- [ADR-011 — API Server — NestJS Primary with Express Legacy Comparison](adr/ADR-011-api-server-nestjs-and-express.md) —
+  why there are two API apps and how they relate
+
+---
+
+## Making Your First Change
+
+1. **Open an issue first.** Every code change starts with a GitHub issue describing the problem
+   or goal — not the implementation. See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full
+   workflow.
+2. **Create a branch** using the naming convention in CONTRIBUTING.md
+   (`feat/issue-<N>-<slug>`, `fix/issue-<N>-<slug>`, etc.).
+3. **Make your changes**, following the commit message format in CONTRIBUTING.md.
+4. **Run the tests** (see below) and confirm they pass before pushing.
+5. **Open a PR** — the title format and merge strategy are in CONTRIBUTING.md.
+
+For significant new features or architectural changes, use the `/propose` skill before opening
+an issue. It guides you through clarifying questions and produces a proposal doc.
+
+---
+
+## Running Tests
+
+```sh
+# Full suite across all workspaces
+npm test
+
+# Single workspace
+npm test -w @lifting-logbook/core
+npm test -w @lifting-logbook/api
+npm test -w @lifting-logbook/web
+```
+
+Run `npm run build` first if you have touched compiled output (e.g., API controllers, shared
+types in `packages/types`). Integration tests that hit the database require `DATABASE_URL` to
+be set in `apps/api/.env`.
+
+---
+
+## Troubleshooting
+
+### 1. Missing environment variables
+
+**Symptom:** `Error: DATABASE_URL is not set` or auth errors on startup.
+
+**Fix:** Make sure you copied `.env.example` in both `apps/api/` and `apps/web/` and filled
+in the required values (see Bootstrap above). The API will not start without `DATABASE_URL`.
+
+### 2. Postgres not running
+
+**Symptom:** `Connection refused` on port 5432 or Prisma migration fails with a network error.
+
+**Fix:**
+
+```sh
+docker compose up db -d
+```
+
+Wait a few seconds for Postgres to finish initializing, then retry migrations.
+
+### 3. Node version mismatch
+
+**Symptom:** Build errors, missing peer dependency warnings, or package resolution failures
+that look unrelated to your changes.
+
+**Fix:**
+
+```sh
+nvm use   # reads .nvmrc and switches to Node 20.11.1
+npm install
+```
+
+If `nvm` is not installed, upgrade your system Node to ≥ 20.11.1.
+
+### Deeper debugging
+
+The full observability stack (Grafana at http://localhost:3030) gives you traces, logs, and
+metrics for local requests. See [docs/runbooks/observability.md](runbooks/observability.md)
+for startup, trace queries, and log↔trace correlation.
+
+---
+
+## Where to Go Next
+
+| Resource | What it covers |
+|----------|----------------|
+| [docs/README.md](README.md) | Full architecture narrative, ADR index, diagram index |
+| [CONTRIBUTING.md](../CONTRIBUTING.md) | Branch workflow, commit format, PR conventions |
+| [docs/deploy.md](deploy.md) | First-time cloud infrastructure setup (GCP, Terraform, Clerk) |
+| [docs/security-review-checklist.md](security-review-checklist.md) | Pre-ship security checklist |
+| [docs/runbooks/](runbooks/) | Incident response guides and operational runbooks |
+| [docs/PRD.md](PRD.md) | Product requirements, user personas, success metrics |


### PR DESCRIPTION
## Summary

- Adds `docs/onboarding.md` as the canonical day-one entry point for new engineers
- Sequences the existing docs (README, CONTRIBUTING, docs/README, docs/deploy, runbooks) without duplicating their content
- Includes a curated ADR reading order (ADR-001 through ADR-004 and ADR-013) and two bonus ADRs for API contributors
- Covers the top three local-dev failure modes: missing env vars, Postgres not running, Node version mismatch
- Inserts a one-line link from the README quick-start section into `docs/onboarding.md`

## Acceptance Criteria

- [x] `docs/onboarding.md` exists and follows a "clone → first PR" narrative
- [x] Links to (does not duplicate) README, CONTRIBUTING, docs/README, docs/deploy, and the relevant ADRs
- [x] ADR reading order section recommends ADR-001–004 and ADR-013 (5 ADRs)
- [x] Troubleshooting section covers the top three local-dev failure modes
- [x] README.md links to `docs/onboarding.md` from its Getting Started section

## Test Results

`npm test` — core and API tests pass (2 successful, all cached). The `@lifting-logbook/web` test failure (`jest-environment-jsdom` not installed) is pre-existing and unrelated to this docs-only change.

Closes #200