### PR TITLE
[docs] Reference dev-setup.sh in onboarding guide + docs audit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ lifting-logbook/
 ```
 
 Tests are co-located with each package and app rather than in a top-level `tests/`
-directory. This keeps each workspace self-contained — `turbo run test --filter=@logbook/core`
+directory. This keeps each workspace self-contained — `turbo run test --filter=@lifting-logbook/core`
 runs only core's tests, with no knowledge of the rest of the monorepo.
 
 ---
@@ -59,6 +59,14 @@ For a guided walkthrough from clone to first PR, see [docs/onboarding.md](docs/o
 - Docker (for local Postgres and the observability stack)
 
 ### Local Development
+
+> **Automated setup:** After cloning, you can run `scripts/dev-setup.sh` instead of the
+> manual steps below. The script checks prerequisites (Node ≥ 20, Docker), installs npm
+> dependencies, copies `.env.example` files, and runs Prisma migrations.
+>
+> ```sh
+> bash scripts/dev-setup.sh
+> ```
 
 ```sh
 # 1. Install dependencies

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ For a guided walkthrough from clone to first PR, see [docs/onboarding.md](docs/o
 > ```sh
 > bash scripts/dev-setup.sh
 > ```
+>
+> The manual steps are kept below for reference or if you prefer to run each step individually.
 
 ```sh
 # 1. Install dependencies

--- a/docs/README.md
+++ b/docs/README.md
@@ -161,6 +161,10 @@ monorepo/
 | Runbook | Covers |
 |---------|--------|
 | [Observability](runbooks/observability.md) | Local stack startup, Grafana dashboards, trace queries, log↔trace correlation, alert silencing, Grafana Cloud credential wiring |
+| [API 5xx surge](runbooks/api-5xx-surge.md) | `APIHighErrorRate` alert response — SEV2 |
+| [Database unreachable](runbooks/database-unreachable.md) | DB connection error triage — SEV1 |
+| [Auth provider outage](runbooks/auth-provider-outage.md) | 401/403 surge + Clerk status incident — SEV2 |
+| [Deploy regression rollback](runbooks/deploy-regression-rollback.md) | Error rate spike correlated with a recent deploy — SEV2 |
 
 ---
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -24,6 +24,16 @@ Before you begin, install:
 
 ## Clone & Bootstrap
 
+> **Automated setup:** After cloning, you can run `scripts/dev-setup.sh` instead of the
+> manual steps below. The script checks prerequisites (Node ≥ 20, Docker), installs npm
+> dependencies, copies `.env.example` files, and runs Prisma migrations.
+>
+> ```sh
+> bash scripts/dev-setup.sh
+> ```
+>
+> The manual steps are kept below for reference or if you prefer to run each step individually.
+
 ```sh
 git clone https://github.com/brownm09/lifting-logbook.git
 cd lifting-logbook


### PR DESCRIPTION
## Summary

Fixes issue #231 and resolves three material gaps surfaced by a one-time commit-history audit.

### Issue #231 — docs/onboarding.md

The Clone & Bootstrap section walked through setup steps manually without mentioning `scripts/dev-setup.sh`, which automates the same flow (prereq checks, npm install, env copy, Prisma migrations). Added a callout blockquote immediately before the manual steps; manual steps remain intact.

### Audit findings (Option A — commit history scan)

Cross-referenced merged PRs that touched `apps/` or `packages/` against PRs that touched `docs/`. Three additional gaps found:

1. **README.md — missing dev-setup.sh reference** — same gap as onboarding.md in the Getting Started section.
2. **README.md — stale package name** — `@logbook/core` → `@lifting-logbook/core` (correct name per `packages/core/package.json`).
3. **docs/README.md — incomplete runbooks index** — only Observability was listed; four production incident runbooks added in PRs #211/#212 (API 5xx surge, database unreachable, auth provider outage, deploy regression rollback) were not indexed.

## Test plan

- [x] `npm test` — docs-only change; no test logic changed. Pre-existing TypeScript build errors in `@lifting-logbook/api` are present on `main` and unrelated to this PR (4 implicit `any` errors in Prisma repository files).
- [x] Reviewed updated sections in all three files for correctness

Closes #231