### PR TITLE
[feat] Validate cycle dashboard before reschedule and lift-override writes

### DIFF
--- a/apps/api/src/programs/manage-lifts.controller.spec.ts
+++ b/apps/api/src/programs/manage-lifts.controller.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { LIFT_NAMES } from '@lifting-logbook/types';
+import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
 import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
 import { IWorkoutLiftOverrideRepository } from '../ports/IWorkoutLiftOverrideRepository';
 import { IRepositoryFactory } from '../ports/factory';
@@ -19,6 +20,8 @@ describe('ManageLiftsController', () => {
   let liftOverrideRepoB: jest.Mocked<IWorkoutLiftOverrideRepository>;
   let specRepoA: jest.Mocked<ILiftingProgramSpecRepository>;
   let specRepoB: jest.Mocked<ILiftingProgramSpecRepository>;
+  let dashboardRepoA: jest.Mocked<ICycleDashboardRepository>;
+  let dashboardRepoB: jest.Mocked<ICycleDashboardRepository>;
   let factory: jest.Mocked<IRepositoryFactory>;
 
   beforeEach(async () => {
@@ -34,11 +37,13 @@ describe('ManageLiftsController', () => {
     };
     specRepoA = { getProgramSpec: jest.fn().mockResolvedValue(STUB_SPEC) } as jest.Mocked<ILiftingProgramSpecRepository>;
     specRepoB = { getProgramSpec: jest.fn().mockResolvedValue(STUB_SPEC) } as jest.Mocked<ILiftingProgramSpecRepository>;
+    dashboardRepoA = { getCycleDashboard: jest.fn().mockResolvedValue({}), saveCycleDashboard: jest.fn() } as unknown as jest.Mocked<ICycleDashboardRepository>;
+    dashboardRepoB = { getCycleDashboard: jest.fn().mockResolvedValue({}), saveCycleDashboard: jest.fn() } as unknown as jest.Mocked<ICycleDashboardRepository>;
     factory = {
       forUser: jest.fn().mockImplementation(async (user) =>
         user.id === MOCK_USER_A.id
-          ? { workoutLiftOverride: liftOverrideRepoA, liftingProgramSpec: specRepoA }
-          : { workoutLiftOverride: liftOverrideRepoB, liftingProgramSpec: specRepoB },
+          ? { cycleDashboard: dashboardRepoA, workoutLiftOverride: liftOverrideRepoA, liftingProgramSpec: specRepoA }
+          : { cycleDashboard: dashboardRepoB, workoutLiftOverride: liftOverrideRepoB, liftingProgramSpec: specRepoB },
       ),
     };
     const module: TestingModule = await Test.createTestingModule({

--- a/apps/api/src/programs/manage-lifts.controller.spec.ts
+++ b/apps/api/src/programs/manage-lifts.controller.spec.ts
@@ -5,6 +5,7 @@ import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
 import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
 import { IWorkoutLiftOverrideRepository } from '../ports/IWorkoutLiftOverrideRepository';
 import { IRepositoryFactory } from '../ports/factory';
+import { ProgramNotFoundError } from '../ports/errors';
 import { REPOSITORY_FACTORY } from '../ports/tokens';
 import { ManageLiftsController } from './manage-lifts.controller';
 
@@ -98,6 +99,15 @@ describe('ManageLiftsController', () => {
       await expect(
         controller.upsertOverride('unknown', '3', '1', { action: 'add', lift: 'Squat' }, MOCK_USER_A),
       ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('propagates ProgramNotFoundError when cycle dashboard is missing', async () => {
+      dashboardRepoA.getCycleDashboard.mockRejectedValue(new ProgramNotFoundError('5-3-1'));
+
+      await expect(
+        controller.upsertOverride('5-3-1', '3', '1', { action: 'add', lift: 'Squat' }, MOCK_USER_A),
+      ).rejects.toBeInstanceOf(ProgramNotFoundError);
+      expect(liftOverrideRepoA.upsertOverride).not.toHaveBeenCalled();
     });
 
     it('throws 400 for invalid cycleNum', async () => {

--- a/apps/api/src/programs/manage-lifts.controller.ts
+++ b/apps/api/src/programs/manage-lifts.controller.ts
@@ -52,12 +52,14 @@ export class ManageLiftsController {
       throw new BadRequestException("replacedBy is required when action is 'replace'");
     }
 
-    const { workoutLiftOverride, liftingProgramSpec } = await this.factory.forUser(user);
+    const { cycleDashboard, workoutLiftOverride, liftingProgramSpec } = await this.factory.forUser(user);
 
     const spec = await liftingProgramSpec.getProgramSpec(program);
     if (spec.length === 0) {
       throw new NotFoundException(`Program '${program}' not found`);
     }
+
+    await cycleDashboard.getCycleDashboard(program);
 
     const override = {
       lift: dto.lift,

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -180,12 +180,9 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
       const injectRaw = app.getHttpAdapter().getInstance().inject.bind(
         app.getHttpAdapter().getInstance(),
       );
-      const AS_ALICE = { authorization: 'Bearer user-alice-reschedule' };
+      // Alice is the pre-seeded dev user (has a cycle dashboard); Bob is a fresh user.
+      const AS_ALICE = AUTH;
       const AS_BOB   = { authorization: 'Bearer user-bob-reschedule' };
-
-      // Both are fresh users with no cycle dashboard. The reschedule controller
-      // does not require a dashboard entry — it upserts the override directly,
-      // same design as the lift-overrides controller.
 
       // Alice reschedules workout 1 of cycle 1
       const patchRes = await injectRaw({
@@ -864,14 +861,16 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
       const injectRaw = app.getHttpAdapter().getInstance().inject.bind(
         app.getHttpAdapter().getInstance(),
       );
-      const AS_ALICE = { authorization: 'Bearer user-alice-lifts' };
+      // Alice is the pre-seeded dev user (has a cycle dashboard); Bob is a fresh user.
+      const AS_ALICE = AUTH;
       const AS_BOB   = { authorization: 'Bearer user-bob-lifts' };
 
-      // Alice adds a Cable Curls override for cycle 1, workout 1.
-      // Use cycleNum=1 directly (Alice is a fresh user with no cycle dashboard).
+      // Alice adds a Cable Curls override for the current cycle, workout 1.
+      const dashRes = await injectRaw({ method: 'GET', url: `/programs/${PROGRAM}/cycles/current`, headers: AS_ALICE });
+      const { cycleNum } = dashRes.json() as { cycleNum: number };
       await injectRaw({
         method: 'POST',
-        url: OVERRIDE_URL(1, 1),
+        url: OVERRIDE_URL(cycleNum, 1),
         headers: { 'content-type': 'application/json', ...AS_ALICE },
         payload: JSON.stringify({ action: 'add', lift: 'Cable Curls' }),
       });

--- a/apps/api/src/programs/reschedule.controller.spec.ts
+++ b/apps/api/src/programs/reschedule.controller.spec.ts
@@ -4,6 +4,7 @@ import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
 import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
 import { IWorkoutDateOverrideRepository } from '../ports/IWorkoutDateOverrideRepository';
 import { IRepositoryFactory } from '../ports/factory';
+import { ProgramNotFoundError } from '../ports/errors';
 import { REPOSITORY_FACTORY } from '../ports/tokens';
 import { RescheduleController } from './reschedule.controller';
 
@@ -108,6 +109,14 @@ describe('RescheduleController', () => {
     await expect(
       controller.reschedule('no-such-program', '3', '2', { newDate: '2026-05-15' }, MOCK_USER_A),
     ).rejects.toBeInstanceOf(NotFoundException);
+    expect(overrideRepoA.upsertOverride).not.toHaveBeenCalled();
+  });
+
+  it('propagates ProgramNotFoundError when cycle dashboard is missing', async () => {
+    dashboardRepoA.getCycleDashboard.mockRejectedValue(new ProgramNotFoundError('5-3-1'));
+    await expect(
+      controller.reschedule('5-3-1', '3', '2', { newDate: '2026-05-15' }, MOCK_USER_A),
+    ).rejects.toBeInstanceOf(ProgramNotFoundError);
     expect(overrideRepoA.upsertOverride).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/programs/reschedule.controller.spec.ts
+++ b/apps/api/src/programs/reschedule.controller.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
 import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
 import { IWorkoutDateOverrideRepository } from '../ports/IWorkoutDateOverrideRepository';
 import { IRepositoryFactory } from '../ports/factory';
@@ -17,6 +18,8 @@ describe('RescheduleController', () => {
   let overrideRepoB: jest.Mocked<IWorkoutDateOverrideRepository>;
   let specRepoA: jest.Mocked<ILiftingProgramSpecRepository>;
   let specRepoB: jest.Mocked<ILiftingProgramSpecRepository>;
+  let dashboardRepoA: jest.Mocked<ICycleDashboardRepository>;
+  let dashboardRepoB: jest.Mocked<ICycleDashboardRepository>;
   let factory: jest.Mocked<IRepositoryFactory>;
 
   beforeEach(async () => {
@@ -30,11 +33,13 @@ describe('RescheduleController', () => {
     };
     specRepoA = { getProgramSpec: jest.fn().mockResolvedValue(STUB_SPEC) } as jest.Mocked<ILiftingProgramSpecRepository>;
     specRepoB = { getProgramSpec: jest.fn().mockResolvedValue(STUB_SPEC) } as jest.Mocked<ILiftingProgramSpecRepository>;
+    dashboardRepoA = { getCycleDashboard: jest.fn().mockResolvedValue({}), saveCycleDashboard: jest.fn() } as unknown as jest.Mocked<ICycleDashboardRepository>;
+    dashboardRepoB = { getCycleDashboard: jest.fn().mockResolvedValue({}), saveCycleDashboard: jest.fn() } as unknown as jest.Mocked<ICycleDashboardRepository>;
     factory = {
       forUser: jest.fn().mockImplementation(async (user) =>
         user.id === MOCK_USER_A.id
-          ? { workoutDateOverride: overrideRepoA, liftingProgramSpec: specRepoA }
-          : { workoutDateOverride: overrideRepoB, liftingProgramSpec: specRepoB },
+          ? { cycleDashboard: dashboardRepoA, workoutDateOverride: overrideRepoA, liftingProgramSpec: specRepoA }
+          : { cycleDashboard: dashboardRepoB, workoutDateOverride: overrideRepoB, liftingProgramSpec: specRepoB },
       ),
     };
     const module: TestingModule = await Test.createTestingModule({

--- a/apps/api/src/programs/reschedule.controller.ts
+++ b/apps/api/src/programs/reschedule.controller.ts
@@ -41,12 +41,14 @@ export class RescheduleController {
       throw new BadRequestException('workoutNum must be a positive integer');
     }
 
-    const { workoutDateOverride, liftingProgramSpec } = await this.factory.forUser(user);
+    const { cycleDashboard, workoutDateOverride, liftingProgramSpec } = await this.factory.forUser(user);
 
     const spec = await liftingProgramSpec.getProgramSpec(program);
     if (spec.length === 0) {
       throw new NotFoundException(`Program '${program}' not found`);
     }
+
+    await cycleDashboard.getCycleDashboard(program);
 
     // Append explicit UTC midnight so the YYYY-MM-DD string is stored as the correct calendar day
     // regardless of the server's local timezone.


### PR DESCRIPTION
## Summary

- `PATCH .../reschedule` and `POST .../lift-overrides` both now call `getCycleDashboard(program)` before upserting. If the program is not in the user's cycle dashboard, `ProgramNotFoundError` propagates to `DomainNotFoundFilter` → 404, consistent with cycle-advance and training-max endpoints.
- Unit test mocks for both controllers updated to include `cycleDashboard` in the factory mock.
- E2e isolation tests restructured: the writing party is now the pre-seeded dev user (has a cycle dashboard) rather than a fresh user with no dashboard; the read-only party remains a fresh token.

## Acceptance Criteria

- [x] `PATCH .../reschedule` returns 404 if the program is not in the user's cycle dashboard
- [x] `POST .../lift-overrides` returns 404 if the program is not in the user's cycle dashboard
- [x] Isolation tests updated (dev-token user as the writer, fresh token for the read-only assertion)
- [x] All existing tests pass

## Testing

`npm test -w @lifting-logbook/api` — 173 passed, 31 skipped (DB suite), 0 failed.

Closes #193