### PR TITLE
[test] Add e2e coverage for POST cycles/initialize

### DIFF
--- a/apps/api/src/programs/programs.db.e2e.spec.ts
+++ b/apps/api/src/programs/programs.db.e2e.spec.ts
@@ -413,8 +413,8 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
       expect(body.program).toBe('5-3-1');
       expect(body.cycleNum).toBe(1);
       expect(body.cycleStartDate).toBe('2026-06-02');
-      expect(body.currentWeekType).toBeDefined();
-      expect(Array.isArray(body.weeks)).toBe(true);
+      expect(body.currentWeekType).toBe('training');
+      expect(body.weeks).toEqual([]);
 
       // DB-level assertion
       const row = await prisma.cycleDashboard.findFirst({

--- a/apps/api/src/programs/programs.db.e2e.spec.ts
+++ b/apps/api/src/programs/programs.db.e2e.spec.ts
@@ -28,8 +28,10 @@ const TEST_USER = 'db-e2e-primary';
 const USER_ALICE = 'db-e2e-alice';
 const USER_BOB = 'db-e2e-bob';
 
+const USER_INIT = 'db-e2e-init';
+
 async function cleanTestUsers(prisma: PrismaClient): Promise<void> {
-  const users = [TEST_USER, USER_ALICE, USER_BOB];
+  const users = [TEST_USER, USER_ALICE, USER_BOB, USER_INIT];
   await prisma.liftRecord.deleteMany({ where: { userId: { in: users } } });
   await prisma.trainingMax.deleteMany({ where: { userId: { in: users } } });
   await prisma.trainingMaxHistory.deleteMany({ where: { userId: { in: users } } });
@@ -388,6 +390,58 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
         { isPR: true },
       );
       expect(res.statusCode).toBe(404);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST cycles/initialize — uses USER_INIT who has no seed data.
+  // Order-sensitive within the block (409 test depends on happy path row).
+  // -------------------------------------------------------------------------
+
+  describe('POST /programs/:program/cycles/initialize (DB)', () => {
+    const AS_INIT = { authorization: `Bearer ${USER_INIT}` };
+
+    it('happy path — creates a CycleDashboard row and returns 201 with expected shape', async () => {
+      const res = await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: '/programs/5-3-1/cycles/initialize',
+        headers: { 'content-type': 'application/json', ...AS_INIT },
+        payload: JSON.stringify({ cycleDate: '2026-06-02' }),
+      });
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.program).toBe('5-3-1');
+      expect(body.cycleNum).toBe(1);
+      expect(body.cycleStartDate).toBe('2026-06-02');
+      expect(body.currentWeekType).toBeDefined();
+      expect(Array.isArray(body.weeks)).toBe(true);
+
+      // DB-level assertion
+      const row = await prisma.cycleDashboard.findFirst({
+        where: { userId: USER_INIT, program: '5-3-1' },
+      });
+      expect(row).not.toBeNull();
+      expect(row?.cycleNum).toBe(1);
+    });
+
+    it('409 Conflict — second call for the same user+program', async () => {
+      const res = await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: '/programs/5-3-1/cycles/initialize',
+        headers: { 'content-type': 'application/json', ...AS_INIT },
+        payload: JSON.stringify({}),
+      });
+      expect(res.statusCode).toBe(409);
+    });
+
+    it('400 Bad Request — unrecognized program ID', async () => {
+      const res = await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: '/programs/not-a-real-program/cycles/initialize',
+        headers: { 'content-type': 'application/json', ...AS_INIT },
+        payload: JSON.stringify({}),
+      });
+      expect(res.statusCode).toBe(400);
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds a `describe('POST /programs/:program/cycles/initialize (DB)')` block to `programs.db.e2e.spec.ts` with three cases matching the issue acceptance criteria
- Happy path: creates a `CycleDashboard` row for a fresh user and returns 201 with the expected response shape; verified at the DB layer via Prisma
- 409 Conflict: a second call for the same user+program returns 409
- 400 Bad Request: an unrecognized program ID (`not-a-real-program`) returns 400
- Adds `USER_INIT = 'db-e2e-init'` to `cleanTestUsers()` so teardown covers the new rows

## Test plan

- [ ] Unit + in-memory e2e: `npm test -w @lifting-logbook/api` — 182 tests pass, db.e2e suite skipped (no `DATABASE_URL`)
- [ ] DB e2e (local Docker):
  ```bash
  docker-compose -f apps/api/docker-compose.test.yml up -d
  DATABASE_URL=postgresql://lifting:lifting@localhost:5433/lifting_test     npx prisma migrate deploy --schema=apps/api/prisma/schema.prisma
  DATABASE_URL=postgresql://lifting:lifting@localhost:5433/lifting_test     npm test -w @lifting-logbook/api -- --testPathPattern=db.e2e
  ```

Closes #247