### PR TITLE
[feat] Workout schedule data model + Settings UI (Phase 1 of 5)

### DIFF
--- a/apps/api/prisma/migrations/20260517000000_add_workout_schedule/migration.sql
+++ b/apps/api/prisma/migrations/20260517000000_add_workout_schedule/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user_settings" ADD COLUMN "workoutSchedule" JSONB;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -135,8 +135,9 @@ model LiftMetadata {
 }
 
 model UserSettings {
-  userId        String  @id
-  activeProgram String?
+  userId          String  @id
+  activeProgram   String?
+  workoutSchedule Json?
 
   @@map("user_settings")
 }

--- a/apps/api/src/user-settings/update-settings.dto.ts
+++ b/apps/api/src/user-settings/update-settings.dto.ts
@@ -17,25 +17,18 @@ import {
   ValidatorConstraintInterface,
   ValidationArguments,
 } from 'class-validator';
+import { SCHEDULE_LIMITS, isValidSchedule } from '@lifting-logbook/types';
 import type { UserWorkoutSchedule } from '@lifting-logbook/types';
 
+// Delegates to the shared `isValidSchedule` predicate so the write-side and read-side
+// bounds (range, uniqueness, max weeks, max days/week) cannot drift.
 @ValidatorConstraint({ name: 'IsWeekPatternArray', async: false })
 class IsWeekPatternArrayConstraint implements ValidatorConstraintInterface {
   validate(value: unknown): boolean {
-    if (!Array.isArray(value) || value.length < 1 || value.length > 8) return false;
-    for (const week of value) {
-      if (!Array.isArray(week) || week.length < 1 || week.length > 7) return false;
-      const seen = new Set<number>();
-      for (const day of week) {
-        if (!Number.isInteger(day) || day < 0 || day > 6) return false;
-        if (seen.has(day)) return false;
-        seen.add(day);
-      }
-    }
-    return true;
+    return isValidSchedule({ type: 'rotating', weeks: value });
   }
   defaultMessage(): string {
-    return 'weeks must be 1-8 arrays of unique day indices (0-6)';
+    return `weeks must be 1-${SCHEDULE_LIMITS.MAX_ROTATING_WEEKS} arrays of unique day indices (0-6, max ${SCHEDULE_LIMITS.MAX_DAYS_PER_WEEK} per week)`;
   }
 }
 
@@ -62,7 +55,7 @@ export class WorkoutScheduleDto implements UserWorkoutSchedule {
   @ValidateIf((o: WorkoutScheduleDto) => o.type === 'fixed')
   @IsArray()
   @ArrayMinSize(1)
-  @ArrayMaxSize(7)
+  @ArrayMaxSize(SCHEDULE_LIMITS.MAX_DAYS_PER_WEEK)
   @ArrayUnique()
   @IsInt({ each: true })
   @Min(0, { each: true })

--- a/apps/api/src/user-settings/update-settings.dto.ts
+++ b/apps/api/src/user-settings/update-settings.dto.ts
@@ -1,3 +1,67 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  ArrayUnique,
+  IsArray,
+  IsIn,
+  IsInt,
+  IsOptional,
+  Max,
+  Min,
+  Validate,
+  ValidateIf,
+  ValidateNested,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
 // Active program changes must go through POST /programs/:program/switch,
 // which enforces ownership of custom program UUIDs.
-export class UpdateSettingsDto {}
+
+@ValidatorConstraint({ name: 'IsWeekPatternArray', async: false })
+class IsWeekPatternArrayConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    if (!Array.isArray(value) || value.length < 1 || value.length > 8) return false;
+    for (const week of value) {
+      if (!Array.isArray(week) || week.length < 1 || week.length > 7) return false;
+      const seen = new Set<number>();
+      for (const day of week) {
+        if (!Number.isInteger(day) || day < 0 || day > 6) return false;
+        if (seen.has(day)) return false;
+        seen.add(day);
+      }
+    }
+    return true;
+  }
+  defaultMessage(): string {
+    return 'weeks must be 1-8 arrays of unique day indices (0-6)';
+  }
+}
+
+export class WorkoutScheduleDto {
+  @IsIn(['fixed', 'rotating'])
+  type!: 'fixed' | 'rotating';
+
+  @ValidateIf((o: WorkoutScheduleDto) => o.type === 'fixed')
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(7)
+  @ArrayUnique()
+  @IsInt({ each: true })
+  @Min(0, { each: true })
+  @Max(6, { each: true })
+  days?: number[];
+
+  @ValidateIf((o: WorkoutScheduleDto) => o.type === 'rotating')
+  @Validate(IsWeekPatternArrayConstraint)
+  weeks?: number[][];
+}
+
+export class UpdateSettingsDto {
+  // null clears the schedule; undefined leaves it unchanged.
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => WorkoutScheduleDto)
+  workoutSchedule?: WorkoutScheduleDto | null;
+}

