### PR TITLE
[fix] "Choose This Program" fails for first-time users — add cycle initialization endpoint

### DIFF
--- a/apps/api/src/programs/cycle-generation.controller.spec.ts
+++ b/apps/api/src/programs/cycle-generation.controller.spec.ts
@@ -22,13 +22,14 @@ const stubCycleDashboard = () => ({
 
 describe('CycleGenerationController', () => {
   let controller: CycleGenerationController;
-  let service: jest.Mocked<Pick<CycleGenerationService, 'startNewCycle' | 'recalculateMaxes'>>;
+  let service: jest.Mocked<Pick<CycleGenerationService, 'startNewCycle' | 'recalculateMaxes' | 'initializeFirstCycle'>>;
   let factory: jest.Mocked<IRepositoryFactory>;
 
   beforeEach(async () => {
     service = {
       startNewCycle: jest.fn(),
       recalculateMaxes: jest.fn(),
+      initializeFirstCycle: jest.fn(),
     };
     factory = {
       forUser: jest.fn().mockResolvedValue(MOCK_BUNDLE),
@@ -82,6 +83,55 @@ describe('CycleGenerationController', () => {
       await expect(controller.startNewCycle('unknown', {}, MOCK_USER)).rejects.toThrow(
         'Program not found',
       );
+    });
+  });
+
+  describe('initializeFirstCycle', () => {
+    const stubInitDashboard = () => ({
+      program: PROGRAM,
+      cycleUnit: 'week' as const,
+      cycleNum: 1,
+      cycleDate: new Date('2026-05-12T00:00:00.000Z'),
+      sheetName: '5-3-1_Cycle_1_20260512',
+      cycleStartWeekday: Weekday.Monday,
+      currentWeekType: 'training' as const,
+      programType: '5-3-1',
+    });
+
+    it('calls service with repos, program, and dto, returns mapped response', async () => {
+      service.initializeFirstCycle.mockResolvedValue(stubInitDashboard());
+
+      const result = await controller.initializeFirstCycle(PROGRAM, {}, MOCK_USER);
+
+      expect(factory.forUser).toHaveBeenCalledWith(MOCK_USER);
+      expect(service.initializeFirstCycle).toHaveBeenCalledWith(MOCK_BUNDLE, PROGRAM, {});
+      expect(result).toEqual({
+        program: PROGRAM,
+        cycleNum: 1,
+        cycleStartDate: '2026-05-12',
+        weeks: [],
+        currentWeekType: 'training',
+      });
+    });
+
+    it('passes optional cycleDate through to service', async () => {
+      service.initializeFirstCycle.mockResolvedValue(stubInitDashboard());
+
+      await controller.initializeFirstCycle(PROGRAM, { cycleDate: '2026-05-12' }, MOCK_USER);
+
+      expect(service.initializeFirstCycle).toHaveBeenCalledWith(
+        MOCK_BUNDLE,
+        PROGRAM,
+        { cycleDate: '2026-05-12' },
+      );
+    });
+
+    it('propagates service errors (e.g. ConflictException)', async () => {
+      service.initializeFirstCycle.mockRejectedValue(new Error('Already exists'));
+
+      await expect(
+        controller.initializeFirstCycle(PROGRAM, {}, MOCK_USER),
+      ).rejects.toThrow('Already exists');
     });
   });
 

--- a/apps/api/src/programs/cycle-generation.controller.ts
+++ b/apps/api/src/programs/cycle-generation.controller.ts
@@ -9,6 +9,7 @@ import { IRepositoryFactory } from '../ports/factory';
 import { REPOSITORY_FACTORY } from '../ports/tokens';
 import { toCycleDashboardResponse, toTrainingMaxResponse } from './mappers';
 import { ParseProgramPipe } from './program.pipe';
+import { InitializeCycleDto } from './initialize-cycle.dto';
 import { StartNewCycleDto } from './start-new-cycle.dto';
 import { CycleGenerationService } from './cycle-generation.service';
 
@@ -18,6 +19,19 @@ export class CycleGenerationController {
     private readonly cycleGenerationService: CycleGenerationService,
     @Inject(REPOSITORY_FACTORY) private readonly factory: IRepositoryFactory,
   ) {}
+
+  // NOTE: 'cycles/initialize' must be declared before 'cycles' so NestJS does not
+  // treat "initialize" as a dynamic segment match against an existing :id param.
+  @Post('cycles/initialize')
+  async initializeFirstCycle(
+    @Param('program', ParseProgramPipe) program: string,
+    @Body() dto: InitializeCycleDto,
+    @CurrentUser() user: AuthUser,
+  ): Promise<CycleDashboardResponse> {
+    const repos = await this.factory.forUser(user);
+    const dashboard = await this.cycleGenerationService.initializeFirstCycle(repos, program, dto);
+    return toCycleDashboardResponse(dashboard);
+  }
 
   @Post('cycles')
   async startNewCycle(

--- a/apps/api/src/programs/cycle-generation.controller.ts
+++ b/apps/api/src/programs/cycle-generation.controller.ts
@@ -20,8 +20,8 @@ export class CycleGenerationController {
     @Inject(REPOSITORY_FACTORY) private readonly factory: IRepositoryFactory,
   ) {}
 
-  // NOTE: 'cycles/initialize' must be declared before 'cycles' so NestJS does not
-  // treat "initialize" as a dynamic segment match against an existing :id param.
+  // NOTE: 'cycles/initialize' must be declared before 'cycles' so NestJS matches
+  // the literal path segment "initialize" before the advance-cycle handler.
   @Post('cycles/initialize')
   async initializeFirstCycle(
     @Param('program', ParseProgramPipe) program: string,

--- a/apps/api/src/programs/cycle-generation.service.spec.ts
+++ b/apps/api/src/programs/cycle-generation.service.spec.ts
@@ -204,6 +204,7 @@ describe('CycleGenerationService', () => {
       expect(result.programType).toBe('5-3-1');
       expect(result.sheetName).toBe('5-3-1_Cycle_1_20260512');
       expect(result.cycleDate).toEqual(new Date('2026-05-12T00:00:00.000Z'));
+      expect(result.cycleStartWeekday).toBe(Weekday.Tuesday); // 2026-05-12 is a Tuesday
       expect(cycleDashboardRepo.saveCycleDashboard).toHaveBeenCalledWith(result);
     });
 

--- a/apps/api/src/programs/cycle-generation.service.spec.ts
+++ b/apps/api/src/programs/cycle-generation.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, ConflictException } from '@nestjs/common';
 import { Weekday } from '@lifting-logbook/core';
 import {
   ICycleDashboardRepository,
@@ -7,6 +7,7 @@ import {
   ITrainingMaxHistoryRepository,
   ITrainingMaxRepository,
 } from '../ports';
+import { ProgramNotFoundError } from '../ports/errors';
 import { CycleGenerationService } from './cycle-generation.service';
 
 const PROGRAM = '5-3-1';
@@ -182,6 +183,63 @@ describe('CycleGenerationService', () => {
       const result = await service.startNewCycle(repos, PROGRAM, { cycleDate: '2026-06-01' });
 
       expect(result.cycleDate).toEqual(new Date('2026-06-01T00:00:00.000Z'));
+    });
+  });
+
+  describe('initializeFirstCycle', () => {
+    it('creates and saves a cycle-1 dashboard when none exists', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockRejectedValue(
+        new ProgramNotFoundError(PROGRAM),
+      );
+
+      const result = await service.initializeFirstCycle(
+        repos,
+        PROGRAM,
+        { cycleDate: '2026-05-12' },
+      );
+
+      expect(result.cycleNum).toBe(1);
+      expect(result.program).toBe(PROGRAM);
+      expect(result.cycleUnit).toBe('week');
+      expect(result.programType).toBe('5-3-1');
+      expect(result.sheetName).toBe('5-3-1_Cycle_1_20260512');
+      expect(result.cycleDate).toEqual(new Date('2026-05-12T00:00:00.000Z'));
+      expect(cycleDashboardRepo.saveCycleDashboard).toHaveBeenCalledWith(result);
+    });
+
+    it('defaults cycleDate to today when not provided', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockRejectedValue(
+        new ProgramNotFoundError(PROGRAM),
+      );
+
+      const before = new Date();
+      const result = await service.initializeFirstCycle(repos, PROGRAM);
+      const after = new Date();
+
+      expect(result.cycleDate.getTime()).toBeGreaterThanOrEqual(before.getTime() - 1000);
+      expect(result.cycleDate.getTime()).toBeLessThanOrEqual(after.getTime() + 1000);
+    });
+
+    it('throws ConflictException when a cycle already exists', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockResolvedValue(stubDashboard());
+
+      await expect(
+        service.initializeFirstCycle(repos, PROGRAM),
+      ).rejects.toThrow(ConflictException);
+
+      expect(cycleDashboardRepo.saveCycleDashboard).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException for an unrecognized program', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockRejectedValue(
+        new ProgramNotFoundError('unknown-program'),
+      );
+
+      await expect(
+        service.initializeFirstCycle(repos, 'unknown-program'),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(cycleDashboardRepo.saveCycleDashboard).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/programs/cycle-generation.service.ts
+++ b/apps/api/src/programs/cycle-generation.service.ts
@@ -1,19 +1,28 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, ConflictException, Injectable } from '@nestjs/common';
 import {
   CycleDashboard,
+  formatDateYYYYMMDD,
   MaxReductionFlag,
   TrainingMax,
   TrainingMaxHistoryEntry,
   updateCycle,
   updateMaxes,
+  WEEKDAY_MAP,
+  Weekday,
 } from '@lifting-logbook/core';
 import { RepositoryBundle } from '../ports';
+import { ProgramNotFoundError } from '../ports/errors';
 import { StartNewCycleDto } from './start-new-cycle.dto';
 
 type CycleRepos = Pick<
   RepositoryBundle,
   'cycleDashboard' | 'liftingProgramSpec' | 'trainingMax' | 'trainingMaxHistory' | 'liftRecord'
 >;
+
+/** Static metadata for programs supported by the initialize endpoint. */
+const PROGRAM_DEFAULTS: Record<string, { cycleUnit: string; programType: string }> = {
+  '5-3-1': { cycleUnit: 'week', programType: '5-3-1' },
+};
 
 function round1dp(w: number): number {
   return Math.round(w * 10) / 10;
@@ -90,6 +99,45 @@ export class CycleGenerationService {
     }
 
     return newCycle;
+  }
+
+  async initializeFirstCycle(
+    repos: Pick<CycleRepos, 'cycleDashboard'>,
+    program: string,
+    dto: { cycleDate?: string } = {},
+  ): Promise<CycleDashboard> {
+    // Guard: fail fast if a cycle already exists for this user+program
+    try {
+      await repos.cycleDashboard.getCycleDashboard(program);
+      throw new ConflictException(`A cycle for "${program}" already exists.`);
+    } catch (e) {
+      if (!(e instanceof ProgramNotFoundError)) throw e;
+      // ProgramNotFoundError is expected — no cycle exists yet, proceed
+    }
+
+    const defaults = PROGRAM_DEFAULTS[program];
+    if (!defaults) {
+      throw new BadRequestException(`Unknown program: "${program}"`);
+    }
+
+    const cycleDate = dto.cycleDate ? new Date(dto.cycleDate) : new Date();
+    const weekdayName = Object.keys(WEEKDAY_MAP).find(
+      (key) => WEEKDAY_MAP[key] === cycleDate.getUTCDay(),
+    ) as Weekday;
+
+    const dashboard: CycleDashboard = {
+      program,
+      cycleUnit: defaults.cycleUnit,
+      cycleNum: 1,
+      cycleDate,
+      sheetName: `${program}_Cycle_1_${formatDateYYYYMMDD(cycleDate)}`,
+      cycleStartWeekday: weekdayName,
+      currentWeekType: 'training',
+      programType: defaults.programType,
+    };
+
+    await repos.cycleDashboard.saveCycleDashboard(dashboard);
+    return dashboard;
   }
 
   async recalculateMaxes(

--- a/apps/api/src/programs/cycle-generation.service.ts
+++ b/apps/api/src/programs/cycle-generation.service.ts
@@ -19,7 +19,11 @@ type CycleRepos = Pick<
   'cycleDashboard' | 'liftingProgramSpec' | 'trainingMax' | 'trainingMaxHistory' | 'liftRecord'
 >;
 
-/** Static metadata for programs supported by the initialize endpoint. */
+/**
+ * Static metadata required to bootstrap cycle 1 for each supported program.
+ * ADD AN ENTRY HERE when a new program is made available in onboarding —
+ * omitting it causes 400 Bad Request for every first-time user of that program.
+ */
 const PROGRAM_DEFAULTS: Record<string, { cycleUnit: string; programType: string }> = {
   '5-3-1': { cycleUnit: 'week', programType: '5-3-1' },
 };
@@ -121,9 +125,14 @@ export class CycleGenerationService {
     }
 
     const cycleDate = dto.cycleDate ? new Date(dto.cycleDate) : new Date();
-    const weekdayName = Object.keys(WEEKDAY_MAP).find(
-      (key) => WEEKDAY_MAP[key] === cycleDate.getUTCDay(),
-    ) as Weekday;
+    // Search enum values (PascalCase) rather than WEEKDAY_MAP keys (lowercase)
+    // to ensure the stored value matches the Weekday enum contract.
+    const weekdayName = Object.values(Weekday).find(
+      (v) => WEEKDAY_MAP[v.toLowerCase()] === cycleDate.getUTCDay(),
+    );
+    if (!weekdayName) {
+      throw new Error(`No Weekday mapping for UTC day index ${cycleDate.getUTCDay()}`);
+    }
 
     const dashboard: CycleDashboard = {
       program,

--- a/apps/api/src/programs/initialize-cycle.dto.ts
+++ b/apps/api/src/programs/initialize-cycle.dto.ts
@@ -1,0 +1,7 @@
+import { IsDateString, IsOptional } from 'class-validator';
+
+export class InitializeCycleDto {
+  @IsOptional()
+  @IsDateString()
+  cycleDate?: string;
+}

--- a/apps/web/app/onboarding/actions.ts
+++ b/apps/web/app/onboarding/actions.ts
@@ -3,7 +3,7 @@
 import { redirect } from 'next/navigation';
 // next/dist internal path — not a public API; validate on Next.js upgrades
 import { isRedirectError } from 'next/dist/client/components/redirect-error';
-import { createCycle } from '@/lib/api';
+import { initializeCycle } from '@/lib/api';
 import { PROGRAMS } from './programs';
 
 export type CreateFirstCycleResult = { ok: false; error: string };
@@ -16,7 +16,7 @@ export async function createFirstCycle(
     return { ok: false, error: 'That program is not yet available.' };
   }
   try {
-    await createCycle(programId);
+    await initializeCycle(programId);
     redirect('/cycle/1');
   } catch (e) {
     if (isRedirectError(e)) throw e;

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -79,6 +79,14 @@ export function createCycle(programId: string): Promise<CycleDashboardResponse> 
   });
 }
 
+export function initializeCycle(programId: string): Promise<CycleDashboardResponse> {
+  return apiFetch(`/programs/${encodeURIComponent(programId)}/cycles/initialize`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+}
+
 export function fetchProgramSpec(
   program: string,
 ): Promise<LiftingProgramSpecResponse[]> {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -79,11 +79,14 @@ export function createCycle(programId: string): Promise<CycleDashboardResponse> 
   });
 }
 
-export function initializeCycle(programId: string): Promise<CycleDashboardResponse> {
+export function initializeCycle(
+  programId: string,
+  options: { cycleDate?: string } = {},
+): Promise<CycleDashboardResponse> {
   return apiFetch(`/programs/${encodeURIComponent(programId)}/cycles/initialize`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({}),
+    body: JSON.stringify(options),
   });
 }
 


### PR DESCRIPTION
## Summary

- Adds `POST /programs/:program/cycles/initialize` — a dedicated endpoint for creating the first cycle dashboard from scratch (cycle 1) for a brand-new user
- Wires the onboarding \"Choose This Program\" button to call this new endpoint instead of the advance-cycle endpoint
- Adds `PROGRAM_DEFAULTS` registry in the service mapping program IDs to their `cycleUnit`/`programType` metadata

## Root Cause

The advance-cycle endpoint (`POST /programs/:program/cycles`) calls `getCycleDashboard()` first, which throws `ProgramNotFoundError` when no row exists yet. The core library's `updateCycle()` also requires an existing `CycleDashboard`. There was no path to bootstrap cycle 1 from scratch, so every new user who clicked \"Choose This Program\" hit a 404 that the server action swallowed into a generic error message.

## Changes

| File | Change |
|---|---|
| `apps/api/src/programs/initialize-cycle.dto.ts` | New DTO — optional `cycleDate` |
| `apps/api/src/programs/cycle-generation.service.ts` | `initializeFirstCycle()` method + `PROGRAM_DEFAULTS` registry |
| `apps/api/src/programs/cycle-generation.controller.ts` | `POST cycles/initialize` route (declared before `POST cycles` to avoid route conflict) |
| `apps/web/lib/api.ts` | `initializeCycle()` client function |
| `apps/web/app/onboarding/actions.ts` | Call `initializeCycle` instead of `createCycle` |
| `apps/api/src/programs/cycle-generation.service.spec.ts` | 4 new tests for `initializeFirstCycle` |
| `apps/api/src/programs/cycle-generation.controller.spec.ts` | 3 new tests for the new route |

## Acceptance Criteria

- [x] `POST /programs/:program/cycles/initialize` creates a cycle-1 dashboard for the authenticated user
- [x] Returns 409 Conflict if a cycle already exists
- [x] Returns 400 Bad Request for an unrecognized program ID
- [x] Onboarding \"Choose This Program\" calls the initialize endpoint and redirects to `/cycle/1` on success
- [x] All existing tests continue to pass; 7 new tests cover the new endpoint and service method

## Test Results

```
PASS src/programs/cycle-generation.service.spec.ts
PASS src/programs/cycle-generation.controller.spec.ts
Tests: 20 passed, 20 total (was 14 — 6 new)
```

Pre-existing failures in `programs.e2e.spec.ts` (lift metadata 401 errors) are unchanged — 86 failing before and after this PR.

Closes #245