### PR TITLE
[chore] Enforce per-feature test coverage requirements before merge

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,14 @@
 ## Testing
 
 - [ ] API change: in-memory E2E test included in this PR
-- [ ] Frontend change: Playwright test included OR manual test plan documented below and linked to #259
+- [ ] Frontend change: Playwright test included OR test plan documented below and linked to #259
 - [ ] Regression test included (for bug fixes)
 - [ ] No new testable behavior introduced (refactor/docs only)
+
+### Test Plan
+
+<!-- For frontend changes until #259 ships, or for any verification not covered by automated tests. Delete this section if not applicable. -->
+
+## Related Issue
+
+Closes #

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Summary
+
+## Testing
+
+- [ ] API change: in-memory E2E test included in this PR
+- [ ] Frontend change: Playwright test included OR manual test plan documented below and linked to #259
+- [ ] Regression test included (for bug fixes)
+- [ ] No new testable behavior introduced (refactor/docs only)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,17 @@ npm test -w @lifting-logbook/api
 npm test -w @lifting-logbook/web
 ```
 
+### Coverage Requirements
+
+| Change type | Required coverage |
+|---|---|
+| New API endpoint | In-memory E2E test in the same PR |
+| New frontend page or interactive feature | Playwright test once #259 is implemented; until then, a written manual test plan in the PR body |
+| Bug fix | Regression test that fails before the fix and passes after |
+| Refactor / docs only | None required — existing tests must pass |
+
+**Blocking rule:** A PR that adds an API endpoint or frontend feature without satisfying the above is not mergeable.
+
 ---
 
 ## Documentation and Citations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,10 +307,12 @@ npm test -w @lifting-logbook/web
 
 ### Coverage Requirements
 
+<!-- When #259 ships: remove the "until then" clause from the frontend row below. Tracked as a checklist item on issue #259. -->
+
 | Change type | Required coverage |
 |---|---|
 | New API endpoint | In-memory E2E test in the same PR |
-| New frontend page or interactive feature | Playwright test once #259 is implemented; until then, a written manual test plan in the PR body |
+| New frontend page or interactive feature | Playwright test once #259 is implemented; until then, a written test plan in the PR body |
 | Bug fix | Regression test that fails before the fix and passes after |
 | Refactor / docs only | None required — existing tests must pass |
 


### PR DESCRIPTION
## Summary

Adds three lightweight enforcement points to prevent features from merging without test coverage — closing the gap exposed by PR #255 (programs management page merged with no tests).

1. **`CLAUDE.md` — Coverage Requirements table** under `## Testing`: maps each change type (new API endpoint, frontend feature, bug fix, refactor) to a required test tier, with an explicit blocking rule.
2. **`.github/pull_request_template.md`** — pre-populates every new PR body with a Testing checklist so skipping coverage requires deliberate action.

A coordinated dev-env PR extends the global "Test before PR" rule with a coverage gate question (see dev-env PR linked below).

## Acceptance Criteria

- [x] `## Testing` section in lifting-logbook `CLAUDE.md` includes a coverage requirements table and an explicit blocking rule
- [x] `.github/pull_request_template.md` created with testing checklist
- [ ] `dev-env` `CLAUDE.md` "Test before PR" rule includes coverage gate question (separate PR)

## Testing

No code changes — docs and config only. Full test suite run: **182 passed, 0 failed** (18 suites, 1 skipped integration suite requiring `DATABASE_URL`).

Closes #265