### PR TITLE
[docs] Propose: Historical lift data backfill via CSV upload

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,6 +61,7 @@ Architecture decisions for data access and security documented.
 |---|---|---|---|
 | [Lift Library and Exercise Tagging](docs/proposals/2026-04-13-lift-library-exercise-tagging.md) | First-class `Lift` domain type with compound/accessory classification, movement tags, and configurable program exercise slots | [#64](https://github.com/brownm09/lifting-logbook/issues/64) | shipped |
 | [Grafana Cloud Observability Stack](docs/proposals/2026-05-08-grafana-cloud-observability-stack.md) | OpenTelemetry tracing, metrics, and logs in `apps/api` and `apps/web` exporting to Grafana Cloud, with RED-style alerts | [#199](https://github.com/brownm09/lifting-logbook/issues/199) | shipped |
+| [Historical Lift Data Backfill](docs/proposals/2026-05-11-historical-lift-data-backfill.md) | CSV upload endpoint and web UI to ingest historical `LiftRecord` rows with all-or-nothing validation | [#225](https://github.com/brownm09/lifting-logbook/issues/225) | draft |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,7 +61,6 @@ Architecture decisions for data access and security documented.
 |---|---|---|---|
 | [Lift Library and Exercise Tagging](docs/proposals/2026-04-13-lift-library-exercise-tagging.md) | First-class `Lift` domain type with compound/accessory classification, movement tags, and configurable program exercise slots | [#64](https://github.com/brownm09/lifting-logbook/issues/64) | shipped |
 | [Grafana Cloud Observability Stack](docs/proposals/2026-05-08-grafana-cloud-observability-stack.md) | OpenTelemetry tracing, metrics, and logs in `apps/api` and `apps/web` exporting to Grafana Cloud, with RED-style alerts | [#199](https://github.com/brownm09/lifting-logbook/issues/199) | shipped |
-| [Historical Lift Data Backfill](docs/proposals/2026-05-11-historical-lift-data-backfill.md) | CSV upload endpoint and web UI to ingest historical `LiftRecord` rows with all-or-nothing validation | [#225](https://github.com/brownm09/lifting-logbook/issues/225) | draft |
 
 ---
 
@@ -108,6 +107,7 @@ Web and mobile clients functional end-to-end. Key user-facing features implement
 | [Strength Goal Tracking](docs/proposals/2026-04-29-strength-goal-tracking.md) | Per-lift, per-tier strength standards (intermediate/advanced/elite) with target and observed dates | [#111](https://github.com/brownm09/lifting-logbook/issues/111) | shipped |
 | [Initial Training Max Discovery](docs/proposals/2026-04-30-initial-training-max-discovery.md) | Estimation utility (Brzycki) and test-week cycle phase for users with no existing training maxes | [#129](https://github.com/brownm09/lifting-logbook/issues/129) | shipped |
 | [On-Call Readiness](docs/proposals/2026-05-08-on-call-readiness.md) | Runbooks, SLOs, incident response guide, and severity/escalation framework; sequences after #199 | [#201](https://github.com/brownm09/lifting-logbook/issues/201) | shipped |
+| [Historical Lift Data Backfill](docs/proposals/2026-05-11-historical-lift-data-backfill.md) | CSV upload endpoint and web UI to ingest historical `LiftRecord` rows with all-or-nothing validation | [#225](https://github.com/brownm09/lifting-logbook/issues/225) | draft |
 
 ---
 

--- a/docs/proposals/2026-05-11-historical-lift-data-backfill.md
+++ b/docs/proposals/2026-05-11-historical-lift-data-backfill.md
@@ -1,0 +1,44 @@
+# Proposal: Historical Lift Data Backfill via CSV Upload
+
+**Status:** `draft`
+**Date:** 2026-05-11
+**Issue:** [#225](https://github.com/brownm09/lifting-logbook/issues/225)
+
+---
+
+## Problem
+
+Intermediate lifters migrating from Google Sheets / Apps Script implementations arrive with months or years of historical lift records they want to carry over. Without a backfill path, the app's progression logic (RPT top-set targeting, 5/3/1 cycle planning) starts from zero on day one, breaking continuity with the program the lifter is mid-cycle on. This blocks the primary persona's adoption: the Consistent Intermediate Lifter will not switch tools if doing so erases their training history.
+
+## Proposed Solution
+
+Add a CSV upload path that ingests historical `LiftRecord` rows for a given program in a single transactional batch. A new `POST /programs/:program/lift-records/import` endpoint accepts a CSV file, parses it via the existing `parseLiftRecords()` utility, resolves lift abbreviations through `DEFAULT_SLOT_MAP`, and persists rows via the existing `appendLiftRecords()` repository method. A complementary file-upload component in `apps/web` calls the endpoint and surfaces validation errors. Validation is all-or-nothing: if any row fails parsing, lift resolution, or schema checks, the request returns the complete list of errors and writes nothing.
+
+## Acceptance Criteria
+
+- [ ] `POST /programs/:program/lift-records/import` accepts a `multipart/form-data` CSV upload and returns `201` with a count of records written and a list of skipped duplicate rows (by row number and natural key) on success.
+- [ ] On any validation failure (unparseable row, unknown lift abbreviation, invalid date, non-numeric weight/reps), the endpoint returns `400` with a structured list of all errors including row numbers, and writes zero records to the database.
+- [ ] The endpoint resolves lift abbreviations via `DEFAULT_SLOT_MAP` and rejects rows whose abbreviation is not mapped.
+- [ ] Successful imports use `appendLiftRecords()` so duplicate rows (matching on natural key) are silently skipped via Prisma `skipDuplicates`.
+- [ ] `apps/web` exposes a file-upload component on the program detail page that calls the import endpoint and renders the validation error list when the upload is rejected, and the skipped-duplicates list when the upload succeeds.
+- [ ] Integration test covers a happy-path import of the ~900-row fixture already used by `parseLiftRecords()` tests.
+- [ ] Integration test covers a rejected file with at least two distinct error types and asserts the database state is unchanged.
+
+## Out of Scope
+
+- Partial imports or per-row error tolerance — the all-or-nothing contract is intentional.
+- Mapping UI for unknown lift abbreviations — unmapped abbreviations are an error, not a prompt.
+- Automatic detection of program type (RPT vs 5/3/1) from CSV contents — the program is specified by the route parameter.
+- Importing program definitions, training maxes, or cycle state — only `LiftRecord` rows are in scope.
+- Export (the reverse direction) — separate proposal.
+- Mobile client upload UI — `apps/mobile` is v0.3.
+
+## Open Questions
+
+- Should the endpoint enforce a maximum file size or row count, and if so what limits? (Suggested: 5 MB / 10,000 rows for v0.2.)
+
+## References
+
+- [Prisma `createMany` documentation](https://www.prisma.io/docs/orm/reference/prisma-client-reference#createmany) — semantics of `skipDuplicates` used by `appendLiftRecords()`.
+- [RFC 7578 — Returning Values from Forms: `multipart/form-data`](https://www.rfc-editor.org/rfc/rfc7578) — wire format for the file upload.
+- [`docs/proposals/2026-04-30-initial-training-max-discovery.md`](2026-04-30-initial-training-max-discovery.md) — prior proposal that explicitly deferred historical import to a separate proposal.

--- a/docs/proposals/2026-05-11-historical-lift-data-backfill.md
+++ b/docs/proposals/2026-05-11-historical-lift-data-backfill.md
@@ -16,10 +16,10 @@ Add a CSV upload path that ingests historical `LiftRecord` rows for a given prog
 
 ## Acceptance Criteria
 
-- [ ] `POST /programs/:program/lift-records/import` accepts a `multipart/form-data` CSV upload and returns `201` with a count of records written and a list of skipped duplicate rows (by row number and natural key) on success.
+- [ ] `POST /programs/:program/lift-records/import` accepts a `multipart/form-data` CSV upload and returns `201` with a count of records written and a list of skipped duplicate rows (by row number and natural key) on success. The endpoint rejects files larger than 5 MB or containing more than 10,000 data rows with a `400`.
 - [ ] On any validation failure (unparseable row, unknown lift abbreviation, invalid date, non-numeric weight/reps), the endpoint returns `400` with a structured list of all errors including row numbers, and writes zero records to the database.
 - [ ] The endpoint resolves lift abbreviations via `DEFAULT_SLOT_MAP` and rejects rows whose abbreviation is not mapped.
-- [ ] Successful imports use `appendLiftRecords()` so duplicate rows (matching on natural key) are silently skipped via Prisma `skipDuplicates`.
+- [ ] Successful imports use `appendLiftRecords()` so duplicate rows (matching on natural key) are skipped without error via Prisma `skipDuplicates`.
 - [ ] `apps/web` exposes a file-upload component on the program detail page that calls the import endpoint and renders the validation error list when the upload is rejected, and the skipped-duplicates list when the upload succeeds.
 - [ ] Integration test covers a happy-path import of the ~900-row fixture already used by `parseLiftRecords()` tests.
 - [ ] Integration test covers a rejected file with at least two distinct error types and asserts the database state is unchanged.
@@ -35,7 +35,7 @@ Add a CSV upload path that ingests historical `LiftRecord` rows for a given prog
 
 ## Open Questions
 
-- Should the endpoint enforce a maximum file size or row count, and if so what limits? (Suggested: 5 MB / 10,000 rows for v0.2.)
+*(none)*
 
 ## References
 


### PR DESCRIPTION
## Summary

- Add proposal doc for historical lift data backfill via CSV upload ([#225](https://github.com/brownm09/lifting-logbook/issues/225))
- Addresses the gap explicitly deferred in the Initial Training Max Discovery proposal: users migrating from Google Sheets need a path to carry over historical lift records
- Update ROADMAP.md v0.2 Proposals table with the new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)