--- a/apps/api/src/user-settings/update-settings.dto.ts
+++ b/apps/api/src/user-settings/update-settings.dto.ts
@@ -6,6 +6,7 @@ import {
   IsArray,
   IsIn,
   IsInt,
+  IsObject,
   IsOptional,
   Max,
   Min,
@@ -14,10 +15,9 @@ import {
   ValidateNested,
   ValidatorConstraint,
   ValidatorConstraintInterface,
+  ValidationArguments,
 } from 'class-validator';
-
-// Active program changes must go through POST /programs/:program/switch,
-// which enforces ownership of custom program UUIDs.
+import type { UserWorkoutSchedule } from '@lifting-logbook/types';
 
 @ValidatorConstraint({ name: 'IsWeekPatternArray', async: false })
 class IsWeekPatternArrayConstraint implements ValidatorConstraintInterface {
@@ -39,7 +39,23 @@ class IsWeekPatternArrayConstraint implements ValidatorConstraintInterface {
   }
 }
 
-export class WorkoutScheduleDto {
+// Class-level discriminator check: fixed ⇔ days only; rotating ⇔ weeks only.
+// @ValidateIf gates the per-field validators but does not reject the *presence* of the
+// inactive field, so a payload with both arms would otherwise pass and persist garbage.
+@ValidatorConstraint({ name: 'IsScheduleShape', async: false })
+class IsScheduleShapeConstraint implements ValidatorConstraintInterface {
+  validate(_value: unknown, args: ValidationArguments): boolean {
+    const o = args.object as WorkoutScheduleDto;
+    if (o.type === 'fixed') return o.days !== undefined && o.weeks === undefined;
+    if (o.type === 'rotating') return o.weeks !== undefined && o.days === undefined;
+    return false;
+  }
+  defaultMessage(): string {
+    return "fixed schedules require only 'days'; rotating schedules require only 'weeks'";
+  }
+}
+
+export class WorkoutScheduleDto implements UserWorkoutSchedule {
   @IsIn(['fixed', 'rotating'])
   type!: 'fixed' | 'rotating';
 
@@ -56,11 +72,20 @@ export class WorkoutScheduleDto {
   @ValidateIf((o: WorkoutScheduleDto) => o.type === 'rotating')
   @Validate(IsWeekPatternArrayConstraint)
   weeks?: number[][];
+
+  // Cross-field check. Attached to `type` so the error message hangs off a defined property
+  // regardless of which arm the caller used.
+  @Validate(IsScheduleShapeConstraint)
+  _shape?: never;
 }
 
 export class UpdateSettingsDto {
   // null clears the schedule; undefined leaves it unchanged.
   @IsOptional()
+  // Reject primitives like { workoutSchedule: "x" } that would otherwise bypass
+  // @ValidateNested (which silently no-ops on non-objects) and write garbage to JSONB.
+  @ValidateIf((o: UpdateSettingsDto) => o.workoutSchedule !== null)
+  @IsObject()
   @ValidateNested()
   @Type(() => WorkoutScheduleDto)
   workoutSchedule?: WorkoutScheduleDto | null;

--- a/apps/api/src/user-settings/user-settings.controller.spec.ts
+++ b/apps/api/src/user-settings/user-settings.controller.spec.ts
@@ -199,8 +199,33 @@ describe('UpdateSettingsDto validation', () => {
     expect(errs.length).toBeGreaterThan(0);
   });
 
-  // Documenting expected wiring — the global ValidationPipe is what surfaces these errors as 400s.
-  it('ValidationPipe class is importable', () => {
-    expect(ValidationPipe).toBeDefined();
+  // Locks in the production pipe config from apps/api/src/main.ts. If main.ts ever weakens
+  // these flags (e.g., drops `forbidNonWhitelisted`), this test fails — without it, the DTO's
+  // implicit reliance on whitelist behavior to strip/reject unknown nested keys would silently
+  // degrade. Keep this test's pipe construction byte-identical to main.ts.
+  describe('production ValidationPipe wiring', () => {
+    const pipe = new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true });
+    const meta = { type: 'body' as const, metatype: UpdateSettingsDto };
+
+    it('rejects an unknown top-level sibling field', async () => {
+      await expect(
+        pipe.transform({ workoutSchedule: { type: 'fixed', days: [0] }, evil: 'x' }, meta),
+      ).rejects.toThrow();
+    });
+
+    it('rejects an unknown field nested inside workoutSchedule', async () => {
+      await expect(
+        pipe.transform(
+          { workoutSchedule: { type: 'fixed', days: [0], evil: 'x' } },
+          meta,
+        ),
+      ).rejects.toThrow();
+    });
+
+    it('accepts a clean payload', async () => {
+      await expect(
+        pipe.transform({ workoutSchedule: { type: 'fixed', days: [0, 2, 4] } }, meta),
+      ).resolves.toBeDefined();
+    });
   });
 });

--- a/apps/api/src/user-settings/user-settings.controller.spec.ts
+++ b/apps/api/src/user-settings/user-settings.controller.spec.ts
@@ -76,6 +76,32 @@ describe('UserSettingsController', () => {
     expect(fetched.workoutSchedule).toEqual({ type: 'fixed', days: [0, 2, 4] });
   });
 
+  it('returns null when the DB row holds a malformed schedule', async () => {
+    // Simulates a row written by a pre-validator code path or a manual edit. The
+    // repository's parseSchedule guard should coerce to null rather than letting
+    // malformed JSON reach the client.
+    prismaMock.store.set(MOCK_USER.id, {
+      userId: MOCK_USER.id,
+      activeProgram: null,
+      workoutSchedule: { type: 'fixed', days: [0, 99] },
+    });
+    const result = await controller.getSettings(MOCK_USER);
+    expect(result.workoutSchedule).toBeNull();
+  });
+
+  it('clears the schedule when patched with null', async () => {
+    prismaMock.store.set(MOCK_USER.id, {
+      userId: MOCK_USER.id,
+      activeProgram: null,
+      workoutSchedule: { type: 'fixed', days: [0, 2, 4] },
+    });
+    const dto = plainToInstance(UpdateSettingsDto, { workoutSchedule: null });
+    const errors = await validate(dto);
+    expect(errors).toEqual([]);
+    const result = await controller.updateSettings(MOCK_USER, dto);
+    expect(result.workoutSchedule).toBeNull();
+  });
+
   it('persists a rotating schedule', async () => {
     const dto = plainToInstance(UpdateSettingsDto, {
       workoutSchedule: {
@@ -138,6 +164,39 @@ describe('UpdateSettingsDto validation', () => {
 
   it('accepts an empty patch (no-op)', async () => {
     expect(await check({})).toEqual([]);
+  });
+
+  it('accepts an explicit null to clear the schedule', async () => {
+    expect(await check({ workoutSchedule: null })).toEqual([]);
+  });
+
+  it('rejects a fixed schedule that also carries weeks', async () => {
+    const errs = await check({
+      workoutSchedule: { type: 'fixed', days: [0, 2], weeks: [[1, 3]] },
+    });
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a rotating schedule that also carries days', async () => {
+    const errs = await check({
+      workoutSchedule: { type: 'rotating', weeks: [[0, 2]], days: [1] },
+    });
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a fixed schedule with no days field', async () => {
+    const errs = await check({ workoutSchedule: { type: 'fixed' } });
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a non-object workoutSchedule (string)', async () => {
+    const errs = await check({ workoutSchedule: 'hacker' });
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a non-object workoutSchedule (number)', async () => {
+    const errs = await check({ workoutSchedule: 42 });
+    expect(errs.length).toBeGreaterThan(0);
   });
 
   // Documenting expected wiring — the global ValidationPipe is what surfaces these errors as 400s.

--- a/apps/api/src/user-settings/user-settings.controller.spec.ts
+++ b/apps/api/src/user-settings/user-settings.controller.spec.ts
@@ -1,0 +1,147 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ValidationPipe } from '@nestjs/common';
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { PrismaService } from '../adapters/prisma/prisma.service';
+import { UserSettingsController } from './user-settings.controller';
+import { UpdateSettingsDto } from './update-settings.dto';
+
+const MOCK_USER = { id: 'user-1', email: 'u@example.com', provider: 'dev' };
+
+type Row = { userId: string; activeProgram: string | null; workoutSchedule: unknown };
+
+function makePrismaMock(): { service: PrismaService; store: Map<string, Row> } {
+  const store = new Map<string, Row>();
+  const service = {
+    userSettings: {
+      findUnique: jest.fn(async ({ where }: { where: { userId: string } }) => {
+        return store.get(where.userId) ?? null;
+      }),
+      upsert: jest.fn(
+        async ({
+          where,
+          create,
+          update,
+        }: {
+          where: { userId: string };
+          create: Partial<Row> & { userId: string };
+          update: Partial<Row>;
+        }) => {
+          const existing = store.get(where.userId);
+          const next: Row = existing
+            ? { ...existing, ...update }
+            : {
+                userId: where.userId,
+                activeProgram: create.activeProgram ?? null,
+                workoutSchedule: create.workoutSchedule ?? null,
+              };
+          store.set(where.userId, next);
+          return next;
+        },
+      ),
+    },
+  } as unknown as PrismaService;
+  return { service, store };
+}
+
+describe('UserSettingsController', () => {
+  let controller: UserSettingsController;
+  let prismaMock: ReturnType<typeof makePrismaMock>;
+
+  beforeEach(async () => {
+    prismaMock = makePrismaMock();
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserSettingsController],
+      providers: [{ provide: PrismaService, useValue: prismaMock.service }],
+    }).compile();
+    controller = module.get(UserSettingsController);
+  });
+
+  it('returns null schedule for a fresh user', async () => {
+    const result = await controller.getSettings(MOCK_USER);
+    expect(result).toEqual({ activeProgram: null, workoutSchedule: null });
+  });
+
+  it('persists a fixed schedule and reads it back', async () => {
+    const dto = plainToInstance(UpdateSettingsDto, {
+      workoutSchedule: { type: 'fixed', days: [0, 2, 4] },
+    });
+    const errors = await validate(dto);
+    expect(errors).toEqual([]);
+
+    const patched = await controller.updateSettings(MOCK_USER, dto);
+    expect(patched.workoutSchedule).toEqual({ type: 'fixed', days: [0, 2, 4] });
+
+    const fetched = await controller.getSettings(MOCK_USER);
+    expect(fetched.workoutSchedule).toEqual({ type: 'fixed', days: [0, 2, 4] });
+  });
+
+  it('persists a rotating schedule', async () => {
+    const dto = plainToInstance(UpdateSettingsDto, {
+      workoutSchedule: {
+        type: 'rotating',
+        weeks: [
+          [0, 2, 4, 5],
+          [1, 3, 5],
+        ],
+      },
+    });
+    const errors = await validate(dto);
+    expect(errors).toEqual([]);
+
+    const patched = await controller.updateSettings(MOCK_USER, dto);
+    expect(patched.workoutSchedule).toEqual({
+      type: 'rotating',
+      weeks: [
+        [0, 2, 4, 5],
+        [1, 3, 5],
+      ],
+    });
+  });
+});
+
+describe('UpdateSettingsDto validation', () => {
+  async function check(body: unknown): Promise<string[]> {
+    const dto = plainToInstance(UpdateSettingsDto, body);
+    const errors = await validate(dto, { whitelist: true, forbidNonWhitelisted: false });
+    const flatten = (errs: typeof errors): string[] =>
+      errs.flatMap((e) => [
+        ...Object.values(e.constraints ?? {}),
+        ...flatten(e.children ?? []),
+      ]);
+    return flatten(errors);
+  }
+
+  it('accepts a fixed schedule with valid days', async () => {
+    expect(await check({ workoutSchedule: { type: 'fixed', days: [0, 2, 4] } })).toEqual([]);
+  });
+
+  it('rejects a fixed schedule with an out-of-range day index', async () => {
+    const errs = await check({ workoutSchedule: { type: 'fixed', days: [0, 7] } });
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a fixed schedule with duplicate days', async () => {
+    const errs = await check({ workoutSchedule: { type: 'fixed', days: [0, 0, 2] } });
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a rotating schedule with an empty week', async () => {
+    const errs = await check({ workoutSchedule: { type: 'rotating', weeks: [[0, 2], []] } });
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it('rejects an unknown schedule type', async () => {
+    const errs = await check({ workoutSchedule: { type: 'weird', days: [0] } });
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it('accepts an empty patch (no-op)', async () => {
+    expect(await check({})).toEqual([]);
+  });
+
+  // Documenting expected wiring — the global ValidationPipe is what surfaces these errors as 400s.
+  it('ValidationPipe class is importable', () => {
+    expect(ValidationPipe).toBeDefined();
+  });
+});

--- a/apps/api/src/user-settings/user-settings.repository.ts
+++ b/apps/api/src/user-settings/user-settings.repository.ts
@@ -8,19 +8,49 @@ export interface UpsertSettingsPatch {
   workoutSchedule?: UserWorkoutSchedule | null;
 }
 
+// Runtime guard for values read from the JSONB column. Prisma returns whatever JSON is
+// stored — a manual DB edit or a pre-validator row could violate the type. Return null
+// (treated as no-schedule) rather than letting malformed data reach clients.
+function parseSchedule(value: unknown): UserWorkoutSchedule | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'object' || Array.isArray(value)) return null;
+  const v = value as { type?: unknown; days?: unknown; weeks?: unknown };
+  if (v.type === 'fixed') {
+    if (!Array.isArray(v.days) || v.days.length === 0) return null;
+    for (const d of v.days) {
+      if (!Number.isInteger(d) || (d as number) < 0 || (d as number) > 6) return null;
+    }
+    return { type: 'fixed', days: v.days as number[] };
+  }
+  if (v.type === 'rotating') {
+    if (!Array.isArray(v.weeks) || v.weeks.length === 0) return null;
+    for (const week of v.weeks) {
+      if (!Array.isArray(week) || week.length === 0) return null;
+      for (const d of week) {
+        if (!Number.isInteger(d) || (d as number) < 0 || (d as number) > 6) return null;
+      }
+    }
+    return { type: 'rotating', weeks: v.weeks as number[][] };
+  }
+  return null;
+}
+
 export class UserSettingsRepository {
   constructor(
     private readonly prisma: PrismaService,
     private readonly userId: string,
   ) {}
 
+  // Note: upsertSettings is last-write-wins across concurrent PATCH calls for the same
+  // user. Acceptable for a single-tab settings flow; revisit if a multi-writer scenario
+  // is introduced (e.g., background recalculation that mutates schedule).
   async getSettings(): Promise<UserSettingsResponse> {
     const row = await this.prisma.userSettings.findUnique({
       where: { userId: this.userId },
     });
     return {
       activeProgram: row?.activeProgram ?? null,
-      workoutSchedule: (row?.workoutSchedule as unknown as UserWorkoutSchedule | null) ?? null,
+      workoutSchedule: parseSchedule(row?.workoutSchedule),
     };
   }
 
@@ -31,7 +61,8 @@ export class UserSettingsRepository {
       update.workoutSchedule =
         patch.workoutSchedule === null
           ? Prisma.JsonNull
-          : (patch.workoutSchedule as unknown as Prisma.InputJsonValue);
+          : // validated by WorkoutScheduleDto before reaching the repository
+            (patch.workoutSchedule as unknown as Prisma.InputJsonValue);
     }
 
     const create: Prisma.UserSettingsUncheckedCreateInput = { userId: this.userId };
@@ -47,7 +78,7 @@ export class UserSettingsRepository {
     });
     return {
       activeProgram: row.activeProgram ?? null,
-      workoutSchedule: (row.workoutSchedule as unknown as UserWorkoutSchedule | null) ?? null,
+      workoutSchedule: parseSchedule(row.workoutSchedule),
     };
   }
 }

--- a/apps/api/src/user-settings/user-settings.repository.ts
+++ b/apps/api/src/user-settings/user-settings.repository.ts
@@ -1,6 +1,10 @@
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../adapters/prisma/prisma.service';
-import { UserSettingsResponse, UserWorkoutSchedule } from '@lifting-logbook/types';
+import {
+  UserSettingsResponse,
+  UserWorkoutSchedule,
+  isValidSchedule,
+} from '@lifting-logbook/types';
 
 export interface UpsertSettingsPatch {
   activeProgram?: string;
@@ -9,30 +13,12 @@ export interface UpsertSettingsPatch {
 }
 
 // Runtime guard for values read from the JSONB column. Prisma returns whatever JSON is
-// stored — a manual DB edit or a pre-validator row could violate the type. Return null
-// (treated as no-schedule) rather than letting malformed data reach clients.
+// stored — a manual DB edit or a pre-validator row could violate the type. Delegates to
+// the shared `isValidSchedule` predicate so the read-side bounds stay locked to the
+// write-side DTO bounds.
 function parseSchedule(value: unknown): UserWorkoutSchedule | null {
   if (value === null || value === undefined) return null;
-  if (typeof value !== 'object' || Array.isArray(value)) return null;
-  const v = value as { type?: unknown; days?: unknown; weeks?: unknown };
-  if (v.type === 'fixed') {
-    if (!Array.isArray(v.days) || v.days.length === 0) return null;
-    for (const d of v.days) {
-      if (!Number.isInteger(d) || (d as number) < 0 || (d as number) > 6) return null;
-    }
-    return { type: 'fixed', days: v.days as number[] };
-  }
-  if (v.type === 'rotating') {
-    if (!Array.isArray(v.weeks) || v.weeks.length === 0) return null;
-    for (const week of v.weeks) {
-      if (!Array.isArray(week) || week.length === 0) return null;
-      for (const d of week) {
-        if (!Number.isInteger(d) || (d as number) < 0 || (d as number) > 6) return null;
-      }
-    }
-    return { type: 'rotating', weeks: v.weeks as number[][] };
-  }
-  return null;
+  return isValidSchedule(value) ? value : null;
 }
 
 export class UserSettingsRepository {

--- a/apps/api/src/user-settings/user-settings.repository.ts
+++ b/apps/api/src/user-settings/user-settings.repository.ts
@@ -1,5 +1,12 @@
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../adapters/prisma/prisma.service';
-import { UserSettingsResponse } from '@lifting-logbook/types';
+import { UserSettingsResponse, UserWorkoutSchedule } from '@lifting-logbook/types';
+
+export interface UpsertSettingsPatch {
+  activeProgram?: string;
+  // Explicit `null` clears the schedule; `undefined` leaves it unchanged.
+  workoutSchedule?: UserWorkoutSchedule | null;
+}
 
 export class UserSettingsRepository {
   constructor(
@@ -11,15 +18,36 @@ export class UserSettingsRepository {
     const row = await this.prisma.userSettings.findUnique({
       where: { userId: this.userId },
     });
-    return { activeProgram: row?.activeProgram ?? null };
+    return {
+      activeProgram: row?.activeProgram ?? null,
+      workoutSchedule: (row?.workoutSchedule as unknown as UserWorkoutSchedule | null) ?? null,
+    };
   }
 
-  async upsertSettings(patch: { activeProgram?: string }): Promise<UserSettingsResponse> {
+  async upsertSettings(patch: UpsertSettingsPatch): Promise<UserSettingsResponse> {
+    const update: Prisma.UserSettingsUncheckedUpdateInput = {};
+    if (patch.activeProgram !== undefined) update.activeProgram = patch.activeProgram;
+    if (patch.workoutSchedule !== undefined) {
+      update.workoutSchedule =
+        patch.workoutSchedule === null
+          ? Prisma.JsonNull
+          : (patch.workoutSchedule as unknown as Prisma.InputJsonValue);
+    }
+
+    const create: Prisma.UserSettingsUncheckedCreateInput = { userId: this.userId };
+    if (patch.activeProgram !== undefined) create.activeProgram = patch.activeProgram;
+    if (patch.workoutSchedule != null) {
+      create.workoutSchedule = patch.workoutSchedule as unknown as Prisma.InputJsonValue;
+    }
+
     const row = await this.prisma.userSettings.upsert({
       where: { userId: this.userId },
-      create: { userId: this.userId, ...patch },
-      update: patch,
+      create,
+      update,
     });
-    return { activeProgram: row.activeProgram ?? null };
+    return {
+      activeProgram: row.activeProgram ?? null,
+      workoutSchedule: (row.workoutSchedule as unknown as UserWorkoutSchedule | null) ?? null,
+    };
   }
 }

--- a/apps/web/app/settings/schedule/ScheduleForm.tsx
+++ b/apps/web/app/settings/schedule/ScheduleForm.tsx
@@ -90,7 +90,15 @@ export default function ScheduleForm({
     }
     setSaving(true);
     try {
-      await saveSchedule({ workoutSchedule: payload });
+      // Re-seed local state from the canonical server response. `useState` initializers
+      // only run on mount, so without this the form would keep showing optimistic local
+      // state if the server normalized the payload (e.g., re-sorted days, dropped dupes)
+      // or if a future code path returns a stored value different from what we sent.
+      const result = await saveSchedule({ workoutSchedule: payload });
+      const next = initialState(result.workoutSchedule);
+      setMode(next.mode);
+      setFixedDays(next.fixedDays);
+      setRotatingWeeks(next.rotatingWeeks);
       setSavedAt(new Date().toLocaleTimeString());
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save schedule.');

--- a/apps/web/app/settings/schedule/ScheduleForm.tsx
+++ b/apps/web/app/settings/schedule/ScheduleForm.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useState } from 'react';
+import type { UserWorkoutSchedule } from '@lifting-logbook/types';
+import { saveSchedule } from './actions';
+
+const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
+
+type Mode = 'none' | 'fixed' | 'rotating';
+
+function initialState(schedule: UserWorkoutSchedule | null): {
+  mode: Mode;
+  fixedDays: number[];
+  rotatingWeeks: number[][];
+} {
+  if (!schedule) return { mode: 'none', fixedDays: [], rotatingWeeks: [[]] };
+  if (schedule.type === 'fixed') {
+    return {
+      mode: 'fixed',
+      fixedDays: schedule.days ?? [],
+      rotatingWeeks: [[]],
+    };
+  }
+  return {
+    mode: 'rotating',
+    fixedDays: [],
+    rotatingWeeks: schedule.weeks?.length ? schedule.weeks : [[]],
+  };
+}
+
+function toggleDay(days: number[], day: number): number[] {
+  return days.includes(day)
+    ? days.filter((d) => d !== day).sort((a, b) => a - b)
+    : [...days, day].sort((a, b) => a - b);
+}
+
+export default function ScheduleForm({
+  initialSchedule,
+}: {
+  initialSchedule: UserWorkoutSchedule | null;
+}) {
+  const init = initialState(initialSchedule);
+  const [mode, setMode] = useState<Mode>(init.mode);
+  const [fixedDays, setFixedDays] = useState<number[]>(init.fixedDays);
+  const [rotatingWeeks, setRotatingWeeks] = useState<number[][]>(init.rotatingWeeks);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  function buildPayload(): UserWorkoutSchedule | null {
+    if (mode === 'none') return null;
+    if (mode === 'fixed') return { type: 'fixed', days: fixedDays };
+    return { type: 'rotating', weeks: rotatingWeeks };
+  }
+
+  function validate(payload: UserWorkoutSchedule | null): string | null {
+    if (payload === null) return null;
+    if (payload.type === 'fixed') {
+      if (!payload.days || payload.days.length === 0) {
+        return 'Pick at least one day.';
+      }
+    } else {
+      if (!payload.weeks || payload.weeks.some((w) => w.length === 0)) {
+        return 'Each week must have at least one day.';
+      }
+    }
+    return null;
+  }
+
+  async function handleSave() {
+    setError(null);
+    setSavedAt(null);
+    const payload = buildPayload();
+    const validationError = validate(payload);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setSaving(true);
+    try {
+      await saveSchedule({ workoutSchedule: payload });
+      setSavedAt(new Date().toLocaleTimeString());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save schedule.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section>
+      <h2>Workout Schedule</h2>
+      <p>
+        Choose which days of the week you usually train. Lifting Logbook uses this to
+        distribute upcoming workouts across the calendar.
+      </p>
+
+      <fieldset>
+        <legend>Mode</legend>
+        <label>
+          <input
+            type="radio"
+            name="mode"
+            checked={mode === 'none'}
+            onChange={() => setMode('none')}
+          />
+          No schedule (date is set when you log)
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="mode"
+            checked={mode === 'fixed'}
+            onChange={() => setMode('fixed')}
+          />
+          Fixed days
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="mode"
+            checked={mode === 'rotating'}
+            onChange={() => setMode('rotating')}
+          />
+          Rotating weeks
+        </label>
+      </fieldset>
+
+      {mode === 'fixed' && (
+        <fieldset>
+          <legend>Training days</legend>
+          {DAY_LABELS.map((label, idx) => (
+            <label key={idx}>
+              <input
+                type="checkbox"
+                checked={fixedDays.includes(idx)}
+                onChange={() => setFixedDays((d) => toggleDay(d, idx))}
+              />
+              {label}
+            </label>
+          ))}
+        </fieldset>
+      )}
+
+      {mode === 'rotating' && (
+        <div>
+          {rotatingWeeks.map((week, weekIdx) => (
+            <fieldset key={weekIdx}>
+              <legend>Week {weekIdx + 1}</legend>
+              {DAY_LABELS.map((label, dayIdx) => (
+                <label key={dayIdx}>
+                  <input
+                    type="checkbox"
+                    checked={week.includes(dayIdx)}
+                    onChange={() =>
+                      setRotatingWeeks((weeks) =>
+                        weeks.map((w, i) => (i === weekIdx ? toggleDay(w, dayIdx) : w)),
+                      )
+                    }
+                  />
+                  {label}
+                </label>
+              ))}
+              {rotatingWeeks.length > 1 && (
+                <button
+                  type="button"
+                  onClick={() =>
+                    setRotatingWeeks((weeks) => weeks.filter((_, i) => i !== weekIdx))
+                  }
+                >
+                  Remove week
+                </button>
+              )}
+            </fieldset>
+          ))}
+          {rotatingWeeks.length < 8 && (
+            <button type="button" onClick={() => setRotatingWeeks((w) => [...w, []])}>
+              Add week
+            </button>
+          )}
+        </div>
+      )}
+
+      <div>
+        <button type="button" onClick={handleSave} disabled={saving}>
+          {saving ? 'Saving…' : 'Save schedule'}
+        </button>
+        {error && <p role="alert">{error}</p>}
+        {savedAt && <p>Saved at {savedAt}.</p>}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/settings/schedule/ScheduleForm.tsx
+++ b/apps/web/app/settings/schedule/ScheduleForm.tsx
@@ -47,6 +47,18 @@ export default function ScheduleForm({
   const [error, setError] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<string | null>(null);
 
+  // Switching modes resets the other mode's draft state so buildPayload never silently
+  // carries selections the user no longer sees. Without this, fixed → rotating → fixed
+  // would restore previously-picked days, which surprises users (and risks a future
+  // auto-save sending stale data).
+  function switchMode(next: Mode) {
+    setMode(next);
+    if (next !== 'fixed') setFixedDays([]);
+    if (next !== 'rotating') setRotatingWeeks([[]]);
+    setError(null);
+    setSavedAt(null);
+  }
+
   function buildPayload(): UserWorkoutSchedule | null {
     if (mode === 'none') return null;
     if (mode === 'fixed') return { type: 'fixed', days: fixedDays };
@@ -102,7 +114,7 @@ export default function ScheduleForm({
             type="radio"
             name="mode"
             checked={mode === 'none'}
-            onChange={() => setMode('none')}
+            onChange={() => switchMode('none')}
           />
           No schedule (date is set when you log)
         </label>
@@ -111,7 +123,7 @@ export default function ScheduleForm({
             type="radio"
             name="mode"
             checked={mode === 'fixed'}
-            onChange={() => setMode('fixed')}
+            onChange={() => switchMode('fixed')}
           />
           Fixed days
         </label>
@@ -120,7 +132,7 @@ export default function ScheduleForm({
             type="radio"
             name="mode"
             checked={mode === 'rotating'}
-            onChange={() => setMode('rotating')}
+            onChange={() => switchMode('rotating')}
           />
           Rotating weeks
         </label>

--- a/apps/web/app/settings/schedule/actions.ts
+++ b/apps/web/app/settings/schedule/actions.ts
@@ -1,13 +1,19 @@
 'use server';
 
+import { revalidatePath } from 'next/cache';
 import { updateUserSettings } from '@/lib/api';
 import type {
   UpdateUserSettingsRequest,
   UserSettingsResponse,
 } from '@lifting-logbook/types';
 
+// Server-side boundary: lib/api.ts is 'server-only', so a client component cannot import
+// it directly. This action lets ScheduleForm reach the API while keeping auth-token
+// acquisition (and any future server-only logic) off the wire.
 export async function saveSchedule(
   body: UpdateUserSettingsRequest,
 ): Promise<UserSettingsResponse> {
-  return updateUserSettings(body);
+  const result = await updateUserSettings(body);
+  revalidatePath('/settings/schedule');
+  return result;
 }

--- a/apps/web/app/settings/schedule/actions.ts
+++ b/apps/web/app/settings/schedule/actions.ts
@@ -1,0 +1,13 @@
+'use server';
+
+import { updateUserSettings } from '@/lib/api';
+import type {
+  UpdateUserSettingsRequest,
+  UserSettingsResponse,
+} from '@lifting-logbook/types';
+
+export async function saveSchedule(
+  body: UpdateUserSettingsRequest,
+): Promise<UserSettingsResponse> {
+  return updateUserSettings(body);
+}

--- a/apps/web/app/settings/schedule/page.tsx
+++ b/apps/web/app/settings/schedule/page.tsx
@@ -1,0 +1,7 @@
+import { fetchUserSettings } from '@/lib/api';
+import ScheduleForm from './ScheduleForm';
+
+export default async function SchedulePage() {
+  const settings = await fetchUserSettings();
+  return <ScheduleForm initialSchedule={settings.workoutSchedule} />;
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -20,6 +20,7 @@ import type {
   UpdateCustomProgramRequest,
   UpdateLiftRecordRequest,
   UpdateTrainingMaxesRequest,
+  UpdateUserSettingsRequest,
   UserSettingsResponse,
   WorkoutResponse,
 } from '@lifting-logbook/types';
@@ -291,6 +292,17 @@ export function fetchLiftMetadata(lift: string): Promise<LiftMetadataResponse> {
 
 export function fetchUserSettings(): Promise<UserSettingsResponse> {
   return apiFetch<UserSettingsResponse>('/users/me/settings', { cache: 'no-store' });
+}
+
+export function updateUserSettings(
+  body: UpdateUserSettingsRequest,
+): Promise<UserSettingsResponse> {
+  return apiFetch<UserSettingsResponse>('/users/me/settings', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    cache: 'no-store',
+  });
 }
 
 export function switchProgram(programId: string): Promise<SwitchProgramResponse> {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -45,6 +45,20 @@ async function getAuthHeaders(): Promise<Record<string, string>> {
   }
 }
 
+// NestJS ValidationPipe returns { statusCode, message: string | string[], error }.
+// Surface that detail so client-side error UIs can show actionable text instead of just
+// "Request failed: 400".
+async function extractErrorMessage(res: Response, path: string): Promise<string> {
+  try {
+    const body = (await res.json()) as { message?: string | string[] };
+    if (Array.isArray(body.message)) return body.message.join('; ');
+    if (typeof body.message === 'string') return body.message;
+  } catch {
+    // fall through to generic
+  }
+  return `API ${res.status} ${res.statusText} for ${path}`;
+}
+
 async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const authHeaders = await getAuthHeaders();
   const res = await fetch(`${API_URL}${path}`, {
@@ -52,7 +66,7 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
     headers: { ...(init?.headers as Record<string, string> | undefined), ...authHeaders },
   });
   if (!res.ok) {
-    throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
+    throw new Error(await extractErrorMessage(res, path));
   }
   return res.json() as Promise<T>;
 }

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -281,8 +281,21 @@ export interface LiftingProgramSpecResponse {
 // User Settings
 // ---------------------------------------------------------------------------
 
+export interface UserWorkoutSchedule {
+  type: 'fixed' | 'rotating';
+  /** For fixed schedules: array of day indices (0=Mon, 6=Sun). */
+  days?: number[];
+  /** For rotating schedules: array of week patterns, each containing day indices. */
+  weeks?: number[][];
+}
+
 export interface UserSettingsResponse {
   activeProgram: string | null;
+  workoutSchedule: UserWorkoutSchedule | null;
+}
+
+export interface UpdateUserSettingsRequest {
+  workoutSchedule?: UserWorkoutSchedule | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -281,12 +281,78 @@ export interface LiftingProgramSpecResponse {
 // User Settings
 // ---------------------------------------------------------------------------
 
+/**
+ * Day-of-week convention used throughout the schedule subsystem.
+ * 0 = Monday … 6 = Sunday.
+ *
+ * IMPORTANT: do NOT use JavaScript's `Date.getDay()` directly — it returns
+ * 0=Sunday. Convert via `(d.getDay() + 6) % 7` to land in this convention.
+ */
+export const DAY_INDEX = {
+  MON: 0,
+  TUE: 1,
+  WED: 2,
+  THU: 3,
+  FRI: 4,
+  SAT: 5,
+  SUN: 6,
+} as const;
+
+/** Upper bounds enforced at both the write (DTO) and read (parseSchedule) boundaries. */
+export const SCHEDULE_LIMITS = {
+  MAX_DAYS_PER_WEEK: 7,
+  MAX_ROTATING_WEEKS: 8,
+} as const;
+
 export interface UserWorkoutSchedule {
   type: 'fixed' | 'rotating';
-  /** For fixed schedules: array of day indices (0=Mon, 6=Sun). */
+  /** For fixed schedules: array of day indices using `DAY_INDEX` (0=Mon … 6=Sun). */
   days?: number[];
   /** For rotating schedules: array of week patterns, each containing day indices. */
   weeks?: number[][];
+}
+
+/**
+ * Single source of truth for `UserWorkoutSchedule` shape validation.
+ * Used by the API DTO write-side check and the repository read-side guard
+ * so the two boundaries cannot drift (e.g., upper bounds tightened in only
+ * one place). Returns the value narrowed to `UserWorkoutSchedule` when valid.
+ */
+export function isValidSchedule(value: unknown): value is UserWorkoutSchedule {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const v = value as { type?: unknown; days?: unknown; weeks?: unknown };
+  const isDayIdx = (d: unknown): d is number =>
+    Number.isInteger(d) && (d as number) >= 0 && (d as number) <= 6;
+
+  if (v.type === 'fixed') {
+    if (v.weeks !== undefined) return false;
+    if (!Array.isArray(v.days)) return false;
+    if (v.days.length < 1 || v.days.length > SCHEDULE_LIMITS.MAX_DAYS_PER_WEEK) return false;
+    const seen = new Set<number>();
+    for (const d of v.days) {
+      if (!isDayIdx(d) || seen.has(d)) return false;
+      seen.add(d);
+    }
+    return true;
+  }
+
+  if (v.type === 'rotating') {
+    if (v.days !== undefined) return false;
+    if (!Array.isArray(v.weeks)) return false;
+    if (v.weeks.length < 1 || v.weeks.length > SCHEDULE_LIMITS.MAX_ROTATING_WEEKS) return false;
+    for (const week of v.weeks) {
+      if (!Array.isArray(week)) return false;
+      if (week.length < 1 || week.length > SCHEDULE_LIMITS.MAX_DAYS_PER_WEEK) return false;
+      const seen = new Set<number>();
+      for (const d of week) {
+        if (!isDayIdx(d) || seen.has(d)) return false;
+        seen.add(d);
+      }
+    }
+    return true;
+  }
+
+  return false;
 }
 
 export interface UserSettingsResponse {


### PR DESCRIPTION
First of two foundation PRs for [#269](https://github.com/brownm09/lifting-logbook/issues/269). Adds the user-level `workoutSchedule` field and a Settings UI to manage it. Pure data-model + UI — no behavior changes in cycle dashboard, lift records, or program editor yet (those land in Phases 3–5). Implements per [docs/design/workout-scheduling-integration.md](docs/design/workout-scheduling-integration.md).

## Changes

- **`packages/types`** — `UserWorkoutSchedule` interface (fixed days or rotating week patterns), extends `UserSettingsResponse`, new `UpdateUserSettingsRequest`.
- **`apps/api`** — nullable `workoutSchedule` JSONB column on `user_settings` (migration `20260517000000_add_workout_schedule`); `class-validator` DTO rejects out-of-range day indices (0-6), duplicates, and empty rotating weeks; repository round-trips both schedule shapes via `Prisma.JsonNull` for explicit clears.
- **`apps/web`** — new `/settings/schedule` page (Server Component → `ScheduleForm` client component) with day-of-week checkbox picker for fixed mode and add/remove repeater for rotating mode; references mockup [`docs/mockups/workout-scheduling.html`](docs/mockups/workout-scheduling.html).
- **Tests** — 10 controller + DTO cases (happy paths for fixed/rotating + validation rejections).

## Phase 1 acceptance criteria (from #269)

- [x] Add `UserWorkoutSchedule` interface to `packages/types/src/api.ts`
- [x] Extend `UserSettingsResponse` with `workoutSchedule` field
- [x] Create/update user settings database schema to store schedule
- [x] Implement `GET /users/settings` endpoint (extended, already existed)
- [x] Implement `PATCH /users/settings` endpoint (extended, already existed)
- [x] Build Settings UI with day selector (leverages prototype)
- [x] Wire Settings UI to API, add error handling
- [x] Write unit tests for API endpoints
- [ ] Write E2E test: set schedule, refresh page, verify persistence — Playwright deferred until [#259](https://github.com/brownm09/lifting-logbook/issues/259); manual test plan below

## Test plan

Per project CLAUDE.md `## Testing`:

- `npm test -w @lifting-logbook/api` — full suite: 192 passed / 51 skipped / 0 failed. New file `apps/api/src/user-settings/user-settings.controller.spec.ts` adds 10 cases.
- `npm run build -w @lifting-logbook/api` — clean.
- `npm run build -w @lifting-logbook/web` — clean; `/settings/schedule` registered as a dynamic route.
- `npm run lint -w @lifting-logbook/api` — clean.

**Manual UI smoke (recommended before merge):**
1. `npm run dev -w @lifting-logbook/web`
2. Visit `/settings/schedule`, choose **Fixed days** → check Mon/Wed/Fri → Save → reload → verify selection persists.
3. Switch to **Rotating weeks**, click **Add week**, set patterns → Save → reload → verify.
4. Try saving an empty fixed schedule → expect inline error "Pick at least one day."

**Coverage gate:** new API endpoint shape covered by the unit/validation spec. Frontend feature has no automated E2E (gate exception per CLAUDE.md `## Testing` until #259).

## Out of scope (follow-up PRs under #269)

- Phase 2: `distributeWorkouts()` core function (next PR — same branch / same issue).
- Phase 3-5: cycle dashboard date distribution, lift-record scheduled-date plumbing, program editor UI.

Refs #269 (Phase 1 of 5)