### PR TITLE
[docs] Fix nvm use instructions for nvm-windows compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Include in your opening brief only: the issue you are working on, current branch
 ## Platform & Environment
 
 - **OS:** Windows 11, Git Bash terminal
-- **Node:** 20.11.1 (managed by nvm for Windows; `.nvmrc` is set — run `nvm use` at session start if not already active)
+- **Node:** 20.11.1 (managed by nvm for Windows; `.nvmrc` is set — run `nvm use $(cat .nvmrc)` at session start if not already active)
 - **Package manager:** npm (workspaces)
 - **`jq` is NOT available.** Use `node -e` with a temp file in the working directory for JSON parsing:
   ```bash

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For a guided walkthrough from clone to first PR, see [docs/onboarding.md](docs/o
 
 ### Prerequisites
 
-- Node.js >= 20.11.1 (use `.nvmrc`: `nvm use`)
+- Node.js >= 20.11.1 (use `.nvmrc`: `nvm use $(cat .nvmrc)`)
 - npm >= 10 (bundled with Node 20)
 - Docker (for local Postgres and the observability stack)
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -11,7 +11,7 @@ Before you begin, install:
 
 - **Node.js 20.11.1** — use [nvm](https://github.com/nvm-sh/nvm) (macOS/Linux) or
   [nvm-windows](https://github.com/coreybutler/nvm-windows) (Windows). The repo ships a
-  `.nvmrc`; run `nvm use` from the repo root and it picks the right version automatically.
+  `.nvmrc`; run `nvm use $(cat .nvmrc)` from the repo root to activate the right version.
 - **npm 10** — bundled with Node 20; no separate install needed.
 - **Docker Desktop** — runs the local Postgres database and the full observability stack
   (Grafana, Tempo, Loki, Prometheus).
@@ -29,7 +29,7 @@ git clone https://github.com/brownm09/lifting-logbook.git
 cd lifting-logbook
 
 # Pick up the correct Node version
-nvm use
+nvm use $(cat .nvmrc)
 
 # Install all workspace dependencies
 npm install
@@ -181,7 +181,7 @@ that look unrelated to your changes.
 **Fix:**
 
 ```sh
-nvm use   # reads .nvmrc and switches to Node 20.11.1
+nvm use $(cat .nvmrc)  # activates Node 20.11.1 (nvm-windows requires explicit version)
 npm install
 ```
 

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -19,7 +19,7 @@ step "Checking prerequisites"
 
 node_version=$(node --version 2>/dev/null | sed 's/v//' || echo "0")
 node_major=$(echo "$node_version" | cut -d. -f1)
-[[ "$node_major" -ge 20 ]] || die "Node.js >= 20 required (found v${node_version}). Run: nvm use $(cat .nvmrc)"
+[[ "$node_major" -ge 20 ]] || die "Node.js >= 20 required (found v${node_version}). Run: nvm use $(cat .nvmrc)"  # $(cat .nvmrc) expands to version at runtime
 ok "Node.js v${node_version}"
 
 docker info &>/dev/null || die "Docker is not running. Start Docker Desktop and re-run this script."

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -19,7 +19,7 @@ step "Checking prerequisites"
 
 node_version=$(node --version 2>/dev/null | sed 's/v//' || echo "0")
 node_major=$(echo "$node_version" | cut -d. -f1)
-[[ "$node_major" -ge 20 ]] || die "Node.js >= 20 required (found v${node_version}). Run: nvm use"
+[[ "$node_major" -ge 20 ]] || die "Node.js >= 20 required (found v${node_version}). Run: nvm use $(cat .nvmrc)"
 ok "Node.js v${node_version}"
 
 docker info &>/dev/null || die "Docker is not running. Start Docker Desktop and re-run this script."


### PR DESCRIPTION
## Summary

- Replaces all bare `nvm use` calls with `nvm use $(cat .nvmrc)` across docs and scripts
- `nvm-windows` does not support reading `.nvmrc` automatically; bare `nvm use` fails with "A version argument is required but missing"
- `nvm use $(cat .nvmrc)` works in Git Bash on Windows and is identical in behavior on macOS/Linux

## Files changed

| File | Occurrences fixed |
|------|-------------------|
| `docs/onboarding.md` | 3 |
| `README.md` | 1 |
| `CLAUDE.md` | 1 |
| `scripts/dev-setup.sh` | 1 |

## Acceptance Criteria

- [x] No bare `nvm use` (without a version argument) remains in any docs or scripts
- [x] Instructions work on Windows (Git Bash + nvm-windows) without error
- [x] `bash -n scripts/dev-setup.sh` passes (syntax clean)

## Test Plan

```bash
bash -n scripts/dev-setup.sh
grep -rn "nvm use" README.md docs/onboarding.md CLAUDE.md scripts/dev-setup.sh
# All lines show nvm use $(cat .nvmrc) — no bare nvm use
```

Closes #229