### PR TITLE
[feat] Catalog-based tag pickers in LiftEditor (substitutions + muscle groups)

### DIFF
--- a/apps/web/components/CatalogTagPicker.module.css
+++ b/apps/web/components/CatalogTagPicker.module.css
@@ -3,64 +3,19 @@
 }
 
 .chipList {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.375rem;
-  align-items: center;
-  padding: 0.375rem 0.5rem;
-  border: 1px solid var(--color-border, #e5e7eb);
-  border-radius: 6px;
-  background: var(--color-surface, #f8f9fa);
-  min-height: 2.5rem;
-  cursor: text;
-}
-
-.chipList:focus-within {
-  border-color: var(--color-primary, #0070f3);
+  composes: chipList from './chip.module.css';
 }
 
 .chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  background: var(--color-surface-alt, #eef0f2);
-  border: 1px solid var(--color-border, #e5e7eb);
-  border-radius: 4px;
-  padding: 0.125rem 0.375rem;
-  font-size: 0.875rem;
+  composes: chip from './chip.module.css';
 }
 
 .chipRemove {
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  color: var(--color-text-secondary, #666);
-  line-height: 1;
-  font-size: 1rem;
-}
-
-.chipRemove:hover {
-  color: var(--color-text, #111);
-}
-
-.chipRemove:disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
+  composes: chipRemove from './chip.module.css';
 }
 
 .textInput {
-  border: none;
-  outline: none;
-  background: transparent;
-  font-size: 0.9375rem;
-  flex: 1;
-  min-width: 120px;
-  color: var(--color-text, #111);
-}
-
-.textInput::placeholder {
-  color: var(--color-text-secondary, #666);
+  composes: textInput from './chip.module.css';
 }
 
 .dropdown {

--- a/apps/web/components/CatalogTagPicker.module.css
+++ b/apps/web/components/CatalogTagPicker.module.css
@@ -1,0 +1,96 @@
+.wrapper {
+  position: relative;
+}
+
+.chipList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  align-items: center;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 6px;
+  background: var(--color-surface, #f8f9fa);
+  min-height: 2.5rem;
+  cursor: text;
+}
+
+.chipList:focus-within {
+  border-color: var(--color-primary, #0070f3);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: var(--color-surface-alt, #eef0f2);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 4px;
+  padding: 0.125rem 0.375rem;
+  font-size: 0.875rem;
+}
+
+.chipRemove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: var(--color-text-secondary, #666);
+  line-height: 1;
+  font-size: 1rem;
+}
+
+.chipRemove:hover {
+  color: var(--color-text, #111);
+}
+
+.chipRemove:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.textInput {
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: 0.9375rem;
+  flex: 1;
+  min-width: 120px;
+  color: var(--color-text, #111);
+}
+
+.textInput::placeholder {
+  color: var(--color-text-secondary, #666);
+}
+
+.dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  background: var(--color-surface, #f8f9fa);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 6px;
+  margin-top: 2px;
+  max-height: 220px;
+  overflow-y: auto;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  list-style: none;
+  padding: 0.25rem 0;
+}
+
+.option {
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.9375rem;
+  color: var(--color-text, #111);
+}
+
+.option:hover {
+  background: var(--color-surface-alt, #eef0f2);
+}

--- a/apps/web/components/CatalogTagPicker.tsx
+++ b/apps/web/components/CatalogTagPicker.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { LIFT_CATALOG } from '@lifting-logbook/core';
+import styles from './CatalogTagPicker.module.css';
+
+interface Props {
+  value: string[];
+  onChange: (value: string[]) => void;
+  disabled?: boolean;
+}
+
+const CATALOG_NAMES = LIFT_CATALOG.map((l) => l.name);
+
+export default function CatalogTagPicker({ value, onChange, disabled }: Props) {
+  const [query, setQuery] = useState('');
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const filtered = CATALOG_NAMES.filter(
+    (name) =>
+      !value.includes(name) &&
+      name.toLowerCase().includes(query.toLowerCase()),
+  );
+  const open = query.trim() !== '' && filtered.length > 0;
+
+  useEffect(() => {
+    function handleMouseDown(e: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setQuery('');
+      }
+    }
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, []);
+
+  function select(name: string) {
+    onChange([...value, name]);
+    setQuery('');
+  }
+
+  function remove(name: string) {
+    onChange(value.filter((v) => v !== name));
+  }
+
+  return (
+    <div ref={wrapperRef} className={styles.wrapper}>
+      <div className={styles.chipList}>
+        {value.map((name) => (
+          <span key={name} className={styles.chip}>
+            {name}
+            <button
+              type="button"
+              className={styles.chipRemove}
+              aria-label={`Remove ${name}`}
+              onClick={() => remove(name)}
+              disabled={disabled}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+        <input
+          className={styles.textInput}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={value.length === 0 ? 'Search lifts…' : ''}
+          disabled={disabled}
+          aria-autocomplete="list"
+          aria-expanded={open}
+        />
+      </div>
+      {open && (
+        <ul className={styles.dropdown} role="listbox">
+          {filtered.map((name) => (
+            <li key={name}>
+              <button
+                type="button"
+                className={styles.option}
+                role="option"
+                aria-selected={false}
+                onMouseDown={(e) => {
+                  e.preventDefault(); // prevent input blur before select fires
+                  select(name);
+                }}
+              >
+                {name}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/CatalogTagPicker.tsx
+++ b/apps/web/components/CatalogTagPicker.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import { LIFT_CATALOG } from '@lifting-logbook/core';
 import styles from './CatalogTagPicker.module.css';
 
 interface Props {
+  id?: string;
   value: string[];
   onChange: (value: string[]) => void;
   disabled?: boolean;
@@ -12,9 +13,10 @@ interface Props {
 
 const CATALOG_NAMES = LIFT_CATALOG.map((l) => l.name);
 
-export default function CatalogTagPicker({ value, onChange, disabled }: Props) {
+export default function CatalogTagPicker({ id, value, onChange, disabled }: Props) {
   const [query, setQuery] = useState('');
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const listboxId = useId();
 
   const filtered = CATALOG_NAMES.filter(
     (name) =>
@@ -42,6 +44,15 @@ export default function CatalogTagPicker({ value, onChange, disabled }: Props) {
     onChange(value.filter((v) => v !== name));
   }
 
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'ArrowDown' && filtered.length > 0) {
+      e.preventDefault();
+      select(filtered[0]);
+    } else if (e.key === 'Escape') {
+      setQuery('');
+    }
+  }
+
   return (
     <div ref={wrapperRef} className={styles.wrapper}>
       <div className={styles.chipList}>
@@ -60,17 +71,21 @@ export default function CatalogTagPicker({ value, onChange, disabled }: Props) {
           </span>
         ))}
         <input
+          id={id}
           className={styles.textInput}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
           placeholder={value.length === 0 ? 'Search lifts…' : ''}
           disabled={disabled}
+          role="combobox"
           aria-autocomplete="list"
           aria-expanded={open}
+          aria-controls={listboxId}
         />
       </div>
       {open && (
-        <ul className={styles.dropdown} role="listbox">
+        <ul id={listboxId} className={styles.dropdown} role="listbox">
           {filtered.map((name) => (
             <li key={name}>
               <button

--- a/apps/web/components/FreeTagPicker.module.css
+++ b/apps/web/components/FreeTagPicker.module.css
@@ -1,60 +1,15 @@
 .chipList {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.375rem;
-  align-items: center;
-  padding: 0.375rem 0.5rem;
-  border: 1px solid var(--color-border, #e5e7eb);
-  border-radius: 6px;
-  background: var(--color-surface, #f8f9fa);
-  min-height: 2.5rem;
-  cursor: text;
-}
-
-.chipList:focus-within {
-  border-color: var(--color-primary, #0070f3);
+  composes: chipList from './chip.module.css';
 }
 
 .chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  background: var(--color-surface-alt, #eef0f2);
-  border: 1px solid var(--color-border, #e5e7eb);
-  border-radius: 4px;
-  padding: 0.125rem 0.375rem;
-  font-size: 0.875rem;
+  composes: chip from './chip.module.css';
 }
 
 .chipRemove {
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  color: var(--color-text-secondary, #666);
-  line-height: 1;
-  font-size: 1rem;
-}
-
-.chipRemove:hover {
-  color: var(--color-text, #111);
-}
-
-.chipRemove:disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
+  composes: chipRemove from './chip.module.css';
 }
 
 .textInput {
-  border: none;
-  outline: none;
-  background: transparent;
-  font-size: 0.9375rem;
-  flex: 1;
-  min-width: 120px;
-  color: var(--color-text, #111);
-}
-
-.textInput::placeholder {
-  color: var(--color-text-secondary, #666);
+  composes: textInput from './chip.module.css';
 }

--- a/apps/web/components/FreeTagPicker.module.css
+++ b/apps/web/components/FreeTagPicker.module.css
@@ -1,0 +1,60 @@
+.chipList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  align-items: center;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 6px;
+  background: var(--color-surface, #f8f9fa);
+  min-height: 2.5rem;
+  cursor: text;
+}
+
+.chipList:focus-within {
+  border-color: var(--color-primary, #0070f3);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: var(--color-surface-alt, #eef0f2);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 4px;
+  padding: 0.125rem 0.375rem;
+  font-size: 0.875rem;
+}
+
+.chipRemove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: var(--color-text-secondary, #666);
+  line-height: 1;
+  font-size: 1rem;
+}
+
+.chipRemove:hover {
+  color: var(--color-text, #111);
+}
+
+.chipRemove:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.textInput {
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: 0.9375rem;
+  flex: 1;
+  min-width: 120px;
+  color: var(--color-text, #111);
+}
+
+.textInput::placeholder {
+  color: var(--color-text-secondary, #666);
+}

--- a/apps/web/components/FreeTagPicker.tsx
+++ b/apps/web/components/FreeTagPicker.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState } from 'react';
+import styles from './FreeTagPicker.module.css';
+
+interface Props {
+  value: string[];
+  onChange: (value: string[]) => void;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+export default function FreeTagPicker({ value, onChange, placeholder, disabled }: Props) {
+  const [draft, setDraft] = useState('');
+
+  function commit() {
+    const trimmed = draft.trim();
+    if (trimmed) {
+      onChange([...value, trimmed]);
+    }
+    setDraft('');
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      commit();
+    } else if (e.key === 'Backspace' && draft === '' && value.length > 0) {
+      onChange(value.slice(0, -1));
+    }
+  }
+
+  function remove(tag: string) {
+    onChange(value.filter((v) => v !== tag));
+  }
+
+  return (
+    <div className={styles.chipList}>
+      {value.map((tag) => (
+        <span key={tag} className={styles.chip}>
+          {tag}
+          <button
+            type="button"
+            className={styles.chipRemove}
+            aria-label={`Remove ${tag}`}
+            onClick={() => remove(tag)}
+            disabled={disabled}
+          >
+            ×
+          </button>
+        </span>
+      ))}
+      <input
+        className={styles.textInput}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={commit}
+        placeholder={value.length === 0 ? placeholder : ''}
+        disabled={disabled}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/FreeTagPicker.tsx
+++ b/apps/web/components/FreeTagPicker.tsx
@@ -4,18 +4,19 @@ import { useState } from 'react';
 import styles from './FreeTagPicker.module.css';
 
 interface Props {
+  id?: string;
   value: string[];
   onChange: (value: string[]) => void;
   placeholder?: string;
   disabled?: boolean;
 }
 
-export default function FreeTagPicker({ value, onChange, placeholder, disabled }: Props) {
+export default function FreeTagPicker({ id, value, onChange, placeholder, disabled }: Props) {
   const [draft, setDraft] = useState('');
 
   function commit() {
     const trimmed = draft.trim();
-    if (trimmed) {
+    if (trimmed && !value.includes(trimmed)) {
       onChange([...value, trimmed]);
     }
     setDraft('');
@@ -51,6 +52,7 @@ export default function FreeTagPicker({ value, onChange, placeholder, disabled }
         </span>
       ))}
       <input
+        id={id}
         className={styles.textInput}
         value={draft}
         onChange={(e) => setDraft(e.target.value)}

--- a/apps/web/components/LiftEditor.tsx
+++ b/apps/web/components/LiftEditor.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { patchLiftMetadata } from '@/lib/client-api';
 import type { LiftMetadataResponse } from '@lifting-logbook/types';
+import CatalogTagPicker from './CatalogTagPicker';
+import FreeTagPicker from './FreeTagPicker';
 import styles from './LiftEditor.module.css';
 
 interface Props {
@@ -12,16 +14,8 @@ interface Props {
   initialMetadata: LiftMetadataResponse;
 }
 
-function parseList(value: string): string[] {
-  return value
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean);
-}
-
 export default function LiftEditor({ cycleNum, workoutNum, initialMetadata }: Props) {
   const router = useRouter();
-  // State is string[] matching the API contract; inputs display as comma-joined for editing.
   const [muscleGroups, setMuscleGroups] = useState<string[]>(initialMetadata.muscleGroups);
   const [substitutions, setSubstitutions] = useState<string[]>(initialMetadata.substitutions);
   const [foundational, setFoundational] = useState(initialMetadata.foundational);
@@ -66,13 +60,11 @@ export default function LiftEditor({ cycleNum, workoutNum, initialMetadata }: Pr
         <label className={styles.label} htmlFor="muscleGroups">
           Muscle Groups
         </label>
-        <input
-          id="muscleGroups"
-          type="text"
-          className={styles.input}
+        <FreeTagPicker
+          value={muscleGroups}
+          onChange={setMuscleGroups}
           placeholder="e.g. Quads, Glutes, Hamstrings"
-          value={muscleGroups.join(', ')}
-          onChange={(e) => setMuscleGroups(parseList(e.target.value))}
+          disabled={saving}
         />
       </div>
 
@@ -80,13 +72,10 @@ export default function LiftEditor({ cycleNum, workoutNum, initialMetadata }: Pr
         <label className={styles.label} htmlFor="substitutions">
           Substitutions
         </label>
-        <input
-          id="substitutions"
-          type="text"
-          className={styles.input}
-          placeholder="e.g. Leg Press, Hack Squat"
-          value={substitutions.join(', ')}
-          onChange={(e) => setSubstitutions(parseList(e.target.value))}
+        <CatalogTagPicker
+          value={substitutions}
+          onChange={setSubstitutions}
+          disabled={saving}
         />
       </div>
 

--- a/apps/web/components/LiftEditor.tsx
+++ b/apps/web/components/LiftEditor.tsx
@@ -61,6 +61,7 @@ export default function LiftEditor({ cycleNum, workoutNum, initialMetadata }: Pr
           Muscle Groups
         </label>
         <FreeTagPicker
+          id="muscleGroups"
           value={muscleGroups}
           onChange={setMuscleGroups}
           placeholder="e.g. Quads, Glutes, Hamstrings"
@@ -73,6 +74,7 @@ export default function LiftEditor({ cycleNum, workoutNum, initialMetadata }: Pr
           Substitutions
         </label>
         <CatalogTagPicker
+          id="substitutions"
           value={substitutions}
           onChange={setSubstitutions}
           disabled={saving}

--- a/apps/web/components/chip.module.css
+++ b/apps/web/components/chip.module.css
@@ -1,0 +1,60 @@
+.chipList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  align-items: center;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 6px;
+  background: var(--color-surface, #f8f9fa);
+  min-height: 2.5rem;
+  cursor: text;
+}
+
+.chipList:focus-within {
+  border-color: var(--color-primary, #0070f3);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: var(--color-surface-alt, #eef0f2);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 4px;
+  padding: 0.125rem 0.375rem;
+  font-size: 0.875rem;
+}
+
+.chipRemove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: var(--color-text-secondary, #666);
+  line-height: 1;
+  font-size: 1rem;
+}
+
+.chipRemove:hover {
+  color: var(--color-text, #111);
+}
+
+.chipRemove:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.textInput {
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: 0.9375rem;
+  flex: 1;
+  min-width: 120px;
+  color: var(--color-text, #111);
+}
+
+.textInput::placeholder {
+  color: var(--color-text-secondary, #666);
+}


### PR DESCRIPTION
## Summary

- Replaces the Substitutions free-text input with `CatalogTagPicker`: a search-as-you-type dropdown constrained to `LIFT_CATALOG`; selections render as removable chip tags; already-selected lifts are excluded; clicking outside closes the dropdown.
- Replaces the Muscle Groups free-text input with `FreeTagPicker`: type a value, press Enter or comma to commit it as a chip; Backspace removes the last chip; blur commits any pending draft.
- Both components produce `string[]` values passed unchanged to `patchLiftMetadata` — no API changes required.

## Acceptance Criteria

- [x] Substitutions field shows a filtered dropdown from LIFT_CATALOG as user types
- [x] Selecting a catalog lift adds it as a chip tag; clicking × removes it
- [x] Already-selected lifts are excluded from the dropdown
- [x] Muscle Groups field accepts free text; pressing Enter or comma commits a chip
- [x] Muscle Groups chips are removable with ×
- [x] Both fields produce `string[]` values passed unchanged to `patchLiftMetadata`
- [x] Clicking outside the dropdown closes it

## New components

- `apps/web/components/CatalogTagPicker.tsx` + `CatalogTagPicker.module.css`
- `apps/web/components/FreeTagPicker.tsx` + `FreeTagPicker.module.css`

## Testing

- `npm test` — 182 tests pass, 0 failures (pre-existing TypeScript error in `app/cycle/[cycleNum]/page.tsx` is unrelated and exists on `main`).
- Manual: navigate to a lift editor, verify both pickers render existing values as chips, accept new values, and submit correctly via Save.

Closes #249