### PR TITLE
[feat] Historical lift data backfill via CSV upload

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.92.0",
     "@clerk/backend": "^3.4.4",
+    "@fastify/multipart": "^10.0.0",
     "@lifting-logbook/core": "*",
     "@lifting-logbook/types": "*",
     "@nestjs/common": "^10.0.0",

--- a/apps/api/src/adapters/in-memory/lift-record.adapter.ts
+++ b/apps/api/src/adapters/in-memory/lift-record.adapter.ts
@@ -13,6 +13,16 @@ export class InMemoryLiftRecordRepository implements ILiftRecordRepository {
     this.store.set(program, [...existing, ...records]);
   }
 
+  async findExistingRecords(program: string, candidates: LiftRecord[]): Promise<LiftRecord[]> {
+    const stored = this.store.get(program) ?? [];
+    const existingKeys = new Set(
+      stored.map((r) => `${r.cycleNum}:${r.workoutNum}:${r.lift}:${r.setNum}`),
+    );
+    return candidates.filter((r) =>
+      existingKeys.has(`${r.cycleNum}:${r.workoutNum}:${r.lift}:${r.setNum}`),
+    );
+  }
+
   async updateLiftRecord(
     program: string,
     id: string,

--- a/apps/api/src/adapters/in-memory/lift-record.adapter.ts
+++ b/apps/api/src/adapters/in-memory/lift-record.adapter.ts
@@ -1,4 +1,4 @@
-import { LiftRecord } from '@lifting-logbook/core';
+import { LiftRecord, liftRecordNaturalKey } from '@lifting-logbook/core';
 import { ILiftRecordRepository } from '../../ports/ILiftRecordRepository';
 
 export class InMemoryLiftRecordRepository implements ILiftRecordRepository {
@@ -8,19 +8,16 @@ export class InMemoryLiftRecordRepository implements ILiftRecordRepository {
     return (this.store.get(program) ?? []).filter((r) => r.cycleNum === cycleNum);
   }
 
-  async appendLiftRecords(program: string, records: LiftRecord[]): Promise<void> {
+  async appendLiftRecords(program: string, records: LiftRecord[]): Promise<number> {
     const existing = this.store.get(program) ?? [];
     this.store.set(program, [...existing, ...records]);
+    return records.length;
   }
 
   async findExistingRecords(program: string, candidates: LiftRecord[]): Promise<LiftRecord[]> {
     const stored = this.store.get(program) ?? [];
-    const existingKeys = new Set(
-      stored.map((r) => `${r.cycleNum}:${r.workoutNum}:${r.lift}:${r.setNum}`),
-    );
-    return candidates.filter((r) =>
-      existingKeys.has(`${r.cycleNum}:${r.workoutNum}:${r.lift}:${r.setNum}`),
-    );
+    const existingKeys = new Set(stored.map(liftRecordNaturalKey));
+    return candidates.filter((r) => existingKeys.has(liftRecordNaturalKey(r)));
   }
 
   async updateLiftRecord(

--- a/apps/api/src/adapters/prisma/lift-record.repository.ts
+++ b/apps/api/src/adapters/prisma/lift-record.repository.ts
@@ -35,6 +35,31 @@ export class PrismaLiftRecordRepository implements ILiftRecordRepository {
     });
   }
 
+  async findExistingRecords(program: string, candidates: LiftRecord[]): Promise<LiftRecord[]> {
+    if (candidates.length === 0) return [];
+    const rows = await this.prisma.liftRecord.findMany({
+      where: {
+        userId: this.userId,
+        program,
+        OR: candidates.map((r) => ({
+          cycleNum: r.cycleNum,
+          workoutNum: r.workoutNum,
+          lift: r.lift,
+          setNum: r.setNum,
+        })),
+      },
+    });
+    const existingKeys = new Set(
+      rows.map(
+        (r: { cycleNum: number; workoutNum: number; lift: string; setNum: number }) =>
+          `${r.cycleNum}:${r.workoutNum}:${r.lift}:${r.setNum}`,
+      ),
+    );
+    return candidates.filter((r) =>
+      existingKeys.has(`${r.cycleNum}:${r.workoutNum}:${r.lift}:${r.setNum}`),
+    );
+  }
+
   async updateLiftRecord(
     program: string,
     id: string,

--- a/apps/api/src/adapters/prisma/lift-record.repository.ts
+++ b/apps/api/src/adapters/prisma/lift-record.repository.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 // Prisma 5.x — error classes moved off the Prisma namespace
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
-import { LiftRecord } from '@lifting-logbook/core';
+import { LiftRecord, liftRecordNaturalKey } from '@lifting-logbook/core';
 import { ILiftRecordRepository } from '../../ports/ILiftRecordRepository';
 
 export class PrismaLiftRecordRepository implements ILiftRecordRepository {
@@ -17,8 +17,8 @@ export class PrismaLiftRecordRepository implements ILiftRecordRepository {
     return rows.map(rowToLiftRecord);
   }
 
-  async appendLiftRecords(program: string, records: LiftRecord[]): Promise<void> {
-    await this.prisma.liftRecord.createMany({
+  async appendLiftRecords(program: string, records: LiftRecord[]): Promise<number> {
+    const { count } = await this.prisma.liftRecord.createMany({
       data: records.map((r) => ({
         userId: this.userId,
         program,
@@ -33,31 +33,39 @@ export class PrismaLiftRecordRepository implements ILiftRecordRepository {
       })),
       skipDuplicates: true,
     });
+    return count;
   }
 
   async findExistingRecords(program: string, candidates: LiftRecord[]): Promise<LiftRecord[]> {
     if (candidates.length === 0) return [];
-    const rows = await this.prisma.liftRecord.findMany({
-      where: {
-        userId: this.userId,
-        program,
-        OR: candidates.map((r) => ({
-          cycleNum: r.cycleNum,
-          workoutNum: r.workoutNum,
-          lift: r.lift,
-          setNum: r.setNum,
-        })),
-      },
-    });
-    const existingKeys = new Set(
-      rows.map(
-        (r: { cycleNum: number; workoutNum: number; lift: string; setNum: number }) =>
-          `${r.cycleNum}:${r.workoutNum}:${r.lift}:${r.setNum}`,
+
+    // Chunk the OR array to stay within Postgres parameter limits (~32k).
+    // Each candidate produces 4 bound parameters; 500 chunks ≈ 2000 params per query.
+    const CHUNK_SIZE = 500;
+    const chunks: LiftRecord[][] = [];
+    for (let i = 0; i < candidates.length; i += CHUNK_SIZE) {
+      chunks.push(candidates.slice(i, i + CHUNK_SIZE));
+    }
+
+    const rowGroups = await Promise.all(
+      chunks.map((chunk) =>
+        this.prisma.liftRecord.findMany({
+          where: {
+            userId: this.userId,
+            program,
+            OR: chunk.map((r) => ({
+              cycleNum: r.cycleNum,
+              workoutNum: r.workoutNum,
+              lift: r.lift,
+              setNum: r.setNum,
+            })),
+          },
+        }),
       ),
     );
-    return candidates.filter((r) =>
-      existingKeys.has(`${r.cycleNum}:${r.workoutNum}:${r.lift}:${r.setNum}`),
-    );
+
+    const existingKeys = new Set(rowGroups.flat().map(liftRecordNaturalKey));
+    return candidates.filter((r) => existingKeys.has(liftRecordNaturalKey(r)));
   }
 
   async updateLiftRecord(

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -7,6 +7,7 @@ import 'reflect-metadata';
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import multipart from '@fastify/multipart';
 import { Logger } from 'nestjs-pino';
 import { AppModule } from './app.module';
 import { DomainNotFoundFilter } from './programs/not-found.filter';
@@ -17,6 +18,8 @@ async function bootstrap() {
     new FastifyAdapter(),
     { bufferLogs: true },
   );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await app.register(multipart as any, { limits: { fileSize: 5 * 1024 * 1024, files: 1 } });
   app.useLogger(app.get(Logger));
   app.useGlobalFilters(new DomainNotFoundFilter());
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }));

--- a/apps/api/src/ports/ILiftRecordRepository.ts
+++ b/apps/api/src/ports/ILiftRecordRepository.ts
@@ -3,7 +3,11 @@ import { LiftRecord } from '@lifting-logbook/core';
 export interface ILiftRecordRepository {
   getLiftRecords(program: string, cycleNum: number): Promise<LiftRecord[]>;
 
-  appendLiftRecords(program: string, records: LiftRecord[]): Promise<void>;
+  /**
+   * Appends records for a program, silently skipping any whose natural key already exists.
+   * Returns the number of rows actually inserted (i.e. excluding duplicates).
+   */
+  appendLiftRecords(program: string, records: LiftRecord[]): Promise<number>;
 
   /**
    * Returns the subset of `candidates` whose natural key

--- a/apps/api/src/ports/ILiftRecordRepository.ts
+++ b/apps/api/src/ports/ILiftRecordRepository.ts
@@ -5,6 +5,13 @@ export interface ILiftRecordRepository {
 
   appendLiftRecords(program: string, records: LiftRecord[]): Promise<void>;
 
+  /**
+   * Returns the subset of `candidates` whose natural key
+   * (cycleNum, workoutNum, lift, setNum) already exists for the given program.
+   * Used by the CSV import endpoint to identify which rows will be skipped as duplicates.
+   */
+  findExistingRecords(program: string, candidates: LiftRecord[]): Promise<LiftRecord[]>;
+
   updateLiftRecord(
     program: string,
     id: string,

--- a/apps/api/src/ports/ports.compile-test.ts
+++ b/apps/api/src/ports/ports.compile-test.ts
@@ -58,8 +58,8 @@ const _programSpecRepo: ILiftingProgramSpecRepository = {
 const _liftRecordRepo: ILiftRecordRepository = {
   getLiftRecords: (): Promise<LiftRecord[]> =>
     Promise.resolve([]),
-  appendLiftRecords: (): Promise<void> =>
-    Promise.resolve(),
+  appendLiftRecords: (): Promise<number> =>
+    Promise.resolve(0),
   findExistingRecords: (): Promise<LiftRecord[]> =>
     Promise.resolve([]),
   updateLiftRecord: (): Promise<LiftRecord | null> =>

--- a/apps/api/src/ports/ports.compile-test.ts
+++ b/apps/api/src/ports/ports.compile-test.ts
@@ -60,6 +60,8 @@ const _liftRecordRepo: ILiftRecordRepository = {
     Promise.resolve([]),
   appendLiftRecords: (): Promise<void> =>
     Promise.resolve(),
+  findExistingRecords: (): Promise<LiftRecord[]> =>
+    Promise.resolve([]),
   updateLiftRecord: (): Promise<LiftRecord | null> =>
     Promise.resolve(null),
 };

--- a/apps/api/src/programs/lift-records.controller.ts
+++ b/apps/api/src/programs/lift-records.controller.ts
@@ -9,6 +9,7 @@ import {
   NotFoundException,
   Param,
   Patch,
+  PayloadTooLargeException,
   Post,
   Req,
 } from '@nestjs/common';
@@ -21,6 +22,7 @@ import {
 } from '@lifting-logbook/types';
 import {
   DEFAULT_SLOT_MAP,
+  liftRecordNaturalKey,
   parseCsvText,
   parseLiftRecords,
   validateLiftImport,
@@ -72,6 +74,23 @@ export class LiftRecordsController {
     return toLiftRecordResponse(record);
   }
 
+  /**
+   * Imports historical lift records from a CSV file.
+   *
+   * Validation is all-or-nothing: if any row fails, the entire upload is rejected
+   * with 400 and no records are written.
+   *
+   * Lift abbreviations (e.g. "Bench P.") are resolved to canonical lift IDs
+   * (e.g. "bench-press") via the DEFAULT_SLOT_MAP. Programs do not restrict which
+   * lifts may be imported — all lifts present in the slot map are accepted for any
+   * program. (Preloaded template programs become custom programs when edited; custom
+   * programs have no lift restrictions.)
+   *
+   * Rows whose natural key (cycleNum, workoutNum, lift, setNum) already exists for
+   * the program are silently skipped and reported in the `skipped` response field.
+   * The `written` count reflects actual rows inserted by the database (via
+   * `createMany({ skipDuplicates: true })`), not a client-side estimate.
+   */
   @Post('lift-records/import')
   @HttpCode(HttpStatus.CREATED)
   async importLiftRecords(
@@ -79,13 +98,42 @@ export class LiftRecordsController {
     @Req() req: FastifyRequest,
     @CurrentUser() user: AuthUser,
   ): Promise<ImportLiftRecordsResponse> {
-    // req.file() is provided by @fastify/multipart registered in main.ts
-    const file = await (req as FastifyRequest & { file(): Promise<{ toBuffer(): Promise<Buffer> } | null> }).file();
+    // Maximum rows accepted per import. Guards against unbounded OR queries in
+    // findExistingRecords and excessive memory usage during parsing.
+    const MAX_IMPORT_ROWS = 5_000;
+
+    // req.file() is provided by @fastify/multipart registered in main.ts.
+    const file = await (req as FastifyRequest & {
+      file(): Promise<{ toBuffer(): Promise<Buffer>; file: { truncated: boolean } } | null>;
+    }).file();
     if (!file) throw new BadRequestException('No file uploaded');
 
-    const csvText = (await file.toBuffer()).toString('utf-8');
+    let csvBuffer: Buffer;
+    try {
+      csvBuffer = await file.toBuffer();
+    } catch (err) {
+      // @fastify/multipart throws with code FST_REQ_FILE_TOO_LARGE when the
+      // file exceeds the configured fileSize limit.
+      if ((err as { code?: string }).code === 'FST_REQ_FILE_TOO_LARGE') {
+        throw new PayloadTooLargeException('File exceeds the 5 MB upload limit');
+      }
+      throw err;
+    }
+    // Also handle the case where @fastify/multipart truncates instead of throwing.
+    if (file.file.truncated) {
+      throw new PayloadTooLargeException('File exceeds the 5 MB upload limit');
+    }
+
+    const csvText = csvBuffer.toString('utf-8');
     const table = parseCsvText(csvText);
     const parsed = parseLiftRecords(table);
+
+    if (parsed.length > MAX_IMPORT_ROWS) {
+      throw new BadRequestException(
+        `Import exceeds the ${MAX_IMPORT_ROWS.toLocaleString()}-row limit. ` +
+          `Split the file into smaller batches.`,
+      );
+    }
 
     const { valid, errors } = validateLiftImport(parsed, DEFAULT_SLOT_MAP);
     if (errors.length > 0) {
@@ -97,22 +145,20 @@ export class LiftRecordsController {
 
     const { liftRecord } = await this.factory.forUser(user);
     const duplicates = await liftRecord.findExistingRecords(program, records);
-    await liftRecord.appendLiftRecords(program, records);
 
-    const dupKeys = new Set(
-      duplicates.map((r) => `${r.cycleNum}:${r.workoutNum}:${r.lift}:${r.setNum}`),
-    );
-    const skipped: SkippedRecord[] = parsed
+    // `written` comes directly from the database's createMany count so it is
+    // accurate even if a concurrent import caused additional rows to be skipped.
+    const written = await liftRecord.appendLiftRecords(program, records);
+
+    const dupKeys = new Set(duplicates.map(liftRecordNaturalKey));
+    // Build skipped from `records` (canonical lift IDs), not `parsed` (CSV abbreviations),
+    // so the naturalKey strings match what findExistingRecords returned.
+    const skipped: SkippedRecord[] = records
       .map((r, i) => ({ r, row: i + 1 }))
-      .filter(({ r }) =>
-        dupKeys.has(`${r.cycleNum}:${r.workoutNum}:${r.lift}:${r.setNum}`),
-      )
-      .map(({ r, row }) => ({
-        row,
-        naturalKey: `${r.cycleNum}:${r.workoutNum}:${r.lift}:${r.setNum}`,
-      }));
+      .filter(({ r }) => dupKeys.has(liftRecordNaturalKey(r)))
+      .map(({ r, row }) => ({ row, naturalKey: liftRecordNaturalKey(r) }));
 
-    return { written: records.length - duplicates.length, skipped };
+    return { written, skipped };
   }
 
   @Patch('lift-records/:id')

--- a/apps/api/src/programs/lift-records.controller.ts
+++ b/apps/api/src/programs/lift-records.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Get,
@@ -9,12 +10,22 @@ import {
   Param,
   Patch,
   Post,
+  Req,
 } from '@nestjs/common';
 import {
   CreateLiftRecordRequest,
+  ImportLiftRecordsResponse,
   LiftRecordResponse,
+  SkippedRecord,
   UpdateLiftRecordRequest,
 } from '@lifting-logbook/types';
+import {
+  DEFAULT_SLOT_MAP,
+  parseCsvText,
+  parseLiftRecords,
+  validateLiftImport,
+} from '@lifting-logbook/core';
+import { FastifyRequest } from 'fastify';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../ports/auth';
 import { IRepositoryFactory } from '../ports/factory';
@@ -59,6 +70,49 @@ export class LiftRecordsController {
     };
     await liftRecord.appendLiftRecords(program, [record]);
     return toLiftRecordResponse(record);
+  }
+
+  @Post('lift-records/import')
+  @HttpCode(HttpStatus.CREATED)
+  async importLiftRecords(
+    @Param('program') program: string,
+    @Req() req: FastifyRequest,
+    @CurrentUser() user: AuthUser,
+  ): Promise<ImportLiftRecordsResponse> {
+    // req.file() is provided by @fastify/multipart registered in main.ts
+    const file = await (req as FastifyRequest & { file(): Promise<{ toBuffer(): Promise<Buffer> } | null> }).file();
+    if (!file) throw new BadRequestException('No file uploaded');
+
+    const csvText = (await file.toBuffer()).toString('utf-8');
+    const table = parseCsvText(csvText);
+    const parsed = parseLiftRecords(table);
+
+    const { valid, errors } = validateLiftImport(parsed, DEFAULT_SLOT_MAP);
+    if (errors.length > 0) {
+      throw new BadRequestException({ message: 'Validation failed', errors });
+    }
+
+    // Stamp each record with the route program before persisting.
+    const records = valid.map((r) => ({ ...r, program }));
+
+    const { liftRecord } = await this.factory.forUser(user);
+    const duplicates = await liftRecord.findExistingRecords(program, records);
+    await liftRecord.appendLiftRecords(program, records);
+
+    const dupKeys = new Set(
+      duplicates.map((r) => `${r.cycleNum}:${r.workoutNum}:${r.lift}:${r.setNum}`),
+    );
+    const skipped: SkippedRecord[] = parsed
+      .map((r, i) => ({ r, row: i + 1 }))
+      .filter(({ r }) =>
+        dupKeys.has(`${r.cycleNum}:${r.workoutNum}:${r.lift}:${r.setNum}`),
+      )
+      .map(({ r, row }) => ({
+        row,
+        naturalKey: `${r.cycleNum}:${r.workoutNum}:${r.lift}:${r.setNum}`,
+      }));
+
+    return { written: records.length - duplicates.length, skipped };
   }
 
   @Patch('lift-records/:id')

--- a/apps/api/src/programs/programs.db.e2e.spec.ts
+++ b/apps/api/src/programs/programs.db.e2e.spec.ts
@@ -5,12 +5,15 @@
 //   npx prisma migrate deploy --schema=apps/api/prisma/schema.prisma && \
 //   npm test -w @lifting-logbook/api -- --testPathPattern=db.e2e
 import 'reflect-metadata';
+import * as fs from 'fs';
+import * as path from 'path';
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import {
   FastifyAdapter,
   NestFastifyApplication,
 } from '@nestjs/platform-fastify';
+import multipart from '@fastify/multipart';
 import { PrismaClient } from '@prisma/client';
 import { AppModule } from '../app.module';
 import {
@@ -78,6 +81,24 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
   const deleteReq = (url: string) =>
     app.getHttpAdapter().getInstance().inject({ method: 'DELETE', url, headers: AUTH });
 
+  const postCsv = (url: string, csvContent: string) => {
+    const boundary = '----LiftRecordImportBoundary';
+    const body = [
+      `--${boundary}`,
+      'Content-Disposition: form-data; name="file"; filename="records.csv"',
+      'Content-Type: text/csv',
+      '',
+      csvContent,
+      `--${boundary}--`,
+    ].join('\r\n');
+    return app.getHttpAdapter().getInstance().inject({
+      method: 'POST',
+      url,
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}`, ...AUTH },
+      payload: body,
+    });
+  };
+
   beforeAll(async () => {
     prisma = new PrismaClient();
 
@@ -130,6 +151,8 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
       new FastifyAdapter(),
       { logger: false },
     );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await app.register(multipart as any, { limits: { fileSize: 5 * 1024 * 1024, files: 1 } });
     app.useGlobalFilters(new DomainNotFoundFilter());
     app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
     await app.init();
@@ -686,6 +709,88 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
         where: { userId: USER_BOB, lift: 'Deadlift' },
       });
       expect(bobRow).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CSV import
+  // ---------------------------------------------------------------------------
+
+  describe('POST /programs/:program/lift-records/import', () => {
+    const IMPORT_URL = `/programs/${SEED_PROGRAM}/lift-records/import`;
+
+    // Resolve fixture path relative to the monorepo root (packages/core/tests/fixtures)
+    const FIXTURE_PATH = path.resolve(
+      __dirname,
+      '../../../../packages/core/tests/fixtures/lift_records.csv',
+    );
+
+    beforeEach(async () => {
+      // Start each import test with a clean slate for this user's lift records
+      await prisma.liftRecord.deleteMany({ where: { userId: TEST_USER, program: SEED_PROGRAM } });
+    });
+
+    it('happy path — imports the full fixture CSV and returns a written count', async () => {
+      const csvContent = fs.readFileSync(FIXTURE_PATH, 'utf8');
+
+      const res = await postCsv(IMPORT_URL, csvContent);
+      expect(res.statusCode).toBe(201);
+
+      const body = res.json() as { written: number; skipped: { row: number; naturalKey: string }[] };
+      expect(body.written).toBeGreaterThan(0);
+      expect(Array.isArray(body.skipped)).toBe(true);
+
+      // Verify rows actually landed in the DB
+      const dbCount = await prisma.liftRecord.count({ where: { userId: TEST_USER, program: SEED_PROGRAM } });
+      expect(dbCount).toBe(body.written);
+    });
+
+    it('re-import returns written=0 and skipped=all rows from first import', async () => {
+      const csvContent = fs.readFileSync(FIXTURE_PATH, 'utf8');
+
+      // First import
+      const first = await postCsv(IMPORT_URL, csvContent);
+      expect(first.statusCode).toBe(201);
+      const firstBody = first.json() as { written: number; skipped: { row: number; naturalKey: string }[] };
+
+      // Second import of the same file
+      const second = await postCsv(IMPORT_URL, csvContent);
+      expect(second.statusCode).toBe(201);
+      const secondBody = second.json() as { written: number; skipped: { row: number; naturalKey: string }[] };
+
+      expect(secondBody.written).toBe(0);
+      expect(secondBody.skipped.length).toBe(firstBody.written);
+    });
+
+    it('rejects a file with validation errors and writes nothing', async () => {
+      // Build a minimal CSV with two bad rows:
+      //   row 1: weight is not a number
+      //   row 2: unknown lift abbreviation
+      const badCsv = [
+        'Program,Cycle #,Workout #,Date,Lift,Set #,Weight,Reps,Notes',
+        'RPT,38,1,12/29/2025,Squat,1,not-a-number,8,',
+        'RPT,38,1,12/29/2025,UnknownLift,2,180,8,',
+      ].join('\n');
+
+      const before = await prisma.liftRecord.count({
+        where: { userId: TEST_USER, program: SEED_PROGRAM },
+      });
+
+      const res = await postCsv(IMPORT_URL, badCsv);
+      expect(res.statusCode).toBe(400);
+
+      const body = res.json() as { message: string; errors: { row: number; field?: string; message: string }[] };
+      expect(body.errors.length).toBeGreaterThanOrEqual(2);
+      // Errors should cover distinct field types
+      const fields = body.errors.map((e) => e.field).filter(Boolean);
+      expect(fields).toContain('weight');
+      expect(fields).toContain('lift');
+
+      // Nothing written
+      const after = await prisma.liftRecord.count({
+        where: { userId: TEST_USER, program: SEED_PROGRAM },
+      });
+      expect(after).toBe(before);
     });
   });
 });

--- a/apps/web/app/cycle/[cycleNum]/program/LiftRecordsImportForm.tsx
+++ b/apps/web/app/cycle/[cycleNum]/program/LiftRecordsImportForm.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import type { ImportError, SkippedRecord } from '@lifting-logbook/types';
+import { importLiftRecords } from '@/lib/client-api';
+
+interface Props {
+  program: string;
+}
+
+type Status = 'idle' | 'loading' | 'success' | 'error';
+
+interface SuccessState {
+  written: number;
+  skipped: SkippedRecord[];
+}
+
+export default function LiftRecordsImportForm({ program }: Props) {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [status, setStatus] = useState<Status>('idle');
+  const [successData, setSuccessData] = useState<SuccessState | null>(null);
+  const [errors, setErrors] = useState<ImportError[]>([]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const file = fileRef.current?.files?.[0];
+    if (!file) return;
+
+    setStatus('loading');
+    setErrors([]);
+    setSuccessData(null);
+
+    const result = await importLiftRecords(program, file);
+    if (result.ok) {
+      setStatus('success');
+      setSuccessData({ written: result.data.written, skipped: result.data.skipped });
+    } else {
+      setStatus('error');
+      setErrors(result.errors);
+    }
+  }
+
+  return (
+    <section style={{ marginTop: '2rem' }}>
+      <h3>Import Historical Lift Records</h3>
+      <p style={{ color: '#666', fontSize: '0.9rem' }}>
+        Upload a CSV file exported from Google Sheets. All rows are validated before
+        any data is written — if any row fails, the entire upload is rejected.
+      </p>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".csv"
+          disabled={status === 'loading'}
+          required
+        />
+        <button type="submit" disabled={status === 'loading'}>
+          {status === 'loading' ? 'Uploading…' : 'Upload'}
+        </button>
+      </form>
+
+      {status === 'success' && successData && (
+        <div style={{ marginTop: '1rem', color: 'green' }}>
+          <strong>
+            Imported {successData.written} record{successData.written !== 1 ? 's' : ''}.
+            {successData.skipped.length > 0 &&
+              ` Skipped ${successData.skipped.length} duplicate${successData.skipped.length !== 1 ? 's' : ''}.`}
+          </strong>
+          {successData.skipped.length > 0 && (
+            <details style={{ marginTop: '0.5rem' }}>
+              <summary>Skipped rows</summary>
+              <ul style={{ fontFamily: 'monospace', fontSize: '0.85rem' }}>
+                {successData.skipped.map((s) => (
+                  <li key={`${s.row}-${s.naturalKey}`}>
+                    Row {s.row}: {s.naturalKey}
+                  </li>
+                ))}
+              </ul>
+            </details>
+          )}
+        </div>
+      )}
+
+      {status === 'error' && errors.length > 0 && (
+        <div style={{ marginTop: '1rem', color: 'red' }}>
+          <strong>Upload rejected — fix the following errors and try again:</strong>
+          <ul style={{ fontFamily: 'monospace', fontSize: '0.85rem', marginTop: '0.5rem' }}>
+            {errors.map((err, i) => (
+              <li key={i}>
+                Row {err.row}
+                {err.field ? ` (${err.field})` : ''}: {err.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/app/cycle/[cycleNum]/program/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/program/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from 'next/navigation';
 import { fetchCycleDashboard, fetchProgramSpec } from '@/lib/api';
 import { deriveProgramSummary } from '@/lib/programPlan';
 import styles from './program.module.css';
+import LiftRecordsImportForm from './LiftRecordsImportForm';
 
 export default async function CycleProgramPage({
   params,
@@ -71,6 +72,8 @@ export default async function CycleProgramPage({
           </li>
         ))}
       </ul>
+
+      <LiftRecordsImportForm program={program} />
     </section>
   );
 }

--- a/apps/web/lib/client-api.ts
+++ b/apps/web/lib/client-api.ts
@@ -4,6 +4,8 @@
 
 import type {
   CreateLiftOverrideRequest,
+  ImportError,
+  ImportLiftRecordsResponse,
   LiftMetadataResponse,
   LiftOverrideResponse,
   CreateLiftRecordRequest,
@@ -136,4 +138,34 @@ export function deleteLiftOverride(
     `/programs/${encodeURIComponent(program)}/cycles/${cycleNum}/workouts/${workoutNum}/lift-overrides/${encodeURIComponent(lift)}`,
     { method: 'DELETE', cache: 'no-store' },
   );
+}
+
+/**
+ * Uploads a CSV file to the lift records import endpoint.
+ * Returns a discriminated union so callers can handle validation errors gracefully
+ * without catching exceptions.
+ */
+export async function importLiftRecords(
+  program: string,
+  file: File,
+): Promise<
+  { ok: true; data: ImportLiftRecordsResponse } | { ok: false; errors: ImportError[] }
+> {
+  const devAuthHeaders: Record<string, string> = devToken
+    ? { Authorization: `Bearer ${devToken}` }
+    : {};
+  const form = new FormData();
+  form.append('file', file);
+  const res = await fetch(
+    `${API_URL}/programs/${encodeURIComponent(program)}/lift-records/import`,
+    { method: 'POST', body: form, headers: devAuthHeaders },
+  );
+  if (res.status === 201) {
+    return { ok: true, data: (await res.json()) as ImportLiftRecordsResponse };
+  }
+  const body = (await res.json()) as { errors?: ImportError[] };
+  return {
+    ok: false,
+    errors: body.errors ?? [{ row: 0, message: `Unexpected error (HTTP ${res.status})` }],
+  };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
         "@clerk/backend": "^3.4.4",
+        "@fastify/multipart": "^10.0.0",
         "@lifting-logbook/core": "*",
         "@lifting-logbook/types": "*",
         "@nestjs/common": "^10.0.0",
@@ -4112,6 +4113,11 @@
         "fast-uri": "^2.0.0"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="
+    },
     "node_modules/@fastify/cors": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-9.0.1.tgz",
@@ -4120,6 +4126,21 @@
         "fastify-plugin": "^4.0.0",
         "mnemonist": "0.39.6"
       }
+    },
+    "node_modules/@fastify/deepmerge": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
+      "integrity": "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
     },
     "node_modules/@fastify/error": {
       "version": "3.4.1",
@@ -4166,6 +4187,73 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
+    },
+    "node_modules/@fastify/multipart": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/multipart/-/multipart-10.0.0.tgz",
+      "integrity": "sha512-pUx3Z1QStY7E7kwvDTIvB6P+rF5lzP+iqPgZyJyG3yBJVPvQaZxzDHYbQD89rbY0ciXrMOyGi8ezHDVexLvJDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "dependencies": {
+        "@fastify/busboy": "^3.0.0",
+        "@fastify/deepmerge": "^3.0.0",
+        "@fastify/error": "^4.0.0",
+        "fastify-plugin": "^5.0.0",
+        "secure-json-parse": "^4.0.0"
+      }
+    },
+    "node_modules/@fastify/multipart/node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
+    "node_modules/@fastify/multipart/node_modules/fastify-plugin": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
+      "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
+    "node_modules/@fastify/multipart/node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.3",
@@ -10583,8 +10671,7 @@
     "node_modules/csv-parse": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
-      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
-      "dev": true
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ=="
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
@@ -20113,10 +20200,10 @@
       "name": "@lifting-logbook/core",
       "version": "0.0.0",
       "dependencies": {
-        "@lifting-logbook/types": "*"
+        "@lifting-logbook/types": "*",
+        "csv-parse": "^6.1.0"
       },
       "devDependencies": {
-        "csv-parse": "^6.1.0",
         "tsc-alias": "^1.8.16"
       }
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,10 +10,10 @@
     "test": "jest"
   },
   "dependencies": {
-    "@lifting-logbook/types": "*"
+    "@lifting-logbook/types": "*",
+    "csv-parse": "^6.1.0"
   },
   "devDependencies": {
-    "csv-parse": "^6.1.0",
     "tsc-alias": "^1.8.16"
   }
 }

--- a/packages/core/src/utils/import/index.ts
+++ b/packages/core/src/utils/import/index.ts
@@ -1,1 +1,2 @@
+export * from './liftRecordNaturalKey';
 export * from './validateLiftImport';

--- a/packages/core/src/utils/import/index.ts
+++ b/packages/core/src/utils/import/index.ts
@@ -1,0 +1,1 @@
+export * from './validateLiftImport';

--- a/packages/core/src/utils/import/liftRecordNaturalKey.ts
+++ b/packages/core/src/utils/import/liftRecordNaturalKey.ts
@@ -1,0 +1,21 @@
+/**
+ * Returns the stringified natural key for a lift record:
+ * `"<cycleNum>:<workoutNum>:<lift>:<setNum>"`
+ *
+ * The natural key uniquely identifies a set within a (userId, program) scope.
+ * It mirrors the `@@unique` constraint in the Prisma schema:
+ * `(userId, program, cycleNum, workoutNum, lift, setNum)`.
+ * `userId` and `program` are omitted here because callers always operate within
+ * a single user/program context.
+ *
+ * Example: `liftRecordNaturalKey({ cycleNum: 3, workoutNum: 2, lift: 'bench-press', setNum: 1 })`
+ * returns `"3:2:bench-press:1"`.
+ */
+export function liftRecordNaturalKey(r: {
+  cycleNum: number;
+  workoutNum: number;
+  lift: string;
+  setNum: number;
+}): string {
+  return `${r.cycleNum}:${r.workoutNum}:${r.lift}:${r.setNum}`;
+}

--- a/packages/core/src/utils/import/validateLiftImport.ts
+++ b/packages/core/src/utils/import/validateLiftImport.ts
@@ -1,0 +1,61 @@
+import { ImportError } from '@lifting-logbook/types';
+import { LiftRecord } from '../../models';
+
+export interface LiftImportValidationResult {
+  /** Records that passed all validation checks, with lift abbreviations resolved to canonical IDs. */
+  valid: LiftRecord[];
+  /** All errors encountered across all rows. */
+  errors: ImportError[];
+}
+
+/**
+ * Validates an array of parsed LiftRecord rows against the provided slot map and
+ * collects all errors before returning (all-or-nothing semantics).
+ *
+ * Row numbers are 1-based and exclude the CSV header row.
+ *
+ * When a row is valid, its `lift` field is resolved from the CSV abbreviation
+ * (e.g. "Bench P.") to the canonical lift ID (e.g. "bench-press") via slotMap.
+ */
+export function validateLiftImport(
+  records: LiftRecord[],
+  slotMap: Readonly<Record<string, string>>,
+): LiftImportValidationResult {
+  const valid: LiftRecord[] = [];
+  const errors: ImportError[] = [];
+
+  records.forEach((r, i) => {
+    const row = i + 1;
+    const rowErrors: ImportError[] = [];
+
+    if (isNaN(r.cycleNum))
+      rowErrors.push({ row, field: 'cycleNum', message: 'cycleNum is not a number' });
+    if (isNaN(r.workoutNum))
+      rowErrors.push({ row, field: 'workoutNum', message: 'workoutNum is not a number' });
+    if (isNaN(r.setNum))
+      rowErrors.push({ row, field: 'setNum', message: 'setNum is not a number' });
+    if (isNaN(r.weight))
+      rowErrors.push({ row, field: 'weight', message: 'weight is not a number' });
+    if (isNaN(r.reps))
+      rowErrors.push({ row, field: 'reps', message: 'reps is not a number' });
+    if (!r.date || isNaN(r.date.getTime()))
+      rowErrors.push({ row, field: 'date', message: 'date is invalid' });
+
+    const liftStr = r.lift as unknown as string;
+    if (!liftStr || !(liftStr in slotMap)) {
+      rowErrors.push({
+        row,
+        field: 'lift',
+        message: `lift abbreviation '${liftStr}' is not in the slot map`,
+      });
+    }
+
+    if (rowErrors.length > 0) {
+      errors.push(...rowErrors);
+    } else {
+      valid.push({ ...r, lift: slotMap[liftStr]! as LiftRecord['lift'] });
+    }
+  });
+
+  return { valid, errors };
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './import';
 export * from './mapper';
 export * from './parser';
 export * from './jsUtil';

--- a/packages/core/src/utils/parser/index.ts
+++ b/packages/core/src/utils/parser/index.ts
@@ -1,3 +1,4 @@
+export * from './parseCsvText';
 export * from './parseCycleDashboard';
 export * from './parseLiftingProgramSpec';
 export * from './parseLiftRecords';

--- a/packages/core/src/utils/parser/parseCsvText.ts
+++ b/packages/core/src/utils/parser/parseCsvText.ts
@@ -1,0 +1,10 @@
+import { parse } from 'csv-parse/sync';
+import { SpreadsheetCell } from '../../models';
+
+/**
+ * Parses a raw CSV string into a 2D array of SpreadsheetCells.
+ * The first row is treated as the header row (same convention as parseLiftRecords).
+ */
+export function parseCsvText(text: string): SpreadsheetCell[][] {
+  return parse(text, { skip_empty_lines: true }) as SpreadsheetCell[][];
+}

--- a/packages/core/tests/core/utils/import/validateLiftImport.test.ts
+++ b/packages/core/tests/core/utils/import/validateLiftImport.test.ts
@@ -1,0 +1,98 @@
+import { validateLiftImport } from "@src/core";
+import { LiftRecord } from "@src/core/models";
+
+/** Minimal slot map covering the fixture abbreviations we test against. */
+const TEST_SLOT_MAP: Readonly<Record<string, string>> = {
+  "Squat": "back-squat",
+  "Bench P.": "bench-press",
+  "Deadlift": "deadlift",
+};
+
+function makeRecord(overrides: Partial<LiftRecord> = {}): LiftRecord {
+  return {
+    program: "RPT",
+    cycleNum: 1,
+    workoutNum: 1,
+    date: new Date("2025-01-01"),
+    lift: "Squat" as LiftRecord["lift"],
+    setNum: 1,
+    weight: 200,
+    reps: 5,
+    notes: "",
+    ...overrides,
+  };
+}
+
+describe("validateLiftImport", () => {
+  it("passes all valid rows and resolves lift abbreviations", () => {
+    const records = [
+      makeRecord({ lift: "Squat" as LiftRecord["lift"] }),
+      makeRecord({ lift: "Bench P." as LiftRecord["lift"], setNum: 2 }),
+    ];
+    const { valid, errors } = validateLiftImport(records, TEST_SLOT_MAP);
+    expect(errors).toHaveLength(0);
+    expect(valid).toHaveLength(2);
+    expect(valid[0]!.lift).toBe("back-squat");
+    expect(valid[1]!.lift).toBe("bench-press");
+  });
+
+  it("flags an unknown lift abbreviation", () => {
+    const records = [makeRecord({ lift: "Cable Curls" as LiftRecord["lift"] })];
+    const { valid, errors } = validateLiftImport(records, TEST_SLOT_MAP);
+    expect(valid).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ row: 1, field: "lift" });
+    expect(errors[0]!.message).toMatch(/Cable Curls/);
+  });
+
+  it("flags a NaN weight", () => {
+    const records = [makeRecord({ weight: NaN })];
+    const { valid, errors } = validateLiftImport(records, TEST_SLOT_MAP);
+    expect(valid).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ row: 1, field: "weight" });
+  });
+
+  it("flags a NaN reps", () => {
+    const records = [makeRecord({ reps: NaN })];
+    const { valid, errors } = validateLiftImport(records, TEST_SLOT_MAP);
+    expect(errors.some((e) => e.field === "reps")).toBe(true);
+  });
+
+  it("flags an invalid date", () => {
+    const records = [makeRecord({ date: new Date("not-a-date") })];
+    const { valid, errors } = validateLiftImport(records, TEST_SLOT_MAP);
+    expect(valid).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ row: 1, field: "date" });
+  });
+
+  it("collects all errors across multiple bad rows", () => {
+    const records = [
+      makeRecord({ weight: NaN }),               // row 1: bad weight
+      makeRecord({ lift: "Unknown" as LiftRecord["lift"], setNum: 2 }), // row 2: bad lift
+    ];
+    const { valid, errors } = validateLiftImport(records, TEST_SLOT_MAP);
+    expect(valid).toHaveLength(0);
+    expect(errors).toHaveLength(2);
+    expect(errors.map((e) => e.row)).toEqual([1, 2]);
+  });
+
+  it("returns valid rows alongside errors (partial pass)", () => {
+    const records = [
+      makeRecord({ lift: "Squat" as LiftRecord["lift"] }),             // row 1: valid
+      makeRecord({ weight: NaN, setNum: 2 }),                          // row 2: invalid
+    ];
+    const { valid, errors } = validateLiftImport(records, TEST_SLOT_MAP);
+    expect(valid).toHaveLength(1);
+    expect(valid[0]!.lift).toBe("back-squat");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.row).toBe(2);
+  });
+
+  it("returns empty results for an empty input", () => {
+    const { valid, errors } = validateLiftImport([], TEST_SLOT_MAP);
+    expect(valid).toHaveLength(0);
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -292,14 +292,35 @@ export interface ImportError {
 
 /** A row that was silently skipped because its natural key already exists. */
 export interface SkippedRecord {
-  /** 1-based data row number. */
+  /**
+   * 1-based data row number, counting only data rows (the CSV header is excluded).
+   * Row 1 is the first data row immediately after the header.
+   */
   row: number;
-  /** Stringified natural key: "cycleNum:workoutNum:lift:setNum". */
+  /**
+   * Stringified natural key identifying the skipped set, in the format:
+   * `"<cycleNum>:<workoutNum>:<lift>:<setNum>"`
+   *
+   * All four components use the canonical (post-import, post-slot-map) values.
+   * Example: `"3:2:bench-press:1"` means cycle 3, workout 2, bench-press, set 1.
+   */
   naturalKey: string;
 }
 
 /** Response body for a successful POST /programs/:program/lift-records/import. */
 export interface ImportLiftRecordsResponse {
+  /** Number of rows actually inserted (excludes duplicates that were skipped). */
   written: number;
+  /**
+   * Rows that were not inserted because their natural key already exists in the database.
+   * Empty array when there are no duplicates.
+   *
+   * Note: lift abbreviations (e.g. "Bench P.") are resolved to canonical lift IDs
+   * (e.g. "bench-press") before the natural key is computed, so the values here
+   * reflect the stored canonical IDs, not the original CSV values.
+   *
+   * Programs do not restrict which lifts may be imported. Preloaded template programs
+   * become custom programs when edited; custom programs have no lift restrictions.
+   */
   skipped: SkippedRecord[];
 }

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -276,3 +276,30 @@ export interface LiftingProgramSpecResponse {
   wtDecrementPct: number;
   activation: string;
 }
+
+// ---------------------------------------------------------------------------
+// Lift Record CSV Import
+// ---------------------------------------------------------------------------
+
+/** A single validation error from a CSV import attempt. */
+export interface ImportError {
+  /** 1-based data row number (excludes the header row). */
+  row: number;
+  /** Which field failed, if determinable. */
+  field?: string;
+  message: string;
+}
+
+/** A row that was silently skipped because its natural key already exists. */
+export interface SkippedRecord {
+  /** 1-based data row number. */
+  row: number;
+  /** Stringified natural key: "cycleNum:workoutNum:lift:setNum". */
+  naturalKey: string;
+}
+
+/** Response body for a successful POST /programs/:program/lift-records/import. */
+export interface ImportLiftRecordsResponse {
+  written: number;
+  skipped: SkippedRecord[];
+}


### PR DESCRIPTION
## Summary

- Adds `POST /programs/:program/lift-records/import` that accepts a `multipart/form-data` CSV upload, validates every row, and bulk-inserts via the existing `appendLiftRecords()` with `skipDuplicates`
- All-or-nothing validation: any bad row returns `400` with a complete list of errors (row number, field, message); nothing is written
- Duplicate detection via a new `findExistingRecords()` port method — skipped rows are reported in the `201` response body by row number and natural key
- `LiftRecordsImportForm` client component added to the program detail page — shows success counts + skipped rows list, or a formatted error table

## Changes

| Area | What changed |
|---|---|
| `packages/types` | `ImportError`, `SkippedRecord`, `ImportLiftRecordsResponse` |
| `packages/core` | `parseCsvText` (csv-parse promoted to runtime dep), `validateLiftImport` |
| `apps/api` | `@fastify/multipart` plugin, `findExistingRecords` on port + both adapters, `importLiftRecords` controller action |
| `apps/api` (tests) | DB e2e: happy-path, re-import-as-duplicates, all-or-nothing rejection |
| `apps/web` | `importLiftRecords` client-api fn, `LiftRecordsImportForm` component on program page |

## Acceptance criteria checklist

- [x] `POST /programs/:program/lift-records/import` accepts multipart/form-data and returns `201` with `written` + `skipped` on success
- [x] Any validation failure returns `400` with a structured error list and writes zero records
- [x] Lift abbreviations resolved via `DEFAULT_SLOT_MAP`; unknown abbreviations → validation error
- [x] Successful imports use `appendLiftRecords()` with `skipDuplicates`
- [x] `apps/web` exposes a file-upload component on the program detail page
- [x] Integration test: happy-path import of `lift_records.csv` fixture (~1398 rows)
- [x] Integration test: rejected file with two distinct error types, DB unchanged

## Test plan

- `npm test` — all unit + integration tests pass (DB e2e skipped without `DATABASE_URL`)
- DB e2e (with Postgres): `DATABASE_URL=... npm test -w @lifting-logbook/api -- --testPathPattern=db.e2e`
- Manual: start API + web, navigate to program detail page, upload `packages/core/tests/fixtures/lift_records.csv`, verify `201` + record count; re-upload to verify skipped list; upload a malformed CSV and verify error list

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)