### PR TITLE
[docs] Add new-design mockup HTML files to docs/mockups/

### DIFF
--- a/docs/mockups/lift-history-v1.html
+++ b/docs/mockups/lift-history-v1.html
@@ -1,0 +1,815 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lifting Logbook - Lift History & TM Tracking</title>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+      background: #fafaf8;
+      color: #1a1a1a;
+      line-height: 1.5;
+    }
+
+    .container {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+      padding: 24px;
+      max-width: 100%;
+    }
+
+    .journey {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      aspect-ratio: 9/16;
+      max-height: 900px;
+    }
+
+    .journey-title {
+      font-size: 14px;
+      font-weight: 700;
+      color: #1a1a1a;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      padding: 0 16px;
+    }
+
+    .screen {
+      background: white;
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+    }
+
+    .screen-header {
+      background: linear-gradient(135deg, #2c3e50 0%, #34495e 100%);
+      color: white;
+      padding: 12px 16px;
+      flex-shrink: 0;
+    }
+
+    .screen-header h3 {
+      font-size: 13px;
+      font-weight: 600;
+      margin-bottom: 2px;
+    }
+
+    .screen-header p {
+      font-size: 11px;
+      opacity: 0.7;
+    }
+
+    .screen-content {
+      padding: 16px;
+      flex: 1;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .form-group {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .form-label {
+      font-size: 11px;
+      font-weight: 700;
+      color: #2c3e50;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+    }
+
+    .form-input {
+      padding: 8px 12px;
+      border: 1px solid #ecf0f1;
+      border-radius: 6px;
+      font-size: 13px;
+      min-height: 36px;
+    }
+
+    .form-input:focus {
+      outline: none;
+      border-color: #3498db;
+      box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.1);
+    }
+
+    .button {
+      padding: 10px 16px;
+      border: none;
+      border-radius: 6px;
+      font-size: 12px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      min-height: 44px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .button-primary {
+      background: #3498db;
+      color: white;
+    }
+
+    .button-primary:hover {
+      background: #2980b9;
+      box-shadow: 0 2px 8px rgba(52, 152, 219, 0.3);
+    }
+
+    .button-secondary {
+      background: #ecf0f1;
+      color: #2c3e50;
+    }
+
+    .button-secondary:hover {
+      background: #bdc3c7;
+    }
+
+    .button-success {
+      background: #27ae60;
+      color: white;
+    }
+
+    .button-success:hover {
+      background: #229954;
+    }
+
+    .data-row {
+      padding: 10px;
+      background: #f8f9fa;
+      border-radius: 6px;
+      border-left: 3px solid #3498db;
+      font-size: 12px;
+    }
+
+    .data-label {
+      font-size: 10px;
+      color: #7f8c8d;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      margin-bottom: 4px;
+    }
+
+    .data-value {
+      font-size: 13px;
+      font-weight: 600;
+      color: #1a1a1a;
+    }
+
+    .lift-entry {
+      padding: 12px;
+      background: #f8f9fa;
+      border-radius: 6px;
+      border-left: 3px solid #3498db;
+      font-size: 12px;
+    }
+
+    .lift-entry-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 8px;
+    }
+
+    .lift-name {
+      font-weight: 600;
+      color: #1a1a1a;
+      font-size: 13px;
+    }
+
+    .lift-date {
+      font-size: 10px;
+      color: #7f8c8d;
+    }
+
+    .lift-detail {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 8px;
+      margin-top: 8px;
+    }
+
+    .lift-detail-item {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .lift-detail-label {
+      font-size: 9px;
+      color: #7f8c8d;
+      text-transform: uppercase;
+      margin-bottom: 2px;
+    }
+
+    .lift-detail-value {
+      font-size: 12px;
+      font-weight: 600;
+      color: #2c3e50;
+    }
+
+    .section-label {
+      font-size: 10px;
+      font-weight: 700;
+      color: #7f8c8d;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      margin-top: 12px;
+      margin-bottom: 8px;
+    }
+
+    .info-box {
+      padding: 10px 12px;
+      background: #e8f4f8;
+      border-left: 3px solid #3498db;
+      border-radius: 6px;
+      font-size: 11px;
+      line-height: 1.5;
+    }
+
+    .info-box strong {
+      color: #2c3e50;
+    }
+
+    .tm-timeline {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .tm-entry {
+      padding: 12px;
+      background: #f8f9fa;
+      border-radius: 6px;
+      border-left: 3px solid #27ae60;
+    }
+
+    .tm-lift {
+      font-weight: 600;
+      font-size: 12px;
+      color: #1a1a1a;
+      margin-bottom: 6px;
+    }
+
+    .tm-value {
+      font-size: 13px;
+      font-weight: 600;
+      color: #27ae60;
+    }
+
+    .tm-date {
+      font-size: 10px;
+      color: #7f8c8d;
+      margin-top: 4px;
+    }
+
+    @media (max-width: 1400px) {
+      .container {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useEffect } = React;
+
+    function LiftHistoryApp() {
+      // TM History: tracks all TM changes over time for each lift
+      const [tmHistory, setTmHistory] = useState([
+        { lift: 'Squat', tm: 315, date: '2025-01-15', source: 'Test Week' },
+        { lift: 'Squat', tm: 310, date: '2025-01-01', source: 'Estimated' },
+        { lift: 'Bench Press', tm: 225, date: '2025-01-15', source: 'Test Week' },
+        { lift: 'Bench Press', tm: 220, date: '2025-01-01', source: 'Estimated' },
+        { lift: 'Deadlift', tm: 405, date: '2025-01-15', source: 'Test Week' },
+        { lift: 'Deadlift', tm: 400, date: '2025-01-01', source: 'Estimated' },
+        { lift: 'Overhead Press', tm: 155, date: '2025-01-15', source: 'Test Week' }
+      ]);
+
+      // Lift History: individual logged sets with program context
+      const [liftHistory, setLiftHistory] = useState([
+        {
+          id: 'lift-1',
+          lift: 'Squat',
+          date: '2025-01-20',
+          weight: 295,
+          reps: 5,
+          trainingMaxAtTime: 315,
+          programPercentage: 85,
+          programName: '5/3/1 Week 2',
+          notes: 'RPE 8',
+          isPR: false
+        },
+        {
+          id: 'lift-2',
+          lift: 'Bench Press',
+          date: '2025-01-20',
+          weight: 190,
+          reps: 8,
+          trainingMaxAtTime: 225,
+          programPercentage: 85,
+          programName: '5/3/1 Week 2',
+          notes: 'Strong',
+          isPR: false
+        },
+        {
+          id: 'lift-3',
+          lift: 'Squat',
+          date: '2025-01-18',
+          weight: 280,
+          reps: 3,
+          trainingMaxAtTime: 315,
+          programPercentage: 75,
+          programName: '5/3/1 Week 1',
+          notes: '',
+          isPR: false
+        },
+        {
+          id: 'lift-4',
+          lift: 'Deadlift',
+          date: '2025-01-15',
+          weight: 405,
+          reps: 1,
+          trainingMaxAtTime: 405,
+          programPercentage: 100,
+          programName: 'Test Week',
+          notes: 'New max!',
+          isPR: true
+        }
+      ]);
+
+      const [view, setView] = useState('history'); // 'history' | 'tm-history' | 'log-lift'
+      const [selectedLift, setSelectedLift] = useState(null);
+      const [searchQuery, setSearchQuery] = useState('');
+      const [newLift, setNewLift] = useState({
+        lift: 'Squat',
+        date: new Date().toISOString().split('T')[0],
+        weight: '',
+        reps: '',
+        notes: ''
+      });
+
+      // Get current TM for a lift
+      const getCurrentTM = (liftName) => {
+        const entry = tmHistory.find(t => t.lift === liftName);
+        return entry ? entry.tm : 0;
+      };
+
+      // Get TM at a specific date
+      const getTMAtDate = (liftName, date) => {
+        const relevant = tmHistory
+          .filter(t => t.lift === liftName && new Date(t.date) <= new Date(date))
+          .sort((a, b) => new Date(b.date) - new Date(a.date));
+        return relevant.length > 0 ? relevant[0].tm : 0;
+      };
+
+      // Get unique lifts from history
+      const getAllLifts = () => {
+        const lifts = new Set([
+          ...liftHistory.map(l => l.lift),
+          ...tmHistory.map(t => t.lift)
+        ]);
+        return Array.from(lifts).sort();
+      };
+
+      // Log a new lift
+      const handleLogLift = () => {
+        if (!newLift.weight || !newLift.reps) {
+          alert('Enter weight and reps');
+          return;
+        }
+
+        const tmAtTime = getTMAtDate(newLift.lift, newLift.date);
+        const percentage = Math.round((parseInt(newLift.weight) / tmAtTime) * 100);
+
+        const entry = {
+          id: `lift-${Date.now()}`,
+          lift: newLift.lift,
+          date: newLift.date,
+          weight: parseInt(newLift.weight),
+          reps: parseInt(newLift.reps),
+          trainingMaxAtTime: tmAtTime,
+          programPercentage: percentage,
+          programName: 'Logged',
+          notes: newLift.notes,
+          isPR: false
+        };
+
+        setLiftHistory([entry, ...liftHistory]);
+        setNewLift({
+          lift: 'Squat',
+          date: new Date().toISOString().split('T')[0],
+          weight: '',
+          reps: '',
+          notes: ''
+        });
+        alert('✓ Lift logged');
+      };
+
+      // Render lift history
+      const renderHistory = () => {
+        const lifts = selectedLift ? liftHistory.filter(l => l.lift === selectedLift) : liftHistory;
+        // Filter by search query
+        const filtered = lifts.filter(l => 
+          l.lift.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          l.notes.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          l.date.includes(searchQuery)
+        );
+
+        return (
+          <div className="screen-content">
+            <div className="info-box">
+              <strong>Lift History</strong> — Each entry shows the TM at that time and program percentage
+            </div>
+
+            <div className="form-group">
+              <label className="form-label">Search</label>
+              <input
+                type="text"
+                className="form-input"
+                placeholder="Lift name, date, or notes…"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+            </div>
+
+            {selectedLift && (
+              <button
+                className="button button-secondary"
+                onClick={() => setSelectedLift(null)}
+                style={{ fontSize: '11px' }}
+              >
+                ← All Lifts
+              </button>
+            )}
+
+            {!selectedLift && (
+              <div>
+                <div className="section-label">Filter by Lift</div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 12 }}>
+                  {getAllLifts().map((lift) => {
+                    const count = liftHistory.filter(l => l.lift === lift).length;
+                    return (
+                      <button
+                        key={lift}
+                        onClick={() => setSelectedLift(lift)}
+                        style={{
+                          padding: '10px 12px',
+                          background: '#f8f9fa',
+                          border: '1px solid #ecf0f1',
+                          borderRadius: 6,
+                          fontSize: 12,
+                          fontWeight: 600,
+                          textAlign: 'left',
+                          cursor: 'pointer',
+                          transition: 'all 0.2s'
+                        }}
+                      >
+                        {lift} <span style={{ color: '#7f8c8d', marginLeft: 'auto' }}>({count})</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            <div className="section-label">{selectedLift ? `${selectedLift} Lifts` : 'All Lifts'} ({filtered.length})</div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, flex: 1 }}>
+              {filtered.length > 0 ? (
+                filtered.map((entry) => (
+                  <div key={entry.id} className="lift-entry">
+                    <div className="lift-entry-header">
+                      <div>
+                        <div className="lift-name">
+                          {entry.lift} {entry.isPR && '🏆'}
+                        </div>
+                        <div className="lift-date">{entry.date}</div>
+                      </div>
+                      <div style={{ textAlign: 'right' }}>
+                        <div style={{ fontSize: '14px', fontWeight: 700, color: '#1a1a1a' }}>
+                          {entry.weight} lbs × {entry.reps}
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="lift-detail">
+                      <div className="lift-detail-item">
+                        <div className="lift-detail-label">TM at Time</div>
+                        <div className="lift-detail-value">{entry.trainingMaxAtTime} lbs</div>
+                      </div>
+                      <div className="lift-detail-item">
+                        <div className="lift-detail-label">% of TM</div>
+                        <div className="lift-detail-value">{entry.programPercentage}%</div>
+                      </div>
+                      <div className="lift-detail-item">
+                        <div className="lift-detail-label">Program</div>
+                        <div className="lift-detail-value">{entry.programName}</div>
+                      </div>
+                    </div>
+
+                    {entry.notes && (
+                      <div style={{ marginTop: 8, fontSize: '11px', color: '#7f8c8d' }}>
+                        📝 {entry.notes}
+                      </div>
+                    )}
+                  </div>
+                ))
+              ) : (
+                <div style={{ textAlign: 'center', color: '#7f8c8d', padding: '20px 0' }}>
+                  {searchQuery ? 'No lifts match your search' : 'No lifts logged yet'}
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      };
+
+      // Render TM history
+      const renderTMHistory = () => {
+        const allLifts = getAllLifts();
+        const filtered = allLifts.filter(lift => 
+          lift.toLowerCase().includes(searchQuery.toLowerCase())
+        );
+
+        return (
+          <div className="screen-content">
+            <div className="info-box">
+              <strong>Training Max History</strong> — View all TM updates for each lift
+            </div>
+
+            <div className="form-group">
+              <label className="form-label">Search</label>
+              <input
+                type="text"
+                className="form-input"
+                placeholder="Search lifts…"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+            </div>
+
+            {filtered.length > 0 ? (
+              filtered.map((lift) => {
+                const entries = tmHistory.filter(t => t.lift === lift).sort((a, b) => new Date(b.date) - new Date(a.date));
+                return (
+                  <div key={lift}>
+                    <div className="section-label">{lift}</div>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 12 }}>
+                      {entries.map((entry, idx) => (
+                        <div key={idx} className="tm-entry">
+                          <div className="tm-lift">{entry.lift}</div>
+                          <div className="tm-value">{entry.tm} lbs</div>
+                          <div className="tm-date">{entry.date} • {entry.source}</div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })
+            ) : (
+              <div style={{ textAlign: 'center', color: '#7f8c8d', padding: '20px 0' }}>
+                No lifts match your search
+              </div>
+            )}
+          </div>
+        );
+      };
+
+      // Render log lift
+      const renderLogLift = () => {
+        const tmAtTime = getTMAtDate(newLift.lift, newLift.date);
+        const percentage = newLift.weight ? Math.round((parseInt(newLift.weight) / tmAtTime) * 100) : 0;
+        const allLifts = getAllLifts();
+        const filteredLifts = searchQuery 
+          ? allLifts.filter(lift => lift.toLowerCase().includes(searchQuery.toLowerCase()))
+          : allLifts;
+
+        return (
+          <div className="screen-content">
+            <div className="info-box">
+              <strong>Log a Lift</strong> — Records weight, reps, and TM context for your programming
+            </div>
+
+            <div className="form-group">
+              <label className="form-label">Lift</label>
+              <input
+                type="text"
+                className="form-input"
+                placeholder="Search or select lift…"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                list="lift-suggestions"
+              />
+              <datalist id="lift-suggestions">
+                {filteredLifts.map((lift) => (
+                  <option key={lift} value={lift} />
+                ))}
+              </datalist>
+              {searchQuery && filteredLifts.length > 0 && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginTop: 4 }}>
+                  {filteredLifts.map((lift) => (
+                    <button
+                      key={lift}
+                      onClick={() => {
+                        setNewLift({ ...newLift, lift });
+                        setSearchQuery('');
+                      }}
+                      style={{
+                        padding: '8px 12px',
+                        background: '#f8f9fa',
+                        border: '1px solid #ecf0f1',
+                        borderRadius: 4,
+                        fontSize: 12,
+                        textAlign: 'left',
+                        cursor: 'pointer',
+                        transition: 'all 0.2s'
+                      }}
+                    >
+                      {lift}
+                    </button>
+                  ))}
+                </div>
+              )}
+              {!searchQuery && (
+                <select
+                  className="form-input"
+                  value={newLift.lift}
+                  onChange={(e) => setNewLift({ ...newLift, lift: e.target.value })}
+                >
+                  {allLifts.map((lift) => (
+                    <option key={lift} value={lift}>{lift}</option>
+                  ))}
+                </select>
+              )}
+            </div>
+
+            <div className="form-group">
+              <label className="form-label">Date</label>
+              <input
+                type="date"
+                className="form-input"
+                value={newLift.date}
+                onChange={(e) => setNewLift({ ...newLift, date: e.target.value })}
+              />
+            </div>
+
+            <div className="form-group">
+              <label className="form-label">Weight (lbs)</label>
+              <input
+                type="number"
+                className="form-input"
+                value={newLift.weight}
+                onChange={(e) => setNewLift({ ...newLift, weight: e.target.value })}
+                placeholder="225"
+              />
+            </div>
+
+            <div className="form-group">
+              <label className="form-label">Reps</label>
+              <input
+                type="number"
+                className="form-input"
+                value={newLift.reps}
+                onChange={(e) => setNewLift({ ...newLift, reps: e.target.value })}
+                placeholder="5"
+              />
+            </div>
+
+            <div className="form-group">
+              <label className="form-label">Notes (optional)</label>
+              <textarea
+                className="form-input"
+                value={newLift.notes}
+                onChange={(e) => setNewLift({ ...newLift, notes: e.target.value })}
+                placeholder="RPE, form notes, etc."
+                style={{ minHeight: '60px', fontFamily: 'monospace', fontSize: '12px' }}
+              />
+            </div>
+
+            {tmAtTime > 0 && (
+              <div className="data-row">
+                <div className="data-label">TM at this date</div>
+                <div className="data-value">{tmAtTime} lbs</div>
+              </div>
+            )}
+
+            {percentage > 0 && (
+              <div className="data-row">
+                <div className="data-label">% of TM</div>
+                <div className="data-value">{percentage}%</div>
+              </div>
+            )}
+
+            <button
+              className="button button-success"
+              onClick={handleLogLift}
+              style={{ marginTop: 'auto', width: '100%' }}
+            >
+              ✓ Log Lift
+            </button>
+          </div>
+        );
+      };
+
+      return (
+        <div className="container">
+          <div className="journey">
+            <h2 className="journey-title">📊 Lift History</h2>
+            <div className="screen">
+              <div className="screen-header">
+                <h3>Lift History</h3>
+                <p>With training max context</p>
+              </div>
+              {view === 'history' && renderHistory()}
+              {view === 'tm-history' && renderTMHistory()}
+              {view === 'log-lift' && renderLogLift()}
+            </div>
+          </div>
+
+          <div className="journey">
+            <h2 className="journey-title">🔧 Controls</h2>
+            <div className="screen">
+              <div className="screen-header">
+                <h3>Navigation</h3>
+                <p>Switch between views</p>
+              </div>
+              <div className="screen-content">
+                <button
+                  className={`button ${view === 'history' ? 'button-primary' : 'button-secondary'}`}
+                  onClick={() => setView('history')}
+                  style={{ width: '100%' }}
+                >
+                  📋 Lift History
+                </button>
+
+                <button
+                  className={`button ${view === 'tm-history' ? 'button-primary' : 'button-secondary'}`}
+                  onClick={() => setView('tm-history')}
+                  style={{ width: '100%' }}
+                >
+                  💪 TM Timeline
+                </button>
+
+                <button
+                  className={`button ${view === 'log-lift' ? 'button-primary' : 'button-secondary'}`}
+                  onClick={() => setView('log-lift')}
+                  style={{ width: '100%' }}
+                >
+                  ➕ Log Lift
+                </button>
+
+                <div className="section-label" style={{ marginTop: '20px' }}>Current Maxes</div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                  {getAllLifts().map((lift) => (
+                    <div key={lift} className="data-row">
+                      <div className="data-label">{lift}</div>
+                      <div className="data-value">{getCurrentTM(lift)} lbs</div>
+                    </div>
+                  ))}
+                </div>
+
+                <div className="section-label" style={{ marginTop: '20px' }}>Quick Stats</div>
+                <div className="data-row">
+                  <div className="data-label">Total Lifts Logged</div>
+                  <div className="data-value">{liftHistory.length}</div>
+                </div>
+                <div className="data-row">
+                  <div className="data-label">PRs</div>
+                  <div className="data-value">{liftHistory.filter(l => l.isPR).length}</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(
+      <LiftHistoryApp />
+    );
+  </script>
+</body>
+</html>

--- a/docs/mockups/programs-v3.html
+++ b/docs/mockups/programs-v3.html
@@ -1,0 +1,1283 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lifting Logbook - Program Management</title>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+      background: #fafaf8;
+      color: #1a1a1a;
+      line-height: 1.5;
+    }
+
+    .container {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      gap: 16px;
+      padding: 24px;
+      max-width: 100%;
+    }
+
+    .journey {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      aspect-ratio: 9/16;
+      max-height: 900px;
+    }
+
+    .journey-title {
+      font-size: 14px;
+      font-weight: 700;
+      color: #1a1a1a;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      padding: 0 16px;
+    }
+
+    .screen {
+      background: white;
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+      transition: all 0.3s ease;
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+    }
+
+    .screen:hover {
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+      transform: translateY(-2px);
+    }
+
+    .screen-header {
+      background: linear-gradient(135deg, #2c3e50 0%, #34495e 100%);
+      color: white;
+      padding: 12px 16px;
+      flex-shrink: 0;
+    }
+
+    .screen-header h3 {
+      font-size: 13px;
+      font-weight: 600;
+      margin-bottom: 2px;
+      opacity: 0.95;
+    }
+
+    .screen-header p {
+      font-size: 11px;
+      opacity: 0.7;
+    }
+
+    .screen-content {
+      padding: 16px;
+      flex: 1;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      font-size: 13px;
+    }
+
+    .form-group {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .form-label {
+      font-size: 11px;
+      font-weight: 700;
+      color: #2c3e50;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+    }
+
+    .form-input {
+      padding: 8px 12px;
+      border: 1px solid #ecf0f1;
+      border-radius: 6px;
+      font-size: 13px;
+      transition: border-color 0.2s ease;
+      min-height: 36px;
+    }
+
+    .form-input:focus {
+      outline: none;
+      border-color: #3498db;
+      box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.1);
+    }
+
+    .button {
+      padding: 10px 16px;
+      border: none;
+      border-radius: 6px;
+      font-size: 12px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      min-height: 44px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .button-primary {
+      background: #3498db;
+      color: white;
+    }
+
+    .button-primary:hover {
+      background: #2980b9;
+      transform: translateY(-1px);
+      box-shadow: 0 2px 8px rgba(52, 152, 219, 0.3);
+    }
+
+    .button-secondary {
+      background: #ecf0f1;
+      color: #2c3e50;
+    }
+
+    .button-secondary:hover {
+      background: #bdc3c7;
+    }
+
+    .button-success {
+      background: #27ae60;
+      color: white;
+    }
+
+    .button-success:hover {
+      background: #229954;
+    }
+
+    .button-warning {
+      background: #f39c12;
+      color: white;
+    }
+
+    .button-warning:hover {
+      background: #d68910;
+    }
+
+    .data-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 8px;
+      padding: 10px;
+      background: #f8f9fa;
+      border-radius: 6px;
+      border-left: 3px solid #3498db;
+      font-size: 12px;
+    }
+
+    .data-label {
+      font-size: 10px;
+      color: #7f8c8d;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+    }
+
+    .data-value {
+      font-size: 13px;
+      font-weight: 600;
+      color: #1a1a1a;
+    }
+
+    .exercise-item {
+      padding: 10px 12px;
+      background: #f8f9fa;
+      border-radius: 6px;
+      border-left: 3px solid #3498db;
+      font-size: 12px;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      min-height: 44px;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
+
+    .exercise-item:active {
+      background: #ecf0f1;
+    }
+
+    .exercise-name {
+      font-weight: 600;
+      color: #1a1a1a;
+      margin-bottom: 2px;
+    }
+
+    .exercise-sets {
+      font-size: 11px;
+      color: #7f8c8d;
+    }
+
+    .status-badge {
+      display: inline-block;
+      padding: 4px 8px;
+      border-radius: 4px;
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.02em;
+      flex-shrink: 0;
+    }
+
+    .status-template {
+      background: #e3f2fd;
+      color: #1976d2;
+    }
+
+    .status-custom {
+      background: #f3e5f5;
+      color: #7b1fa2;
+    }
+
+    .status-running {
+      background: #e8f5e9;
+      color: #388e3c;
+    }
+
+    .section-label {
+      font-size: 10px;
+      font-weight: 700;
+      color: #7f8c8d;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      margin-top: 12px;
+      margin-bottom: 8px;
+    }
+
+    .info-box {
+      padding: 10px 12px;
+      background: #e8f4f8;
+      border-left: 3px solid #3498db;
+      border-radius: 6px;
+      font-size: 11px;
+      line-height: 1.5;
+    }
+
+    .info-box strong {
+      color: #2c3e50;
+    }
+
+    .alert-box {
+      padding: 12px;
+      background: #fff3cd;
+      border-left: 3px solid #f39c12;
+      border-radius: 6px;
+      font-size: 11px;
+      line-height: 1.5;
+    }
+
+    .alert-box strong {
+      color: #856404;
+    }
+
+    .category-tabs {
+      display: flex;
+      gap: 4px;
+      margin-bottom: 12px;
+      border-bottom: 1px solid #ecf0f1;
+      padding-bottom: 8px;
+    }
+
+    .category-tab {
+      flex: 1;
+      padding: 8px 12px;
+      font-size: 11px;
+      border-radius: 4px 4px 0 0;
+      border: 1px solid #ecf0f1;
+      background: #f8f9fa;
+      cursor: 'pointer';
+      font-weight: 600;
+      text-align: center;
+      transition: all 0.2s ease;
+    }
+
+    .category-tab.active {
+      border-color: #3498db;
+      background: #ecf0f1;
+      border-bottom-color: #ecf0f1;
+    }
+
+    .program-card {
+      padding: 12px;
+      background: #f8f9fa;
+      border-radius: 6px;
+      border-left: 3px solid #3498db;
+      cursor: pointer;
+      transition: all 0.2s ease;
+    }
+
+    .program-card:hover {
+      background: #ecf0f1;
+      transform: translateX(2px);
+    }
+
+    .program-card.template {
+      border-left-color: #1976d2;
+    }
+
+    .program-card.custom {
+      border-left-color: #7b1fa2;
+    }
+
+    .program-card-title {
+      font-weight: 600;
+      color: #1a1a1a;
+      margin-bottom: 4px;
+      font-size: 12px;
+    }
+
+    .program-card-desc {
+      font-size: 10px;
+      color: #7f8c8d;
+      line-height: 1.4;
+      margin-bottom: 8px;
+    }
+
+    .program-card-meta {
+      display: flex;
+      gap: 8px;
+      font-size: 9px;
+      color: #7f8c8d;
+      flex-wrap: wrap;
+    }
+
+    .filter-tags {
+      display: flex;
+      gap: 4px;
+      flex-wrap: wrap;
+    }
+
+    .filter-tag {
+      padding: 4px 8px;
+      background: #f0f0f0;
+      border: 1px solid #bdc3c7;
+      border-radius: 3px;
+      font-size: 10px;
+      cursor: pointer;
+      transition: all 0.2s ease;
+    }
+
+    .filter-tag.active {
+      background: #3498db;
+      color: white;
+      border-color: #3498db;
+    }
+
+    @media (max-width: 1400px) {
+      .container {
+        grid-template-columns: 1fr 1fr;
+      }
+    }
+
+    @media (max-width: 900px) {
+      .container {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useEffect } = React;
+
+    // ============ PROGRAM MANAGEMENT SYSTEM ============
+    function ProgramManagementJourney() {
+      const [view, setView] = useState('category-select'); // 'category-select' | 'browse' | 'program-detail' | 'edit-custom' | 'create-custom'
+      const [selectedCategory, setSelectedCategory] = useState(null); // 'beginner' | 'intermediate' | 'advanced' | 'custom'
+      const [selectedProgram, setSelectedProgram] = useState(null);
+      const [editingProgram, setEditingProgram] = useState(null);
+      const [editingWorkoutIdx, setEditingWorkoutIdx] = useState(null);
+      const [showConvertAlert, setShowConvertAlert] = useState(false);
+      const [convertingProgramId, setConvertingProgramId] = useState(null);
+
+      // Custom programs storage (in real app, would be database)
+      const [customPrograms, setCustomPrograms] = useState([
+        {
+          id: 'custom-1',
+          name: 'My Modified 5/3/1',
+          baseTemplate: '531',
+          cycles: 3,
+          blocksPerCycle: 4,
+          description: 'Custom version with added conditioning',
+          createdAt: '2025-01-15',
+          workouts: [
+            { name: 'Day 1', lifts: ['Squat 5/3/1', 'Leg Press 3x8'], block: 1, deload: false, usesPercentTM: true, percentTM: null },
+            { name: 'Day 2', lifts: ['Bench Press 5/3/1', 'Dips 3x8'], block: 1, deload: false, usesPercentTM: true, percentTM: null },
+            { name: 'Day 3', lifts: ['Deadlift 5/3/1', 'Rows 3x8'], block: 1, deload: false, usesPercentTM: true, percentTM: null },
+            { name: 'Day 4', lifts: ['OHP 5/3/1', 'Assistance'], block: 2, deload: false, usesPercentTM: true, percentTM: null }
+          ]
+        }
+      ]);
+
+      const [runningProgram, setRunningProgram] = useState({
+        id: 'running-1',
+        programId: '531',
+        programType: 'template',
+        name: '5/3/1',
+        baseTemplate: null,
+        startDate: '2025-01-01',
+        currentCycle: 1,
+        totalCycles: 3,
+        workouts: [],
+        hasLocalEdits: false
+      });
+
+      // Template programs database
+      const templatePrograms = {
+        beginner: [
+          {
+            id: 'ss',
+            name: 'Starting Strength',
+            description: 'Classic linear progression for absolute beginners. 3 full-body sessions/week.',
+            daysPerWeek: 3,
+            split: 'full-body',
+            goals: ['strength', 'muscle-gain'],
+            cycles: 'Continuous linear progression',
+            workouts: [
+              { 
+                name: 'Monday', 
+                exercises: [
+                  { name: 'Squat', sets: 3, reps: 5, progression: 'linear', increment: '+10lbs', mechanics: '3×5' },
+                  { name: 'Bench Press', sets: 3, reps: 5, progression: 'linear', increment: '+5lbs', mechanics: '3×5' },
+                  { name: 'Deadlift', sets: 1, reps: 5, progression: 'linear', increment: '+10lbs', mechanics: '1×5' }
+                ], 
+                deload: false 
+              },
+              { 
+                name: 'Wednesday', 
+                exercises: [
+                  { name: 'Squat', sets: 3, reps: 5, progression: 'linear', increment: '+10lbs', mechanics: '3×5' },
+                  { name: 'Overhead Press', sets: 3, reps: 5, progression: 'linear', increment: '+5lbs', mechanics: '3×5' },
+                  { name: 'Deadlift', sets: 1, reps: 5, progression: 'linear', increment: '+10lbs', mechanics: '1×5' }
+                ], 
+                deload: false 
+              },
+              { 
+                name: 'Friday', 
+                exercises: [
+                  { name: 'Squat', sets: 3, reps: 5, progression: 'linear', increment: '+10lbs', mechanics: '3×5' },
+                  { name: 'Bench Press', sets: 3, reps: 5, progression: 'linear', increment: '+5lbs', mechanics: '3×5' },
+                  { name: 'Deadlift', sets: 1, reps: 5, progression: 'linear', increment: '+10lbs', mechanics: '1×5' }
+                ], 
+                deload: false 
+              }
+            ]
+          },
+          {
+            id: 'stronglifts',
+            name: 'StrongLifts 5×5',
+            description: 'Alternating upper/lower with 5×5 main lifts. 3 days/week.',
+            daysPerWeek: 3,
+            split: 'full-body',
+            goals: ['strength', 'muscle-gain'],
+            cycles: 'Continuous with automatic resets',
+            workouts: [
+              { 
+                name: 'A Workout', 
+                exercises: [
+                  { name: 'Squat', sets: 5, reps: 5, progression: 'linear', increment: '+5lbs', mechanics: '5×5' },
+                  { name: 'Bench Press', sets: 5, reps: 5, progression: 'linear', increment: '+5lbs', mechanics: '5×5' },
+                  { name: 'Barbell Row', sets: 5, reps: 5, progression: 'linear', increment: '+5lbs', mechanics: '5×5' }
+                ], 
+                deload: false 
+              },
+              { 
+                name: 'B Workout', 
+                exercises: [
+                  { name: 'Squat', sets: 5, reps: 5, progression: 'linear', increment: '+5lbs', mechanics: '5×5' },
+                  { name: 'Overhead Press', sets: 5, reps: 5, progression: 'linear', increment: '+5lbs', mechanics: '5×5' },
+                  { name: 'Deadlift', sets: 1, reps: 5, progression: 'linear', increment: '+5lbs', mechanics: '1×5' }
+                ], 
+                deload: false 
+              }
+            ]
+          }
+        ],
+        intermediate: [
+          {
+            id: 'rpt',
+            name: 'Reverse Pyramid Training',
+            description: 'Advanced fatigue management with descending sets. 3 days/week.',
+            daysPerWeek: 3,
+            split: 'full-body',
+            goals: ['strength', 'muscle-gain', 'body-composition'],
+            cycles: 'Accumulation → Intensification → Realization (4 weeks each with deload)',
+            workouts: [
+              { name: 'Day 1', lifts: ['Heavy compound 1×3-5', 'Decline sets 2-3×6-8'], deload: false },
+              { name: 'Day 2', lifts: ['Heavy compound 1×3-5', 'Decline sets 2-3×6-8'], deload: false },
+              { name: 'Day 3', lifts: ['Heavy compound 1×3-5', 'Decline sets 2-3×6-8'], deload: false }
+            ]
+          },
+          {
+            id: 'ppl',
+            name: 'Push/Pull/Legs',
+            description: 'Dedicated muscle group days. 6 days/week split.',
+            daysPerWeek: 6,
+            split: 'split',
+            goals: ['muscle-gain', 'body-composition'],
+            cycles: '4-5 week blocks with deload',
+            workouts: [
+              { name: 'Push', lifts: ['Bench Press 4×6-8', 'OHP 3×8-10', 'Accessories'], deload: false },
+              { name: 'Pull', lifts: ['Row 4×6-8', 'Pull-ups 3×6-10', 'Accessories'], deload: false },
+              { name: 'Legs', lifts: ['Squat 4×6-8', 'RDL 3×8-10', 'Leg Press 3×8-10'], deload: false }
+            ]
+          },
+          {
+            id: 'upper-lower',
+            name: 'Upper/Lower Split',
+            description: 'Balanced 4-day split for strength and hypertrophy.',
+            daysPerWeek: 4,
+            split: 'split',
+            goals: ['strength', 'muscle-gain', 'body-composition'],
+            cycles: '4-week blocks with deload',
+            workouts: [
+              { name: 'Upper A', lifts: ['Bench 4×5-6', 'Rows 3×8-10'], deload: false },
+              { name: 'Lower A', lifts: ['Squat 4×5-6', 'Leg Press 3×8-10'], deload: false },
+              { name: 'Upper B', lifts: ['Deadlift 3×3-5', 'OHP 3×6-8'], deload: false },
+              { name: 'Lower B', lifts: ['Squat 3×6-8', 'Accessories'], deload: false }
+            ]
+          },
+          {
+            id: '531',
+            name: '5/3/1',
+            description: 'Wendler\'s proven strength program. 4 days/week with periodized waves.',
+            daysPerWeek: 4,
+            split: 'full-body',
+            goals: ['strength'],
+            cycles: '4-week microcycles (weeks 1-3 training + week 4 deload)',
+            workouts: [
+              { 
+                name: 'Squat Day', 
+                exercises: [
+                  { name: 'Squat', sets: null, reps: null, progression: '5/3/1', percentTM: '65/75/85', mechanics: 'Wave loading', tmIncrement: '+5lbs/cycle' },
+                  { name: 'Squat', sets: 5, reps: null, progression: 'FSL', percentTM: '65%', mechanics: '5×FSL' },
+                  { name: 'Leg Press', sets: 3, reps: '8-10', progression: 'reps', increment: '+2 reps', mechanics: '3×8-10' }
+                ], 
+                deload: false 
+              },
+              { 
+                name: 'Bench Day', 
+                exercises: [
+                  { name: 'Bench Press', sets: null, reps: null, progression: '5/3/1', percentTM: '65/75/85', mechanics: 'Wave loading', tmIncrement: '+2.5lbs/cycle' },
+                  { name: 'Bench Press', sets: 5, reps: null, progression: 'FSL', percentTM: '65%', mechanics: '5×FSL' },
+                  { name: 'Dips', sets: 3, reps: '6-8', progression: 'reps', increment: '+1 rep', mechanics: '3×6-8' }
+                ], 
+                deload: false 
+              },
+              { 
+                name: 'Deadlift Day', 
+                exercises: [
+                  { name: 'Deadlift', sets: null, reps: null, progression: '5/3/1', percentTM: '65/75/85', mechanics: 'Wave loading', tmIncrement: '+5lbs/cycle' },
+                  { name: 'Deadlift', sets: 5, reps: null, progression: 'FSL', percentTM: '65%', mechanics: '5×FSL' },
+                  { name: 'Leg Curl', sets: 3, reps: '8-10', progression: 'reps', increment: '+2 reps', mechanics: '3×8-10' }
+                ], 
+                deload: false 
+              },
+              { 
+                name: 'OHP Day', 
+                exercises: [
+                  { name: 'Overhead Press', sets: null, reps: null, progression: '5/3/1', percentTM: '65/75/85', mechanics: 'Wave loading', tmIncrement: '+2.5lbs/cycle' },
+                  { name: 'Overhead Press', sets: 5, reps: null, progression: 'FSL', percentTM: '65%', mechanics: '5×FSL' },
+                  { name: 'Face Pulls', sets: 3, reps: '12-15', progression: 'reps', increment: '+2 reps', mechanics: '3×12-15' }
+                ], 
+                deload: false 
+              }
+            ]
+          },
+          {
+            id: '531-bbb',
+            name: '5/3/1 BBB',
+            description: 'High-volume strength + hypertrophy. 4 days/week.',
+            daysPerWeek: 4,
+            split: 'full-body',
+            goals: ['strength', 'muscle-gain'],
+            cycles: '4-week microcycles with BBB supplemental work',
+            workouts: [
+              { name: 'Day 1', lifts: ['Main 5/3/1', '10×5 @ 50%', 'Accessories'], deload: false },
+              { name: 'Day 2', lifts: ['Main 5/3/1', '10×5 @ 50%', 'Accessories'], deload: false },
+              { name: 'Day 3', lifts: ['Main 5/3/1', '10×5 @ 50%', 'Accessories'], deload: false },
+              { name: 'Day 4', lifts: ['Main 5/3/1', '10×5 @ 50%', 'Accessories'], deload: false }
+            ]
+          }
+        ],
+        advanced: [
+          {
+            id: 'conjugate',
+            name: 'Conjugate Method',
+            description: 'Westside-style concurrent training. 4 days/week.',
+            daysPerWeek: 4,
+            split: 'full-body',
+            goals: ['strength'],
+            cycles: '3 4-week microcycles per block with rotation',
+            workouts: [
+              { name: 'ME Lower', lifts: ['Max effort squat variant 1×2-3', 'Speed deadlift 8×2'], deload: false },
+              { name: 'DE Upper', lifts: ['Dynamic bench 8×3', 'Speed row 8×3'], deload: false },
+              { name: 'ME Upper', lifts: ['Max effort bench variant 1×2-3', 'Speed row 8×2'], deload: false },
+              { name: 'DE Lower', lifts: ['Dynamic squat 8×3', 'Speed deadlift 8×2'], deload: false }
+            ]
+          },
+          {
+            id: 'juggernaut',
+            name: 'Juggernaut Method',
+            description: 'Block periodization with rep wave loading. 4 days/week.',
+            daysPerWeek: 4,
+            split: 'full-body',
+            goals: ['strength', 'muscle-gain'],
+            cycles: '3 4-week blocks (accumulation → intensification → realization)',
+            workouts: [
+              { name: 'Day 1', lifts: ['Main lift', 'Secondary work', 'Accessories'], deload: false },
+              { name: 'Day 2', lifts: ['Main lift', 'Secondary work', 'Accessories'], deload: false },
+              { name: 'Day 3', lifts: ['Main lift', 'Secondary work', 'Accessories'], deload: false },
+              { name: 'Day 4', lifts: ['Main lift', 'Secondary work', 'Accessories'], deload: false }
+            ]
+          },
+          {
+            id: 'creeping-death',
+            name: 'Creeping Death II',
+            description: 'High-frequency hypertrophy with autoregulation. 5 days/week.',
+            daysPerWeek: 5,
+            split: 'split',
+            goals: ['muscle-gain'],
+            cycles: '3 4-week cycles with increasing volume',
+            workouts: [
+              { name: 'Squat Focus', lifts: ['Squat 5×5 RPE 7', 'Leg work'], deload: false },
+              { name: 'Bench Focus', lifts: ['Bench 5×5 RPE 7', 'Upper work'], deload: false },
+              { name: 'Deadlift Focus', lifts: ['Deadlift 4×3-5 RPE 7', 'Back work'], deload: false },
+              { name: 'OHP/Row Focus', lifts: ['OHP & Row 4×6-8', 'Accessories'], deload: false },
+              { name: 'Volume Day', lifts: ['Compounds 4×8-10 RPE 6', 'High-rep work'], deload: false }
+            ]
+          }
+        ]
+      };
+
+      // Get all programs by category
+      const getAllProgramsByCategory = (category) => {
+        if (category === 'custom') return customPrograms;
+        return templatePrograms[category] || [];
+      };
+
+      // Render program list view
+      const renderProgramList = () => {
+        if (!selectedCategory) {
+          return (
+            <div className="screen-content">
+              <div className="info-box">
+                <strong>Select a program category</strong> to browse templates or your custom programs.
+              </div>
+              <div className="section-label">Program Categories</div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                {['Beginner', 'Intermediate', 'Advanced', 'Custom'].map((cat) => {
+                  const catKey = cat.toLowerCase();
+                  const count = getAllProgramsByCategory(catKey).length;
+                  return (
+                    <div
+                      key={cat}
+                      onClick={() => {
+                        setSelectedCategory(catKey);
+                        setView('browse');
+                      }}
+                      className="program-card"
+                      style={{
+                        cursor: 'pointer',
+                        borderLeftColor: catKey === 'custom' ? '#7b1fa2' : '#1976d2'
+                      }}
+                    >
+                      <div className="program-card-title">{cat}</div>
+                      <div className="program-card-desc">
+                        {count} program{count !== 1 ? 's' : ''}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        }
+
+        const programs = getAllProgramsByCategory(selectedCategory);
+
+        return (
+          <div className="screen-content">
+            <button
+              className="button button-secondary"
+              onClick={() => setSelectedCategory(null)}
+              style={{ fontSize: '11px', marginBottom: 8 }}
+            >
+              ← All Categories
+            </button>
+
+            <div className="section-label">
+              {selectedCategory === 'custom' ? 'Custom Programs' : selectedCategory.toUpperCase()}
+            </div>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, flex: 1 }}>
+              {programs.length > 0 ? (
+                programs.map((prog) => (
+                  <div
+                    key={prog.id}
+                    onClick={() => {
+                      setSelectedProgram(prog);
+                      setView('program-detail');
+                    }}
+                    className="program-card"
+                    style={{
+                      cursor: 'pointer',
+                      borderLeftColor: selectedCategory === 'custom' ? '#7b1fa2' : '#1976d2'
+                    }}
+                  >
+                    <div className="program-card-title">{prog.name}</div>
+                    <div className="program-card-desc">{prog.description}</div>
+                    <div className="program-card-meta">
+                      <span>{prog.daysPerWeek}x/week</span>
+                      <span>•</span>
+                      <span>{prog.split === 'full-body' ? 'Full Body' : 'Split'}</span>
+                      {selectedCategory === 'custom' && (
+                        <>
+                          <span>•</span>
+                          <span>{prog.cycles} cycles</span>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                ))
+              ) : (
+                <div style={{ textAlign: 'center', color: '#7f8c8d', padding: '20px 0' }}>
+                  No programs in this category
+                </div>
+              )}
+            </div>
+
+            {selectedCategory === 'custom' && (
+              <button
+                className="button button-success"
+                onClick={() => {
+                  setSelectedProgram(null);
+                  setView('create-custom');
+                }}
+                style={{ width: '100%', marginTop: 'auto' }}
+              >
+                ➕ Create Custom Program
+              </button>
+            )}
+          </div>
+        );
+      };
+
+      // Render program detail view
+      const renderProgramDetail = () => {
+        if (!selectedProgram) return null;
+
+        const isTemplate = selectedCategory !== 'custom';
+        const isRunning = runningProgram.programId === selectedProgram.id;
+
+        return (
+          <div className="screen-content">
+            <button
+              className="button button-secondary"
+              onClick={() => setView('browse')}
+              style={{ fontSize: '11px', marginBottom: 8 }}
+            >
+              ← Back to Programs
+            </button>
+
+            <div style={{ marginBottom: 12 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 8, marginBottom: 8 }}>
+                <div className="exercise-name" style={{ fontSize: '14px' }}>{selectedProgram.name}</div>
+                <span className={`status-badge status-${isTemplate ? 'template' : 'custom'}`}>
+                  {isTemplate ? '📘 Template' : '✏️ Custom'}
+                </span>
+              </div>
+              <div style={{ fontSize: '11px', color: '#7f8c8d', lineHeight: '1.5' }}>
+                {selectedProgram.description}
+              </div>
+            </div>
+
+            <div className="data-row">
+              <div className="data-label">Days/Week</div>
+              <div className="data-value">{selectedProgram.daysPerWeek}x</div>
+            </div>
+
+            <div className="data-row">
+              <div className="data-label">Type</div>
+              <div className="data-value">{selectedProgram.split === 'full-body' ? 'Full Body' : 'Split'}</div>
+            </div>
+
+            <div className="data-row">
+              <div className="data-label">Cycles</div>
+              <div className="data-value">{selectedProgram.cycles}</div>
+            </div>
+
+            <div className="section-label">Workouts ({selectedProgram.workouts.length})</div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 12 }}>
+              {selectedProgram.workouts.map((wo, i) => (
+                <div key={i} className="exercise-item" style={{ borderLeftColor: '#3498db' }}>
+                  <div className="exercise-name">{wo.name}</div>
+                  <div style={{ fontSize: '10px', color: '#7f8c8d', marginTop: 4 }}>
+                    {wo.lifts.join(' • ')}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 'auto' }}>
+              {isRunning && (
+                <div className="info-box">
+                  <strong>✓ Currently Running</strong> — This is your active program
+                </div>
+              )}
+              
+              {isTemplate && (
+                <>
+                  <button
+                    className="button button-success"
+                    onClick={() => {
+                      setRunningProgram({
+                        id: `running-${Date.now()}`,
+                        programId: selectedProgram.id,
+                        programType: 'template',
+                        name: selectedProgram.name,
+                        baseTemplate: null,
+                        startDate: new Date().toISOString().split('T')[0],
+                        currentCycle: 1,
+                        totalCycles: 3,
+                        workouts: selectedProgram.workouts,
+                        hasLocalEdits: false
+                      });
+                      alert('✓ Running: ' + selectedProgram.name);
+                    }}
+                  >
+                    ▶ Start This Template
+                  </button>
+                  <button
+                    className="button button-warning"
+                    onClick={() => {
+                      setShowConvertAlert(true);
+                      setConvertingProgramId(selectedProgram.id);
+                    }}
+                  >
+                    ✎ Edit as Custom
+                  </button>
+                  <button
+                    className="button button-secondary"
+                    onClick={() => {
+                      const newCustom = {
+                        id: `custom-${Date.now()}`,
+                        name: selectedProgram.name + ' (Copy)',
+                        baseTemplate: selectedProgram.id,
+                        cycles: 3,
+                        description: selectedProgram.description,
+                        createdAt: new Date().toISOString().split('T')[0],
+                        workouts: JSON.parse(JSON.stringify(selectedProgram.workouts))
+                      };
+                      setCustomPrograms([...customPrograms, newCustom]);
+                      alert('✓ Copied to Custom Programs');
+                    }}
+                  >
+                    📋 Copy to Custom
+                  </button>
+                </>
+              )}
+
+              {!isTemplate && (
+                <>
+                  <button
+                    className="button button-success"
+                    onClick={() => {
+                      setRunningProgram({
+                        id: `running-${Date.now()}`,
+                        programId: selectedProgram.id,
+                        programType: 'custom',
+                        name: selectedProgram.name,
+                        baseTemplate: selectedProgram.baseTemplate,
+                        startDate: new Date().toISOString().split('T')[0],
+                        currentCycle: 1,
+                        totalCycles: selectedProgram.cycles,
+                        workouts: selectedProgram.workouts,
+                        hasLocalEdits: false
+                      });
+                      alert('✓ Running: ' + selectedProgram.name);
+                    }}
+                  >
+                    ▶ Start This Program
+                  </button>
+                  <button
+                    className="button button-warning"
+                    onClick={() => {
+                      setEditingProgram(selectedProgram);
+                      setView('edit-custom');
+                    }}
+                  >
+                    ✎ Edit Program
+                  </button>
+                  <button
+                    className="button button-secondary"
+                    onClick={() => {
+                      if (confirm('Delete this custom program?')) {
+                        setCustomPrograms(customPrograms.filter(p => p.id !== selectedProgram.id));
+                        setSelectedProgram(null);
+                        setView('browse');
+                      }
+                    }}
+                  >
+                    🗑 Delete
+                  </button>
+                </>
+              )}
+            </div>
+
+            {showConvertAlert && convertingProgramId === selectedProgram.id && (
+              <div className="alert-box" style={{ marginTop: 12 }}>
+                <strong>Create Custom Version?</strong> Editing a template will create a new custom program you can modify and save.
+                <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+                  <button
+                    className="button button-success"
+                    onClick={() => {
+                      const newCustom = {
+                        id: `custom-${Date.now()}`,
+                        name: selectedProgram.name + ' (Custom)',
+                        baseTemplate: selectedProgram.id,
+                        cycles: 3,
+                        description: selectedProgram.description,
+                        createdAt: new Date().toISOString().split('T')[0],
+                        workouts: JSON.parse(JSON.stringify(selectedProgram.workouts))
+                      };
+                      setCustomPrograms([...customPrograms, newCustom]);
+                      setEditingProgram(newCustom);
+                      setView('edit-custom');
+                      setShowConvertAlert(false);
+                    }}
+                    style={{ flex: 1, fontSize: '11px' }}
+                  >
+                    Create & Edit
+                  </button>
+                  <button
+                    className="button button-secondary"
+                    onClick={() => setShowConvertAlert(false)}
+                    style={{ flex: 1, fontSize: '11px' }}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      };
+
+      // Render custom program editor
+      const renderEditCustom = () => {
+        if (!editingProgram) return null;
+
+        // If editing a specific workout
+        if (editingWorkoutIdx !== null) {
+          const wo = editingProgram.workouts[editingWorkoutIdx];
+          
+          return (
+            <div className="screen-content">
+              <button
+                className="button button-secondary"
+                onClick={() => setEditingWorkoutIdx(null)}
+                style={{ fontSize: '11px', marginBottom: 8 }}
+              >
+                ← Back to Workouts
+              </button>
+
+              <div className="form-group">
+                <label className="form-label">Workout Name</label>
+                <input
+                  type="text"
+                  className="form-input"
+                  value={wo.name}
+                  onChange={(e) => {
+                    const newWorkouts = [...editingProgram.workouts];
+                    newWorkouts[editingWorkoutIdx].name = e.target.value;
+                    setEditingProgram({ ...editingProgram, workouts: newWorkouts });
+                  }}
+                />
+              </div>
+
+              <div className="form-group">
+                <label className="form-label">Exercises (one per line)</label>
+                <textarea
+                  className="form-input"
+                  value={wo.lifts.join('\n')}
+                  onChange={(e) => {
+                    const newWorkouts = [...editingProgram.workouts];
+                    newWorkouts[editingWorkoutIdx].lifts = e.target.value.split('\n').filter(l => l.trim());
+                    setEditingProgram({ ...editingProgram, workouts: newWorkouts });
+                  }}
+                  style={{ minHeight: '80px', fontFamily: 'monospace', fontSize: '12px' }}
+                />
+              </div>
+
+              <div className="form-group">
+                <label className="form-label">Block Number</label>
+                <input
+                  type="number"
+                  className="form-input"
+                  value={wo.block || 1}
+                  onChange={(e) => {
+                    const newWorkouts = [...editingProgram.workouts];
+                    newWorkouts[editingWorkoutIdx].block = parseInt(e.target.value) || 1;
+                    setEditingProgram({ ...editingProgram, workouts: newWorkouts });
+                  }}
+                  min="1"
+                  max={editingProgram.blocksPerCycle || 4}
+                />
+              </div>
+
+              <div className="form-group">
+                <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+                  <input
+                    type="checkbox"
+                    checked={wo.usesPercentTM || false}
+                    onChange={(e) => {
+                      const newWorkouts = [...editingProgram.workouts];
+                      newWorkouts[editingWorkoutIdx].usesPercentTM = e.target.checked;
+                      setEditingProgram({ ...editingProgram, workouts: newWorkouts });
+                    }}
+                  />
+                  <span className="form-label" style={{ margin: 0 }}>Uses Training Max %</span>
+                </label>
+              </div>
+
+              {wo.usesPercentTM && (
+                <div className="form-group">
+                  <label className="form-label">Training Max % (e.g., 90, 85, 75)</label>
+                  <input
+                    type="text"
+                    className="form-input"
+                    value={wo.percentTM || ''}
+                    onChange={(e) => {
+                      const newWorkouts = [...editingProgram.workouts];
+                      newWorkouts[editingWorkoutIdx].percentTM = e.target.value;
+                      setEditingProgram({ ...editingProgram, workouts: newWorkouts });
+                    }}
+                    placeholder="e.g., 90%"
+                  />
+                </div>
+              )}
+
+              <div className="form-group">
+                <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+                  <input
+                    type="checkbox"
+                    checked={wo.deload}
+                    onChange={(e) => {
+                      const newWorkouts = [...editingProgram.workouts];
+                      newWorkouts[editingWorkoutIdx].deload = e.target.checked;
+                      setEditingProgram({ ...editingProgram, workouts: newWorkouts });
+                    }}
+                  />
+                  <span className="form-label" style={{ margin: 0 }}>This is a deload week</span>
+                </label>
+              </div>
+
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 'auto' }}>
+                <button
+                  className="button button-success"
+                  onClick={() => setEditingWorkoutIdx(null)}
+                >
+                  ✓ Done Editing
+                </button>
+                <button
+                  className="button button-secondary"
+                  onClick={() => {
+                    const newWorkouts = editingProgram.workouts.filter((_, i) => i !== editingWorkoutIdx);
+                    setEditingProgram({ ...editingProgram, workouts: newWorkouts });
+                    setEditingWorkoutIdx(null);
+                  }}
+                >
+                  🗑 Delete Workout
+                </button>
+              </div>
+            </div>
+          );
+        }
+
+        // Main program editor view
+        return (
+          <div className="screen-content">
+            <button
+              className="button button-secondary"
+              onClick={() => {
+                setEditingProgram(null);
+                setView('program-detail');
+              }}
+              style={{ fontSize: '11px', marginBottom: 8 }}
+            >
+              ← Back
+            </button>
+
+            <div className="form-group">
+              <label className="form-label">Program Name</label>
+              <input
+                type="text"
+                className="form-input"
+                value={editingProgram.name}
+                onChange={(e) => setEditingProgram({ ...editingProgram, name: e.target.value })}
+              />
+            </div>
+
+            <div className="form-group">
+              <label className="form-label">Number of Cycles</label>
+              <input
+                type="number"
+                className="form-input"
+                value={editingProgram.cycles}
+                onChange={(e) => setEditingProgram({ ...editingProgram, cycles: parseInt(e.target.value) || 1 })}
+                min="1"
+                max="12"
+              />
+            </div>
+
+            <div className="form-group">
+              <label className="form-label">Blocks Per Cycle</label>
+              <input
+                type="number"
+                className="form-input"
+                value={editingProgram.blocksPerCycle || 4}
+                onChange={(e) => setEditingProgram({ ...editingProgram, blocksPerCycle: parseInt(e.target.value) || 1 })}
+                min="1"
+                max="12"
+              />
+            </div>
+
+            <div className="section-label">Workouts ({editingProgram.workouts.length})</div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 12, maxHeight: 300, overflowY: 'auto' }}>
+              {editingProgram.workouts.map((wo, idx) => (
+                <div 
+                  key={idx} 
+                  className="exercise-item" 
+                  onClick={() => setEditingWorkoutIdx(idx)}
+                  style={{ borderLeftColor: wo.deload ? '#f39c12' : '#3498db', cursor: 'pointer' }}
+                >
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', width: '100%', gap: 8 }}>
+                    <div style={{ flex: 1 }}>
+                      <div className="exercise-name">{wo.name}</div>
+                      <div style={{ fontSize: '10px', color: '#7f8c8d', marginTop: 2 }}>
+                        Block {wo.block || 1} {wo.usesPercentTM && wo.percentTM ? `• ${wo.percentTM} TM` : ''}
+                      </div>
+                      <div style={{ fontSize: '10px', color: '#7f8c8d', marginTop: 4 }}>
+                        {wo.lifts.join(' • ')}
+                      </div>
+                      {wo.deload && <div style={{ fontSize: '9px', color: '#f39c12', marginTop: 4, fontWeight: 600 }}>⏸ Deload</div>}
+                    </div>
+                    <span style={{ fontSize: '12px', color: '#3498db', fontWeight: 600 }}>✎</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <button
+              className="button button-secondary"
+              onClick={() => {
+                const newWorkout = { name: `Day ${editingProgram.workouts.length + 1}`, lifts: ['Exercise'], deload: false };
+                setEditingProgram({
+                  ...editingProgram,
+                  workouts: [...editingProgram.workouts, newWorkout]
+                });
+              }}
+              style={{ fontSize: '11px', width: '100%', marginBottom: 12 }}
+            >
+              ➕ Add Workout
+            </button>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 'auto' }}>
+              <button
+                className="button button-success"
+                onClick={() => {
+                  // Update in custom programs list
+                  setCustomPrograms(customPrograms.map(p => 
+                    p.id === editingProgram.id ? editingProgram : p
+                  ));
+                  setSelectedProgram(editingProgram);
+                  setEditingProgram(null);
+                  setView('program-detail');
+                  alert('✓ Saved!');
+                }}
+              >
+                ✓ Save Changes
+              </button>
+              <button
+                className="button button-secondary"
+                onClick={() => {
+                  setEditingProgram(null);
+                  setView('program-detail');
+                }}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        );
+      };
+
+      // Router
+      let content;
+      if (view === 'browse' || view === 'program-detail') {
+        if (view === 'program-detail') {
+          content = renderProgramDetail();
+        } else {
+          content = renderProgramList();
+        }
+      } else if (view === 'edit-custom') {
+        content = renderEditCustom();
+      } else {
+        // category-select
+        content = renderProgramList();
+      }
+
+      return (
+        <div className="journey">
+          <h2 className="journey-title">📋 Programs</h2>
+          <div className="screen">
+            <div className="screen-header">
+              <h3>
+                {view === 'program-detail' && selectedProgram ? selectedProgram.name : 
+                 view === 'edit-custom' && editingProgram ? 'Edit: ' + editingProgram.name :
+                 selectedCategory ? selectedCategory.toUpperCase() : 'All Programs'}
+              </h3>
+              <p>
+                {view === 'program-detail' && selectedProgram ? 
+                  (selectedCategory === 'custom' ? '✏️ Custom' : '📘 Template') :
+                 view === 'edit-custom' ? 'Custom Program Editor' :
+                 selectedCategory ? `${getAllProgramsByCategory(selectedCategory).length} programs` :
+                 'Browse all categories'}
+              </p>
+            </div>
+            {content}
+          </div>
+        </div>
+      );
+    }
+
+    // Render the app
+    ReactDOM.createRoot(document.getElementById('root')).render(
+      <ProgramManagementJourney />
+    );
+  </script>
+</body>
+</html>

--- a/docs/mockups/user-journeys.html
+++ b/docs/mockups/user-journeys.html
@@ -544,6 +544,9 @@
       const [viewingProgramDetail, setViewingProgramDetail] = useState(null);
       const [viewFullCatalog, setViewFullCatalog] = useState(false);
       const [catalogGoalFilter, setCatalogGoalFilter] = useState('all'); // 'all' | 'strength' | 'muscle-gain' | 'body-composition' | 'fat-loss'
+      const [catalogDaysFilter, setCatalogDaysFilter] = useState('all'); // 'all' | '3' | '4' | '5' | '6'
+      const [catalogSplitFilter, setCatalogSplitFilter] = useState('all'); // 'all' | 'full-body' | 'split'
+      const [catalogStatusFilter, setCatalogStatusFilter] = useState('available'); // 'available' | 'coming-soon' | 'all'
 
       const steps = ['Choose Method', 'Enter Data', 'Confirm Maxes', 'Choose Program'];
 
@@ -563,10 +566,12 @@
             weeks: 12,
             daysPerWeek: 3,
             progression: 'Add 5 lbs each workout (upper body) or 10 lbs (lower body)',
-            deloads: 'No formal deload weeks; program resets if stalled 3 sessions in a row',
-            cycles: 'Continuous linear progression; no built-in cycles',
+            deloads: 'No formal deload weeks; program resets if stalled 3 consecutive sessions (resets are recovery mechanism)',
+            cycles: 'Continuous linear progression; resets function as brief recovery when stalled',
             purposes: ['Strength', 'Beginner'],
             goals: ['strength', 'muscle-gain'],
+            fullBodySplit: 'full-body',
+            status: 'available',
             lifts: ['Squat', 'Bench Press', 'Deadlift', 'Barbell Row', 'Overhead Press'],
             schedule: [
               { day: 'Monday', lifts: ['Squat 3×5', 'Bench Press 3×5', 'Deadlift 1×5'] },
@@ -581,10 +586,12 @@
             weeks: 12,
             daysPerWeek: 3,
             progression: 'Add 5 lbs when all sets are completed',
-            deloads: 'No formal deload weeks; deload automatically when failing lifts',
-            cycles: 'Continuous progression with automatic resets',
+            deloads: 'No formal deload weeks; automatic reset when failing lifts serves as recovery mechanism',
+            cycles: 'Continuous progression with automatic resets as built-in recovery',
             purposes: ['Strength', 'Beginner'],
             goals: ['strength', 'muscle-gain'],
+            fullBodySplit: 'full-body',
+            status: 'available',
             lifts: ['Squat', 'Bench Press', 'Deadlift', 'Barbell Row', 'Overhead Press'],
             schedule: [
               { day: 'A Workout', lifts: ['Squat 5×5', 'Bench Press 5×5', 'Barbell Row 5×5'] },
@@ -600,10 +607,12 @@
             weeks: 12,
             daysPerWeek: 3,
             progression: 'Heavy single, then 2–3 declining sets; increase top weight when RPE ≤ 7',
-            deloads: 'Week 4 & Week 8 — full deload weeks at 50-60% intensity',
-            cycles: 'Three 4-week cycles: accumulation (moderate), intensification (heavy), realization (peak)',
+            deloads: 'Week 4 deload (50-60%) concludes accumulation cycle; Week 8 deload concludes intensification cycle',
+            cycles: 'Accumulation (weeks 1-4 with deload), Intensification (weeks 5-8 with deload), Realization (weeks 9-12)',
             purposes: ['Strength', 'Hypertrophy', 'Intermediate'],
             goals: ['strength', 'muscle-gain', 'body-composition'],
+            fullBodySplit: 'full-body',
+            status: 'available',
             lifts: ['Bench Press', 'Barbell Row', 'Overhead Press', 'Squat', 'Deadlift', 'Leg Press'],
             schedule: [
               { day: 'Week 1-3', lifts: ['Accumulation: Moderate intensity, higher volume'] },
@@ -618,10 +627,12 @@
             weeks: 12,
             daysPerWeek: 6,
             progression: 'Add reps to target sets; increase weight when hitting rep ranges',
-            deloads: 'Recommended: 1 deload week every 4-5 weeks at 60-70% intensity',
-            cycles: 'Continuous with recommended periodic deloads; can be run in 4-week blocks',
+            deloads: '1 deload week every 4-5 weeks concludes each training block at 60-70% intensity',
+            cycles: 'Continuous training with periodic 4-5 week blocks; each block ends with a deload week',
             purposes: ['Hypertrophy', 'Bodybuilding', 'Intermediate'],
             goals: ['muscle-gain', 'body-composition'],
+            fullBodySplit: 'split',
+            status: 'available',
             lifts: ['Bench Press', 'Overhead Press', 'Barbell Row', 'Deadlift', 'Squat'],
             schedule: [
               { day: 'Push', lifts: ['Bench Press 4×6-8', 'Overhead Press 3×8-10', 'Dumbbell Bench 3×8-10'] },
@@ -636,10 +647,12 @@
             weeks: 12,
             daysPerWeek: 4,
             progression: 'Drive strength on main lifts; hit rep ranges on accessories',
-            deloads: 'Recommended: Week 4 and Week 8 at 60-70% intensity',
-            cycles: 'Continuous with periodic 1-week deloads every 3-4 weeks',
+            deloads: 'Week 4 and Week 8 deloads (60-70%) conclude each 4-week training block',
+            cycles: 'Four-week blocks: weeks 1-3 main training + week 4 deload, repeating twice per 12-week program',
             purposes: ['Strength', 'Hypertrophy', 'Intermediate'],
             goals: ['strength', 'muscle-gain', 'body-composition'],
+            fullBodySplit: 'split',
+            status: 'available',
             lifts: ['Bench Press', 'Barbell Row', 'Squat', 'Deadlift'],
             schedule: [
               { day: 'Upper A', lifts: ['Bench Press 4×5-6', 'Weighted Dips 3×6-8', 'Barbell Row 3×8-10'] },
@@ -655,10 +668,12 @@
             weeks: 12,
             daysPerWeek: 4,
             progression: 'Weekly waves (5s, 3s, 1s) with 90% FSL; increase TM by 5 lbs (lower) or 2.5 lbs (upper) every cycle',
-            deloads: 'Deload week every 4 weeks (Week 4) at reduced intensity and volume',
-            cycles: 'Four-week microcycles repeating throughout the program; continuous progression',
+            deloads: 'Week 4 deload (reduced intensity/volume) concludes each 4-week training microcycle',
+            cycles: 'Four-week microcycles repeating throughout the program: weeks 1-3 training + week 4 deload',
             purposes: ['Strength', 'Intermediate'],
             goals: ['strength'],
+            fullBodySplit: 'full-body',
+            status: 'available',
             lifts: ['Squat', 'Bench Press', 'Deadlift', 'Overhead Press'],
             schedule: [
               { day: 'Day 1', lifts: ['Squat: 5/3/1, 5×FSL', 'Accessory work'] },
@@ -674,10 +689,12 @@
             weeks: 12,
             daysPerWeek: 4,
             progression: 'Main lift 5/3/1; BBB sets at 50% TM, 10 sets of 5 reps for each lift',
-            deloads: 'Deload week every 4 weeks with reduced volume and intensity',
-            cycles: 'Four-week microcycles; accumulation of volume drives hypertrophy',
+            deloads: 'Week 4 deload concludes each 4-week microcycle with reduced volume and intensity',
+            cycles: 'Three 4-week microcycles: weeks 1-3 training + week 4 deload; volume accumulation across cycles drives hypertrophy',
             purposes: ['Strength', 'Hypertrophy', 'Intermediate'],
             goals: ['strength', 'muscle-gain'],
+            fullBodySplit: 'full-body',
+            status: 'available',
             lifts: ['Squat', 'Bench Press', 'Deadlift', 'Overhead Press'],
             schedule: [
               { day: 'Day 1', lifts: ['Squat 5/3/1 + 10×5 @ 50%', 'Assistance work'] },
@@ -693,10 +710,12 @@
             weeks: 12,
             daysPerWeek: 4,
             progression: 'Autoregulated: select your own supplemental work based on session quality and RPE',
-            deloads: 'Deload week every 4 weeks; can also deload individual lifts as needed',
-            cycles: 'Four-week microcycles with flexibility to repeat or reset based on progress',
+            deloads: 'Week 4 deload concludes each 4-week microcycle; individual lifts can be deloaded independently as needed',
+            cycles: 'Four-week microcycles with autoregulated deload weeks: weeks 1-3 training + week 4 deload',
             purposes: ['Strength', 'Hypertrophy', 'Intermediate'],
             goals: ['strength', 'muscle-gain', 'body-composition'],
+            fullBodySplit: 'full-body',
+            status: 'available',
             lifts: ['Squat', 'Bench Press', 'Deadlift', 'Overhead Press'],
             schedule: [
               { day: 'Day 1', lifts: ['Main Lift: 5/3/1 + Supplemental + Assistance'] },
@@ -712,10 +731,12 @@
             weeks: 12,
             daysPerWeek: 3,
             progression: 'Linear progression: add weight when you hit rep targets; eat surplus on training days, deficit on rest days',
-            deloads: 'Deload every 8 weeks by reducing volume 40-50%; intensity stays high',
-            cycles: 'Eight-week accumulation block followed by 1-week deload; cycles repeat',
+            deloads: 'Week 8 deload (40-50% volume reduction) concludes each 8-week accumulation block; intensity stays high',
+            cycles: 'Eight-week accumulation blocks followed by 1-week deload; cycles repeat throughout program',
             purposes: ['Strength', 'Intermediate'],
             goals: ['strength', 'body-composition', 'fat-loss'],
+            fullBodySplit: 'full-body',
+            status: 'available',
             lifts: ['Squat', 'Deadlift', 'Bench Press', 'Barbell Row'],
             schedule: [
               { day: 'Day A (Mon)', lifts: ['Squat 4-6 reps', 'Bench Press 6-8 reps', 'Dumbbell Row 6-8 reps'] },
@@ -732,10 +753,12 @@
             weeks: 12,
             daysPerWeek: 4,
             progression: 'Rotate competition lifts, accessory exercises, and training methods every 3 weeks',
-            deloads: 'Built-in throughout program via rotation; recovery week every 4 weeks',
-            cycles: 'Three 4-week microcycles per 12-week block; rotating methods prevent stagnation',
+            deloads: 'Built-in via exercise rotation; recovery week every 4 weeks concludes each microcycle',
+            cycles: 'Three 4-week microcycles per 12-week block: weeks 1-3 training + week 4 recovery; rotating methods prevent stagnation',
             purposes: ['Strength', 'Powerlifting', 'Advanced'],
             goals: ['strength'],
+            fullBodySplit: 'full-body',
+            status: 'available',
             lifts: ['Squat', 'Bench Press', 'Deadlift', 'Barbell Row'],
             schedule: [
               { day: 'Max Effort Lower', lifts: ['Max effort squat variant 1×2-3', 'Speed deadlift 8×2', 'Leg work'] },
@@ -751,10 +774,12 @@
             weeks: 13,
             daysPerWeek: 4,
             progression: 'Carefully planned volume and intensity waves; average daily volume increases over 13 weeks',
-            deloads: 'Week 2 is a deload week; final week is test week at 100%',
-            cycles: 'Single 13-week block: preparatory (4w), base (5w), intensification (3w), peaking (1w)',
+            deloads: 'Week 2 deload concludes preparatory phase; final week (week 13) is test week at 100%',
+            cycles: 'Single 13-week block: preparatory (weeks 1-2 with deload) → base (weeks 3-7) → intensification (weeks 8-10) → peaking & test (weeks 11-13)',
             purposes: ['Strength', 'Powerlifting', 'Advanced'],
             goals: ['strength'],
+            fullBodySplit: 'full-body',
+            status: 'available',
             lifts: ['Squat'],
             schedule: [
               { day: 'Preparatory Phase (4 weeks)', lifts: ['Squat 6×6 at 65-75% (M/W)', 'Squat 3×6 at 75-80% (F)', 'Squat 4×5 at 75-85% (Sa)'] },
@@ -769,10 +794,12 @@
             weeks: 12,
             daysPerWeek: 4,
             progression: 'Block-based progression: accumulation (rep ranges 6-8) → intensification (3-5) → realization (1-3)',
-            deloads: 'Built into block transitions; 1 week deload every 3-4 weeks between blocks',
-            cycles: 'Three 4-week blocks per program; alternating rep ranges prevent accommodation',
+            deloads: 'Deload week concludes each 4-week block during block transitions',
+            cycles: 'Three 4-week blocks per program: accumulation (6-8 reps) + deload → intensification (3-5 reps) + deload → realization (1-3 reps)',
             purposes: ['Strength', 'Hypertrophy', 'Powerlifting', 'Advanced'],
             goals: ['strength', 'muscle-gain'],
+            fullBodySplit: 'full-body',
+            status: 'available',
             lifts: ['Squat', 'Bench Press', 'Deadlift', 'Barbell Row'],
             schedule: [
               { day: 'Block 1: Accumulation (4w)', lifts: ['Main lift 6×3 at 75-80%', 'Secondary 4×6-8', 'Accessory work'] },
@@ -787,10 +814,12 @@
             weeks: 12,
             daysPerWeek: 5,
             progression: 'Add reps first, then weight; multiple main lifts per session with declining intensity',
-            deloads: 'Week 4 & Week 8 at reduced volume and intensity',
-            cycles: 'Three 4-week cycles; volume increases each cycle; intensity controlled by RPE',
+            deloads: 'Week 4 and Week 8 deloads conclude each 4-week accumulation block',
+            cycles: 'Three 4-week cycles: weeks 1-3 accumulation + week 4 deload, repeating with increasing volume each cycle',
             purposes: ['Hypertrophy', 'Bodybuilding', 'Advanced'],
             goals: ['muscle-gain'],
+            fullBodySplit: 'split',
+            status: 'available',
             lifts: ['Squat', 'Bench Press', 'Deadlift', 'Barbell Row', 'Overhead Press'],
             schedule: [
               { day: 'Squat Focus', lifts: ['Squat 5×5 at RPE 7', 'Leg Press 4×8-10', 'Accessories'] },
@@ -798,6 +827,27 @@
               { day: 'Deadlift Focus', lifts: ['Deadlift 4×3-5 at RPE 7', 'Back work', 'Accessories'] },
               { day: 'OHP/Row Focus', lifts: ['Overhead Press 4×6-8', 'Barbell Row 4×6-8', 'Accessories'] },
               { day: 'Volume Day', lifts: ['Compound lifts 4×8-10 at RPE 6', 'High-rep accessories'] }
+            ]
+          },
+          {
+            id: '531-fat-loss',
+            name: '5/3/1 for Fat Loss',
+            description: 'Jim Wendler\'s 5/3/1 adapted specifically for fat loss and body recomposition. Preserves strength while maximizing metabolic demand.',
+            weeks: 12,
+            daysPerWeek: 4,
+            progression: 'Main lifts 5/3/1 at reduced TM (90% of actual); high rep supplemental work (8-15 reps)',
+            deloads: 'Week 4 deload concludes each 4-week microcycle with reduced intensity and volume',
+            cycles: 'Four-week microcycles: weeks 1-3 training + week 4 deload; high-rep accessory emphasis maintains metabolic demand',
+            purposes: ['Fat Loss', 'Strength', 'Advanced'],
+            goals: ['fat-loss', 'body-composition', 'strength'],
+            fullBodySplit: 'full-body',
+            status: 'coming-soon',
+            lifts: ['Squat', 'Bench Press', 'Deadlift', 'Overhead Press'],
+            schedule: [
+              { day: 'Day 1', lifts: ['Squat 5/3/1, High-rep leg accessories 4×8-15', 'Core work'] },
+              { day: 'Day 2', lifts: ['Bench Press 5/3/1, High-rep upper accessories 4×8-15', 'Conditioning'] },
+              { day: 'Day 3', lifts: ['Deadlift 5/3/1, High-rep pulling 4×8-15', 'Core work'] },
+              { day: 'Day 4', lifts: ['Overhead Press 5/3/1, High-rep upper accessories 4×8-15', 'Conditioning'] }
             ]
           }
         ]
@@ -945,9 +995,13 @@
             // Full catalog view
             if (viewFullCatalog) {
               const allPrograms = [...programs.beginner, ...programs.intermediate, ...programs.advanced];
-              const filteredPrograms = catalogGoalFilter === 'all' 
-                ? allPrograms 
-                : allPrograms.filter(p => p.goals.includes(catalogGoalFilter));
+              const filteredPrograms = allPrograms.filter(p => {
+                const goalMatch = catalogGoalFilter === 'all' || p.goals.includes(catalogGoalFilter);
+                const daysMatch = catalogDaysFilter === 'all' || p.daysPerWeek === parseInt(catalogDaysFilter);
+                const splitMatch = catalogSplitFilter === 'all' || p.fullBodySplit === catalogSplitFilter;
+                const statusMatch = catalogStatusFilter === 'all' || p.status === catalogStatusFilter;
+                return goalMatch && daysMatch && splitMatch && statusMatch;
+              });
 
               if (viewingProgramDetail) {
                 const program = allPrograms.find(p => p.id === viewingProgramDetail);
@@ -1063,6 +1117,78 @@
                           }}
                         >
                           {goal === 'all' ? 'All Goals' : goalLabels[goal]}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="form-group">
+                    <label className="form-label">Days Per Week</label>
+                    <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+                      {['all', '3', '4', '5', '6'].map(days => (
+                        <button
+                          key={days}
+                          onClick={() => setCatalogDaysFilter(days)}
+                          style={{
+                            padding: '6px 10px',
+                            fontSize: '10px',
+                            borderRadius: 4,
+                            border: catalogDaysFilter === days ? '2px solid #3498db' : '1px solid #bdc3c7',
+                            background: catalogDaysFilter === days ? '#ecf0f1' : '#f8f9fa',
+                            color: '#2c3e50',
+                            cursor: 'pointer',
+                            fontWeight: 600
+                          }}
+                        >
+                          {days === 'all' ? 'Any' : `${days}x/week`}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="form-group">
+                    <label className="form-label">Program Type</label>
+                    <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+                      {['all', 'full-body', 'split'].map(split => (
+                        <button
+                          key={split}
+                          onClick={() => setCatalogSplitFilter(split)}
+                          style={{
+                            padding: '6px 10px',
+                            fontSize: '10px',
+                            borderRadius: 4,
+                            border: catalogSplitFilter === split ? '2px solid #3498db' : '1px solid #bdc3c7',
+                            background: catalogSplitFilter === split ? '#ecf0f1' : '#f8f9fa',
+                            color: '#2c3e50',
+                            cursor: 'pointer',
+                            fontWeight: 600
+                          }}
+                        >
+                          {split === 'all' ? 'Any' : split === 'full-body' ? 'Full Body' : 'Upper/Lower Split'}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="form-group">
+                    <label className="form-label">Availability</label>
+                    <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+                      {['available', 'coming-soon', 'all'].map(status => (
+                        <button
+                          key={status}
+                          onClick={() => setCatalogStatusFilter(status)}
+                          style={{
+                            padding: '6px 10px',
+                            fontSize: '10px',
+                            borderRadius: 4,
+                            border: catalogStatusFilter === status ? '2px solid #3498db' : '1px solid #bdc3c7',
+                            background: catalogStatusFilter === status ? '#ecf0f1' : '#f8f9fa',
+                            color: '#2c3e50',
+                            cursor: 'pointer',
+                            fontWeight: 600
+                          }}
+                        >
+                          {status === 'available' ? '✓ Available' : status === 'coming-soon' ? '⏰ Coming Soon' : 'All'}
                         </button>
                       ))}
                     </div>
@@ -1384,14 +1510,14 @@
       });
 
       const [workouts, setWorkouts] = useState([
-        { id: 0, week: 'W1', date: 'Mon, May 6', status: 'completed', lifts: ['Bench: 225×5', 'Row: 185×6', 'OHP: 135×4'] },
-        { id: 1, week: 'W1', date: 'Wed, May 8', status: 'completed', lifts: ['Squat: 315×5', 'Leg Press: 405×8'] },
-        { id: 2, week: 'W1', date: 'Fri, May 10', status: 'completed', lifts: ['Deadlift: 405×3', 'Back Ext: 135×10'] },
-        { id: 3, week: 'W2', date: 'Mon, May 13', status: 'upcoming', lifts: ['Bench: 235×5', 'Row: 195×6', 'OHP: 140×4'] },
-        { id: 4, week: 'W2', date: 'Wed, May 15', status: 'upcoming', lifts: ['Squat: 325×5', 'Leg Press: 415×8'] },
-        { id: 5, week: 'W2', date: 'Fri, May 17', status: 'upcoming', lifts: ['Deadlift: 415×3', 'Back Ext: 140×10'] },
-        { id: 6, week: 'W3', date: 'Mon, May 20', status: 'upcoming', lifts: ['Bench: 245×5', 'Row: 205×6', 'OHP: 145×4'] },
-        { id: 7, week: 'W3', date: 'Wed, May 22', status: 'upcoming', lifts: ['Squat: 335×5', 'Leg Press: 425×8'] },
+        { id: 0, block: 'Cycle 1, Block 1', date: 'Mon, May 6', status: 'completed', lifts: ['Bench: 225×5', 'Row: 185×6', 'OHP: 135×4'] },
+        { id: 1, block: 'Cycle 1, Block 1', date: 'Wed, May 8', status: 'completed', lifts: ['Squat: 315×5', 'Leg Press: 405×8'] },
+        { id: 2, block: 'Cycle 1, Block 1', date: 'Fri, May 10', status: 'completed', lifts: ['Deadlift: 405×3', 'Back Ext: 135×10'] },
+        { id: 3, block: 'Cycle 1, Block 2', date: 'Mon, May 13', status: 'upcoming', lifts: ['Bench: 235×5', 'Row: 195×6', 'OHP: 140×4'] },
+        { id: 4, block: 'Cycle 1, Block 2', date: 'Wed, May 15', status: 'upcoming', lifts: ['Squat: 325×5', 'Leg Press: 415×8'] },
+        { id: 5, block: 'Cycle 1, Block 2', date: 'Fri, May 17', status: 'upcoming', lifts: ['Deadlift: 415×3', 'Back Ext: 140×10'] },
+        { id: 6, block: 'Cycle 1, Block 3', date: 'Mon, May 20', status: 'upcoming', lifts: ['Bench: 245×5', 'Row: 205×6', 'OHP: 145×4'] },
+        { id: 7, block: 'Cycle 1, Block 3', date: 'Wed, May 22', status: 'upcoming', lifts: ['Squat: 335×5', 'Leg Press: 425×8'] },
       ]);
 
       const programPlan = {
@@ -1402,50 +1528,26 @@
         cycles: [
           { 
             num: 1, 
-            weeks: 'W1–W3', 
-            workouts: 9, 
-            type: 'training',
-            description: 'Accumulation phase — moderate intensity',
+            weeks: 'W1–W4', 
+            workouts: 12, 
+            type: 'accumulation',
+            description: '3-week accumulation phase (moderate intensity, high volume) + 1-week deload',
             status: 'in-progress'
           },
           { 
             num: 2, 
-            weeks: 'W4', 
-            workouts: 3, 
-            type: 'deload',
-            description: 'Deload week — recover & consolidate',
+            weeks: 'W5–W8', 
+            workouts: 12, 
+            type: 'intensification',
+            description: '3-week intensification phase (heavier loads, lower volume) + 1-week deload',
             status: 'upcoming'
           },
           { 
             num: 3, 
-            weeks: 'W5–W7', 
-            workouts: 9, 
-            type: 'training',
-            description: 'Intensification phase — heavier loads',
-            status: 'upcoming'
-          },
-          { 
-            num: 4, 
-            weeks: 'W8', 
-            workouts: 3, 
-            type: 'deload',
-            description: 'Deload week — recover & consolidate',
-            status: 'upcoming'
-          },
-          { 
-            num: 5, 
-            weeks: 'W9–W11', 
-            workouts: 9, 
-            type: 'training',
-            description: 'Realization phase — peak intensity',
-            status: 'upcoming'
-          },
-          { 
-            num: 6, 
-            weeks: 'W12', 
-            workouts: 3, 
-            type: 'test',
-            description: 'Test week — assess new maxes',
+            weeks: 'W9–W12', 
+            workouts: 12, 
+            type: 'realization',
+            description: '3-week realization phase (peak intensity) + 1-week test week',
             status: 'upcoming'
           },
         ]
@@ -1537,9 +1639,10 @@
                       className="exercise-item"
                       style={{
                         borderLeft: 
-                          cycle.type === 'deload' ? '3px solid #f39c12' :
-                          cycle.type === 'test' ? '3px solid #e74c3c' :
-                          '3px solid #3498db',
+                          cycle.type === 'accumulation' ? '3px solid #3498db' :
+                          cycle.type === 'intensification' ? '3px solid #e67e22' :
+                          cycle.type === 'realization' ? '3px solid #e74c3c' :
+                          '3px solid #9b59b6',
                         background:
                           cycle.status === 'in-progress' ? '#ecf0f1' :
                           cycle.status === 'completed' ? '#a8e6cf' :
@@ -1615,7 +1718,7 @@
             <div className="screen">
               <div className="screen-header">
                 <h3>Reschedule Workout</h3>
-                <p>{workout.week}</p>
+                <p>{workout.block}</p>
               </div>
               <div className="screen-content">
                 <div className="info-box">
@@ -2040,7 +2143,7 @@
               <div className="screen">
                 <div className="screen-header">
                   <h3>Manage Lifts</h3>
-                  <p>{workout.week}</p>
+                  <p>{workout.block}</p>
                 </div>
                 <div className="screen-content">
                   <div className="info-box">
@@ -2205,27 +2308,73 @@
                 <p>{workout.date}</p>
               </div>
               <div className="screen-content">
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
-                  <span className="exercise-name">{workout.week}</span>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+                  <span className="exercise-name">{workout.block}</span>
                   <span className={`status-badge status-${workout.status}`}>
                     {workout.status === 'completed' ? '✓ Done' : 'Upcoming'}
                   </span>
                 </div>
 
-                <div className="section-label">Planned Lifts</div>
-                {workout.lifts.map((lift, i) => (
-                  <div
-                    key={i}
-                    className="exercise-item"
-                    onClick={() => setSelectedLift(lift)}
-                  >
-                    <div style={{ flex: 1 }}>
-                      <div className="exercise-name">{lift}</div>
-                      <div className="exercise-sets">3 warm-up • 3 working</div>
-                    </div>
-                    <span style={{ fontSize: '12px', color: '#3498db', fontWeight: 600 }}>→</span>
+                {/* Cycle Progress */}
+                <div style={{ marginBottom: 16 }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
+                    <div className="form-label">Cycle Progress</div>
+                    <div style={{ fontSize: '11px', color: '#7f8c8d', fontWeight: 600 }}>3 of 12 workouts</div>
                   </div>
-                ))}
+                  <div className="progress-bar">
+                    <div className="progress-fill" style={{ width: '25%' }}></div>
+                  </div>
+                </div>
+
+                <div className="section-label">Planned Lifts</div>
+                {workout.lifts.map((lift, i) => {
+                  // Parse lift name and extract training max info
+                  let liftName = lift;
+                  let trainingMax = null;
+                  
+                  if (lift.includes('(')) {
+                    const match = lift.match(/(.+?)\s*\((.+?)\)/);
+                    if (match) {
+                      liftName = match[1].trim();
+                      trainingMax = parseInt(match[2]);
+                    }
+                  }
+                  
+                  // Sample planned sets with percentages
+                  const plannedSets = [
+                    { weight: trainingMax ? Math.round(trainingMax * 0.5) : 135, reps: 5, percentage: '50%' },
+                    { weight: trainingMax ? Math.round(trainingMax * 0.65) : 175, reps: 3, percentage: '65%' },
+                    { weight: trainingMax ? Math.round(trainingMax * 0.75) : 205, reps: 3, percentage: '75%' },
+                    { weight: trainingMax ? Math.round(trainingMax * 0.85) : 235, reps: 3, percentage: '85%' },
+                    { weight: trainingMax ? Math.round(trainingMax * 0.85) : 235, reps: 3, percentage: '85%' },
+                    { weight: trainingMax ? Math.round(trainingMax * 0.85) : 235, reps: 3, percentage: '85%' }
+                  ];
+                  
+                  return (
+                    <div key={i} style={{ marginBottom: 12 }}>
+                      <div className="exercise-item" onClick={() => setSelectedLift(lift)} style={{ cursor: 'pointer', marginBottom: 8 }}>
+                        <div style={{ flex: 1 }}>
+                          <div className="exercise-name">{liftName}</div>
+                          {trainingMax && <div className="exercise-sets">TM: {trainingMax} lbs</div>}
+                        </div>
+                        <span style={{ fontSize: '12px', color: '#3498db', fontWeight: 600 }}>→</span>
+                      </div>
+                      
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 6, paddingLeft: 8 }}>
+                        {plannedSets.map((set, setIdx) => (
+                          <div key={setIdx} className="set-item" style={{ background: '#f0f7ff', borderLeft: '3px solid #3498db' }}>
+                            <div className="set-number">{setIdx + 1}</div>
+                            <div style={{ flex: 1 }}>
+                              <div style={{ fontSize: '11px', fontWeight: 600, color: '#7f8c8d' }}>Planned</div>
+                              <div style={{ fontSize: '12px', color: '#1a1a1a', fontWeight: 600 }}>{set.weight}×{set.reps}</div>
+                              <div style={{ fontSize: '10px', color: '#3498db', fontWeight: 600, marginTop: 2 }}>{set.percentage} of TM</div>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  );
+                })}
 
                 <button
                   className="button button-secondary"
@@ -3012,12 +3161,28 @@
               <p>Reverse Pyramid Training</p>
             </div>
             <div className="screen-content">
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
-                <div className="form-label">Progress</div>
-                <div style={{ fontSize: '11px', color: '#7f8c8d' }}>3 of 12</div>
-              </div>
-              <div className="progress-bar" style={{ marginBottom: 12 }}>
-                <div className="progress-fill" style={{ width: '25%' }}></div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginBottom: 16 }}>
+                {/* Program Progress */}
+                <div>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
+                    <div className="form-label">Program Progress</div>
+                    <div style={{ fontSize: '11px', color: '#7f8c8d', fontWeight: 600 }}>3 of 12 workouts</div>
+                  </div>
+                  <div className="progress-bar">
+                    <div className="progress-fill" style={{ width: '25%' }}></div>
+                  </div>
+                </div>
+
+                {/* Cycle Progress */}
+                <div>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
+                    <div className="form-label">Cycle Progress</div>
+                    <div style={{ fontSize: '11px', color: '#7f8c8d', fontWeight: 600 }}>3 of 4 workouts</div>
+                  </div>
+                  <div className="progress-bar">
+                    <div className="progress-fill" style={{ width: '75%' }}></div>
+                  </div>
+                </div>
               </div>
 
               <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 12 }}>
@@ -3061,7 +3226,7 @@
                   >
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 8 }}>
                       <div style={{ flex: 1 }}>
-                        <div className="exercise-name">{w.week} • {w.date}</div>
+                        <div className="exercise-name">{w.block} • {w.date}</div>
                         <div className="exercise-sets">{w.lifts.length} lifts</div>
                       </div>
                       <span className={`status-badge status-${w.status}`} style={{ marginTop: 2, fontSize: '9px' }}>

--- a/docs/mockups/workout-detail-collapsible-lifts.html
+++ b/docs/mockups/workout-detail-collapsible-lifts.html
@@ -1,0 +1,879 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Workout Details - Collapsible Lifts</title>
+  <style>
+    /* Base typography and layout system from existing codebase */
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      background: #fafaf8;
+      color: #1a1a1a;
+      line-height: 1.5;
+      font-size: 16px;
+    }
+
+    h1, h2, h3, h4, h5, h6 {
+      color: #2c3e50;
+      font-weight: 700;
+      line-height: 1.25;
+      margin: 0;
+    }
+
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    button {
+      font: inherit;
+      cursor: pointer;
+      border: none;
+      background: none;
+      color: inherit;
+    }
+
+    /* =========================================================================
+       Design tokens (from globals.css)
+       ========================================================================= */
+    :root {
+      --space-1: 0.25rem;
+      --space-2: 0.5rem;
+      --space-3: 0.75rem;
+      --space-4: 1rem;
+      --space-5: 1.25rem;
+      --space-6: 1.5rem;
+      --space-8: 2rem;
+      --radius-sm: 4px;
+      --radius-md: 6px;
+      --radius-lg: 8px;
+      --font-size-xs: 0.75rem;
+      --font-size-sm: 0.875rem;
+      --font-size-base: 1rem;
+      --font-size-lg: 1.125rem;
+      --font-size-xl: 1.375rem;
+      --transition-fast: 0.2s ease;
+      --transition-base: 0.3s ease;
+
+      /* Theme: navy (default) */
+      --color-bg: #fafaf8;
+      --color-surface: #f8f9fa;
+      --color-surface-alt: #ecf0f1;
+      --color-border: #ecf0f1;
+      --color-border-strong: #ddd;
+      --color-text: #1a1a1a;
+      --color-text-muted: #7f8c8d;
+      --color-text-heading: #2c3e50;
+      --color-accent: #3498db;
+      --color-accent-hover: #2980b9;
+      --color-success: #27ae60;
+      --color-success-text: #00b894;
+      --color-success-bg: #a8e6cf;
+      --color-error-text: #c0392b;
+      --color-warn-text: #856404;
+      --color-warn-bg: #fff3cd;
+      --color-upcoming-bg: #fffdf0;
+      --color-upcoming-text: #d63031;
+      --color-missed-bg: #fff5f5;
+    }
+
+    /* =========================================================================
+       Layout
+       ========================================================================= */
+    .container {
+      padding: var(--space-4);
+      max-width: 600px;
+      margin: 0 auto;
+    }
+
+    .backLink {
+      display: inline-block;
+      font-size: var(--font-size-sm);
+      color: var(--color-text-muted);
+      margin-bottom: var(--space-4);
+      transition: color var(--transition-fast);
+    }
+
+    .backLink:hover {
+      color: var(--color-text);
+    }
+
+    /* =========================================================================
+       Header with metadata
+       ========================================================================= */
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: var(--space-6);
+      gap: var(--space-3);
+    }
+
+    .headerMeta {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-1);
+    }
+
+    .date {
+      font-size: var(--font-size-lg);
+      font-weight: 600;
+    }
+
+    .weekLabel {
+      font-size: var(--font-size-sm);
+      color: var(--color-text-muted);
+    }
+
+    .badge {
+      padding: var(--space-1) var(--space-3);
+      border-radius: var(--radius-sm);
+      font-size: var(--font-size-xs);
+      font-weight: 600;
+      white-space: nowrap;
+    }
+
+    .badge_completed {
+      background: var(--color-success-bg);
+      color: var(--color-success-text);
+    }
+
+    .badge_upcoming {
+      background: var(--color-warn-bg);
+      color: var(--color-warn-text);
+    }
+
+    .badge_missed {
+      background: var(--color-missed-bg);
+      color: var(--color-upcoming-text);
+    }
+
+    /* =========================================================================
+       Summary section (NEW)
+       ========================================================================= */
+    .summarySection {
+      background: var(--color-surface);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-md);
+      padding: var(--space-4);
+      margin-bottom: var(--space-6);
+    }
+
+    .summaryTitle {
+      font-size: var(--font-size-sm);
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--color-text-muted);
+      margin-bottom: var(--space-3);
+    }
+
+    .summaryGrid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: var(--space-4);
+    }
+
+    .summaryItem {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-1);
+    }
+
+    .summaryLabel {
+      font-size: var(--font-size-sm);
+      color: var(--color-text-muted);
+    }
+
+    .summaryValue {
+      font-size: var(--font-size-lg);
+      font-weight: 600;
+    }
+
+    /* =========================================================================
+       Lifts section with collapsible items (UPDATED)
+       ========================================================================= */
+    .liftsSection {
+      margin-bottom: var(--space-6);
+    }
+
+    .sectionHeading {
+      font-size: var(--font-size-base);
+      font-weight: 600;
+      margin-bottom: var(--space-3);
+    }
+
+    .liftList {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-md);
+      overflow: hidden;
+    }
+
+    .liftItem {
+      border-top: 1px solid var(--color-border);
+    }
+
+    .liftItem:first-child {
+      border-top: none;
+    }
+
+    /* Collapsible lift item (NEW) */
+    .liftItemHeader {
+      display: flex;
+      align-items: center;
+      gap: var(--space-3);
+      padding: var(--space-3) var(--space-4);
+      background: none;
+      width: 100%;
+      text-align: left;
+      cursor: pointer;
+      transition: background var(--transition-fast);
+    }
+
+    .liftItemHeader:hover {
+      background: var(--color-surface-alt);
+    }
+
+    .liftToggleIcon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 20px;
+      height: 20px;
+      color: var(--color-text-muted);
+      transition: transform var(--transition-fast);
+      flex-shrink: 0;
+    }
+
+    .liftItem.expanded .liftToggleIcon {
+      transform: rotate(90deg);
+    }
+
+    .liftName {
+      font-weight: 600;
+      font-size: var(--font-size-sm);
+      flex: 1;
+      display: flex;
+      align-items: center;
+      gap: var(--space-2);
+    }
+
+    .liftTM {
+      font-weight: 400;
+      font-size: var(--font-size-xs);
+      color: var(--color-text-muted);
+    }
+
+    .liftSummary {
+      font-size: var(--font-size-sm);
+      color: var(--color-text-muted);
+    }
+
+    .liftHistoryBtn {
+      padding: var(--space-2) var(--space-3);
+      background: var(--color-surface);
+      border: 1px solid var(--color-border-strong);
+      border-radius: var(--radius-sm);
+      font-size: var(--font-size-xs);
+      color: var(--color-text-muted);
+      transition: all var(--transition-fast);
+      flex-shrink: 0;
+    }
+
+    .liftHistoryBtn:hover {
+      background: var(--color-surface-alt);
+      color: var(--color-text);
+    }
+
+    /* Collapsed content (NEW) */
+    .liftItemContent {
+      max-height: 0;
+      overflow: hidden;
+      transition: max-height var(--transition-base), opacity var(--transition-base);
+      opacity: 0;
+    }
+
+    .liftItem.expanded .liftItemContent {
+      max-height: 500px;
+      opacity: 1;
+    }
+
+    .liftItemContentInner {
+      padding: 0 var(--space-4) var(--space-4) var(--space-4);
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-3);
+      border-top: 1px solid var(--color-border);
+    }
+
+    .setGroup {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2);
+    }
+
+    .setGroupLabel {
+      font-size: var(--font-size-xs);
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--color-text-muted);
+    }
+
+    .setRow {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: var(--space-2) var(--space-3);
+      background: var(--color-surface);
+      border-radius: var(--radius-sm);
+      font-size: var(--font-size-sm);
+    }
+
+    .setLabel {
+      color: var(--color-text-muted);
+    }
+
+    .setSpec {
+      font-weight: 600;
+    }
+
+    /* =========================================================================
+       Actions section
+       ========================================================================= */
+    .actions {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-3);
+    }
+
+    .btnPrimary {
+      display: block;
+      padding: var(--space-2) var(--space-4);
+      background: var(--color-accent);
+      color: white;
+      border-radius: var(--radius-md);
+      font-size: var(--font-size-sm);
+      font-weight: 600;
+      text-align: center;
+      text-decoration: none;
+      width: 100%;
+      transition: opacity var(--transition-fast);
+    }
+
+    .btnPrimary:hover {
+      opacity: 0.88;
+    }
+
+    .btnSecondary {
+      padding: var(--space-2) var(--space-4);
+      background: transparent;
+      color: var(--color-text);
+      border: 1px solid var(--color-border-strong);
+      border-radius: var(--radius-md);
+      font-size: var(--font-size-sm);
+      font-weight: 600;
+      width: 100%;
+      text-align: center;
+      text-decoration: none;
+      transition: background var(--transition-fast);
+    }
+
+    .btnSecondary:hover {
+      background: var(--color-surface-alt);
+    }
+
+    /* =========================================================================
+       Lift Editor (Program Editor section) - NEW DESIGN
+       ========================================================================= */
+    .sectionDivider {
+      margin: var(--space-8) 0 var(--space-6);
+      padding-top: var(--space-6);
+      border-top: 2px solid var(--color-border);
+    }
+
+    .editorContainer {
+      background: var(--color-surface);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-md);
+      padding: var(--space-4);
+    }
+
+    .editorTitle {
+      font-size: var(--font-size-lg);
+      font-weight: 600;
+      margin-bottom: var(--space-4);
+    }
+
+    .editorField {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2);
+      margin-bottom: var(--space-4);
+    }
+
+    .editorLabel {
+      font-size: var(--font-size-sm);
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--color-text-muted);
+    }
+
+    .editorReadOnly {
+      font-size: var(--font-size-base);
+      font-weight: 600;
+      padding: var(--space-2) var(--space-3);
+      background: var(--color-bg);
+      border-radius: var(--radius-sm);
+    }
+
+    /* Lift picker with catalog (NEW - replaces free text) */
+    .liftPickerField {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2);
+    }
+
+    .liftPickerInput {
+      padding: var(--space-2) var(--space-3);
+      font-size: var(--font-size-base);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-md);
+      background: var(--color-bg);
+      width: 100%;
+    }
+
+    .liftPickerInput:focus {
+      outline: none;
+      border-color: var(--color-accent);
+      box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+    }
+
+    .liftPickerDropdown {
+      max-height: 300px;
+      overflow-y: auto;
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-md);
+      background: white;
+      box-shadow: var(--color-border) 0 4px 12px rgba(0, 0, 0, 0.12);
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    .liftPickerItem {
+      padding: var(--space-3) var(--space-4);
+      border-bottom: 1px solid var(--color-border);
+      cursor: pointer;
+      transition: background var(--transition-fast);
+      font-size: var(--font-size-sm);
+    }
+
+    .liftPickerItem:last-child {
+      border-bottom: none;
+    }
+
+    .liftPickerItem:hover {
+      background: var(--color-surface-alt);
+    }
+
+    .liftPickerItem.selected {
+      background: var(--color-accent);
+      color: white;
+      font-weight: 600;
+    }
+
+    .tagsContainer {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-2);
+      margin-top: var(--space-2);
+    }
+
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--space-2);
+      padding: var(--space-1) var(--space-3);
+      background: var(--color-accent);
+      color: white;
+      border-radius: var(--radius-md);
+      font-size: var(--font-size-sm);
+      font-weight: 500;
+    }
+
+    .tagRemove {
+      cursor: pointer;
+      opacity: 0.8;
+      transition: opacity var(--transition-fast);
+    }
+
+    .tagRemove:hover {
+      opacity: 1;
+    }
+
+    .checkboxField {
+      display: flex;
+      align-items: center;
+      gap: var(--space-2);
+      margin-bottom: var(--space-4);
+    }
+
+    .checkboxField input[type="checkbox"] {
+      cursor: pointer;
+      width: 18px;
+      height: 18px;
+    }
+
+    .editorActions {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-3);
+    }
+
+    .btnSave {
+      padding: var(--space-2) var(--space-4);
+      background: var(--color-accent);
+      color: white;
+      border-radius: var(--radius-md);
+      font-size: var(--font-size-sm);
+      font-weight: 600;
+      width: 100%;
+      transition: opacity var(--transition-fast);
+    }
+
+    .btnSave:hover {
+      opacity: 0.88;
+    }
+
+    .btnReset {
+      padding: var(--space-2) var(--space-4);
+      background: transparent;
+      color: var(--color-text);
+      border: 1px solid var(--color-border-strong);
+      border-radius: var(--radius-md);
+      font-size: var(--font-size-sm);
+      font-weight: 600;
+      width: 100%;
+      transition: background var(--transition-fast);
+    }
+
+    .btnReset:hover {
+      background: var(--color-surface-alt);
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <!-- WORKOUT DETAILS VIEW ============================================ -->
+    <a href="#" class="backLink">← Back to Cycle</a>
+
+    <!-- Header with metadata -->
+    <header class="header">
+      <div class="headerMeta">
+        <time class="date">2026-05-13</time>
+        <span class="weekLabel">Week 1</span>
+      </div>
+      <span class="badge badge_upcoming">Upcoming</span>
+    </header>
+
+    <!-- NEW: Summary section at the top -->
+    <section class="summarySection">
+      <h3 class="summaryTitle">Workout Summary</h3>
+      <div class="summaryGrid">
+        <div class="summaryItem">
+          <span class="summaryLabel">Total Lifts</span>
+          <span class="summaryValue">3</span>
+        </div>
+        <div class="summaryItem">
+          <span class="summaryLabel">Total Sets</span>
+          <span class="summaryValue">9</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- Lifts section with collapsible items -->
+    <section class="liftsSection">
+      <h2 class="sectionHeading">Planned Lifts</h2>
+      <ul class="liftList">
+        <!-- Lift 1: Bench Press (expanded by default to show content) -->
+        <li class="liftItem expanded">
+          <button class="liftItemHeader" onclick="this.parentElement.classList.toggle('expanded')">
+            <span class="liftToggleIcon">›</span>
+            <span class="liftName">Bench Press <span class="liftTM">TM: 285 lbs</span></span>
+            <span class="liftSummary">1 warm-up • 3 working</span>
+            <button class="liftHistoryBtn" onclick="event.stopPropagation(); alert('Show history for Bench Press')">
+              📊 History
+            </button>
+          </button>
+          <div class="liftItemContent">
+            <div class="liftItemContentInner">
+              <div class="setGroup">
+                <div class="setGroupLabel">Warm-up</div>
+                <div class="setRow">
+                  <span class="setLabel">Warm-up set 1</span>
+                  <span class="setSpec">5 × 135 lbs</span>
+                </div>
+              </div>
+              <div class="setGroup">
+                <div class="setGroupLabel">Working Sets</div>
+                <div class="setRow">
+                  <span class="setLabel">Set 1</span>
+                  <span class="setSpec">5 × 200 lbs</span>
+                </div>
+                <div class="setRow">
+                  <span class="setLabel">Set 2</span>
+                  <span class="setSpec">3 × 230 lbs</span>
+                </div>
+                <div class="setRow">
+                  <span class="setLabel">Set 3</span>
+                  <span class="setSpec">1+ × 260 lbs</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+
+        <!-- Lift 2: Incline Dumbbell Press (collapsed by default) -->
+        <li class="liftItem">
+          <button class="liftItemHeader" onclick="this.parentElement.classList.toggle('expanded')">
+            <span class="liftToggleIcon">›</span>
+            <span class="liftName">Incline Dumbbell Press <span class="liftTM">TM: 110 lbs</span></span>
+            <span class="liftSummary">3 working</span>
+            <button class="liftHistoryBtn" onclick="event.stopPropagation(); alert('Show history for Incline Dumbbell Press')">
+              📊 History
+            </button>
+          </button>
+          <div class="liftItemContent">
+            <div class="liftItemContentInner">
+              <div class="setGroup">
+                <div class="setGroupLabel">Working Sets</div>
+                <div class="setRow">
+                  <span class="setLabel">Set 1</span>
+                  <span class="setSpec">8 × 50 lbs (each)</span>
+                </div>
+                <div class="setRow">
+                  <span class="setLabel">Set 2</span>
+                  <span class="setSpec">8 × 50 lbs (each)</span>
+                </div>
+                <div class="setRow">
+                  <span class="setLabel">Set 3</span>
+                  <span class="setSpec">8+ × 50 lbs (each)</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+
+        <!-- Lift 3: Barbell Rows (collapsed by default) -->
+        <li class="liftItem">
+          <button class="liftItemHeader" onclick="this.parentElement.classList.toggle('expanded')">
+            <span class="liftToggleIcon">›</span>
+            <span class="liftName">Barbell Rows <span class="liftTM">TM: 305 lbs</span></span>
+            <span class="liftSummary">1 warm-up • 3 working</span>
+            <button class="liftHistoryBtn" onclick="event.stopPropagation(); alert('Show history for Barbell Rows')">
+              📊 History
+            </button>
+          </button>
+          <div class="liftItemContent">
+            <div class="liftItemContentInner">
+              <div class="setGroup">
+                <div class="setGroupLabel">Warm-up</div>
+                <div class="setRow">
+                  <span class="setLabel">Warm-up set 1</span>
+                  <span class="setSpec">5 × 135 lbs</span>
+                </div>
+              </div>
+              <div class="setGroup">
+                <div class="setGroupLabel">Working Sets</div>
+                <div class="setRow">
+                  <span class="setLabel">Set 1</span>
+                  <span class="setSpec">5 × 200 lbs</span>
+                </div>
+                <div class="setRow">
+                  <span class="setLabel">Set 2</span>
+                  <span class="setSpec">3 × 230 lbs</span>
+                </div>
+                <div class="setRow">
+                  <span class="setLabel">Set 3</span>
+                  <span class="setSpec">1+ × 260 lbs</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </section>
+
+    <!-- Actions -->
+    <section class="actions">
+      <button class="btnPrimary" onclick="alert('Navigate to logging workout')">Start Logging</button>
+      <button class="btnSecondary" onclick="alert('Navigate to manage lifts')">✏️ Manage Lifts</button>
+    </section>
+
+    <!-- PROGRAM EDITOR SECTION ========================================== -->
+    <div class="sectionDivider"></div>
+
+    <section class="editorContainer">
+      <h2 class="editorTitle">Edit Lift Metadata</h2>
+
+      <!-- Lift name (read-only) -->
+      <div class="editorField">
+        <label class="editorLabel">Lift</label>
+        <div class="editorReadOnly">Bench Press</div>
+      </div>
+
+      <!-- Muscle groups (NEW: using lift picker instead of free text) -->
+      <div class="editorField">
+        <label class="editorLabel">Muscle Groups</label>
+        <div class="liftPickerField" id="muscleGroupsField">
+          <input
+            type="text"
+            class="liftPickerInput"
+            placeholder="Search muscle groups…"
+            id="muscleSearch"
+            onkeyup="filterMuscleList()"
+          />
+          <ul class="liftPickerDropdown" id="muscleDropdown">
+            <li class="liftPickerItem" onclick="addMuscleGroup('Chest')">Chest</li>
+            <li class="liftPickerItem" onclick="addMuscleGroup('Front Delts')">Front Delts</li>
+            <li class="liftPickerItem" onclick="addMuscleGroup('Triceps')">Triceps</li>
+            <li class="liftPickerItem" onclick="addMuscleGroup('Shoulders')">Shoulders</li>
+          </ul>
+          <div class="tagsContainer" id="muscleGroupsTags">
+            <div class="tag">
+              Chest
+              <span class="tagRemove" onclick="removeMuscleGroup('Chest')">×</span>
+            </div>
+            <div class="tag">
+              Front Delts
+              <span class="tagRemove" onclick="removeMuscleGroup('Front Delts')">×</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Substitutions (NEW: using lift picker with catalog) -->
+      <div class="editorField">
+        <label class="editorLabel">Substitutions</label>
+        <div class="liftPickerField" id="substitutionsField">
+          <input
+            type="text"
+            class="liftPickerInput"
+            placeholder="Search lifts to add as substitutions…"
+            id="substitutionSearch"
+            onkeyup="filterSubstitutionList()"
+          />
+          <ul class="liftPickerDropdown" id="substitutionDropdown">
+            <li class="liftPickerItem" onclick="addSubstitution('Dumbbell Bench Press')">Dumbbell Bench Press</li>
+            <li class="liftPickerItem" onclick="addSubstitution('Smith Machine Bench')">Smith Machine Bench</li>
+            <li class="liftPickerItem" onclick="addSubstitution('Machine Chest Press')">Machine Chest Press</li>
+            <li class="liftPickerItem" onclick="addSubstitution('Cable Chest Fly')">Cable Chest Fly</li>
+            <li class="liftPickerItem" onclick="addSubstitution('Push-ups')">Push-ups</li>
+          </ul>
+          <div class="tagsContainer" id="substitutionsTags">
+            <div class="tag">
+              Dumbbell Bench Press
+              <span class="tagRemove" onclick="removeSubstitution('Dumbbell Bench Press')">×</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Foundational checkbox -->
+      <div class="checkboxField">
+        <input id="foundational" type="checkbox" checked />
+        <label class="editorLabel" for="foundational" style="margin: 0; text-transform: none; letter-spacing: 0;">
+          Foundational lift
+        </label>
+      </div>
+
+      <!-- Actions -->
+      <div class="editorActions">
+        <button class="btnSave" onclick="alert('Changes saved!')">Save Changes</button>
+        <button class="btnReset" onclick="alert('Form reset')">Reset</button>
+      </div>
+    </section>
+  </div>
+
+  <script>
+    // Helper functions for the lift picker dropdowns
+    function filterMuscleList() {
+      const input = document.getElementById('muscleSearch');
+      const dropdown = document.getElementById('muscleDropdown');
+      const filter = input.value.toLowerCase();
+
+      Array.from(dropdown.children).forEach(item => {
+        const text = item.textContent.toLowerCase();
+        item.style.display = text.includes(filter) ? '' : 'none';
+      });
+    }
+
+    function filterSubstitutionList() {
+      const input = document.getElementById('substitutionSearch');
+      const dropdown = document.getElementById('substitutionDropdown');
+      const filter = input.value.toLowerCase();
+
+      Array.from(dropdown.children).forEach(item => {
+        const text = item.textContent.toLowerCase();
+        item.style.display = text.includes(filter) ? '' : 'none';
+      });
+    }
+
+    function addMuscleGroup(name) {
+      const tags = document.getElementById('muscleGroupsTags');
+      const existing = Array.from(tags.children).some(tag => tag.textContent.trim().startsWith(name));
+      if (!existing) {
+        const tag = document.createElement('div');
+        tag.className = 'tag';
+        tag.innerHTML = `${name}<span class="tagRemove" onclick="removeMuscleGroup('${name}')">×</span>`;
+        tags.appendChild(tag);
+      }
+      document.getElementById('muscleSearch').value = '';
+      filterMuscleList();
+    }
+
+    function removeMuscleGroup(name) {
+      const tags = document.getElementById('muscleGroupsTags');
+      Array.from(tags.children).forEach(tag => {
+        if (tag.textContent.includes(name)) {
+          tag.remove();
+        }
+      });
+    }
+
+    function addSubstitution(name) {
+      const tags = document.getElementById('substitutionsTags');
+      const existing = Array.from(tags.children).some(tag => tag.textContent.trim().startsWith(name));
+      if (!existing) {
+        const tag = document.createElement('div');
+        tag.className = 'tag';
+        tag.innerHTML = `${name}<span class="tagRemove" onclick="removeSubstitution('${name}')">×</span>`;
+        tags.appendChild(tag);
+      }
+      document.getElementById('substitutionSearch').value = '';
+      filterSubstitutionList();
+    }
+
+    function removeSubstitution(name) {
+      const tags = document.getElementById('substitutionsTags');
+      Array.from(tags.children).forEach(tag => {
+        if (tag.textContent.includes(name)) {
+          tag.remove();
+        }
+      });
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds `workout-detail-collapsible-lifts.html` — source mockup for Feature A (collapsible lifts + summary card, shipped in #252)
- Adds `lift-history-v1.html` — source mockup for Feature C (global /history page, shipped in #254)
- Adds `programs-v3.html` — source mockup for Feature D (programs management, shipped in #255)
- Updates `user-journeys.html` to the newer v2 revision (165 lines added; reference doc used during Feature A–D planning)

No separate catalog-pickers mockup existed — Feature B (#253) was derived from the collapsible-lifts mockup.

## Test plan

- [ ] Docs-only change — no automated tests required
- [ ] Confirm all four files open correctly in a browser

Closes #257