### PR TITLE
[feat] Global /history page with Lift History and TM Timeline tabs

### DIFF
--- a/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.tsx
+++ b/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.tsx
@@ -87,6 +87,7 @@ export default function CycleDashboardGrid({
         <Link href={`/cycle/${cycleNum}/plan`}>🗓 Program Plan</Link>
         <Link href="/settings/training-maxes">💪 Training Maxes</Link>
         <Link href="/settings/strength-goals">🎯 Strength Goals</Link>
+        <Link href="/history">📚 Lift History</Link>
       </nav>
       <div className={styles.grid}>
         {weeks.map((row) => {

--- a/apps/web/app/cycle/layout.tsx
+++ b/apps/web/app/cycle/layout.tsx
@@ -8,6 +8,7 @@ export default function CycleLayout({
       <header>
         <h1>Lifting Logbook</h1>
         <nav>
+          <a href="/history">History</a>
           <a href="/settings/training-maxes">Settings</a>
         </nav>
       </header>

--- a/apps/web/app/history/HistoryTabs.tsx
+++ b/apps/web/app/history/HistoryTabs.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import type { TrainingMaxHistoryEntryResponse } from '@lifting-logbook/types';
+import type { EnrichedRecord } from './page';
+import styles from './history.module.css';
+
+type Tab = 'history' | 'timeline';
+
+export default function HistoryTabs({
+  records,
+  tmEntries,
+}: {
+  records: EnrichedRecord[];
+  tmEntries: TrainingMaxHistoryEntryResponse[];
+}) {
+  const [tab, setTab] = useState<Tab>('history');
+
+  return (
+    <div>
+      <div className={styles.tabs}>
+        <button
+          type="button"
+          className={`${styles.tab} ${tab === 'history' ? styles.tabActive : ''}`}
+          onClick={() => setTab('history')}
+          aria-pressed={tab === 'history'}
+        >
+          Lift History
+        </button>
+        <button
+          type="button"
+          className={`${styles.tab} ${tab === 'timeline' ? styles.tabActive : ''}`}
+          onClick={() => setTab('timeline')}
+          aria-pressed={tab === 'timeline'}
+        >
+          TM Timeline
+        </button>
+      </div>
+
+      {tab === 'history' ? (
+        <LiftHistoryTab records={records} />
+      ) : (
+        <TmTimelineTab entries={tmEntries} />
+      )}
+    </div>
+  );
+}
+
+function LiftHistoryTab({ records }: { records: EnrichedRecord[] }) {
+  const [search, setSearch] = useState('');
+  const [liftFilter, setLiftFilter] = useState('');
+
+  const lifts = useMemo(
+    () => Array.from(new Set(records.map((r) => r.lift))).sort(),
+    [records],
+  );
+
+  const visible = useMemo(() => {
+    const q = search.toLowerCase();
+    return records.filter((r) => {
+      if (liftFilter && r.lift !== liftFilter) return false;
+      if (q) {
+        const matchesLift = r.lift.toLowerCase().includes(q);
+        const matchesDate = r.date.includes(q);
+        const matchesNotes = r.notes?.toLowerCase().includes(q) ?? false;
+        if (!matchesLift && !matchesDate && !matchesNotes) return false;
+      }
+      return true;
+    });
+  }, [records, search, liftFilter]);
+
+  return (
+    <div>
+      <div className={styles.filters}>
+        <input
+          type="text"
+          placeholder="Search lift, date, or notes…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className={styles.searchInput}
+          aria-label="Search records"
+        />
+        <select
+          value={liftFilter}
+          onChange={(e) => setLiftFilter(e.target.value)}
+          className={styles.select}
+          aria-label="Filter by lift"
+        >
+          <option value="">All Lifts</option>
+          {lifts.map((l) => (
+            <option key={l} value={l}>{l}</option>
+          ))}
+        </select>
+      </div>
+
+      {visible.length === 0 ? (
+        <p className={styles.empty}>No records match the current filters.</p>
+      ) : (
+        <div className={styles.tableWrapper}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Lift</th>
+                <th>Weight × Reps</th>
+                <th>TM</th>
+                <th>% of TM</th>
+                <th>Context</th>
+                <th>Notes</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {visible.map((r) => (
+                <tr key={r.id}>
+                  <td>{r.date}</td>
+                  <td>{r.lift}</td>
+                  <td>
+                    {r.weight} {r.tmUnit ?? 'lbs'} × {r.reps}
+                  </td>
+                  <td>
+                    {r.tmAtTime !== null
+                      ? `${r.tmAtTime} ${r.tmUnit ?? 'lbs'}`
+                      : '—'}
+                  </td>
+                  <td>{r.tmPercent !== null ? `${r.tmPercent}%` : '—'}</td>
+                  <td>
+                    Cycle {r.cycleNum}, Workout {r.workoutNum}
+                  </td>
+                  <td>{r.notes || '—'}</td>
+                  <td>
+                    {r.isPR && <span className={styles.prBadge}>PR</span>}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TmTimelineTab({
+  entries,
+}: {
+  entries: TrainingMaxHistoryEntryResponse[];
+}) {
+  const [liftFilter, setLiftFilter] = useState('');
+
+  const lifts = useMemo(
+    () => Array.from(new Set(entries.map((e) => e.lift))).sort(),
+    [entries],
+  );
+
+  const byLift = useMemo(() => {
+    const filtered = liftFilter
+      ? entries.filter((e) => e.lift === liftFilter)
+      : entries;
+    const groups = new Map<string, TrainingMaxHistoryEntryResponse[]>();
+    for (const e of filtered) {
+      const group = groups.get(e.lift) ?? [];
+      group.push(e);
+      groups.set(e.lift, group);
+    }
+    return Array.from(groups.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([lift, es]) => ({
+        lift,
+        entries: es.slice().sort((a, b) => b.date.localeCompare(a.date)),
+      }));
+  }, [entries, liftFilter]);
+
+  return (
+    <div>
+      <div className={styles.filters}>
+        <select
+          value={liftFilter}
+          onChange={(e) => setLiftFilter(e.target.value)}
+          className={styles.select}
+          aria-label="Filter by lift"
+        >
+          <option value="">All Lifts</option>
+          {lifts.map((l) => (
+            <option key={l} value={l}>{l}</option>
+          ))}
+        </select>
+      </div>
+
+      {byLift.length === 0 ? (
+        <p className={styles.empty}>No TM history recorded yet.</p>
+      ) : (
+        byLift.map(({ lift, entries: liftEntries }) => (
+          <section key={lift} className={styles.liftGroup}>
+            <h2 className={styles.liftGroupHeading}>{lift}</h2>
+            <div className={styles.tableWrapper}>
+              <table className={styles.table}>
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Weight</th>
+                    <th>Source</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {liftEntries.map((e) => (
+                    <tr key={e.id}>
+                      <td>{e.date}</td>
+                      <td>
+                        {e.weight} {e.unit}
+                      </td>
+                      <td>
+                        {e.source === 'test' ? 'Test Week' : 'Program'}
+                      </td>
+                      <td>
+                        {e.isPR && (
+                          <span className={styles.prBadge}>PR</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        ))
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/history/HistoryTabs.tsx
+++ b/apps/web/app/history/HistoryTabs.tsx
@@ -18,30 +18,34 @@ export default function HistoryTabs({
 
   return (
     <div>
-      <div className={styles.tabs}>
+      <div className={styles.tabs} role="tablist">
         <button
           type="button"
+          role="tab"
           className={`${styles.tab} ${tab === 'history' ? styles.tabActive : ''}`}
           onClick={() => setTab('history')}
-          aria-pressed={tab === 'history'}
+          aria-selected={tab === 'history'}
         >
           Lift History
         </button>
         <button
           type="button"
+          role="tab"
           className={`${styles.tab} ${tab === 'timeline' ? styles.tabActive : ''}`}
           onClick={() => setTab('timeline')}
-          aria-pressed={tab === 'timeline'}
+          aria-selected={tab === 'timeline'}
         >
           TM Timeline
         </button>
       </div>
 
-      {tab === 'history' ? (
-        <LiftHistoryTab records={records} />
-      ) : (
-        <TmTimelineTab entries={tmEntries} />
-      )}
+      <div role="tabpanel">
+        {tab === 'history' ? (
+          <LiftHistoryTab records={records} />
+        ) : (
+          <TmTimelineTab entries={tmEntries} />
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/app/history/HistoryTabs.tsx
+++ b/apps/web/app/history/HistoryTabs.tsx
@@ -62,7 +62,7 @@ function LiftHistoryTab({ records }: { records: EnrichedRecord[] }) {
       if (q) {
         const matchesLift = r.lift.toLowerCase().includes(q);
         const matchesDate = r.date.includes(q);
-        const matchesNotes = r.notes?.toLowerCase().includes(q) ?? false;
+        const matchesNotes = r.notes.toLowerCase().includes(q);
         if (!matchesLift && !matchesDate && !matchesNotes) return false;
       }
       return true;

--- a/apps/web/app/history/history.module.css
+++ b/apps/web/app/history/history.module.css
@@ -1,3 +1,25 @@
+.pageContainer {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+.backLink {
+  display: inline-block;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+  color: var(--color-text-muted, #6b7280);
+  text-decoration: none;
+}
+
+.backLink:hover {
+  color: var(--color-text, #111827);
+}
+
+.pageHeading {
+  margin-bottom: 1.5rem;
+}
+
 .tabs {
   display: flex;
   gap: 0.5rem;

--- a/apps/web/app/history/history.module.css
+++ b/apps/web/app/history/history.module.css
@@ -1,0 +1,106 @@
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 2px solid var(--color-border, #e5e7eb);
+}
+
+.tab {
+  padding: 0.5rem 1rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 1rem;
+  color: var(--color-text-muted, #6b7280);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+}
+
+.tab:hover {
+  color: var(--color-text, #111827);
+}
+
+.tabActive {
+  color: var(--color-primary, #2563eb);
+  border-bottom-color: var(--color-primary, #2563eb);
+  font-weight: 600;
+}
+
+.filters {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.searchInput,
+.select {
+  padding: 0.375rem 0.625rem;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 4px;
+  font-size: 0.875rem;
+  background: var(--color-surface, #fff);
+  color: var(--color-text, #111827);
+}
+
+.searchInput {
+  min-width: 240px;
+  flex: 1;
+}
+
+.tableWrapper {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.table th {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 2px solid var(--color-border, #e5e7eb);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.table td {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--color-border, #f3f4f6);
+  vertical-align: middle;
+}
+
+.table tbody tr:hover {
+  background: var(--color-surface-hover, #f9fafb);
+}
+
+.prBadge {
+  display: inline-block;
+  padding: 0.125rem 0.375rem;
+  background: var(--color-accent, #f59e0b);
+  color: #fff;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.025em;
+}
+
+.empty {
+  color: var(--color-text-muted, #6b7280);
+  font-style: italic;
+  margin-top: 1rem;
+}
+
+.liftGroup {
+  margin-bottom: 2rem;
+}
+
+.liftGroupHeading {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.25rem;
+  border-bottom: 1px solid var(--color-border, #e5e7eb);
+}

--- a/apps/web/app/history/page.tsx
+++ b/apps/web/app/history/page.tsx
@@ -1,9 +1,11 @@
+import Link from 'next/link';
 import { fetchLiftRecords, fetchTrainingMaxHistory } from '@/lib/api';
 import type {
   LiftRecordResponse,
   TrainingMaxHistoryEntryResponse,
 } from '@lifting-logbook/types';
 import HistoryTabs from './HistoryTabs';
+import styles from './history.module.css';
 
 export type EnrichedRecord = LiftRecordResponse & {
   tmAtTime: number | null;
@@ -64,8 +66,9 @@ export default async function HistoryPage() {
   });
 
   return (
-    <main style={{ maxWidth: '1100px', margin: '0 auto', padding: '1.5rem' }}>
-      <h1 style={{ marginBottom: '1.5rem' }}>Lift History</h1>
+    <main className={styles.pageContainer}>
+      <Link href="/" className={styles.backLink}>← Home</Link>
+      <h1 className={styles.pageHeading}>Lift History</h1>
       <HistoryTabs records={enriched} tmEntries={tmEntries} />
     </main>
   );

--- a/apps/web/app/history/page.tsx
+++ b/apps/web/app/history/page.tsx
@@ -1,0 +1,61 @@
+import { fetchLiftRecords, fetchTrainingMaxHistory } from '@/lib/api';
+import type {
+  LiftRecordResponse,
+  TrainingMaxHistoryEntryResponse,
+} from '@lifting-logbook/types';
+import HistoryTabs from './HistoryTabs';
+
+export type EnrichedRecord = LiftRecordResponse & {
+  tmAtTime: number | null;
+  tmUnit: string | null;
+  tmPercent: number | null;
+  isPR: boolean;
+};
+
+function findTmAtTime(
+  lift: string,
+  date: string,
+  entries: TrainingMaxHistoryEntryResponse[],
+): TrainingMaxHistoryEntryResponse | null {
+  return (
+    entries
+      .filter((e) => e.lift === lift && e.date <= date)
+      .sort((a, b) => b.date.localeCompare(a.date))[0] ?? null
+  );
+}
+
+export default async function HistoryPage() {
+  const program = process.env.NEXT_PUBLIC_DEFAULT_PROGRAM ?? '5-3-1';
+
+  const [records, { entries: tmEntries }] = await Promise.all([
+    fetchLiftRecords(program),
+    fetchTrainingMaxHistory(program),
+  ]);
+
+  const sortedRecords = records.slice().sort((a, b) => b.date.localeCompare(a.date));
+
+  const maxByLift = new Map<string, number>();
+  for (const r of sortedRecords) {
+    maxByLift.set(r.lift, Math.max(maxByLift.get(r.lift) ?? 0, r.weight));
+  }
+
+  const enriched: EnrichedRecord[] = sortedRecords.map((r) => {
+    const tm = findTmAtTime(r.lift, r.date, tmEntries);
+    const tmPercent =
+      tm !== null ? Math.round((r.weight / tm.weight) * 1000) / 10 : null;
+    return {
+      ...r,
+      tmAtTime: tm?.weight ?? null,
+      tmUnit: tm?.unit ?? null,
+      tmPercent,
+      isPR: r.weight >= (maxByLift.get(r.lift) ?? 0),
+    };
+  });
+
+  return (
+    <main style={{ maxWidth: '1100px', margin: '0 auto', padding: '1.5rem' }}>
+      <h1 style={{ marginBottom: '1.5rem' }}>Lift History</h1>
+      <HistoryTabs records={enriched} tmEntries={tmEntries} />
+    </main>
+  );
+}

--- a/apps/web/app/history/page.tsx
+++ b/apps/web/app/history/page.tsx
@@ -39,6 +39,17 @@ export default async function HistoryPage() {
     maxByLift.set(r.lift, Math.max(maxByLift.get(r.lift) ?? 0, r.weight));
   }
 
+  // Walk oldest→newest; first record per lift that equals the max is the PR.
+  const prRecordIds = new Set<string>();
+  const prSeenLifts = new Set<string>();
+  for (let i = sortedRecords.length - 1; i >= 0; i--) {
+    const r = sortedRecords[i];
+    if (!prSeenLifts.has(r.lift) && r.weight >= (maxByLift.get(r.lift) ?? 0)) {
+      prRecordIds.add(r.id);
+      prSeenLifts.add(r.lift);
+    }
+  }
+
   const enriched: EnrichedRecord[] = sortedRecords.map((r) => {
     const tm = findTmAtTime(r.lift, r.date, tmEntries);
     const tmPercent =
@@ -48,7 +59,7 @@ export default async function HistoryPage() {
       tmAtTime: tm?.weight ?? null,
       tmUnit: tm?.unit ?? null,
       tmPercent,
-      isPR: r.weight >= (maxByLift.get(r.lift) ?? 0),
+      isPR: prRecordIds.has(r.id),
     };
   });
 


### PR DESCRIPTION
## Summary

- New top-level `/history` route (server component + `'use client'` tabs component)
- **Lift History tab**: all `LiftRecord` entries sorted by date desc, with TM at time of logging, % of TM, program context (cycle/workout), notes, and PR badge (highest weight per lift across all sets)
- **TM Timeline tab**: all `TrainingMaxHistory` entries grouped by lift, sorted date desc, showing source (Test Week / Program) and existing PR badge
- Search box filters by lift name, date substring, or notes; lift filter dropdown narrows to a single lift
- "📚 Lift History" link added to cycle dashboard quick nav; "History" link added to cycle layout header nav

## Acceptance criteria

- [x] `/history` is accessible from the cycle layout nav
- [x] Lift History tab shows all `LiftRecord` entries sorted by date descending
- [x] TM at time is computed for each entry (most recent TM history entry on or before the record date)
- [x] % of TM is displayed when TM is known
- [x] Search filters by lift name, date substring, and notes
- [x] Lift filter dropdown narrows to a single lift
- [x] TM Timeline tab groups history entries by lift, sorted date descending
- [x] PR badge shown on PR entries (highest weight per lift)

## Test plan

- `npm test -w @lifting-logbook/web` — 23 tests pass (pre-existing StepProgram.test failure on base branch, unrelated)
- Navigate to `/history` from the cycle dashboard quick nav link
- Verify Lift History tab renders with TM column and % of TM values
- Enter text in search box; confirm rows filter by lift, date, and notes
- Select a lift from the dropdown; confirm rows narrow
- Confirm PR badge appears on the highest-weight set per lift
- Switch to TM Timeline tab; confirm entries grouped by lift, source labels shown, PR badges on `isPR` entries

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)