### PR TITLE
[docs] Add Workout Scheduling Override design, proposal, and prototype

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,6 +108,7 @@ Web and mobile clients functional end-to-end. Key user-facing features implement
 | [Initial Training Max Discovery](docs/proposals/2026-04-30-initial-training-max-discovery.md) | Estimation utility (Brzycki) and test-week cycle phase for users with no existing training maxes | [#129](https://github.com/brownm09/lifting-logbook/issues/129) | shipped |
 | [On-Call Readiness](docs/proposals/2026-05-08-on-call-readiness.md) | Runbooks, SLOs, incident response guide, and severity/escalation framework; sequences after #199 | [#201](https://github.com/brownm09/lifting-logbook/issues/201) | shipped |
 | [Historical Lift Data Backfill](docs/proposals/2026-05-11-historical-lift-data-backfill.md) | CSV upload endpoint and web UI to ingest historical `LiftRecord` rows with all-or-nothing validation | [#225](https://github.com/brownm09/lifting-logbook/issues/225) | draft |
+| [Workout Scheduling Override](docs/proposals/2026-05-17-workout-scheduling-override.md) | User-defined preferred workout days (fixed or rotating A/B) + per-program `workoutsPerWeek` override with automatic cycle date distribution | [#267](https://github.com/brownm09/lifting-logbook/issues/267) | draft |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -168,6 +168,20 @@ monorepo/
 
 ---
 
+## Feature Design Documents
+
+Design, proposal, and prototype artifacts live under three sibling directories:
+
+| Directory | Purpose |
+|-----------|---------|
+| [`docs/design/`](design/) | Integration design docs: data model, API contracts, algorithm pseudo-code, testing strategy |
+| [`docs/proposals/`](proposals/) | Feature proposals created via `/propose`: problem statement, acceptance criteria, phased roadmap |
+| [`docs/mockups/`](mockups/) | Interactive HTML prototypes for UI features |
+
+Proposals link to their corresponding design doc and mockup. See [`docs/proposals/README.md`](proposals/README.md) for the proposal lifecycle (`draft` → `accepted` → `shipped`).
+
+---
+
 ## Architecture Diagrams
 
 Visual representations of the system are in [`docs/diagrams/`](diagrams/):

--- a/docs/design/workout-scheduling-integration.md
+++ b/docs/design/workout-scheduling-integration.md
@@ -1,7 +1,7 @@
 # Workout Scheduling Integration Design
 
 **Status:** Design (not yet implemented)  
-**Last Updated:** May 16, 2026  
+**Last Updated:** May 17, 2026  
 **Scope:** Program editing with per-program workouts/week override and automatic workout date distribution
 
 ## Overview
@@ -11,6 +11,20 @@ This design document specifies how to integrate the workout scheduling feature i
 1. Define a preferred workout schedule (fixed days or rotating pattern) in settings
 2. Override the prescribed workouts-per-week for any program independently
 3. Automatically distribute cycle workouts across actual calendar dates respecting the user's schedule
+
+### No-Schedule Mode
+
+When no `workoutSchedule` is set in user settings, the system operates in **no-schedule mode**:
+- No dates are assigned to pending/planned workouts
+- The effective date of a workout is set to the date the user logs their first set for that workout
+- This is the default state for new users and the fallback when a user explicitly declines to apply their schedule to a program
+
+### Schedule Incompatibility
+
+An incompatibility exists when the user's schedule day count does not match a program's prescribed workouts-per-week (e.g., a Mon-Wed-Fri schedule with a 4-day/week program). When incompatibility is detected — either when the user sets a new schedule while a program is active, or when the user selects a program that conflicts with their current schedule — the system prompts the user to choose:
+
+1. **Override the program** — run the program at the schedule's effective workouts/week and recalculate all pending workout dates. The override value is stored on the program (`workoutsPerWeekOverride`).
+2. **No-schedule mode for this program** — treat the active program as if no schedule is set: no pending dates, date set at logging time. The program's `workoutsPerWeekOverride` is set to `null`.
 
 ## Data Model
 
@@ -37,19 +51,10 @@ export interface UserSettingsResponse {
 
 ### Program Override Model
 
-Extend `UpdateCycleOverrides` to support per-program override:
+The override is stored at the **program level**, not per-cycle. `UpdateCycleOverrides` is not extended. When creating or updating a custom program:
 
 ```typescript
 // packages/types/src/api.ts
-
-export interface UpdateCycleOverrides {
-  targetWeekday?: string;
-  today?: Date;
-  overrideDate?: Date;
-  updateStartWeekday?: boolean;
-  // NEW: per-program workout frequency override
-  workoutsPerWeekOverride?: number | null;
-}
 
 // When creating/updating a custom program:
 export interface CustomProgramResponse {
@@ -59,7 +64,7 @@ export interface CustomProgramResponse {
   baseTemplate: string | null;
   createdAt: string;
   specs: CustomProgramSpecRow[];
-  // NEW: override workouts/week (null = use prescribed)
+  // null = use prescribed; set when user accepts incompatibility override
   workoutsPerWeekOverride?: number | null;
 }
 
@@ -196,8 +201,8 @@ function getWeekPattern(
     return schedule.days || [];
   } else {
     // Rotating: select week pattern cyclically
-    const weekIndex = weekIndex % schedule.weeks!.length;
-    return schedule.weeks![weekIndex];
+    const patternIndex = weekIndex % schedule.weeks!.length;
+    return schedule.weeks![patternIndex];
   }
 }
 ```
@@ -228,23 +233,36 @@ For each lift in the cycle spec:
 
 **Location:** `packages/core/src/services/workout/calculateEffectiveWorkoutsPerWeek.ts` (new)
 
+Returns `null` when no schedule is set, signalling no-schedule mode to the caller.
+
 **Logic:**
 ```typescript
 function calculateEffectiveWorkoutsPerWeek(
   program: CustomProgramResponse,
-  userOverride?: number | null
-): number {
-  // If program has an explicit override, use it
+  userSchedule: UserWorkoutSchedule | null
+): number | null {
+  // No schedule → no-schedule mode; dates are set at logging time, not pre-assigned
+  if (!userSchedule) return null;
+
+  // User accepted an incompatibility override for this program — use the stored value
   if (program.workoutsPerWeekOverride !== null && program.workoutsPerWeekOverride !== undefined) {
     return program.workoutsPerWeekOverride;
   }
 
-  // Otherwise, infer from program spec:
-  // For 5/3/1-style programs, count unique offsets in the first week
-  // For general programs, count rows where week === 1
-  
+  // Compatible: infer prescribed frequency from program spec
+  // Count unique offsets in the first week's specs
   const firstWeekSpecs = program.specs.filter(s => s.week === 1);
   return firstWeekSpecs.length;
+}
+
+/** Returns how many workouts per week the user's schedule supports. */
+function getScheduleWorkoutsPerWeek(schedule: UserWorkoutSchedule): number {
+  if (schedule.type === 'fixed') {
+    return (schedule.days || []).length;
+  } else {
+    // Rotating: use the maximum week length to avoid under-scheduling
+    return Math.max(...(schedule.weeks || [[]]).map(w => w.length));
+  }
 }
 ```
 
@@ -257,28 +275,53 @@ function calculateEffectiveWorkoutsPerWeek(
 When a custom program is created or its specs are updated:
 1. If `workoutsPerWeekOverride` is set, validate it's > 0
 2. Store the override with the program
-3. Trigger cycle recalculation if a cycle is active
+3. Trigger pending-date recalculation if a cycle is active and a schedule is set
 
-### 2. Cycle Dashboard Generation
+### 2. Schedule Compatibility Check
+
+**File:** `packages/core/src/services/workout/` (new helper, called from settings and program selection flows)
+
+Fires in two situations:
+- User sets or updates their `workoutSchedule` while a program is active
+- User selects a program whose prescribed workouts/week differs from the current schedule's day count
+
+**Logic:**
+```
+schedulePerWeek = getScheduleWorkoutsPerWeek(userSchedule)
+prescribedPerWeek = inferPrescribedFromSpec(program)
+
+if schedulePerWeek !== prescribedPerWeek:
+  prompt user:
+    Option A — "Run at my schedule pace (N days/week)"
+      → set program.workoutsPerWeekOverride = schedulePerWeek
+      → recalculate pending workout dates via distributeWorkouts()
+    Option B — "No scheduled dates for this program"
+      → set program.workoutsPerWeekOverride = null
+      → clear any pending dates; date set at logging time
+```
+
+If there is no active program when the schedule is set, no prompt is shown; the schedule is saved and will be applied when the next program is selected.
+
+### 3. Cycle Dashboard Generation
 
 **File:** `packages/core/src/services/dashboard/` (extend existing)
 
 When generating a cycle dashboard:
 1. Load user's `workoutSchedule` from settings
-2. Load the program's `workoutsPerWeekOverride` (if any)
-3. Calculate effective workouts/week
-4. Call `distributeWorkouts()` to get workout dates
-5. Store workout dates in the cycle or cycle weeks
+2. Call `calculateEffectiveWorkoutsPerWeek(program, userSchedule)`
+3. If result is `null` (no-schedule mode) → return cycle data with no pending workout dates
+4. Otherwise call `distributeWorkouts()` with the effective frequency and store dates in the cycle
 
-### 3. Lift Record Creation
+### 4. Lift Record Creation
 
 **File:** `packages/core/src/services/workout/extractLiftRecords.ts`
 
-Existing logic extracts lift records from user input. When a user logs a set:
-1. If no explicit date provided, use the scheduled date from `distributeWorkouts()`
-2. Allow user to override the scheduled date (manual reschedule)
+When a user logs a set:
+1. If the workout has a pre-assigned scheduled date (schedule mode), default to that date
+2. If the workout has no scheduled date (no-schedule mode), use today's date as the effective workout date
+3. Allow the user to override the date in either case (manual reschedule)
 
-### 4. Settings API
+### 5. Settings API
 
 **File:** `apps/api/src/controllers/` or `apps/api/src/routes/`
 
@@ -286,7 +329,7 @@ Add endpoints:
 - `GET /users/settings` — return `workoutSchedule`
 - `PATCH /users/settings` — update `workoutSchedule`
 
-### 5. Program API
+### 6. Program API
 
 **File:** `apps/api/src/controllers/programs.ts`
 
@@ -300,9 +343,9 @@ Extend program endpoints:
 ### In `packages/types/src/api.ts`:
 - Add `UserWorkoutSchedule` interface
 - Extend `UserSettingsResponse` with `workoutSchedule`
-- Extend `UpdateCycleOverrides` with `workoutsPerWeekOverride`
 - Extend `CustomProgramResponse` with `workoutsPerWeekOverride`
 - Extend `UpdateCustomProgramRequest` with `workoutsPerWeekOverride`
+- `UpdateCycleOverrides` is **not** extended — the override is program-scoped, not cycle-scoped
 - (Optional) Add new `WorkoutDistributionResponse` if exposing distribution via API
 
 ### In `packages/core/src/models/`:
@@ -318,41 +361,47 @@ Extend program endpoints:
 - Edge cases: 1 workout, 10 workouts/week (capping), schedule with no days selected
 
 **`packages/core/tests/services/workout/calculateEffectiveWorkoutsPerWeek.test.ts`:**
-- Program with override: returns override value
-- Program without override: calculates from spec (first week count or offset count)
-- Edge cases: empty spec, malformed override
+- No schedule → returns `null` (no-schedule mode)
+- Schedule set, program has override → returns override value
+- Schedule set, no override → calculates from spec (first week count or offset count)
+- Edge cases: empty spec, schedule with no days
 
 ### Integration Tests
 
 **`apps/api/tests/programs.test.ts`:**
 - PATCH program with `workoutsPerWeekOverride` → persists and returns in GET
-- GET cycle dashboard → includes workout dates distributed per user schedule
-- Create lift records at distributed dates
+- GET cycle dashboard, no schedule set → no pending dates returned
+- GET cycle dashboard, schedule set and compatible → workout dates distributed
+- GET cycle dashboard, incompatibility accepted → dates distributed at override frequency
+- Create lift records with no scheduled date → date defaults to today
 
 **`apps/api/tests/users.test.ts`:**
 - PATCH settings with `workoutSchedule` → persists
 - GET settings → returns schedule with correct structure
+- Setting schedule while incompatible program active → API surfaces incompatibility flag
 
 ### E2E Tests (Playwright, once #259 is implemented)
 
-- User sets workout schedule to Mon-Wed-Fri
-- User creates a program with 12 workouts, override to 3/week
-- System calculates 4 weeks and distributes workouts
-- User views cycle dashboard → sees workouts on correct days
-- User logs a set → defaults to scheduled date, can override
+- No schedule set: user logs a set → workout date = today (no pre-assigned date shown)
+- User sets Mon-Wed-Fri schedule; program prescribes 3/week → compatible, dates distributed
+- User sets Mon-Wed-Fri schedule; program prescribes 4/week → incompatibility prompt shown
+  - User chooses override → cycle dashboard shows 3 workouts/week on correct days
+  - User chooses no-schedule → cycle dashboard shows no pending dates
+- User changes schedule while cycle active → incompatibility prompt fires again if needed
 
 ## Migration & Backwards Compatibility
 
-- Existing programs without `workoutsPerWeekOverride` default to `null` (use prescribed)
-- Existing users without `workoutSchedule` default to `null` (no override applied)
-- When `workoutSchedule` is `null`, system should not error; use a sensible default (e.g., Mon-Wed-Fri) or require user to set it on first use
+- Existing users without `workoutSchedule` default to `null` → no-schedule mode; no pending dates; no behavior change from current system
+- Existing programs without `workoutsPerWeekOverride` default to `null` → prescribed frequency used when a schedule is later set
+- No data migration required: the new columns are nullable and the no-schedule fallback is the correct default for all existing data
 
 ## Open Questions
 
 1. **UI for rotating schedules:** Should the rotation start on a specific date, or always be "week A, week B, week A, week B..."?
-2. **Partial week handling:** If a cycle ends mid-week, do we distribute remaining workouts across partial week, or start fresh next week?
-3. **Holiday/deload handling:** Should users be able to mark weeks as deloads, pushing remaining workouts forward?
+2. **Partial week handling:** `distributeWorkouts()` stops placing workouts once N are placed — if the last week is partial, remaining days in that week are unused. Is this the correct behavior, or should the system always fill out the final week?
+3. **Holiday/deload handling:** Out of scope for MVP. Deferred to future enhancement.
 4. **Workout-to-lift mapping:** Is offset the only way to know which lifts belong together, or do we need an explicit "lift group"?
+5. **Incompatibility prompt placement:** Should the prompt appear in the Settings flow (when schedule is saved) or in the Program selection flow (when a program is picked), or both? Which should take precedence when both trigger simultaneously?
 
 ## References
 

--- a/docs/design/workout-scheduling-integration.md
+++ b/docs/design/workout-scheduling-integration.md
@@ -19,12 +19,18 @@ When no `workoutSchedule` is set in user settings, the system operates in **no-s
 - The effective date of a workout is set to the date the user logs their first set for that workout
 - This is the default state for new users and the fallback when a user explicitly declines to apply their schedule to a program
 
-### Schedule Incompatibility
+### Schedule Mode
 
-An incompatibility exists when the user's schedule day count does not match a program's prescribed workouts-per-week (e.g., a Mon-Wed-Fri schedule with a 4-day/week program). When incompatibility is detected — either when the user sets a new schedule while a program is active, or when the user selects a program that conflicts with their current schedule — the system prompts the user to choose:
+When a `workoutSchedule` is set in user settings, the system can operate in **schedule mode** for a program. The schedule determines which days of the week workouts fall on; the program provides the sequence of workouts. The pace (workouts per week) is an emergent property of the schedule — not a separately configured value.
 
-1. **Override the program** — run the program at the schedule's effective workouts/week and recalculate all pending workout dates. The override value is stored on the program (`workoutsPerWeekOverride`).
-2. **No-schedule mode for this program** — treat the active program as if no schedule is set: no pending dates, date set at logging time. The program's `workoutsPerWeekOverride` is set to `null`.
+When a user sets a schedule or selects a program while a schedule is active, the system prompts:
+
+> "Use your schedule (Mon/Wed/Fri) to distribute workout dates for this program?"
+
+- **Yes** → schedule mode: dates are distributed using `distributeWorkouts()` and displayed in the cycle dashboard
+- **No** → no-schedule mode: no dates are pre-assigned; date is set at logging time
+
+A program does not store a "workouts per week" override — the schedule is the sole source of date distribution. Duration is derivable: `⌈cycleWorkouts / scheduleWorkoutsPerWeek⌉` weeks, shown as an informational estimate in the UI.
 
 ## Data Model
 
@@ -49,14 +55,13 @@ export interface UserSettingsResponse {
 }
 ```
 
-### Program Override Model
+### Program Model
 
-The override is stored at the **program level**, not per-cycle. `UpdateCycleOverrides` is not extended. When creating or updating a custom program:
+Programs do not store a workouts-per-week value. The schedule is the sole source of date distribution. `UpdateCycleOverrides` is not extended.
 
 ```typescript
 // packages/types/src/api.ts
 
-// When creating/updating a custom program:
 export interface CustomProgramResponse {
   id: string;
   name: string;
@@ -64,15 +69,12 @@ export interface CustomProgramResponse {
   baseTemplate: string | null;
   createdAt: string;
   specs: CustomProgramSpecRow[];
-  // null = use prescribed; set when user accepts incompatibility override
-  workoutsPerWeekOverride?: number | null;
 }
 
 export interface UpdateCustomProgramRequest {
   name?: string;
   description?: string;
   specs?: CustomProgramSpecRow[];
-  workoutsPerWeekOverride?: number | null;
 }
 ```
 
@@ -116,7 +118,6 @@ export interface UpdateCustomProgramRequest {
   "description": null,
   "baseTemplate": "5-3-1",
   "createdAt": "2026-05-10T14:23:00Z",
-  "workoutsPerWeekOverride": 3,
   "specs": [
     {
       "week": 1,
@@ -134,16 +135,6 @@ export interface UpdateCustomProgramRequest {
     // ... more specs
   ]
 }
-```
-
-### PATCH /programs/:program
-
-**Request:**
-```json
-{
-  "workoutsPerWeekOverride": 3
-}
-```
 
 ## Core Service Logic
 
@@ -157,10 +148,9 @@ export interface UpdateCustomProgramRequest {
 
 ```typescript
 function distributeWorkouts(
-  cycleWorkouts: number,           // 12
-  effectiveWorkoutsPerWeek: number, // 3 (after override applied)
+  cycleWorkouts: number,            // 12
   userSchedule: UserWorkoutSchedule, // { type: 'fixed', days: [0, 2, 4] }
-  cycleStartDate: Date              // May 19, 2026 (Monday)
+  cycleStartDate: Date               // May 19, 2026 (Monday)
 ): { week: number; workouts: Date[] }[] {
   const distribution = [];
   let workoutsPlaced = 0;
@@ -229,41 +219,26 @@ For each lift in the cycle spec:
   3. Assign that date to all lifts in the offset group
 ```
 
-### Effective Workouts/Week Calculation
+### Schedule Workouts Per Week (Display Helper)
 
-**Location:** `packages/core/src/services/workout/calculateEffectiveWorkoutsPerWeek.ts` (new)
+Not used to drive distribution — the schedule drives that directly. Used only to display an estimated cycle duration to the user.
 
-Returns `null` when no schedule is set, signalling no-schedule mode to the caller.
+**Location:** `packages/core/src/services/workout/` (inline helper or utility)
 
-**Logic:**
 ```typescript
-function calculateEffectiveWorkoutsPerWeek(
-  program: CustomProgramResponse,
-  userSchedule: UserWorkoutSchedule | null
-): number | null {
-  // No schedule → no-schedule mode; dates are set at logging time, not pre-assigned
-  if (!userSchedule) return null;
-
-  // User accepted an incompatibility override for this program — use the stored value
-  if (program.workoutsPerWeekOverride !== null && program.workoutsPerWeekOverride !== undefined) {
-    return program.workoutsPerWeekOverride;
-  }
-
-  // Compatible: infer prescribed frequency from program spec
-  // Count unique offsets in the first week's specs
-  const firstWeekSpecs = program.specs.filter(s => s.week === 1);
-  return firstWeekSpecs.length;
-}
-
-/** Returns how many workouts per week the user's schedule supports. */
+/** Returns the number of workouts per week the schedule supports — used for duration estimates only. */
 function getScheduleWorkoutsPerWeek(schedule: UserWorkoutSchedule): number {
   if (schedule.type === 'fixed') {
     return (schedule.days || []).length;
   } else {
-    // Rotating: use the maximum week length to avoid under-scheduling
-    return Math.max(...(schedule.weeks || [[]]).map(w => w.length));
+    // Rotating: average across all week patterns
+    const weeks = schedule.weeks || [[]];
+    return Math.round(weeks.reduce((sum, w) => sum + w.length, 0) / weeks.length);
   }
 }
+
+// Estimated cycle duration (display only):
+// Math.ceil(cycleWorkouts / getScheduleWorkoutsPerWeek(userSchedule)) weeks
 ```
 
 ## Integration Points
@@ -273,34 +248,29 @@ function getScheduleWorkoutsPerWeek(schedule: UserWorkoutSchedule): number {
 **File:** `packages/core/src/services/workout/` (service or controller layer)
 
 When a custom program is created or its specs are updated:
-1. If `workoutsPerWeekOverride` is set, validate it's > 0
-2. Store the override with the program
-3. Trigger pending-date recalculation if a cycle is active and a schedule is set
+1. No frequency override to validate or store — the schedule handles date distribution
+2. If a cycle is active and the user is in schedule mode, trigger pending-date recalculation via `distributeWorkouts()`
 
-### 2. Schedule Compatibility Check
+### 2. Schedule Mode Activation
 
-**File:** `packages/core/src/services/workout/` (new helper, called from settings and program selection flows)
+**File:** `packages/core/src/services/workout/` (called from settings and program selection flows)
 
 Fires in two situations:
 - User sets or updates their `workoutSchedule` while a program is active
-- User selects a program whose prescribed workouts/week differs from the current schedule's day count
+- User selects a program while a schedule is active
 
 **Logic:**
 ```
-schedulePerWeek = getScheduleWorkoutsPerWeek(userSchedule)
-prescribedPerWeek = inferPrescribedFromSpec(program)
-
-if schedulePerWeek !== prescribedPerWeek:
-  prompt user:
-    Option A — "Run at my schedule pace (N days/week)"
-      → set program.workoutsPerWeekOverride = schedulePerWeek
-      → recalculate pending workout dates via distributeWorkouts()
-    Option B — "No scheduled dates for this program"
-      → set program.workoutsPerWeekOverride = null
-      → clear any pending dates; date set at logging time
+prompt user:
+  "Use your schedule (Mon/Wed/Fri) to distribute workout dates for this program?"
+    Yes → schedule mode: call distributeWorkouts(cycleWorkouts, userSchedule, cycleStartDate)
+          store dates; display in cycle dashboard
+    No  → no-schedule mode: no dates pre-assigned; date set at logging time
 ```
 
-If there is no active program when the schedule is set, no prompt is shown; the schedule is saved and will be applied when the next program is selected.
+No frequency comparison is performed — any schedule works with any program. The pace follows naturally from the schedule.
+
+If there is no active program when the schedule is set, no prompt is shown; the schedule is saved and the prompt fires when the next program is selected.
 
 ### 3. Cycle Dashboard Generation
 
@@ -308,9 +278,8 @@ If there is no active program when the schedule is set, no prompt is shown; the 
 
 When generating a cycle dashboard:
 1. Load user's `workoutSchedule` from settings
-2. Call `calculateEffectiveWorkoutsPerWeek(program, userSchedule)`
-3. If result is `null` (no-schedule mode) → return cycle data with no pending workout dates
-4. Otherwise call `distributeWorkouts()` with the effective frequency and store dates in the cycle
+2. If no schedule, or user chose no-schedule mode for this program → return cycle data with no pending workout dates
+3. Otherwise call `distributeWorkouts(cycleWorkouts, userSchedule, cycleStartDate)` and store dates in the cycle
 
 ### 4. Lift Record Creation
 
@@ -333,19 +302,15 @@ Add endpoints:
 
 **File:** `apps/api/src/controllers/programs.ts`
 
-Extend program endpoints:
-- `GET /programs/:program` — include `workoutsPerWeekOverride` in response
-- `PATCH /programs/:program` — accept `workoutsPerWeekOverride` in request
-- `POST /programs` — accept `workoutsPerWeekOverride` in request
+No changes to existing program endpoints beyond what is already implemented — programs do not store a workouts-per-week value.
 
 ## Type Dependencies
 
 ### In `packages/types/src/api.ts`:
 - Add `UserWorkoutSchedule` interface
 - Extend `UserSettingsResponse` with `workoutSchedule`
-- Extend `CustomProgramResponse` with `workoutsPerWeekOverride`
-- Extend `UpdateCustomProgramRequest` with `workoutsPerWeekOverride`
-- `UpdateCycleOverrides` is **not** extended — the override is program-scoped, not cycle-scoped
+- `CustomProgramResponse` and `UpdateCustomProgramRequest` are **not** extended — no workouts-per-week field is stored on programs
+- `UpdateCycleOverrides` is **not** extended — date distribution is driven by the schedule, not a cycle-level override
 - (Optional) Add new `WorkoutDistributionResponse` if exposing distribution via API
 
 ### In `packages/core/src/models/`:
@@ -360,34 +325,32 @@ Extend program endpoints:
 - Rotating schedule: 12 workouts, alternating 4/3 per week → validates distribution respects pattern
 - Edge cases: 1 workout, 10 workouts/week (capping), schedule with no days selected
 
-**`packages/core/tests/services/workout/calculateEffectiveWorkoutsPerWeek.test.ts`:**
-- No schedule → returns `null` (no-schedule mode)
-- Schedule set, program has override → returns override value
-- Schedule set, no override → calculates from spec (first week count or offset count)
-- Edge cases: empty spec, schedule with no days
+**`packages/core/tests/services/workout/getScheduleWorkoutsPerWeek.test.ts`:**
+- Fixed schedule → returns day count
+- Rotating schedule → returns rounded average of week lengths
+- Edge cases: empty days array, single-week rotation
 
 ### Integration Tests
 
 **`apps/api/tests/programs.test.ts`:**
-- PATCH program with `workoutsPerWeekOverride` → persists and returns in GET
 - GET cycle dashboard, no schedule set → no pending dates returned
-- GET cycle dashboard, schedule set and compatible → workout dates distributed
-- GET cycle dashboard, incompatibility accepted → dates distributed at override frequency
+- GET cycle dashboard, schedule set and schedule mode active → workout dates distributed
+- GET cycle dashboard, schedule set but no-schedule mode chosen → no pending dates returned
 - Create lift records with no scheduled date → date defaults to today
 
 **`apps/api/tests/users.test.ts`:**
 - PATCH settings with `workoutSchedule` → persists
 - GET settings → returns schedule with correct structure
-- Setting schedule while incompatible program active → API surfaces incompatibility flag
+- Setting schedule while program active → schedule-mode prompt flag returned (for UI to render)
 
 ### E2E Tests (Playwright, once #259 is implemented)
 
 - No schedule set: user logs a set → workout date = today (no pre-assigned date shown)
-- User sets Mon-Wed-Fri schedule; program prescribes 3/week → compatible, dates distributed
-- User sets Mon-Wed-Fri schedule; program prescribes 4/week → incompatibility prompt shown
-  - User chooses override → cycle dashboard shows 3 workouts/week on correct days
-  - User chooses no-schedule → cycle dashboard shows no pending dates
-- User changes schedule while cycle active → incompatibility prompt fires again if needed
+- User sets Mon-Wed-Fri schedule; program active → schedule-mode prompt shown
+  - User chooses schedule mode → cycle dashboard shows dates on Mon/Wed/Fri
+  - User declines → cycle dashboard shows no pending dates
+- User sets Mon-Tue-Wed-Thu schedule; program active → schedule-mode prompt shown; dates distributed on Mon/Tue/Wed/Thu
+- User changes schedule while cycle active → schedule-mode prompt fires again
 
 ## Migration & Backwards Compatibility
 
@@ -401,7 +364,7 @@ Extend program endpoints:
 2. **Partial week handling:** `distributeWorkouts()` stops placing workouts once N are placed — if the last week is partial, remaining days in that week are unused. Is this the correct behavior, or should the system always fill out the final week?
 3. **Holiday/deload handling:** Out of scope for MVP. Deferred to future enhancement.
 4. **Workout-to-lift mapping:** Is offset the only way to know which lifts belong together, or do we need an explicit "lift group"?
-5. **Incompatibility prompt placement:** Should the prompt appear in the Settings flow (when schedule is saved) or in the Program selection flow (when a program is picked), or both? Which should take precedence when both trigger simultaneously?
+5. **Schedule-mode prompt placement:** Should the prompt appear in the Settings flow (when schedule is saved) or in the Program selection flow (when a program is picked), or both? Both trigger the same yes/no question, so a single flow entry point may be preferable.
 
 ## References
 

--- a/docs/design/workout-scheduling-integration.md
+++ b/docs/design/workout-scheduling-integration.md
@@ -1,0 +1,362 @@
+# Workout Scheduling Integration Design
+
+**Status:** Design (not yet implemented)  
+**Last Updated:** May 16, 2026  
+**Scope:** Program editing with per-program workouts/week override and automatic workout date distribution
+
+## Overview
+
+This design document specifies how to integrate the workout scheduling feature into Lifting Logbook. The feature allows users to:
+
+1. Define a preferred workout schedule (fixed days or rotating pattern) in settings
+2. Override the prescribed workouts-per-week for any program independently
+3. Automatically distribute cycle workouts across actual calendar dates respecting the user's schedule
+
+## Data Model
+
+### User Settings Extension
+
+Add to the user settings document/record:
+
+```typescript
+// packages/types/src/api.ts
+
+export interface UserWorkoutSchedule {
+  type: 'fixed' | 'rotating';
+  /** For fixed schedules: array of day indices (0=Mon, 6=Sun) */
+  days?: number[];
+  /** For rotating schedules: array of week patterns, each containing day indices */
+  weeks?: number[][];
+}
+
+export interface UserSettingsResponse {
+  activeProgram: string | null;
+  workoutSchedule?: UserWorkoutSchedule;
+}
+```
+
+### Program Override Model
+
+Extend `UpdateCycleOverrides` to support per-program override:
+
+```typescript
+// packages/types/src/api.ts
+
+export interface UpdateCycleOverrides {
+  targetWeekday?: string;
+  today?: Date;
+  overrideDate?: Date;
+  updateStartWeekday?: boolean;
+  // NEW: per-program workout frequency override
+  workoutsPerWeekOverride?: number | null;
+}
+
+// When creating/updating a custom program:
+export interface CustomProgramResponse {
+  id: string;
+  name: string;
+  description: string | null;
+  baseTemplate: string | null;
+  createdAt: string;
+  specs: CustomProgramSpecRow[];
+  // NEW: override workouts/week (null = use prescribed)
+  workoutsPerWeekOverride?: number | null;
+}
+
+export interface UpdateCustomProgramRequest {
+  name?: string;
+  description?: string;
+  specs?: CustomProgramSpecRow[];
+  workoutsPerWeekOverride?: number | null;
+}
+```
+
+## API Contracts
+
+### GET /users/settings
+
+**Response:**
+```json
+{
+  "activeProgram": "5-3-1-custom",
+  "workoutSchedule": {
+    "type": "fixed",
+    "days": [0, 2, 4]
+  }
+}
+```
+
+### PATCH /users/settings
+
+**Request:**
+```json
+{
+  "workoutSchedule": {
+    "type": "rotating",
+    "weeks": [
+      [0, 2, 4, 5],
+      [1, 3, 5]
+    ]
+  }
+}
+```
+
+### GET /programs/:program
+
+**Response (custom program):**
+```json
+{
+  "id": "5-3-1-custom",
+  "name": "5/3/1 (Custom)",
+  "description": null,
+  "baseTemplate": "5-3-1",
+  "createdAt": "2026-05-10T14:23:00Z",
+  "workoutsPerWeekOverride": 3,
+  "specs": [
+    {
+      "week": 1,
+      "offset": 0,
+      "lift": "Squat",
+      "increment": 5,
+      "order": 1,
+      "sets": 3,
+      "reps": 5,
+      "amrap": false,
+      "warmUpPct": "40%, 50%, 60%",
+      "wtDecrementPct": 10,
+      "activation": "leg press"
+    }
+    // ... more specs
+  ]
+}
+```
+
+### PATCH /programs/:program
+
+**Request:**
+```json
+{
+  "workoutsPerWeekOverride": 3
+}
+```
+
+## Core Service Logic
+
+### Workout Distribution Algorithm
+
+**Purpose:** Given N workouts in a cycle, M workouts/week, and a user schedule pattern, produce a list of dates for each workout.
+
+**Location:** `packages/core/src/services/workout/distributeWorkouts.ts` (new file)
+
+**Pseudo-code:**
+
+```typescript
+function distributeWorkouts(
+  cycleWorkouts: number,           // 12
+  effectiveWorkoutsPerWeek: number, // 3 (after override applied)
+  userSchedule: UserWorkoutSchedule, // { type: 'fixed', days: [0, 2, 4] }
+  cycleStartDate: Date              // May 19, 2026 (Monday)
+): { week: number; workouts: Date[] }[] {
+  const distribution = [];
+  let workoutsPlaced = 0;
+  let weekCounter = 0;
+  let currentWeekStart = alignToMonday(cycleStartDate);
+
+  while (workoutsPlaced < cycleWorkouts) {
+    const weekPattern = getWeekPattern(userSchedule, weekCounter);
+    const weekWorkouts: Date[] = [];
+
+    for (const dayIndex of weekPattern) {
+      if (workoutsPlaced >= cycleWorkouts) break;
+
+      const workoutDate = addDaysToDate(currentWeekStart, dayIndex);
+      weekWorkouts.push(workoutDate);
+      workoutsPlaced++;
+    }
+
+    if (weekWorkouts.length > 0) {
+      distribution.push({
+        week: weekCounter + 1,
+        workouts: weekWorkouts
+      });
+    }
+
+    currentWeekStart = addDaysToDate(currentWeekStart, 7);
+    weekCounter++;
+  }
+
+  return distribution;
+}
+
+function getWeekPattern(
+  schedule: UserWorkoutSchedule,
+  weekIndex: number
+): number[] {
+  if (schedule.type === 'fixed') {
+    return schedule.days || [];
+  } else {
+    // Rotating: select week pattern cyclically
+    const weekIndex = weekIndex % schedule.weeks!.length;
+    return schedule.weeks![weekIndex];
+  }
+}
+```
+
+**Returns:** Array of week objects, each containing the dates of that week's workouts.
+
+### Lift Date Scheduling
+
+**Purpose:** When a cycle is created or updated, schedule each lift's dates based on its offset and the workout distribution.
+
+**Location:** Extend `packages/core/src/services/workout/updateLiftDates.ts`
+
+**Changes:**
+- Current function updates lift dates when user manually edits one
+- New function: `scheduleLiftDates()` — applies the distribution algorithm to all lifts in a cycle spec
+- Accepts: cycle number, program spec, user schedule, effective workouts/week
+- Produces: lift date assignments for each lift based on its offset
+
+**Algorithm:**
+```
+For each lift in the cycle spec:
+  1. Find all lifts with the same offset (they belong to the same "day")
+  2. Get the offset-th workout date from the distribution
+  3. Assign that date to all lifts in the offset group
+```
+
+### Effective Workouts/Week Calculation
+
+**Location:** `packages/core/src/services/workout/calculateEffectiveWorkoutsPerWeek.ts` (new)
+
+**Logic:**
+```typescript
+function calculateEffectiveWorkoutsPerWeek(
+  program: CustomProgramResponse,
+  userOverride?: number | null
+): number {
+  // If program has an explicit override, use it
+  if (program.workoutsPerWeekOverride !== null && program.workoutsPerWeekOverride !== undefined) {
+    return program.workoutsPerWeekOverride;
+  }
+
+  // Otherwise, infer from program spec:
+  // For 5/3/1-style programs, count unique offsets in the first week
+  // For general programs, count rows where week === 1
+  
+  const firstWeekSpecs = program.specs.filter(s => s.week === 1);
+  return firstWeekSpecs.length;
+}
+```
+
+## Integration Points
+
+### 1. Custom Program Creation/Update
+
+**File:** `packages/core/src/services/workout/` (service or controller layer)
+
+When a custom program is created or its specs are updated:
+1. If `workoutsPerWeekOverride` is set, validate it's > 0
+2. Store the override with the program
+3. Trigger cycle recalculation if a cycle is active
+
+### 2. Cycle Dashboard Generation
+
+**File:** `packages/core/src/services/dashboard/` (extend existing)
+
+When generating a cycle dashboard:
+1. Load user's `workoutSchedule` from settings
+2. Load the program's `workoutsPerWeekOverride` (if any)
+3. Calculate effective workouts/week
+4. Call `distributeWorkouts()` to get workout dates
+5. Store workout dates in the cycle or cycle weeks
+
+### 3. Lift Record Creation
+
+**File:** `packages/core/src/services/workout/extractLiftRecords.ts`
+
+Existing logic extracts lift records from user input. When a user logs a set:
+1. If no explicit date provided, use the scheduled date from `distributeWorkouts()`
+2. Allow user to override the scheduled date (manual reschedule)
+
+### 4. Settings API
+
+**File:** `apps/api/src/controllers/` or `apps/api/src/routes/`
+
+Add endpoints:
+- `GET /users/settings` — return `workoutSchedule`
+- `PATCH /users/settings` — update `workoutSchedule`
+
+### 5. Program API
+
+**File:** `apps/api/src/controllers/programs.ts`
+
+Extend program endpoints:
+- `GET /programs/:program` — include `workoutsPerWeekOverride` in response
+- `PATCH /programs/:program` — accept `workoutsPerWeekOverride` in request
+- `POST /programs` — accept `workoutsPerWeekOverride` in request
+
+## Type Dependencies
+
+### In `packages/types/src/api.ts`:
+- Add `UserWorkoutSchedule` interface
+- Extend `UserSettingsResponse` with `workoutSchedule`
+- Extend `UpdateCycleOverrides` with `workoutsPerWeekOverride`
+- Extend `CustomProgramResponse` with `workoutsPerWeekOverride`
+- Extend `UpdateCustomProgramRequest` with `workoutsPerWeekOverride`
+- (Optional) Add new `WorkoutDistributionResponse` if exposing distribution via API
+
+### In `packages/core/src/models/`:
+- Optionally create model classes for distribution results if the service layer needs them
+
+## Testing Strategy
+
+### Unit Tests
+
+**`packages/core/tests/services/workout/distributeWorkouts.test.ts`:**
+- Fixed schedule: 12 workouts, 3/week, Mon-Wed-Fri → validates 4 weeks, correct day indices
+- Rotating schedule: 12 workouts, alternating 4/3 per week → validates distribution respects pattern
+- Edge cases: 1 workout, 10 workouts/week (capping), schedule with no days selected
+
+**`packages/core/tests/services/workout/calculateEffectiveWorkoutsPerWeek.test.ts`:**
+- Program with override: returns override value
+- Program without override: calculates from spec (first week count or offset count)
+- Edge cases: empty spec, malformed override
+
+### Integration Tests
+
+**`apps/api/tests/programs.test.ts`:**
+- PATCH program with `workoutsPerWeekOverride` → persists and returns in GET
+- GET cycle dashboard → includes workout dates distributed per user schedule
+- Create lift records at distributed dates
+
+**`apps/api/tests/users.test.ts`:**
+- PATCH settings with `workoutSchedule` → persists
+- GET settings → returns schedule with correct structure
+
+### E2E Tests (Playwright, once #259 is implemented)
+
+- User sets workout schedule to Mon-Wed-Fri
+- User creates a program with 12 workouts, override to 3/week
+- System calculates 4 weeks and distributes workouts
+- User views cycle dashboard → sees workouts on correct days
+- User logs a set → defaults to scheduled date, can override
+
+## Migration & Backwards Compatibility
+
+- Existing programs without `workoutsPerWeekOverride` default to `null` (use prescribed)
+- Existing users without `workoutSchedule` default to `null` (no override applied)
+- When `workoutSchedule` is `null`, system should not error; use a sensible default (e.g., Mon-Wed-Fri) or require user to set it on first use
+
+## Open Questions
+
+1. **UI for rotating schedules:** Should the rotation start on a specific date, or always be "week A, week B, week A, week B..."?
+2. **Partial week handling:** If a cycle ends mid-week, do we distribute remaining workouts across partial week, or start fresh next week?
+3. **Holiday/deload handling:** Should users be able to mark weeks as deloads, pushing remaining workouts forward?
+4. **Workout-to-lift mapping:** Is offset the only way to know which lifts belong together, or do we need an explicit "lift group"?
+
+## References
+
+- Current implementation: `packages/core/src/services/workout/updateLiftDates.ts` (shows offset-based grouping)
+- Type definitions: `packages/types/src/api.ts` and `packages/types/src/domain.ts`
+- Cycle model: `packages/core/src/models/CycleDashboard.ts`
+- Program spec: `packages/core/src/models/LiftingProgramSpec.ts`

--- a/docs/mockups/workout-scheduling.html
+++ b/docs/mockups/workout-scheduling.html
@@ -1,0 +1,953 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lifting Logbook - Workout Scheduling</title>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+      background: #fafaf8;
+      color: #1a1a1a;
+      line-height: 1.5;
+    }
+
+    .viewport {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 24px;
+      padding: 24px;
+      max-width: 100%;
+      min-height: 100vh;
+    }
+
+    .panel {
+      background: white;
+      border-radius: 12px;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .panel-header {
+      background: linear-gradient(135deg, #2c3e50 0%, #34495e 100%);
+      color: white;
+      padding: 16px 20px;
+      flex-shrink: 0;
+    }
+
+    .panel-header h2 {
+      font-size: 16px;
+      font-weight: 700;
+      margin-bottom: 4px;
+    }
+
+    .panel-header p {
+      font-size: 12px;
+      opacity: 0.85;
+    }
+
+    .panel-content {
+      padding: 20px;
+      flex: 1;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .section {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .section-title {
+      font-size: 12px;
+      font-weight: 700;
+      color: #2c3e50;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+    }
+
+    .calendar-grid {
+      display: grid;
+      grid-template-columns: repeat(7, 1fr);
+      gap: 1px;
+      background: #ecf0f1;
+      padding: 1px;
+      border-radius: 6px;
+      overflow: hidden;
+    }
+
+    .calendar-cell {
+      background: white;
+      padding: 8px;
+      min-height: 70px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 11px;
+    }
+
+    .calendar-cell.header {
+      background: #2c3e50;
+      color: white;
+      font-weight: 700;
+      text-align: center;
+      text-transform: uppercase;
+      letter-spacing: 0.02em;
+      min-height: auto;
+      padding: 6px 4px;
+    }
+
+    .calendar-cell.other-month {
+      background: #f8f9fa;
+      color: #bdc3c7;
+    }
+
+    .calendar-cell.today {
+      background: #e8f4f8;
+      border: 1px solid #3498db;
+      padding: 7px;
+    }
+
+    .calendar-date {
+      font-weight: 700;
+      color: #2c3e50;
+      font-size: 12px;
+    }
+
+    .calendar-cell.other-month .calendar-date {
+      color: #bdc3c7;
+    }
+
+    .calendar-workout {
+      display: inline-block;
+      padding: 2px 4px;
+      background: #27ae60;
+      color: white;
+      border-radius: 2px;
+      font-size: 9px;
+      font-weight: 600;
+      width: 100%;
+      text-align: center;
+    }
+
+    .calendar-rest {
+      display: inline-block;
+      padding: 2px 4px;
+      background: #ecf0f1;
+      color: #7f8c8d;
+      border-radius: 2px;
+      font-size: 9px;
+      font-weight: 600;
+      width: 100%;
+      text-align: center;
+    }
+
+    .legend {
+      display: flex;
+      gap: 12px;
+      padding: 12px;
+      background: #f8f9fa;
+      border-radius: 6px;
+      font-size: 11px;
+      flex-wrap: wrap;
+    }
+
+    .legend-item {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .legend-swatch {
+      width: 16px;
+      height: 16px;
+      border-radius: 2px;
+    }
+
+    .day-selector {
+      display: grid;
+      grid-template-columns: repeat(7, 1fr);
+      gap: 6px;
+    }
+
+    .day-button {
+      aspect-ratio: 1;
+      border: 2px solid #ecf0f1;
+      border-radius: 6px;
+      background: white;
+      color: #7f8c8d;
+      font-size: 11px;
+      font-weight: 700;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 44px;
+    }
+
+    .day-button:hover {
+      border-color: #3498db;
+      background: #f0f7ff;
+    }
+
+    .day-button.selected {
+      background: #3498db;
+      color: white;
+      border-color: #3498db;
+    }
+
+    .pattern-presets {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .preset-button {
+      padding: 12px 16px;
+      border: 1px solid #ecf0f1;
+      border-radius: 6px;
+      background: white;
+      color: #2c3e50;
+      font-size: 13px;
+      font-weight: 500;
+      cursor: pointer;
+      text-align: left;
+      transition: all 0.2s ease;
+    }
+
+    .preset-button:hover {
+      background: #f8f9fa;
+      border-color: #3498db;
+    }
+
+    .preset-button.active {
+      background: #e3f2fd;
+      border-color: #3498db;
+      color: #1976d2;
+      font-weight: 600;
+    }
+
+    .rotating-pattern {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      padding: 12px;
+      background: #f8f9fa;
+      border-radius: 6px;
+      border-left: 3px solid #3498db;
+    }
+
+    .rotating-week {
+      font-size: 12px;
+      font-weight: 600;
+      color: #1a1a1a;
+      margin-bottom: 4px;
+    }
+
+    .rotating-days {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+    }
+
+    .day-tag {
+      display: inline-block;
+      padding: 4px 8px;
+      background: white;
+      border: 1px solid #bdc3c7;
+      border-radius: 4px;
+      font-size: 11px;
+      font-weight: 500;
+      color: #2c3e50;
+    }
+
+    .form-group {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .form-label {
+      font-size: 12px;
+      font-weight: 700;
+      color: #2c3e50;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+    }
+
+    .form-input,
+    .form-select {
+      padding: 10px 12px;
+      border: 1px solid #ecf0f1;
+      border-radius: 6px;
+      font-size: 13px;
+      transition: border-color 0.2s ease;
+      font-family: inherit;
+    }
+
+    .form-input:focus,
+    .form-select:focus {
+      outline: none;
+      border-color: #3498db;
+      box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.1);
+    }
+
+    .button {
+      padding: 10px 16px;
+      border: none;
+      border-radius: 6px;
+      font-size: 12px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      min-height: 44px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .button-primary {
+      background: #3498db;
+      color: white;
+    }
+
+    .button-primary:hover {
+      background: #2980b9;
+      transform: translateY(-1px);
+      box-shadow: 0 2px 8px rgba(52, 152, 219, 0.3);
+    }
+
+    .button-secondary {
+      background: #ecf0f1;
+      color: #2c3e50;
+    }
+
+    .button-secondary:hover {
+      background: #bdc3c7;
+    }
+
+    .calendar {
+      display: grid;
+      grid-template-columns: repeat(7, 1fr);
+      gap: 2px;
+      background: #ecf0f1;
+      padding: 2px;
+      border-radius: 6px;
+      overflow: hidden;
+    }
+
+    .calendar-header {
+      background: #2c3e50;
+      color: white;
+      padding: 8px;
+      font-size: 11px;
+      font-weight: 700;
+      text-align: center;
+      text-transform: uppercase;
+      letter-spacing: 0.02em;
+    }
+
+    .calendar-day {
+      background: white;
+      padding: 8px;
+      min-height: 60px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 11px;
+    }
+
+    .calendar-day.other-month {
+      background: #f8f9fa;
+      color: #bdc3c7;
+    }
+
+    .calendar-day.today {
+      background: #e8f4f8;
+      border: 1px solid #3498db;
+    }
+
+    .calendar-day-num {
+      font-weight: 700;
+      color: #2c3e50;
+    }
+
+    .calendar-day.other-month .calendar-day-num {
+      color: #bdc3c7;
+    }
+
+    .workout-marker {
+      display: inline-block;
+      padding: 2px 6px;
+      background: #27ae60;
+      color: white;
+      border-radius: 3px;
+      font-size: 10px;
+      font-weight: 600;
+      text-align: center;
+      width: 100%;
+    }
+
+    .rest-marker {
+      display: inline-block;
+      padding: 2px 6px;
+      background: #bdc3c7;
+      color: white;
+      border-radius: 3px;
+      font-size: 10px;
+      font-weight: 600;
+      text-align: center;
+      width: 100%;
+    }
+
+    .info-box {
+      padding: 12px;
+      background: #e8f4f8;
+      border-left: 3px solid #3498db;
+      border-radius: 6px;
+      font-size: 12px;
+      line-height: 1.5;
+    }
+
+    .info-box strong {
+      color: #2c3e50;
+    }
+
+    .cycle-info {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      padding: 12px;
+      background: #f8f9fa;
+      border-left: 3px solid #3498db;
+      border-radius: 6px;
+      font-size: 13px;
+    }
+
+    .cycle-info-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .cycle-info-label {
+      font-size: 11px;
+      font-weight: 700;
+      color: #7f8c8d;
+      text-transform: uppercase;
+      letter-spacing: 0.02em;
+    }
+
+    .cycle-info-value {
+      font-size: 14px;
+      font-weight: 700;
+      color: #1a1a1a;
+    }
+
+    .alert-box {
+      padding: 12px;
+      background: #fff3cd;
+      border-left: 3px solid #f39c12;
+      border-radius: 6px;
+      font-size: 12px;
+      line-height: 1.5;
+    }
+
+    .alert-box strong {
+      color: #856404;
+    }
+
+    @media (max-width: 1200px) {
+      .viewport {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useMemo } = React;
+
+    const DAYS_OF_WEEK = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+    const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+
+    const PRESET_PATTERNS = {
+      'Mon-Wed-Fri': { type: 'fixed', days: [0, 2, 4] },
+      'Mon-Tue-Thu-Fri': { type: 'fixed', days: [0, 1, 3, 4] },
+      'Tue-Thu-Sat': { type: 'fixed', days: [1, 3, 5] },
+      'Rotating (A/B)': {
+        type: 'rotating',
+        weeks: [
+          [0, 2, 4],        // Week A: Mon-Wed-Fri
+          [1, 3, 5],        // Week B: Tue-Thu-Sat
+        ]
+      },
+      'Rotating (3-4)': {
+        type: 'rotating',
+        weeks: [
+          [0, 2, 4, 5],     // Week A: Mon-Wed-Fri-Sat
+          [1, 3, 5],        // Week B: Tue-Thu-Sat
+        ]
+      }
+    };
+
+    function SettingsPanel({ patternType, setPatternType, selectedDays, toggleDay, rotatingWeeks, toggleRotatingDay, applyPreset }) {
+
+      const workoutsPerWeek = patternType === 'fixed' 
+        ? selectedDays.length 
+        : Math.max(...rotatingWeeks.map((w) => w.length));
+
+      return (
+        <div className="panel">
+          <div className="panel-header">
+            <h2>Workout Schedule Settings</h2>
+            <p>Define your preferred training days</p>
+          </div>
+          <div className="panel-content">
+            <div className="section">
+              <div className="section-title">Quick Presets</div>
+              <div className="pattern-presets">
+                {Object.keys(PRESET_PATTERNS).map((key) => (
+                  <button
+                    key={key}
+                    className={`preset-button ${
+                      patternType === PRESET_PATTERNS[key].type && 
+                      JSON.stringify(patternType === 'fixed' ? selectedDays : rotatingWeeks) === 
+                      JSON.stringify(patternType === 'fixed' ? PRESET_PATTERNS[key].days : PRESET_PATTERNS[key].weeks)
+                        ? 'active'
+                        : ''
+                    }`}
+                    onClick={() => applyPreset(key)}
+                  >
+                    {key}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="section">
+              <div className="section-title">Pattern Type</div>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <button
+                  className={`button ${patternType === 'fixed' ? 'button-primary' : 'button-secondary'}`}
+                  onClick={() => setPatternType('fixed')}
+                >
+                  Fixed Schedule
+                </button>
+                <button
+                  className={`button ${patternType === 'rotating' ? 'button-primary' : 'button-secondary'}`}
+                  onClick={() => setPatternType('rotating')}
+                >
+                  Rotating
+                </button>
+              </div>
+            </div>
+
+            {patternType === 'fixed' && (
+              <div className="section">
+                <div className="section-title">Select Training Days</div>
+                <div className="day-selector">
+                  {DAYS_OF_WEEK.map((day, idx) => (
+                    <button
+                      key={idx}
+                      className={`day-button ${selectedDays.includes(idx) ? 'selected' : ''}`}
+                      onClick={() => toggleDay(idx)}
+                    >
+                      {day}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {patternType === 'rotating' && (
+              <div className="section">
+                <div className="section-title">Rotating Pattern</div>
+                {rotatingWeeks.map((weekDays, weekIdx) => (
+                  <div key={weekIdx} className="rotating-pattern">
+                    <div className="rotating-week">Week {String.fromCharCode(65 + weekIdx)}</div>
+                    <div className="day-selector">
+                      {DAYS_OF_WEEK.map((day, dayIdx) => (
+                        <button
+                          key={dayIdx}
+                          className={`day-button ${weekDays.includes(dayIdx) ? 'selected' : ''}`}
+                          onClick={() => toggleRotatingDay(weekIdx, dayIdx)}
+                        >
+                          {day}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="info-box">
+              <strong>Current Schedule:</strong> {
+                patternType === 'fixed'
+                  ? `${selectedDays.map((i) => DAYS_OF_WEEK[i]).join(', ')} (${selectedDays.length}/week)`
+                  : `${rotatingWeeks.map((w, i) => `Week ${String.fromCharCode(65 + i)}: ${w.map((d) => DAYS_OF_WEEK[d]).join(', ')}`).join('; ')}`
+              }
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    function ProgramEditPanel({ selectedDays, rotatingWeeks, patternType }) {
+      const [programName, setProgramName] = useState('5/3/1 (Custom)');
+      const [baseWorkoutsPerWeek, setBaseWorkoutsPerWeek] = useState(4);
+      const [overrideWorkoutsPerWeek, setOverrideWorkoutsPerWeek] = useState(3);
+      const [cycleWorkouts, setCycleWorkouts] = useState(12);
+      const [useOverride, setUseOverride] = useState(true);
+      const [cycleStartDate, setCycleStartDate] = useState(new Date(2026, 4, 19)); // May 19, 2026
+      const [showCalendar, setShowCalendar] = useState(true);
+
+      const effectiveWorkoutsPerWeek = useOverride ? overrideWorkoutsPerWeek : baseWorkoutsPerWeek;
+      
+      const weeksToCompleteCycle = useMemo(() => {
+        if (effectiveWorkoutsPerWeek <= 0) return 0;
+        return Math.ceil(cycleWorkouts / effectiveWorkoutsPerWeek);
+      }, [cycleWorkouts, effectiveWorkoutsPerWeek]);
+
+      const estimatedEndDate = useMemo(() => {
+        const date = new Date(cycleStartDate);
+        date.setDate(date.getDate() + (weeksToCompleteCycle * 7) - 1);
+        return date;
+      }, [cycleStartDate, weeksToCompleteCycle]);
+
+      // Generate workout distribution across weeks using the user's schedule
+      const workoutDistribution = useMemo(() => {
+        const distribution = [];
+        let workoutsPlaced = 0;
+        let currentDate = new Date(cycleStartDate);
+        let weekCounter = 0;
+
+        while (workoutsPlaced < cycleWorkouts) {
+          const workoutDays = patternType === 'fixed' 
+            ? selectedDays 
+            : rotatingWeeks[weekCounter % rotatingWeeks.length];
+          
+          const weekWorkouts = [];
+          for (const dayIdx of workoutDays) {
+            if (workoutsPlaced >= cycleWorkouts) break;
+            
+            const workoutDate = new Date(currentDate);
+            const currentDayOfWeek = workoutDate.getDay();
+            let daysToAdd = (dayIdx === 0 ? 1 : dayIdx) - currentDayOfWeek;
+            if (daysToAdd <= 0) daysToAdd += 7;
+            
+            workoutDate.setDate(workoutDate.getDate() + daysToAdd);
+            weekWorkouts.push(new Date(workoutDate));
+            workoutsPlaced++;
+          }
+          
+          if (weekWorkouts.length > 0) {
+            distribution.push({
+              weekNum: weekCounter + 1,
+              workouts: weekWorkouts
+            });
+          }
+          
+          currentDate.setDate(currentDate.getDate() + 7);
+          weekCounter++;
+        }
+
+        return distribution;
+      }, [cycleWorkouts, effectiveWorkoutsPerWeek, cycleStartDate, selectedDays, rotatingWeeks, patternType]);
+
+      // Generate calendar grid with workout markers
+      const calendarData = useMemo(() => {
+        const start = new Date(cycleStartDate);
+        start.setDate(start.getDate() - start.getDay() + 1); // Start on Monday
+        
+        const workoutDates = new Set();
+        workoutDistribution.forEach((week) => {
+          week.workouts.forEach((date) => {
+            workoutDates.add(date.toDateString());
+          });
+        });
+
+        const days = [];
+        const current = new Date(start);
+        const end = new Date(estimatedEndDate);
+        end.setDate(end.getDate() + 7);
+
+        while (current <= end) {
+          days.push({
+            date: new Date(current),
+            isWorkout: workoutDates.has(current.toDateString()),
+            isInCycle: current >= cycleStartDate && current <= estimatedEndDate,
+            isToday: current.toDateString() === new Date().toDateString()
+          });
+          current.setDate(current.getDate() + 1);
+        }
+
+        return days;
+      }, [cycleStartDate, estimatedEndDate, workoutDistribution]);
+
+      const formatDate = (date) => {
+        return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+      };
+
+      return (
+        <div className="panel">
+          <div className="panel-header">
+            <h2>Program Editor</h2>
+            <p>Adjust workouts per week and see cycle duration</p>
+          </div>
+          <div className="panel-content">
+            <div className="form-group">
+              <label className="form-label">Program Name</label>
+              <input
+                type="text"
+                className="form-input"
+                value={programName}
+                onChange={(e) => setProgramName(e.target.value)}
+              />
+            </div>
+
+            <div className="section">
+              <div className="section-title">Program Spec</div>
+              <div className="form-group">
+                <label className="form-label">Workouts in Cycle</label>
+                <input
+                  type="number"
+                  className="form-input"
+                  value={cycleWorkouts}
+                  onChange={(e) => setCycleWorkouts(Math.max(1, parseInt(e.target.value) || 1))}
+                  min="1"
+                />
+              </div>
+              <div className="form-group">
+                <label className="form-label">Prescribed Workouts/Week</label>
+                <input
+                  type="number"
+                  className="form-input"
+                  value={baseWorkoutsPerWeek}
+                  onChange={(e) => setBaseWorkoutsPerWeek(Math.max(1, parseInt(e.target.value) || 1))}
+                  min="1"
+                />
+              </div>
+            </div>
+
+            <div className="section">
+              <div className="section-title">Override</div>
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                <input
+                  type="checkbox"
+                  id="useOverride"
+                  checked={useOverride}
+                  onChange={(e) => setUseOverride(e.target.checked)}
+                  style={{ width: 18, height: 18, cursor: 'pointer' }}
+                />
+                <label htmlFor="useOverride" style={{ cursor: 'pointer', flex: 1 }}>
+                  Override workouts/week for this program
+                </label>
+              </div>
+              {useOverride && (
+                <div className="form-group" style={{ marginTop: 12 }}>
+                  <label className="form-label">Your Workouts/Week</label>
+                  <input
+                    type="number"
+                    className="form-input"
+                    value={overrideWorkoutsPerWeek}
+                    onChange={(e) => setOverrideWorkoutsPerWeek(Math.max(1, parseInt(e.target.value) || 1))}
+                    min="1"
+                  />
+                </div>
+              )}
+            </div>
+
+            <div className="cycle-info">
+              <div className="cycle-info-row">
+                <span className="cycle-info-label">Effective Workouts/Week</span>
+                <span className="cycle-info-value">{effectiveWorkoutsPerWeek}</span>
+              </div>
+              <div className="cycle-info-row">
+                <span className="cycle-info-label">Weeks to Complete</span>
+                <span className="cycle-info-value">{weeksToCompleteCycle}</span>
+              </div>
+              <div className="cycle-info-row">
+                <span className="cycle-info-label">Workouts Scheduled</span>
+                <span className="cycle-info-value">{workoutDistribution.reduce((sum, w) => sum + w.workouts.length, 0)} of {cycleWorkouts}</span>
+              </div>
+              <div className="cycle-info-row">
+                <span className="cycle-info-label">Est. End Date</span>
+                <span className="cycle-info-value">{estimatedEndDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</span>
+              </div>
+            </div>
+
+            <div className="info-box">
+              <strong>How it works:</strong> The cycle contains {cycleWorkouts} workouts. At {effectiveWorkoutsPerWeek} workouts/week, it takes {weeksToCompleteCycle} weeks to complete. Your schedule distributes them across your preferred days.
+            </div>
+
+            <div className="form-group">
+              <label className="form-label">Cycle Start Date</label>
+              <input
+                type="date"
+                className="form-input"
+                value={formatDate(cycleStartDate)}
+                onChange={(e) => setCycleStartDate(new Date(e.target.value))}
+              />
+            </div>
+
+            <button
+              className="button button-secondary"
+              onClick={() => setShowCalendar(!showCalendar)}
+              style={{ marginTop: 12 }}
+            >
+              {showCalendar ? 'Hide Calendar' : 'Show Calendar'}
+            </button>
+
+            {showCalendar && (
+              <div style={{ marginTop: 16 }}>
+                <div className="section-title" style={{ marginBottom: 12 }}>Workout Distribution</div>
+                
+                <div className="legend" style={{ marginBottom: 12 }}>
+                  <div className="legend-item">
+                    <div className="legend-swatch" style={{ background: '#27ae60' }}></div>
+                    <span>Workout Day</span>
+                  </div>
+                  <div className="legend-item">
+                    <div className="legend-swatch" style={{ background: '#ecf0f1' }}></div>
+                    <span>Rest Day</span>
+                  </div>
+                  <div className="legend-item">
+                    <div className="legend-swatch" style={{ background: '#e8f4f8', border: '1px solid #3498db' }}></div>
+                    <span>Today</span>
+                  </div>
+                </div>
+
+                <div className="calendar-grid">
+                  {['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'].map((day) => (
+                    <div key={day} className="calendar-cell header">
+                      {day}
+                    </div>
+                  ))}
+                  {calendarData.map((day, idx) => {
+                    const isOtherMonth = day.date < cycleStartDate || day.date > estimatedEndDate;
+                    return (
+                      <div
+                        key={idx}
+                        className={`calendar-cell ${isOtherMonth ? 'other-month' : ''} ${day.isToday ? 'today' : ''}`}
+                      >
+                        <div className="calendar-date">{day.date.getDate()}</div>
+                        {day.isInCycle && (day.isWorkout ? (
+                          <div className="calendar-workout">WO</div>
+                        ) : (
+                          <div className="calendar-rest">Rest</div>
+                        ))}
+                      </div>
+                    );
+                  })}
+                </div>
+
+                {workoutDistribution.length > 0 && (
+                  <div style={{ marginTop: 16 }}>
+                    <div className="section-title" style={{ marginBottom: 12 }}>Week Breakdown</div>
+                    {workoutDistribution.map((week, idx) => (
+                      <div key={idx} className="cycle-info" style={{ marginBottom: 8 }}>
+                        <div className="cycle-info-row">
+                          <span className="cycle-info-label">Week {week.weekNum}</span>
+                          <span className="cycle-info-value">{week.workouts.length} workouts</span>
+                        </div>
+                        <div style={{ fontSize: 11, color: '#7f8c8d' }}>
+                          {week.workouts.map((d) => d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })).join(', ')}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    function App() {
+      const [patternType, setPatternType] = useState('fixed');
+      const [selectedDays, setSelectedDays] = useState([0, 2, 4]); // Mon-Wed-Fri
+      const [rotatingWeeks, setRotatingWeeks] = useState([
+        [0, 2, 4],
+        [1, 3, 5]
+      ]);
+
+      const toggleDay = (dayIndex) => {
+        setSelectedDays((prev) =>
+          prev.includes(dayIndex)
+            ? prev.filter((d) => d !== dayIndex)
+            : [...prev, dayIndex].sort((a, b) => a - b)
+        );
+      };
+
+      const toggleRotatingDay = (weekIndex, dayIndex) => {
+        setRotatingWeeks((prev) => {
+          const newWeeks = prev.map((week) => [...week]);
+          const dayList = newWeeks[weekIndex];
+          if (dayList.includes(dayIndex)) {
+            newWeeks[weekIndex] = dayList.filter((d) => d !== dayIndex);
+          } else {
+            newWeeks[weekIndex] = [...dayList, dayIndex].sort((a, b) => a - b);
+          }
+          return newWeeks;
+        });
+      };
+
+      const applyPreset = (presetKey) => {
+        const preset = PRESET_PATTERNS[presetKey];
+        setPatternType(preset.type);
+        if (preset.type === 'fixed') {
+          setSelectedDays(preset.days);
+        } else {
+          setRotatingWeeks(preset.weeks);
+        }
+      };
+
+      return (
+        <div className="viewport">
+          <SettingsPanel 
+            patternType={patternType}
+            setPatternType={setPatternType}
+            selectedDays={selectedDays}
+            setSelectedDays={setSelectedDays}
+            toggleDay={toggleDay}
+            rotatingWeeks={rotatingWeeks}
+            setRotatingWeeks={setRotatingWeeks}
+            toggleRotatingDay={toggleRotatingDay}
+            applyPreset={applyPreset}
+          />
+          <ProgramEditPanel 
+            selectedDays={selectedDays}
+            rotatingWeeks={rotatingWeeks}
+            patternType={patternType}
+          />
+        </div>
+      );
+    }
+
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(<App />);
+  </script>
+</body>
+</html>

--- a/docs/mockups/workout-scheduling.html
+++ b/docs/mockups/workout-scheduling.html
@@ -650,7 +650,9 @@
           const weekWorkouts = [];
           for (const dayIdx of workoutDays) {
             if (workoutsPlaced >= cycleWorkouts) break;
-            
+
+            // Simplified placement for prototype only — not the canonical algorithm.
+            // See docs/design/workout-scheduling-integration.md → distributeWorkouts()
             const workoutDate = new Date(currentDate);
             const currentDayOfWeek = workoutDate.getDay();
             let daysToAdd = (dayIdx === 0 ? 1 : dayIdx) - currentDayOfWeek;

--- a/docs/proposals/2026-05-17-workout-scheduling-override.md
+++ b/docs/proposals/2026-05-17-workout-scheduling-override.md
@@ -8,24 +8,22 @@
 
 ## Problem Statement
 
-Currently, users cannot adjust the prescribed workouts-per-week frequency for a program based on personal schedule or recovery capacity. A 5/3/1 program prescribes 4 workouts/week, but a user with limited time may want to run it at 3/week — the system should accommodate this without requiring a code change or manual date management.
+Currently, users cannot define a preferred workout schedule (e.g., Mon-Wed-Fri) and have the system automatically distribute upcoming workout dates to match it. A 5/3/1 program with 12 workouts runs at whatever pace the user trains — the system should place those workouts on the user's chosen days and show them in the cycle dashboard.
 
 **Example:**
-- Program spec: 12 workouts, 4/week (prescribed)
-- User's schedule: Mon-Wed-Fri (3 days available)
-- User's setting: "I want Mon-Wed-Fri every week"
-- Expected outcome: 4 weeks to complete the cycle, workouts on those 3 days
+- Program spec: 12 workouts
+- User's schedule: Mon-Wed-Fri
+- Expected outcome: 4 weeks to complete the cycle, workouts on Mon/Wed/Fri
 
-Additionally, users should be able to define their workout schedule once in settings and have all programs respect it when distributing workout dates.
+The pace follows naturally from the schedule — no separate "workouts per week" override is needed.
 
 ## Success Criteria
 
 - [ ] User can define preferred workout days (fixed or rotating pattern) in Settings
-- [ ] User can override workouts-per-week when editing a custom program
-- [ ] System calculates cycle duration based on override, not prescription
+- [ ] When a schedule is set and a program is active, user is prompted to enable schedule mode
 - [ ] System distributes workout dates respecting the user's schedule
 - [ ] Rotating schedules (e.g., A/B weeks) are supported
-- [ ] Existing programs without override continue to work (backward compatible)
+- [ ] Existing programs without a schedule continue to work (no-schedule mode — backward compatible)
 - [ ] Cycle dashboard shows workout dates on the correct days
 
 ## Phases
@@ -55,27 +53,20 @@ Additionally, users should be able to define their workout schedule once in sett
 
 ---
 
-### Phase 2: Program Override — Data & Core Logic (1 week)
+### Phase 2: Distribution Core Logic (1 week)
 
 **Acceptance Criteria:**
-- [ ] Custom programs can store `workoutsPerWeekOverride` (nullable)
-- [ ] Existing programs default to `null` (use prescribed)
-- [ ] API returns `workoutsPerWeekOverride` in program response
-- [ ] Core service calculates effective workouts/week (override or prescribed)
-- [ ] `distributeWorkouts()` algorithm correctly distributes N workouts across weeks
+- [ ] `distributeWorkouts()` algorithm correctly distributes N workouts across schedule days
 - [ ] `distributeWorkouts()` respects user's workout schedule (fixed or rotating)
+- [ ] Schedule-mode prompt is surfaced by the API when a schedule is set and a program is active
 - [ ] Unit tests validate distribution logic (fixed schedule, rotating schedule, edge cases)
 
 **Tasks:**
-1. Extend `CustomProgramResponse` with `workoutsPerWeekOverride: number | null`
-2. Extend `UpdateCustomProgramRequest` with `workoutsPerWeekOverride`
-3. Update database schema: add `workoutsPerWeekOverride` column to programs table
-4. Implement `calculateEffectiveWorkoutsPerWeek()` in `packages/core`
-5. Implement `distributeWorkouts()` in `packages/core/src/services/workout/`
-6. Write unit tests for distribution algorithm (fixed, rotating, edge cases)
-7. Implement API endpoint `PATCH /programs/:program` to accept override
-8. Implement API endpoint `GET /programs/:program` to return override
-9. Write integration test: create program with override, verify response
+1. Implement `distributeWorkouts()` in `packages/core/src/services/workout/`
+2. Implement `getScheduleWorkoutsPerWeek()` display helper (duration estimate)
+3. Write unit tests for distribution algorithm (fixed, rotating, edge cases)
+4. Add schedule-mode flag to settings or program-activation response (for UI to trigger prompt)
+5. Write integration test: set schedule + activate program, verify schedule-mode flag returned
 
 **Owned by:** Backend (Core + API)
 
@@ -198,26 +189,27 @@ Additionally, users should be able to define their workout schedule once in sett
 ## Testing Checklist
 
 ### Unit Tests
-- [ ] `calculateEffectiveWorkoutsPerWeek()` with override
-- [ ] `calculateEffectiveWorkoutsPerWeek()` without override
 - [ ] `distributeWorkouts()` with fixed schedule
 - [ ] `distributeWorkouts()` with rotating schedule (2-week pattern)
 - [ ] `distributeWorkouts()` with 1 workout
 - [ ] `distributeWorkouts()` with 0 days in schedule (edge case)
+- [ ] `getScheduleWorkoutsPerWeek()` with fixed schedule
+- [ ] `getScheduleWorkoutsPerWeek()` with rotating schedule (average of week lengths)
 
 ### Integration Tests
 - [ ] Create user with schedule, retrieve via API
 - [ ] Update schedule, verify in GET response
-- [ ] Create program with override, retrieve via API
-- [ ] Create cycle, verify dates distributed correctly
+- [ ] Set schedule while program active → API returns schedule-mode prompt flag
+- [ ] Enable schedule mode → create cycle, verify dates distributed correctly
 - [ ] Log lift record at scheduled date
-- [ ] Create cycle with no user schedule (expect error or default)
+- [ ] Create cycle with no user schedule → no pending dates (no-schedule mode)
 
 ### E2E Tests
 - [ ] Settings: set Mon-Wed-Fri, refresh, verify persisted
 - [ ] Settings: switch to rotating (A/B), refresh, verify persisted
-- [ ] Program Editor: set override to 3/week, view calendar, verify 4 weeks
-- [ ] Program Editor: change override, calendar updates live
+- [ ] Settings: set schedule while program active → schedule-mode prompt shown
+- [ ] Schedule mode: enable → cycle dashboard shows dates on Mon/Wed/Fri
+- [ ] Schedule mode: decline → cycle dashboard shows no pending dates
 - [ ] Cycle Dashboard: view dates on calendar, all on correct days
 - [ ] Lift Logging: log set, verify default date is scheduled date
 

--- a/docs/proposals/2026-05-17-workout-scheduling-override.md
+++ b/docs/proposals/2026-05-17-workout-scheduling-override.md
@@ -2,7 +2,7 @@
 
 **Status:** Proposal  
 **Linked Design:** [`docs/design/workout-scheduling-integration.md`](../design/workout-scheduling-integration.md)  
-**Linked Prototype:** `docs/mockups/workout-scheduling.html`  
+**Linked Prototype:** [`docs/mockups/workout-scheduling.html`](../mockups/workout-scheduling.html)  
 **Epic:** Client Applications  
 **Milestone:** v0.3 — Client Applications
 

--- a/docs/proposals/2026-05-17-workout-scheduling-override.md
+++ b/docs/proposals/2026-05-17-workout-scheduling-override.md
@@ -1,0 +1,230 @@
+# Workout Scheduling Override — Implementation Roadmap
+
+**Status:** Proposal  
+**Linked Design:** [`docs/design/workout-scheduling-integration.md`](../design/workout-scheduling-integration.md)  
+**Linked Prototype:** `docs/mockups/workout-scheduling.html`  
+**Epic:** Client Applications  
+**Milestone:** v0.3 — Client Applications
+
+## Problem Statement
+
+Currently, users cannot adjust the prescribed workouts-per-week frequency for a program based on personal schedule or recovery capacity. A 5/3/1 program prescribes 4 workouts/week, but a user with limited time may want to run it at 3/week — the system should accommodate this without requiring a code change or manual date management.
+
+**Example:**
+- Program spec: 12 workouts, 4/week (prescribed)
+- User's schedule: Mon-Wed-Fri (3 days available)
+- User's setting: "I want Mon-Wed-Fri every week"
+- Expected outcome: 4 weeks to complete the cycle, workouts on those 3 days
+
+Additionally, users should be able to define their workout schedule once in settings and have all programs respect it when distributing workout dates.
+
+## Success Criteria
+
+- [ ] User can define preferred workout days (fixed or rotating pattern) in Settings
+- [ ] User can override workouts-per-week when editing a custom program
+- [ ] System calculates cycle duration based on override, not prescription
+- [ ] System distributes workout dates respecting the user's schedule
+- [ ] Rotating schedules (e.g., A/B weeks) are supported
+- [ ] Existing programs without override continue to work (backward compatible)
+- [ ] Cycle dashboard shows workout dates on the correct days
+
+## Phases
+
+### Phase 1: Settings UI & Data Model (1 week)
+
+**Acceptance Criteria:**
+- [ ] User can access Settings and set preferred workout days
+- [ ] Settings support both fixed (Mon-Wed-Fri) and rotating (A/B weeks) patterns
+- [ ] Settings are persisted to database and retrieved on app load
+- [ ] API exposes `GET /users/settings` with `workoutSchedule` field
+- [ ] API exposes `PATCH /users/settings` to update schedule
+- [ ] No errors on app startup for users without a schedule set
+
+**Tasks:**
+1. Add `UserWorkoutSchedule` interface to `packages/types/src/api.ts`
+2. Extend `UserSettingsResponse` with `workoutSchedule` field
+3. Create/update user settings database schema to store schedule
+4. Implement `GET /users/settings` endpoint in `apps/api`
+5. Implement `PATCH /users/settings` endpoint in `apps/api`
+6. Build Settings UI in `apps/web` with day selector (leverage prototype)
+7. Wire Settings UI to API, add error handling
+8. Write unit tests for API endpoints
+9. Write E2E test: set schedule, refresh page, verify persistence
+
+**Owned by:** Backend (API + schema), Frontend (Settings UI)
+
+---
+
+### Phase 2: Program Override — Data & Core Logic (1 week)
+
+**Acceptance Criteria:**
+- [ ] Custom programs can store `workoutsPerWeekOverride` (nullable)
+- [ ] Existing programs default to `null` (use prescribed)
+- [ ] API returns `workoutsPerWeekOverride` in program response
+- [ ] Core service calculates effective workouts/week (override or prescribed)
+- [ ] `distributeWorkouts()` algorithm correctly distributes N workouts across weeks
+- [ ] `distributeWorkouts()` respects user's workout schedule (fixed or rotating)
+- [ ] Unit tests validate distribution logic (fixed schedule, rotating schedule, edge cases)
+
+**Tasks:**
+1. Extend `CustomProgramResponse` with `workoutsPerWeekOverride: number | null`
+2. Extend `UpdateCustomProgramRequest` with `workoutsPerWeekOverride`
+3. Update database schema: add `workoutsPerWeekOverride` column to programs table
+4. Implement `calculateEffectiveWorkoutsPerWeek()` in `packages/core`
+5. Implement `distributeWorkouts()` in `packages/core/src/services/workout/`
+6. Write unit tests for distribution algorithm (fixed, rotating, edge cases)
+7. Implement API endpoint `PATCH /programs/:program` to accept override
+8. Implement API endpoint `GET /programs/:program` to return override
+9. Write integration test: create program with override, verify response
+
+**Owned by:** Backend (Core + API)
+
+---
+
+### Phase 3: Cycle Dashboard Integration (1 week)
+
+**Acceptance Criteria:**
+- [ ] When a cycle is created, system distributes workout dates per user schedule
+- [ ] Cycle dashboard includes workout dates in `CycleWeekSummary` or similar structure
+- [ ] Dates respect user's schedule and program override
+- [ ] System gracefully handles users without a schedule set (uses default or error)
+- [ ] Existing cycles continue to work (no regression)
+- [ ] E2E test: create cycle, verify dates are correct
+
+**Tasks:**
+1. Extend `CycleDashboardResponse` to include workout dates (or create new field)
+2. Modify cycle creation logic to call `distributeWorkouts()`
+3. Store workout dates in database (cycle_workouts table or similar)
+4. Modify `GET /programs/:program/cycles/:cycleNum` to return dates
+5. Write integration test: create cycle with override + schedule, verify dates
+6. Write E2E test: create cycle in UI, view calendar, verify dates
+
+**Owned by:** Backend (Services + API)
+
+---
+
+### Phase 4: Lift Record Scheduling (1 week)
+
+**Acceptance Criteria:**
+- [ ] When user logs a lift, system suggests the scheduled date
+- [ ] User can override the suggested date
+- [ ] Lift records respect the scheduled dates from distribution
+- [ ] Existing lift records continue to work (no regression)
+- [ ] E2E test: log a lift, verify it defaults to scheduled date
+
+**Tasks:**
+1. Modify lift record creation to fetch scheduled date from distribution
+2. Update `CreateLiftRecordRequest` to accept optional `scheduledDate` (for suggestions)
+3. Modify UI to show scheduled date when logging a set
+4. Allow user to override scheduled date in UI
+5. Write integration test: create lift record, verify date
+6. Write E2E test: log lift, verify date suggestion, override it
+
+**Owned by:** Backend (Services + API), Frontend (Lift logging UI)
+
+---
+
+### Phase 5: Program Editor UI (1 week)
+
+**Acceptance Criteria:**
+- [ ] User can edit a custom program and set `workoutsPerWeekOverride`
+- [ ] UI shows effective workouts/week and estimated cycle duration
+- [ ] UI shows calendar preview of workout distribution
+- [ ] User can toggle between prescribed and override
+- [ ] Changes are persisted to API
+- [ ] E2E test: edit program, set override, verify calendar updates
+
+**Tasks:**
+1. Build Program Editor UI (leverage prototype)
+2. Wire override input to `PATCH /programs/:program` API
+3. Add calendar preview showing workout distribution
+4. Add info boxes explaining the math (how many weeks, when it ends)
+5. Write E2E test: create program, set override, verify calendar
+6. Write E2E test: edit program, change override, verify dates update
+
+**Owned by:** Frontend
+
+---
+
+## Estimated Effort
+
+| Phase | Backend | Frontend | Duration |
+|-------|---------|----------|----------|
+| 1: Settings | 3d | 2d | 1 week |
+| 2: Override Logic | 3d | — | 1 week |
+| 3: Cycle Dashboard | 2d | 1d | 1 week |
+| 4: Lift Scheduling | 2d | 2d | 1 week |
+| 5: Program Editor UI | — | 3d | 1 week |
+| **Total** | **10d** | **8d** | **5 weeks** |
+
+## Dependencies & Blockers
+
+- **Phase 1 blocks:** Phase 3, 4, 5 (need user schedule to calculate dates)
+- **Phase 2 blocks:** Phase 3, 5 (need override + algorithm for distribution)
+- **Phase 3 blocks:** Phase 4 (need cycle with dates to schedule lifts)
+- **No external blockers** identified; all work is contained in Lifting Logbook codebase
+
+## Rollout Strategy
+
+1. Deploy Phase 1 + 2 together (Settings + Core Logic)
+   - Users can set schedule, programs can store override
+   - No visible changes to workflow yet
+2. Deploy Phase 3 (Cycle Dashboard)
+   - Existing cycles still work; new cycles use distributed dates
+   - Users see dates in dashboard (but UI may not show them yet)
+3. Deploy Phase 4 + 5 together (Lift Logging + Program Editor)
+   - Users can now interact with the feature end-to-end
+   - Settings → Program Editor → Cycle Dashboard → Lift Logging
+
+## Risk Mitigation
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|-----------|
+| Distribution algorithm has off-by-one errors | Medium | Medium | Unit tests with edge cases; manual QA with rotating schedules |
+| Users with no schedule set → crashes | Medium | High | Default behavior: return error or use fallback schedule; test explicitly |
+| Existing cycles/lifts break | Low | Critical | Keep backward compatibility; migration tests for legacy data |
+| Rotating schedule logic is confusing | Medium | Medium | Clear docs + UI tooltips; limit to 2–3 week patterns in MVP |
+| Partial week handling edge cases | Low | Medium | Document behavior; defer complex cases (holidays) to Phase 2 |
+
+## Future Enhancements (Out of Scope)
+
+- Holiday/deload weeks that automatically skip or push workouts forward
+- Auto-reschedule on missed workouts (e.g., "I missed Wed, move remaining to next week")
+- Integration with calendar APIs (Google Calendar, Outlook)
+- Workout notifications based on scheduled dates
+- Seasonal periodization (different schedules at different times of year)
+- Coach-managed programs with collaborative scheduling
+
+## Testing Checklist
+
+### Unit Tests
+- [ ] `calculateEffectiveWorkoutsPerWeek()` with override
+- [ ] `calculateEffectiveWorkoutsPerWeek()` without override
+- [ ] `distributeWorkouts()` with fixed schedule
+- [ ] `distributeWorkouts()` with rotating schedule (2-week pattern)
+- [ ] `distributeWorkouts()` with 1 workout
+- [ ] `distributeWorkouts()` with 0 days in schedule (edge case)
+
+### Integration Tests
+- [ ] Create user with schedule, retrieve via API
+- [ ] Update schedule, verify in GET response
+- [ ] Create program with override, retrieve via API
+- [ ] Create cycle, verify dates distributed correctly
+- [ ] Log lift record at scheduled date
+- [ ] Create cycle with no user schedule (expect error or default)
+
+### E2E Tests
+- [ ] Settings: set Mon-Wed-Fri, refresh, verify persisted
+- [ ] Settings: switch to rotating (A/B), refresh, verify persisted
+- [ ] Program Editor: set override to 3/week, view calendar, verify 4 weeks
+- [ ] Program Editor: change override, calendar updates live
+- [ ] Cycle Dashboard: view dates on calendar, all on correct days
+- [ ] Lift Logging: log set, verify default date is scheduled date
+
+## References
+
+- **Design Doc:** `docs/design/workout-scheduling-integration.md`
+- **Prototype:** `docs/mockups/workout-scheduling.html`
+- **Related Types:** `packages/types/src/api.ts`, `packages/types/src/domain.ts`
+- **Related Services:** `packages/core/src/services/workout/updateLiftDates.ts`
+- **Related Models:** `packages/core/src/models/CycleDashboard.ts`, `packages/core/src/models/LiftingProgramSpec.ts`


### PR DESCRIPTION
## Summary

Adds the design doc, 5-phase implementation proposal, and interactive HTML prototype for the **Workout Scheduling Override** feature. Introduces `docs/design/` as a new top-level docs subdirectory.

- `docs/design/workout-scheduling-integration.md` — `UserWorkoutSchedule` types, API contracts for `/users/settings` and `/programs/:program`, `distributeWorkouts()` pseudo-code, integration points across core/api/UI, unit + integration + E2E test strategy
- `docs/proposals/2026-05-17-workout-scheduling-override.md` — 5-phase roadmap (~18 dev days), per-phase acceptance criteria, rollout strategy, risk table
- `docs/mockups/workout-scheduling.html` — interactive prototype: Settings panel with day-of-week selector and rotating pattern support; Program Editor with override controls; live calendar that updates as inputs change
- `ROADMAP.md` — Proposals row under v0.3 — Client Applications linking to the proposal with status `draft`

**Authored externally** and landed here under project conventions (dated proposal slug, issue-first, ROADMAP entry). `/propose` was bypassed because the artifacts were already complete.

No code changes — implementation deferred to 5 follow-up issues per the proposal.

## Acceptance criteria

- [x] `docs/design/workout-scheduling-integration.md` exists and renders cleanly
- [x] `docs/proposals/2026-05-17-workout-scheduling-override.md` exists with dated-slug convention
- [x] `docs/mockups/workout-scheduling.html` exists; calendar updates interactively
- [x] ROADMAP.md has a Proposals row under v0.3 linking to the proposal with status `draft`
- [x] `npm test` passes (10/10 tasks, 182 + 28 tests passed across api and web)

## Test plan

- [x] `npm test` from repo root — passed (1m44s; api: 18/19 suites, 182 tests pass; web: 3 suites, 28 tests pass)
- [x] Per project coverage matrix: docs-only change → no new tests required
- [ ] Reviewer: open `docs/mockups/workout-scheduling.html` in a browser and confirm the calendar/day-selector interactivity

Closes #267