### PR TITLE
[feat] Workout distribution integration (Phase 3 of 5)

### DIFF
--- a/apps/api/prisma/migrations/20260517000001_add_cycle_scheduled_workout/migration.sql
+++ b/apps/api/prisma/migrations/20260517000001_add_cycle_scheduled_workout/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "cycle_scheduled_workout" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "program" TEXT NOT NULL,
+    "cycleNum" INTEGER NOT NULL,
+    "workoutNum" INTEGER NOT NULL,
+    "weekNum" INTEGER NOT NULL,
+    "scheduledDate" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "cycle_scheduled_workout_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "cycle_scheduled_workout_userId_program_cycleNum_workoutNum_key" ON "cycle_scheduled_workout"("userId", "program", "cycleNum", "workoutNum");
+
+-- CreateIndex
+CREATE INDEX "cycle_scheduled_workout_userId_program_cycleNum_idx" ON "cycle_scheduled_workout"("userId", "program", "cycleNum");

--- a/apps/api/prisma/migrations/20260517000002_cycle_scheduled_workout_date_column/migration.sql
+++ b/apps/api/prisma/migrations/20260517000002_cycle_scheduled_workout_date_column/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable: change scheduledDate from TIMESTAMP(3) to DATE
+ALTER TABLE "cycle_scheduled_workout" ALTER COLUMN "scheduledDate" TYPE DATE USING "scheduledDate"::DATE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -142,6 +142,20 @@ model UserSettings {
   @@map("user_settings")
 }
 
+model CycleScheduledWorkout {
+  id            String   @id @default(uuid())
+  userId        String
+  program       String
+  cycleNum      Int
+  workoutNum    Int
+  weekNum       Int
+  scheduledDate DateTime
+
+  @@unique([userId, program, cycleNum, workoutNum])
+  @@index([userId, program, cycleNum])
+  @@map("cycle_scheduled_workout")
+}
+
 model CustomProgram {
   id           String              @id @default(uuid())
   userId       String

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -149,7 +149,7 @@ model CycleScheduledWorkout {
   cycleNum      Int
   workoutNum    Int
   weekNum       Int
-  scheduledDate DateTime
+  scheduledDate DateTime @db.Date
 
   @@unique([userId, program, cycleNum, workoutNum])
   @@index([userId, program, cycleNum])

--- a/apps/api/src/adapters/factory/in-memory-repository-factory.ts
+++ b/apps/api/src/adapters/factory/in-memory-repository-factory.ts
@@ -3,6 +3,7 @@ import { LiftRecord } from '@lifting-logbook/core';
 import { AuthUser } from '../../ports/auth';
 import { IRepositoryFactory, RepositoryBundle } from '../../ports/factory';
 import { InMemoryCycleDashboardRepository } from '../in-memory/cycle-dashboard.adapter';
+import { InMemoryCycleScheduledWorkoutRepository } from '../in-memory/cycle-scheduled-workout.adapter';
 import { InMemoryLiftMetadataRepository } from '../in-memory/lift-metadata.adapter';
 import { InMemoryLiftingProgramSpecRepository } from '../in-memory/lifting-program-spec.adapter';
 import { InMemoryLiftRecordRepository } from '../in-memory/lift-record.adapter';
@@ -10,6 +11,7 @@ import { InMemoryProgramPhilosophyRepository } from '../in-memory/program-philos
 import { InMemoryStrengthGoalRepository } from '../in-memory/strength-goal.adapter';
 import { InMemoryTrainingMaxRepository } from '../in-memory/training-max.adapter';
 import { InMemoryTrainingMaxHistoryRepository } from '../in-memory/training-max-history.adapter';
+import { InMemoryUserSettingsRepository } from '../in-memory/user-settings.adapter';
 import { InMemoryWorkoutDateOverrideRepository } from '../in-memory/workout-date-override.adapter';
 import { InMemoryWorkoutLiftOverrideRepository } from '../in-memory/workout-lift-override.adapter';
 import { InMemoryWorkoutRepository } from '../in-memory/workout.adapter';
@@ -33,6 +35,7 @@ export class InMemoryRepositoryFactory implements IRepositoryFactory {
         : new Map();
       this.bundles.set(user.id, {
         cycleDashboard: new InMemoryCycleDashboardRepository(preSeed),
+        cycleScheduledWorkout: new InMemoryCycleScheduledWorkoutRepository(),
         liftMetadata: new InMemoryLiftMetadataRepository(),
         liftingProgramSpec: new InMemoryLiftingProgramSpecRepository(preSeed),
         liftRecord: new InMemoryLiftRecordRepository(sharedRecords),
@@ -40,6 +43,7 @@ export class InMemoryRepositoryFactory implements IRepositoryFactory {
         strengthGoal: new InMemoryStrengthGoalRepository(),
         trainingMax: new InMemoryTrainingMaxRepository(preSeed),
         trainingMaxHistory: new InMemoryTrainingMaxHistoryRepository(),
+        userSettings: new InMemoryUserSettingsRepository(),
         workout: new InMemoryWorkoutRepository(sharedRecords),
         workoutDateOverride: new InMemoryWorkoutDateOverrideRepository(),
         workoutLiftOverride: new InMemoryWorkoutLiftOverrideRepository(),

--- a/apps/api/src/adapters/factory/system-db-repository-factory.ts
+++ b/apps/api/src/adapters/factory/system-db-repository-factory.ts
@@ -21,9 +21,13 @@ import { InMemoryProgramPhilosophyRepository } from '../in-memory/program-philos
 import { InMemoryStrengthGoalRepository } from '../in-memory/strength-goal.adapter';
 import { InMemoryTrainingMaxRepository } from '../in-memory/training-max.adapter';
 import { InMemoryTrainingMaxHistoryRepository } from '../in-memory/training-max-history.adapter';
+import { InMemoryCycleScheduledWorkoutRepository } from '../in-memory/cycle-scheduled-workout.adapter';
+import { InMemoryUserSettingsRepository } from '../in-memory/user-settings.adapter';
 import { InMemoryWorkoutDateOverrideRepository } from '../in-memory/workout-date-override.adapter';
 import { InMemoryWorkoutLiftOverrideRepository } from '../in-memory/workout-lift-override.adapter';
 import { InMemoryWorkoutRepository } from '../in-memory/workout.adapter';
+import { PrismaCycleScheduledWorkoutRepository } from '../prisma/cycle-scheduled-workout.repository';
+import { UserSettingsRepository } from '../../user-settings/user-settings.repository';
 
 interface UserDataSourceRow {
   adapter_type: string;
@@ -79,17 +83,19 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
     if (adapterType === 'postgres') {
       const prisma = this.getOrCreatePrisma();
       return {
+        cycleDashboard: new PrismaCycleDashboardRepository(prisma, userId),
+        cycleScheduledWorkout: new PrismaCycleScheduledWorkoutRepository(prisma, userId),
         liftMetadata: new PrismaLiftMetadataRepository(prisma, userId),
         liftRecord: new PrismaLiftRecordRepository(prisma, userId),
+        programPhilosophy: this.philosophyRepo,
         strengthGoal: new PrismaStrengthGoalRepository(prisma, userId),
         trainingMax: new PrismaTrainingMaxRepository(prisma, userId),
         trainingMaxHistory: new PrismaTrainingMaxHistoryRepository(prisma, userId),
-        cycleDashboard: new PrismaCycleDashboardRepository(prisma, userId),
+        userSettings: new UserSettingsRepository(prisma as never, userId),
         workout: new PrismaWorkoutRepository(prisma, userId),
         workoutDateOverride: new PrismaWorkoutDateOverrideRepository(prisma, userId),
         workoutLiftOverride: new PrismaWorkoutLiftOverrideRepository(prisma, userId),
         liftingProgramSpec: this.programSpecRepo,
-        programPhilosophy: this.philosophyRepo,
       };
     }
 
@@ -99,6 +105,7 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
     const sharedRecords: Map<string, LiftRecord[]> = new Map();
     return {
       cycleDashboard: new InMemoryCycleDashboardRepository(),
+      cycleScheduledWorkout: new InMemoryCycleScheduledWorkoutRepository(),
       liftMetadata: new InMemoryLiftMetadataRepository(),
       liftingProgramSpec: this.programSpecRepo,
       liftRecord: new InMemoryLiftRecordRepository(sharedRecords),
@@ -106,6 +113,7 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
       strengthGoal: new InMemoryStrengthGoalRepository(),
       trainingMax: new InMemoryTrainingMaxRepository(),
       trainingMaxHistory: new InMemoryTrainingMaxHistoryRepository(),
+      userSettings: new InMemoryUserSettingsRepository(),
       workout: new InMemoryWorkoutRepository(sharedRecords),
       workoutDateOverride: new InMemoryWorkoutDateOverrideRepository(),
       workoutLiftOverride: new InMemoryWorkoutLiftOverrideRepository(),

--- a/apps/api/src/adapters/factory/system-db-repository-factory.ts
+++ b/apps/api/src/adapters/factory/system-db-repository-factory.ts
@@ -91,7 +91,7 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
         strengthGoal: new PrismaStrengthGoalRepository(prisma, userId),
         trainingMax: new PrismaTrainingMaxRepository(prisma, userId),
         trainingMaxHistory: new PrismaTrainingMaxHistoryRepository(prisma, userId),
-        userSettings: new UserSettingsRepository(prisma as never, userId),
+        userSettings: new UserSettingsRepository(prisma, userId),
         workout: new PrismaWorkoutRepository(prisma, userId),
         workoutDateOverride: new PrismaWorkoutDateOverrideRepository(prisma, userId),
         workoutLiftOverride: new PrismaWorkoutLiftOverrideRepository(prisma, userId),

--- a/apps/api/src/adapters/in-memory/cycle-scheduled-workout.adapter.ts
+++ b/apps/api/src/adapters/in-memory/cycle-scheduled-workout.adapter.ts
@@ -1,0 +1,17 @@
+import { ICycleScheduledWorkoutRepository, ScheduledWorkout } from '../../ports/ICycleScheduledWorkoutRepository';
+
+export class InMemoryCycleScheduledWorkoutRepository implements ICycleScheduledWorkoutRepository {
+  private readonly store = new Map<string, ScheduledWorkout[]>();
+
+  private key(program: string, cycleNum: number): string {
+    return `${program}:${cycleNum}`;
+  }
+
+  async getScheduledWorkouts(program: string, cycleNum: number): Promise<ScheduledWorkout[]> {
+    return this.store.get(this.key(program, cycleNum)) ?? [];
+  }
+
+  async saveScheduledWorkouts(program: string, cycleNum: number, workouts: ScheduledWorkout[]): Promise<void> {
+    this.store.set(this.key(program, cycleNum), [...workouts]);
+  }
+}

--- a/apps/api/src/adapters/in-memory/user-settings.adapter.ts
+++ b/apps/api/src/adapters/in-memory/user-settings.adapter.ts
@@ -1,0 +1,19 @@
+import { UserSettingsResponse, UserWorkoutSchedule } from '@lifting-logbook/types';
+import { IUserSettingsRepository } from '../../ports/IUserSettingsRepository';
+
+export class InMemoryUserSettingsRepository implements IUserSettingsRepository {
+  private activeProgram: string | null = null;
+  private workoutSchedule: UserWorkoutSchedule | null = null;
+
+  async getSettings(): Promise<UserSettingsResponse> {
+    return { activeProgram: this.activeProgram, workoutSchedule: this.workoutSchedule };
+  }
+
+  setSchedule(schedule: UserWorkoutSchedule | null): void {
+    this.workoutSchedule = schedule;
+  }
+
+  setActiveProgram(program: string | null): void {
+    this.activeProgram = program;
+  }
+}

--- a/apps/api/src/adapters/in-memory/workout-date-override.adapter.ts
+++ b/apps/api/src/adapters/in-memory/workout-date-override.adapter.ts
@@ -11,6 +11,17 @@ export class InMemoryWorkoutDateOverrideRepository
     return `${program}\0${cycleNum}\0${workoutNum}`;
   }
 
+  async getOverridesForCycle(program: string, cycleNum: number): Promise<Map<number, Date>> {
+    const result = new Map<number, Date>();
+    for (const [k, date] of this.store) {
+      const parts = k.split('\0');
+      if (parts[0] === program && Number(parts[1]) === cycleNum) {
+        result.set(Number(parts[2]), date);
+      }
+    }
+    return result;
+  }
+
   async getOverride(
     program: string,
     cycleNum: number,

--- a/apps/api/src/adapters/prisma/cycle-scheduled-workout.repository.ts
+++ b/apps/api/src/adapters/prisma/cycle-scheduled-workout.repository.ts
@@ -1,0 +1,39 @@
+import { PrismaClient } from '@prisma/client';
+import { ICycleScheduledWorkoutRepository, ScheduledWorkout } from '../../ports/ICycleScheduledWorkoutRepository';
+
+export class PrismaCycleScheduledWorkoutRepository implements ICycleScheduledWorkoutRepository {
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly userId: string,
+  ) {}
+
+  async getScheduledWorkouts(program: string, cycleNum: number): Promise<ScheduledWorkout[]> {
+    const rows = await this.prisma.cycleScheduledWorkout.findMany({
+      where: { userId: this.userId, program, cycleNum },
+      orderBy: { workoutNum: 'asc' },
+    });
+    return rows.map((r) => ({
+      workoutNum: r.workoutNum,
+      weekNum: r.weekNum,
+      scheduledDate: r.scheduledDate,
+    }));
+  }
+
+  async saveScheduledWorkouts(program: string, cycleNum: number, workouts: ScheduledWorkout[]): Promise<void> {
+    await this.prisma.$transaction([
+      this.prisma.cycleScheduledWorkout.deleteMany({
+        where: { userId: this.userId, program, cycleNum },
+      }),
+      this.prisma.cycleScheduledWorkout.createMany({
+        data: workouts.map((w) => ({
+          userId: this.userId,
+          program,
+          cycleNum,
+          workoutNum: w.workoutNum,
+          weekNum: w.weekNum,
+          scheduledDate: w.scheduledDate,
+        })),
+      }),
+    ]);
+  }
+}

--- a/apps/api/src/adapters/prisma/cycle-scheduled-workout.repository.ts
+++ b/apps/api/src/adapters/prisma/cycle-scheduled-workout.repository.ts
@@ -20,6 +20,10 @@ export class PrismaCycleScheduledWorkoutRepository implements ICycleScheduledWor
   }
 
   async saveScheduledWorkouts(program: string, cycleNum: number, workouts: ScheduledWorkout[]): Promise<void> {
+    // deleteMany + createMany replaces the full row set for (userId, program, cycleNum).
+    // Concurrent cycle creation (e.g., double-submit) can race and hit the unique constraint.
+    // Acceptable given cycle creation is a rare, deliberate user action; harden with
+    // upsert-per-row semantics if this surfaces in practice.
     await this.prisma.$transaction([
       this.prisma.cycleScheduledWorkout.deleteMany({
         where: { userId: this.userId, program, cycleNum },

--- a/apps/api/src/adapters/prisma/prisma-repository-factory.ts
+++ b/apps/api/src/adapters/prisma/prisma-repository-factory.ts
@@ -2,17 +2,19 @@ import { Injectable } from '@nestjs/common';
 import { AuthUser } from '../../ports/auth';
 import { IRepositoryFactory, RepositoryBundle } from '../../ports/factory';
 import { PrismaService } from './prisma.service';
+import { PrismaCycleDashboardRepository } from './cycle-dashboard.repository';
+import { PrismaCycleScheduledWorkoutRepository } from './cycle-scheduled-workout.repository';
+import { PrismaLiftMetadataRepository } from './lift-metadata.repository';
 import { PrismaLiftRecordRepository } from './lift-record.repository';
 import { PrismaStrengthGoalRepository } from './strength-goal.repository';
 import { PrismaTrainingMaxRepository } from './training-max.repository';
 import { PrismaTrainingMaxHistoryRepository } from './training-max-history.repository';
-import { PrismaCycleDashboardRepository } from './cycle-dashboard.repository';
 import { PrismaWorkoutDateOverrideRepository } from './workout-date-override.repository';
-import { PrismaLiftMetadataRepository } from './lift-metadata.repository';
 import { PrismaWorkoutLiftOverrideRepository } from './workout-lift-override.repository';
 import { PrismaWorkoutRepository } from './workout.repository';
 import { HybridLiftingProgramSpecRepository } from './hybrid-program-spec.repository';
 import { InMemoryProgramPhilosophyRepository } from '../in-memory/program-philosophy.adapter';
+import { UserSettingsRepository } from '../../user-settings/user-settings.repository';
 
 @Injectable()
 export class PrismaRepositoryFactory implements IRepositoryFactory {
@@ -26,17 +28,19 @@ export class PrismaRepositoryFactory implements IRepositoryFactory {
 
   async forUser(user: AuthUser): Promise<RepositoryBundle> {
     return {
+      cycleDashboard: new PrismaCycleDashboardRepository(this.prisma, user.id),
+      cycleScheduledWorkout: new PrismaCycleScheduledWorkoutRepository(this.prisma, user.id),
       liftMetadata: new PrismaLiftMetadataRepository(this.prisma, user.id),
       liftRecord: new PrismaLiftRecordRepository(this.prisma, user.id),
+      programPhilosophy: this.philosophyRepo,
       strengthGoal: new PrismaStrengthGoalRepository(this.prisma, user.id),
       trainingMax: new PrismaTrainingMaxRepository(this.prisma, user.id),
       trainingMaxHistory: new PrismaTrainingMaxHistoryRepository(this.prisma, user.id),
-      cycleDashboard: new PrismaCycleDashboardRepository(this.prisma, user.id),
+      userSettings: new UserSettingsRepository(this.prisma, user.id),
       workout: new PrismaWorkoutRepository(this.prisma, user.id),
       workoutDateOverride: new PrismaWorkoutDateOverrideRepository(this.prisma, user.id),
       workoutLiftOverride: new PrismaWorkoutLiftOverrideRepository(this.prisma, user.id),
       liftingProgramSpec: this.programSpecRepo,
-      programPhilosophy: this.philosophyRepo,
     };
   }
 }

--- a/apps/api/src/adapters/prisma/workout-date-override.repository.ts
+++ b/apps/api/src/adapters/prisma/workout-date-override.repository.ts
@@ -27,6 +27,13 @@ export class PrismaWorkoutDateOverrideRepository
     return row?.newDate ?? null;
   }
 
+  async getOverridesForCycle(program: string, cycleNum: number): Promise<Map<number, Date>> {
+    const rows = await this.prisma.workoutDateOverride.findMany({
+      where: { userId: this.userId, program, cycleNum },
+    });
+    return new Map(rows.map((r) => [r.workoutNum, r.newDate]));
+  }
+
   async upsertOverride(
     program: string,
     cycleNum: number,

--- a/apps/api/src/ports/ICycleScheduledWorkoutRepository.ts
+++ b/apps/api/src/ports/ICycleScheduledWorkoutRepository.ts
@@ -1,0 +1,10 @@
+export interface ScheduledWorkout {
+  workoutNum: number;
+  weekNum: number;
+  scheduledDate: Date;
+}
+
+export interface ICycleScheduledWorkoutRepository {
+  getScheduledWorkouts(program: string, cycleNum: number): Promise<ScheduledWorkout[]>;
+  saveScheduledWorkouts(program: string, cycleNum: number, workouts: ScheduledWorkout[]): Promise<void>;
+}

--- a/apps/api/src/ports/IUserSettingsRepository.ts
+++ b/apps/api/src/ports/IUserSettingsRepository.ts
@@ -1,0 +1,5 @@
+import { UserSettingsResponse } from '@lifting-logbook/types';
+
+export interface IUserSettingsRepository {
+  getSettings(): Promise<UserSettingsResponse>;
+}

--- a/apps/api/src/ports/IWorkoutDateOverrideRepository.ts
+++ b/apps/api/src/ports/IWorkoutDateOverrideRepository.ts
@@ -5,6 +5,11 @@ export interface IWorkoutDateOverrideRepository {
     workoutNum: number,
   ): Promise<Date | null>;
 
+  getOverridesForCycle(
+    program: string,
+    cycleNum: number,
+  ): Promise<Map<number, Date>>;
+
   upsertOverride(
     program: string,
     cycleNum: number,

--- a/apps/api/src/ports/factory.ts
+++ b/apps/api/src/ports/factory.ts
@@ -1,5 +1,6 @@
 import { AuthUser } from './auth';
 import { ICycleDashboardRepository } from './ICycleDashboardRepository';
+import { ICycleScheduledWorkoutRepository } from './ICycleScheduledWorkoutRepository';
 import { ILiftMetadataRepository } from './ILiftMetadataRepository';
 import { ILiftingProgramSpecRepository } from './ILiftingProgramSpecRepository';
 import { ILiftRecordRepository } from './ILiftRecordRepository';
@@ -7,12 +8,14 @@ import { IProgramPhilosophyRepository } from './IProgramPhilosophyRepository';
 import { IStrengthGoalRepository } from './IStrengthGoalRepository';
 import { ITrainingMaxHistoryRepository } from './ITrainingMaxHistoryRepository';
 import { ITrainingMaxRepository } from './ITrainingMaxRepository';
+import { IUserSettingsRepository } from './IUserSettingsRepository';
 import { IWorkoutDateOverrideRepository } from './IWorkoutDateOverrideRepository';
 import { IWorkoutLiftOverrideRepository } from './IWorkoutLiftOverrideRepository';
 import { IWorkoutRepository } from './IWorkoutRepository';
 
 export interface RepositoryBundle {
   cycleDashboard: ICycleDashboardRepository;
+  cycleScheduledWorkout: ICycleScheduledWorkoutRepository;
   liftMetadata: ILiftMetadataRepository;
   liftingProgramSpec: ILiftingProgramSpecRepository;
   liftRecord: ILiftRecordRepository;
@@ -20,6 +23,7 @@ export interface RepositoryBundle {
   strengthGoal: IStrengthGoalRepository;
   trainingMax: ITrainingMaxRepository;
   trainingMaxHistory: ITrainingMaxHistoryRepository;
+  userSettings: IUserSettingsRepository;
   workout: IWorkoutRepository;
   workoutDateOverride: IWorkoutDateOverrideRepository;
   workoutLiftOverride: IWorkoutLiftOverrideRepository;

--- a/apps/api/src/ports/ports.compile-test.ts
+++ b/apps/api/src/ports/ports.compile-test.ts
@@ -122,6 +122,7 @@ const _programPhilosophyRepo: IProgramPhilosophyRepository = {
 
 const _workoutDateOverrideRepo: IWorkoutDateOverrideRepository = {
   getOverride: () => Promise.resolve(null),
+  getOverridesForCycle: () => Promise.resolve(new Map()),
   upsertOverride: () => Promise.resolve(),
 };
 

--- a/apps/api/src/ports/ports.compile-test.ts
+++ b/apps/api/src/ports/ports.compile-test.ts
@@ -11,6 +11,7 @@ import { AuthUser, IAuthProvider } from './auth';
 import { IBodyWeightRepository } from './IBodyWeightRepository';
 import { IRepositoryFactory, RepositoryBundle } from './factory';
 import { ICycleDashboardRepository } from './ICycleDashboardRepository';
+import { ICycleScheduledWorkoutRepository } from './ICycleScheduledWorkoutRepository';
 import { ILiftingProgramSpecRepository } from './ILiftingProgramSpecRepository';
 import { ILiftRecordRepository } from './ILiftRecordRepository';
 import { IProgramPhilosophyRepository } from './IProgramPhilosophyRepository';
@@ -18,6 +19,7 @@ import { ITrainingMaxRepository } from './ITrainingMaxRepository';
 import { ITrainingMaxHistoryRepository } from './ITrainingMaxHistoryRepository';
 import { ILiftMetadataRepository } from './ILiftMetadataRepository';
 import { IStrengthGoalRepository } from './IStrengthGoalRepository';
+import { IUserSettingsRepository } from './IUserSettingsRepository';
 import { IWorkoutDateOverrideRepository } from './IWorkoutDateOverrideRepository';
 import { IWorkoutLiftOverrideRepository } from './IWorkoutLiftOverrideRepository';
 import { IWorkoutRepository } from './IWorkoutRepository';
@@ -141,8 +143,18 @@ const _workoutLiftOverrideRepo: IWorkoutLiftOverrideRepository = {
   deleteOverride: () => Promise.resolve(),
 };
 
+const _cycleScheduledWorkoutRepo: ICycleScheduledWorkoutRepository = {
+  getScheduledWorkouts: () => Promise.resolve([]),
+  saveScheduledWorkouts: () => Promise.resolve(),
+};
+
+const _userSettingsRepo: IUserSettingsRepository = {
+  getSettings: () => Promise.resolve({ activeProgram: null, workoutSchedule: null }),
+};
+
 const _repositoryBundle: RepositoryBundle = {
   cycleDashboard: _cycleDashboardRepo,
+  cycleScheduledWorkout: _cycleScheduledWorkoutRepo,
   liftMetadata: _liftMetadataRepo,
   liftingProgramSpec: _programSpecRepo,
   liftRecord: _liftRecordRepo,
@@ -150,6 +162,7 @@ const _repositoryBundle: RepositoryBundle = {
   strengthGoal: _strengthGoalRepo,
   trainingMax: _trainingMaxRepo,
   trainingMaxHistory: _trainingMaxHistoryRepo,
+  userSettings: _userSettingsRepo,
   workout: _workoutRepo,
   workoutDateOverride: _workoutDateOverrideRepo,
   workoutLiftOverride: _workoutLiftOverrideRepo,
@@ -173,5 +186,7 @@ void _liftMetadataRepo;
 void _strengthGoalRepo;
 void _workoutDateOverrideRepo;
 void _workoutLiftOverrideRepo;
+void _cycleScheduledWorkoutRepo;
+void _userSettingsRepo;
 void _repositoryBundle;
 void _repositoryFactory;

--- a/apps/api/src/programs/cycle-dashboard.controller.spec.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.spec.ts
@@ -155,7 +155,6 @@ describe('CycleDashboardController', () => {
     ]);
     overrideRepo.getOverridesForCycle.mockResolvedValue(new Map([[1, new Date('2026-04-25T00:00:00.000Z')]]));
 
-
     const result = await controller.getCurrentCycle('5-3-1', MOCK_USER);
 
     expect(result.weeks[0]?.workoutDates).toEqual(['2026-04-25']);

--- a/apps/api/src/programs/cycle-dashboard.controller.spec.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.spec.ts
@@ -70,6 +70,7 @@ describe('CycleDashboardController', () => {
     };
     overrideRepo = {
       getOverride: jest.fn().mockResolvedValue(null),
+      getOverridesForCycle: jest.fn().mockResolvedValue(new Map()),
       upsertOverride: jest.fn(),
     };
     factory = {
@@ -152,7 +153,8 @@ describe('CycleDashboardController', () => {
     scheduledRepo.getScheduledWorkouts.mockResolvedValue([
       { workoutNum: 1, weekNum: 1, scheduledDate: new Date('2026-04-21T00:00:00.000Z') },
     ]);
-    overrideRepo.getOverride.mockResolvedValue(new Date('2026-04-25T00:00:00.000Z'));
+    overrideRepo.getOverridesForCycle.mockResolvedValue(new Map([[1, new Date('2026-04-25T00:00:00.000Z')]]));
+
 
     const result = await controller.getCurrentCycle('5-3-1', MOCK_USER);
 

--- a/apps/api/src/programs/cycle-dashboard.controller.spec.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.spec.ts
@@ -1,7 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { Weekday } from '@lifting-logbook/core';
 import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
+import { ICycleScheduledWorkoutRepository, ScheduledWorkout } from '../ports/ICycleScheduledWorkoutRepository';
+import { ILiftRecordRepository } from '../ports/ILiftRecordRepository';
 import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
+import { IWorkoutDateOverrideRepository } from '../ports/IWorkoutDateOverrideRepository';
 import { IRepositoryFactory } from '../ports/factory';
 import { REPOSITORY_FACTORY } from '../ports/tokens';
 import { CycleDashboardController } from './cycle-dashboard.controller';
@@ -34,10 +37,19 @@ const stubSpec = (weekType: 'training' | 'test' | 'deload' = 'training') => [{
   weekType,
 }];
 
+const stubScheduled = (): ScheduledWorkout[] => [
+  { workoutNum: 1, weekNum: 1, scheduledDate: new Date('2026-04-21T00:00:00.000Z') },
+  { workoutNum: 2, weekNum: 1, scheduledDate: new Date('2026-04-23T00:00:00.000Z') },
+  { workoutNum: 3, weekNum: 2, scheduledDate: new Date('2026-04-28T00:00:00.000Z') },
+];
+
 describe('CycleDashboardController', () => {
   let controller: CycleDashboardController;
   let repo: jest.Mocked<ICycleDashboardRepository>;
   let specRepo: jest.Mocked<ILiftingProgramSpecRepository>;
+  let scheduledRepo: jest.Mocked<ICycleScheduledWorkoutRepository>;
+  let liftRecordRepo: jest.Mocked<ILiftRecordRepository>;
+  let overrideRepo: jest.Mocked<IWorkoutDateOverrideRepository>;
   let factory: jest.Mocked<IRepositoryFactory>;
 
   beforeEach(async () => {
@@ -46,10 +58,27 @@ describe('CycleDashboardController', () => {
       saveCycleDashboard: jest.fn(),
     };
     specRepo = { getProgramSpec: jest.fn() };
+    scheduledRepo = {
+      getScheduledWorkouts: jest.fn().mockResolvedValue([]),
+      saveScheduledWorkouts: jest.fn(),
+    };
+    liftRecordRepo = {
+      getLiftRecords: jest.fn().mockResolvedValue([]),
+      appendLiftRecords: jest.fn(),
+      findExistingRecords: jest.fn(),
+      updateLiftRecord: jest.fn(),
+    };
+    overrideRepo = {
+      getOverride: jest.fn().mockResolvedValue(null),
+      upsertOverride: jest.fn(),
+    };
     factory = {
       forUser: jest.fn().mockResolvedValue({
         cycleDashboard: repo,
+        cycleScheduledWorkout: scheduledRepo,
         liftingProgramSpec: specRepo,
+        liftRecord: liftRecordRepo,
+        workoutDateOverride: overrideRepo,
       }),
     };
 
@@ -85,5 +114,81 @@ describe('CycleDashboardController', () => {
     const result = await controller.getCurrentCycle('5-3-1', MOCK_USER);
 
     expect(result.currentWeekType).toBe('test');
+  });
+
+  it('returns weeks:[] when no scheduled workouts exist (no-schedule mode)', async () => {
+    repo.getCycleDashboard.mockResolvedValue(stubDashboard());
+    specRepo.getProgramSpec.mockResolvedValue(stubSpec());
+    scheduledRepo.getScheduledWorkouts.mockResolvedValue([]);
+
+    const result = await controller.getCurrentCycle('5-3-1', MOCK_USER);
+
+    expect(result.weeks).toEqual([]);
+  });
+
+  it('returns populated weeks when scheduled workouts exist', async () => {
+    repo.getCycleDashboard.mockResolvedValue(stubDashboard());
+    specRepo.getProgramSpec.mockResolvedValue(stubSpec());
+    scheduledRepo.getScheduledWorkouts.mockResolvedValue(stubScheduled());
+
+    const result = await controller.getCurrentCycle('5-3-1', MOCK_USER);
+
+    expect(result.weeks).toHaveLength(2);
+    expect(result.weeks[0]).toEqual({
+      week: 1,
+      workoutDates: ['2026-04-21', '2026-04-23'],
+      completed: false,
+    });
+    expect(result.weeks[1]).toEqual({
+      week: 2,
+      workoutDates: ['2026-04-28'],
+      completed: false,
+    });
+  });
+
+  it('uses override date instead of scheduled date when override exists', async () => {
+    repo.getCycleDashboard.mockResolvedValue(stubDashboard());
+    specRepo.getProgramSpec.mockResolvedValue(stubSpec());
+    scheduledRepo.getScheduledWorkouts.mockResolvedValue([
+      { workoutNum: 1, weekNum: 1, scheduledDate: new Date('2026-04-21T00:00:00.000Z') },
+    ]);
+    overrideRepo.getOverride.mockResolvedValue(new Date('2026-04-25T00:00:00.000Z'));
+
+    const result = await controller.getCurrentCycle('5-3-1', MOCK_USER);
+
+    expect(result.weeks[0]?.workoutDates).toEqual(['2026-04-25']);
+  });
+
+  it('marks a week as completed when all its workouts have lift records', async () => {
+    repo.getCycleDashboard.mockResolvedValue(stubDashboard());
+    specRepo.getProgramSpec.mockResolvedValue(stubSpec());
+    scheduledRepo.getScheduledWorkouts.mockResolvedValue([
+      { workoutNum: 1, weekNum: 1, scheduledDate: new Date('2026-04-21T00:00:00.000Z') },
+      { workoutNum: 2, weekNum: 1, scheduledDate: new Date('2026-04-23T00:00:00.000Z') },
+    ]);
+    liftRecordRepo.getLiftRecords.mockResolvedValue([
+      { program: '5-3-1', cycleNum: 2, workoutNum: 1, date: new Date(), lift: 'Squat', setNum: 1, weight: 200, reps: 5, notes: '' },
+      { program: '5-3-1', cycleNum: 2, workoutNum: 2, date: new Date(), lift: 'Bench', setNum: 1, weight: 150, reps: 5, notes: '' },
+    ]);
+
+    const result = await controller.getCurrentCycle('5-3-1', MOCK_USER);
+
+    expect(result.weeks[0]?.completed).toBe(true);
+  });
+
+  it('marks a week as not completed when only some workouts have lift records', async () => {
+    repo.getCycleDashboard.mockResolvedValue(stubDashboard());
+    specRepo.getProgramSpec.mockResolvedValue(stubSpec());
+    scheduledRepo.getScheduledWorkouts.mockResolvedValue([
+      { workoutNum: 1, weekNum: 1, scheduledDate: new Date('2026-04-21T00:00:00.000Z') },
+      { workoutNum: 2, weekNum: 1, scheduledDate: new Date('2026-04-23T00:00:00.000Z') },
+    ]);
+    liftRecordRepo.getLiftRecords.mockResolvedValue([
+      { program: '5-3-1', cycleNum: 2, workoutNum: 1, date: new Date(), lift: 'Squat', setNum: 1, weight: 200, reps: 5, notes: '' },
+    ]);
+
+    const result = await controller.getCurrentCycle('5-3-1', MOCK_USER);
+
+    expect(result.weeks[0]?.completed).toBe(false);
   });
 });

--- a/apps/api/src/programs/cycle-dashboard.controller.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.ts
@@ -5,7 +5,7 @@ import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../ports/auth';
 import { IRepositoryFactory } from '../ports/factory';
 import { REPOSITORY_FACTORY } from '../ports/tokens';
-import { toCycleDashboardResponse } from './mappers';
+import { buildCycleDashboardResponse } from './mappers';
 
 @Controller('programs/:program')
 export class CycleDashboardController {
@@ -18,12 +18,30 @@ export class CycleDashboardController {
     @Param('program') program: string,
     @CurrentUser() user: AuthUser,
   ): Promise<CycleDashboardResponse> {
-    const { cycleDashboard, liftingProgramSpec } = await this.factory.forUser(user);
+    const { cycleDashboard, cycleScheduledWorkout, liftingProgramSpec, liftRecord, workoutDateOverride } =
+      await this.factory.forUser(user);
+
     const [dashboard, programSpec] = await Promise.all([
       cycleDashboard.getCycleDashboard(program),
       liftingProgramSpec.getProgramSpec(program),
     ]);
     dashboard.currentWeekType = weekTypeForDate(dashboard.cycleDate, programSpec);
-    return toCycleDashboardResponse(dashboard);
+
+    const [scheduledWorkouts, liftRecords] = await Promise.all([
+      cycleScheduledWorkout.getScheduledWorkouts(program, dashboard.cycleNum),
+      liftRecord.getLiftRecords(program, dashboard.cycleNum),
+    ]);
+
+    const overrideDates = await Promise.all(
+      scheduledWorkouts.map((sw) =>
+        workoutDateOverride.getOverride(program, dashboard.cycleNum, sw.workoutNum),
+      ),
+    );
+    const overrideMap = new Map<number, Date | null>(
+      scheduledWorkouts.map((sw, i) => [sw.workoutNum, overrideDates[i]!]),
+    );
+    const completedWorkoutNums = new Set(liftRecords.map((r) => r.workoutNum));
+
+    return buildCycleDashboardResponse(dashboard, scheduledWorkouts, overrideMap, completedWorkoutNums);
   }
 }

--- a/apps/api/src/programs/cycle-dashboard.controller.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.ts
@@ -27,19 +27,11 @@ export class CycleDashboardController {
     ]);
     dashboard.currentWeekType = weekTypeForDate(dashboard.cycleDate, programSpec);
 
-    const [scheduledWorkouts, liftRecords] = await Promise.all([
+    const [scheduledWorkouts, liftRecords, overrideMap] = await Promise.all([
       cycleScheduledWorkout.getScheduledWorkouts(program, dashboard.cycleNum),
       liftRecord.getLiftRecords(program, dashboard.cycleNum),
+      workoutDateOverride.getOverridesForCycle(program, dashboard.cycleNum),
     ]);
-
-    const overrideDates = await Promise.all(
-      scheduledWorkouts.map((sw) =>
-        workoutDateOverride.getOverride(program, dashboard.cycleNum, sw.workoutNum),
-      ),
-    );
-    const overrideMap = new Map<number, Date | null>(
-      scheduledWorkouts.map((sw, i) => [sw.workoutNum, overrideDates[i]!]),
-    );
     const completedWorkoutNums = new Set(liftRecords.map((r) => r.workoutNum));
 
     return buildCycleDashboardResponse(dashboard, scheduledWorkouts, overrideMap, completedWorkoutNums);

--- a/apps/api/src/programs/cycle-generation.service.spec.ts
+++ b/apps/api/src/programs/cycle-generation.service.spec.ts
@@ -7,6 +7,8 @@ import {
   ITrainingMaxHistoryRepository,
   ITrainingMaxRepository,
 } from '../ports';
+import { ICycleScheduledWorkoutRepository } from '../ports/ICycleScheduledWorkoutRepository';
+import { IUserSettingsRepository } from '../ports/IUserSettingsRepository';
 import { ProgramNotFoundError } from '../ports/errors';
 import { CycleGenerationService } from './cycle-generation.service';
 
@@ -67,12 +69,16 @@ describe('CycleGenerationService', () => {
   let trainingMaxRepo: jest.Mocked<ITrainingMaxRepository>;
   let trainingMaxHistoryRepo: jest.Mocked<ITrainingMaxHistoryRepository>;
   let liftRecordRepo: jest.Mocked<ILiftRecordRepository>;
+  let userSettingsRepo: jest.Mocked<IUserSettingsRepository>;
+  let cycleScheduledWorkoutRepo: jest.Mocked<ICycleScheduledWorkoutRepository>;
   let repos: {
     cycleDashboard: jest.Mocked<ICycleDashboardRepository>;
+    cycleScheduledWorkout: jest.Mocked<ICycleScheduledWorkoutRepository>;
     liftingProgramSpec: jest.Mocked<ILiftingProgramSpecRepository>;
     trainingMax: jest.Mocked<ITrainingMaxRepository>;
     trainingMaxHistory: jest.Mocked<ITrainingMaxHistoryRepository>;
     liftRecord: jest.Mocked<ILiftRecordRepository>;
+    userSettings: jest.Mocked<IUserSettingsRepository>;
   };
 
   beforeEach(() => {
@@ -81,7 +87,7 @@ describe('CycleGenerationService', () => {
       saveCycleDashboard: jest.fn().mockResolvedValue(undefined),
     };
     programSpecRepo = {
-      getProgramSpec: jest.fn(),
+      getProgramSpec: jest.fn().mockResolvedValue(stubProgramSpec()),
     };
     trainingMaxRepo = {
       getTrainingMaxes: jest.fn(),
@@ -96,12 +102,21 @@ describe('CycleGenerationService', () => {
       getLiftRecords: jest.fn(),
       appendLiftRecords: jest.fn().mockResolvedValue(undefined),
     };
+    userSettingsRepo = {
+      getSettings: jest.fn().mockResolvedValue({ activeProgram: null, workoutSchedule: null }),
+    };
+    cycleScheduledWorkoutRepo = {
+      getScheduledWorkouts: jest.fn().mockResolvedValue([]),
+      saveScheduledWorkouts: jest.fn().mockResolvedValue(undefined),
+    };
     repos = {
       cycleDashboard: cycleDashboardRepo,
+      cycleScheduledWorkout: cycleScheduledWorkoutRepo,
       liftingProgramSpec: programSpecRepo,
       trainingMax: trainingMaxRepo,
       trainingMaxHistory: trainingMaxHistoryRepo,
       liftRecord: liftRecordRepo,
+      userSettings: userSettingsRepo,
     };
     service = new CycleGenerationService();
   });
@@ -184,6 +199,38 @@ describe('CycleGenerationService', () => {
 
       expect(result.cycleDate).toEqual(new Date('2026-06-01T00:00:00.000Z'));
     });
+
+    it('saves scheduled dates when user has a workout schedule', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockResolvedValue(stubDashboard());
+      programSpecRepo.getProgramSpec.mockResolvedValue(stubProgramSpec());
+      trainingMaxRepo.getTrainingMaxes.mockResolvedValue(stubTrainingMaxes());
+      liftRecordRepo.getLiftRecords.mockResolvedValue(stubLiftRecords());
+      userSettingsRepo.getSettings.mockResolvedValue({
+        activeProgram: null,
+        workoutSchedule: { type: 'fixed', days: [0, 2, 4] },
+      });
+
+      await service.startNewCycle(repos, PROGRAM);
+
+      expect(cycleScheduledWorkoutRepo.saveScheduledWorkouts).toHaveBeenCalledWith(
+        PROGRAM,
+        2,
+        expect.arrayContaining([
+          expect.objectContaining({ workoutNum: 1, weekNum: 1 }),
+        ]),
+      );
+    });
+
+    it('does not save scheduled dates when user has no workout schedule', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockResolvedValue(stubDashboard());
+      programSpecRepo.getProgramSpec.mockResolvedValue(stubProgramSpec());
+      trainingMaxRepo.getTrainingMaxes.mockResolvedValue(stubTrainingMaxes());
+      liftRecordRepo.getLiftRecords.mockResolvedValue(stubLiftRecords());
+
+      await service.startNewCycle(repos, PROGRAM);
+
+      expect(cycleScheduledWorkoutRepo.saveScheduledWorkouts).not.toHaveBeenCalled();
+    });
   });
 
   describe('initializeFirstCycle', () => {
@@ -241,6 +288,37 @@ describe('CycleGenerationService', () => {
       ).rejects.toThrow(BadRequestException);
 
       expect(cycleDashboardRepo.saveCycleDashboard).not.toHaveBeenCalled();
+    });
+
+    it('saves scheduled dates when user has a workout schedule', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockRejectedValue(
+        new ProgramNotFoundError(PROGRAM),
+      );
+      programSpecRepo.getProgramSpec.mockResolvedValue(stubProgramSpec());
+      userSettingsRepo.getSettings.mockResolvedValue({
+        activeProgram: null,
+        workoutSchedule: { type: 'fixed', days: [0, 2, 4] },
+      });
+
+      await service.initializeFirstCycle(repos, PROGRAM, { cycleDate: '2026-05-12' });
+
+      expect(cycleScheduledWorkoutRepo.saveScheduledWorkouts).toHaveBeenCalledWith(
+        PROGRAM,
+        1,
+        expect.arrayContaining([
+          expect.objectContaining({ workoutNum: 1, weekNum: 1 }),
+        ]),
+      );
+    });
+
+    it('does not save scheduled dates when user has no workout schedule', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockRejectedValue(
+        new ProgramNotFoundError(PROGRAM),
+      );
+
+      await service.initializeFirstCycle(repos, PROGRAM, { cycleDate: '2026-05-12' });
+
+      expect(cycleScheduledWorkoutRepo.saveScheduledWorkouts).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/programs/cycle-generation.service.ts
+++ b/apps/api/src/programs/cycle-generation.service.ts
@@ -1,9 +1,11 @@
 import { BadRequestException, ConflictException, Injectable } from '@nestjs/common';
+import { UserWorkoutSchedule } from '@lifting-logbook/types';
 import {
   CycleDashboard,
   LiftingProgramSpec,
   distributeWorkouts,
   formatDateYYYYMMDD,
+  getScheduleWorkoutsPerWeek,
   MaxReductionFlag,
   TrainingMax,
   TrainingMaxHistoryEntry,
@@ -51,17 +53,16 @@ const PROGRAM_DEFAULTS: Record<string, { cycleUnit: string; programType: string 
 };
 
 async function saveScheduledDates(
-  repos: Pick<CycleRepos, 'userSettings' | 'cycleScheduledWorkout'>,
+  repos: Pick<CycleRepos, 'cycleScheduledWorkout'>,
   program: string,
   cycleNum: number,
   cycleDate: Date,
   programSpec: LiftingProgramSpec[],
+  workoutSchedule: UserWorkoutSchedule,
 ): Promise<void> {
-  const settings = await repos.userSettings.getSettings();
-  if (!settings.workoutSchedule) return;
-
-  const offsets = [...new Set(programSpec.map((s) => s.offset))].sort((a, b) => a - b);
-  const distributed = distributeWorkouts(offsets.length, settings.workoutSchedule, cycleDate);
+  const numWeeks = Math.max(...programSpec.map((s) => s.week));
+  const workoutsPerWeek = getScheduleWorkoutsPerWeek(workoutSchedule);
+  const distributed = distributeWorkouts(numWeeks * workoutsPerWeek, workoutSchedule, cycleDate);
 
   const workouts: ScheduledWorkout[] = [];
   let workoutNum = 1;
@@ -140,11 +141,15 @@ export class CycleGenerationService {
     // to the caller when advancing a cycle. Use recalculateMaxes to review flagged reductions.
     const { maxes: newMaxes } = updateMaxes(programSpec, trainingMaxes, liftRecords);
 
-    // Write order: maxes before dashboard — if dashboard write fails, cycle counter
-    // hasn't advanced and a retry is safe. True atomicity requires a transaction.
+    // Write order: maxes → scheduled dates → dashboard. If dashboard write fails,
+    // cycleNum hasn't advanced in the dashboard so a retry is safe. Scheduled date
+    // rows use replace-all semantics and are idempotent across retries.
     await repos.trainingMax.saveTrainingMaxes(program, newMaxes);
+    const settings = await repos.userSettings.getSettings();
+    if (settings.workoutSchedule) {
+      await saveScheduledDates(repos, program, newCycle.cycleNum, newCycle.cycleDate, programSpec, settings.workoutSchedule);
+    }
     await repos.cycleDashboard.saveCycleDashboard(newCycle);
-    await saveScheduledDates(repos, program, newCycle.cycleNum, newCycle.cycleDate, programSpec);
 
     const source = dashboard.currentWeekType === 'test' ? 'test' : 'program';
     const historyEntries = buildHistoryEntries(trainingMaxes, newMaxes, newCycle.cycleDate, source);
@@ -197,9 +202,12 @@ export class CycleGenerationService {
       programType: defaults.programType,
     };
 
+    const settings = await repos.userSettings.getSettings();
+    if (settings.workoutSchedule) {
+      const spec = await repos.liftingProgramSpec.getProgramSpec(program);
+      await saveScheduledDates(repos, program, dashboard.cycleNum, dashboard.cycleDate, spec, settings.workoutSchedule);
+    }
     await repos.cycleDashboard.saveCycleDashboard(dashboard);
-    const spec = await repos.liftingProgramSpec.getProgramSpec(program);
-    await saveScheduledDates(repos, program, dashboard.cycleNum, dashboard.cycleDate, spec);
     return dashboard;
   }
 

--- a/apps/api/src/programs/cycle-generation.service.ts
+++ b/apps/api/src/programs/cycle-generation.service.ts
@@ -60,13 +60,21 @@ async function saveScheduledDates(
   programSpec: LiftingProgramSpec[],
   workoutSchedule: UserWorkoutSchedule,
 ): Promise<void> {
+  // numWeeks * workoutsPerWeek assumes schedule days/week equals program
+  // workouts/week. Phase 5 adds a user-confirmation prompt that validates
+  // this match before schedule mode is activated.
   const numWeeks = Math.max(...programSpec.map((s) => s.week));
   const workoutsPerWeek = getScheduleWorkoutsPerWeek(workoutSchedule);
   const distributed = distributeWorkouts(numWeeks * workoutsPerWeek, workoutSchedule, cycleDate);
 
   const workouts: ScheduledWorkout[] = [];
   let workoutNum = 1;
+  let lastWeek = 0;
   for (const week of distributed) {
+    if (week.week <= lastWeek) {
+      throw new Error(`distributeWorkouts returned out-of-order week: ${week.week}`);
+    }
+    lastWeek = week.week;
     for (const date of week.workouts) {
       workouts.push({ workoutNum, weekNum: week.week, scheduledDate: date });
       workoutNum++;

--- a/apps/api/src/programs/cycle-generation.service.ts
+++ b/apps/api/src/programs/cycle-generation.service.ts
@@ -1,6 +1,8 @@
 import { BadRequestException, ConflictException, Injectable } from '@nestjs/common';
 import {
   CycleDashboard,
+  LiftingProgramSpec,
+  distributeWorkouts,
   formatDateYYYYMMDD,
   MaxReductionFlag,
   TrainingMax,
@@ -11,12 +13,19 @@ import {
   Weekday,
 } from '@lifting-logbook/core';
 import { RepositoryBundle } from '../ports';
+import { ScheduledWorkout } from '../ports/ICycleScheduledWorkoutRepository';
 import { ProgramNotFoundError } from '../ports/errors';
 import { StartNewCycleDto } from './start-new-cycle.dto';
 
 type CycleRepos = Pick<
   RepositoryBundle,
-  'cycleDashboard' | 'liftingProgramSpec' | 'trainingMax' | 'trainingMaxHistory' | 'liftRecord'
+  | 'cycleDashboard'
+  | 'cycleScheduledWorkout'
+  | 'liftingProgramSpec'
+  | 'liftRecord'
+  | 'trainingMax'
+  | 'trainingMaxHistory'
+  | 'userSettings'
 >;
 
 /**
@@ -40,6 +49,33 @@ const PROGRAM_DEFAULTS: Record<string, { cycleUnit: string; programType: string 
   'juggernaut': { cycleUnit: 'week', programType: 'juggernaut' },
   'creeping-death-2': { cycleUnit: 'week', programType: 'creeping-death-2' },
 };
+
+async function saveScheduledDates(
+  repos: Pick<CycleRepos, 'userSettings' | 'cycleScheduledWorkout'>,
+  program: string,
+  cycleNum: number,
+  cycleDate: Date,
+  programSpec: LiftingProgramSpec[],
+): Promise<void> {
+  const settings = await repos.userSettings.getSettings();
+  if (!settings.workoutSchedule) return;
+
+  const offsets = [...new Set(programSpec.map((s) => s.offset))].sort((a, b) => a - b);
+  const distributed = distributeWorkouts(offsets.length, settings.workoutSchedule, cycleDate);
+
+  const workouts: ScheduledWorkout[] = [];
+  let workoutNum = 1;
+  for (const week of distributed) {
+    for (const date of week.workouts) {
+      workouts.push({ workoutNum, weekNum: week.week, scheduledDate: date });
+      workoutNum++;
+    }
+  }
+
+  if (workouts.length > 0) {
+    await repos.cycleScheduledWorkout.saveScheduledWorkouts(program, cycleNum, workouts);
+  }
+}
 
 function round1dp(w: number): number {
   return Math.round(w * 10) / 10;
@@ -108,6 +144,7 @@ export class CycleGenerationService {
     // hasn't advanced and a retry is safe. True atomicity requires a transaction.
     await repos.trainingMax.saveTrainingMaxes(program, newMaxes);
     await repos.cycleDashboard.saveCycleDashboard(newCycle);
+    await saveScheduledDates(repos, program, newCycle.cycleNum, newCycle.cycleDate, programSpec);
 
     const source = dashboard.currentWeekType === 'test' ? 'test' : 'program';
     const historyEntries = buildHistoryEntries(trainingMaxes, newMaxes, newCycle.cycleDate, source);
@@ -119,7 +156,7 @@ export class CycleGenerationService {
   }
 
   async initializeFirstCycle(
-    repos: Pick<CycleRepos, 'cycleDashboard'>,
+    repos: Pick<CycleRepos, 'cycleDashboard' | 'cycleScheduledWorkout' | 'liftingProgramSpec' | 'userSettings'>,
     program: string,
     dto: { cycleDate?: string } = {},
   ): Promise<CycleDashboard> {
@@ -161,6 +198,8 @@ export class CycleGenerationService {
     };
 
     await repos.cycleDashboard.saveCycleDashboard(dashboard);
+    const spec = await repos.liftingProgramSpec.getProgramSpec(program);
+    await saveScheduledDates(repos, program, dashboard.cycleNum, dashboard.cycleDate, spec);
     return dashboard;
   }
 

--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -111,31 +111,32 @@ export const toCycleDashboardResponse = (
 export function buildCycleDashboardResponse(
   d: CycleDashboard,
   scheduled: ScheduledWorkout[],
-  overrides: Map<number, Date | null>,
+  overrides: Map<number, Date>,
   completedWorkoutNums: Set<number>,
 ): CycleDashboardResponse {
   if (scheduled.length === 0) {
     return toCycleDashboardResponse(d);
   }
 
-  const weekMap = new Map<number, string[]>();
+  const weekAcc = new Map<number, { dates: string[]; workouts: ScheduledWorkout[] }>();
   for (const sw of scheduled) {
     const effectiveDate = overrides.get(sw.workoutNum) ?? sw.scheduledDate;
-    const dateStr = isoDate(effectiveDate);
-    const existing = weekMap.get(sw.weekNum) ?? [];
-    existing.push(dateStr);
-    weekMap.set(sw.weekNum, existing);
+    const acc = weekAcc.get(sw.weekNum) ?? { dates: [], workouts: [] };
+    acc.dates.push(isoDate(effectiveDate));
+    acc.workouts.push(sw);
+    weekAcc.set(sw.weekNum, acc);
   }
 
-  const weekNums = [...new Set(scheduled.map((sw) => sw.weekNum))].sort((a, b) => a - b);
-  const weeks: CycleWeekSummary[] = weekNums.map((weekNum) => {
-    const workoutsInWeek = scheduled.filter((sw) => sw.weekNum === weekNum);
-    return {
-      week: weekNum as WeekNumber,
-      workoutDates: weekMap.get(weekNum) ?? [],
-      completed: workoutsInWeek.every((sw) => completedWorkoutNums.has(sw.workoutNum)),
-    };
-  });
+  const weeks: CycleWeekSummary[] = [...weekAcc.keys()]
+    .sort((a, b) => a - b)
+    .map((weekNum) => {
+      const { dates, workouts } = weekAcc.get(weekNum)!;
+      return {
+        week: weekNum as WeekNumber,
+        workoutDates: dates,
+        completed: workouts.every((sw) => completedWorkoutNums.has(sw.workoutNum)),
+      };
+    });
 
   return {
     program: d.program,

--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -9,6 +9,7 @@ import {
 import {
   CycleDashboardResponse,
   CyclePlanResponse,
+  CycleWeekSummary,
   LiftOverrideResponse,
   LiftRecordResponse,
   LiftingProgramSpecResponse,
@@ -21,6 +22,7 @@ import {
   WorkoutResponse,
 } from '@lifting-logbook/types';
 import { CyclePlanResult } from '../ports/ICyclePlanningAgent';
+import { ScheduledWorkout } from '../ports/ICycleScheduledWorkoutRepository';
 import { LiftOverride } from '../ports/IWorkoutLiftOverrideRepository';
 
 // All API date fields are emitted as `YYYY-MM-DD` in UTC. Domain `Date`
@@ -87,10 +89,8 @@ export const toLiftingProgramSpecResponse = (
 });
 
 /**
- * Maps a CycleDashboard to a CycleDashboardResponse.
- * Per-week summary composition (workout dates, completion status) requires
- * combining the dashboard with workouts and lift records — that belongs in a
- * core use case, not the mapper. Returns weeks=[] until that lands.
+ * Maps a CycleDashboard to a CycleDashboardResponse with no schedule data.
+ * Used when no scheduled workouts exist (no-schedule mode).
  */
 export const toCycleDashboardResponse = (
   d: CycleDashboard,
@@ -101,6 +101,50 @@ export const toCycleDashboardResponse = (
   weeks: [],
   currentWeekType: d.currentWeekType,
 });
+
+/**
+ * Builds a CycleDashboardResponse with per-week summaries derived from scheduled
+ * workout dates. When an override date exists for a workout it wins over the
+ * system-assigned scheduled date. A week is marked completed when every workout
+ * in that week has at least one lift record for the current cycle.
+ */
+export function buildCycleDashboardResponse(
+  d: CycleDashboard,
+  scheduled: ScheduledWorkout[],
+  overrides: Map<number, Date | null>,
+  completedWorkoutNums: Set<number>,
+): CycleDashboardResponse {
+  if (scheduled.length === 0) {
+    return toCycleDashboardResponse(d);
+  }
+
+  const weekMap = new Map<number, string[]>();
+  for (const sw of scheduled) {
+    const effectiveDate = overrides.get(sw.workoutNum) ?? sw.scheduledDate;
+    const dateStr = isoDate(effectiveDate);
+    const existing = weekMap.get(sw.weekNum) ?? [];
+    existing.push(dateStr);
+    weekMap.set(sw.weekNum, existing);
+  }
+
+  const weekNums = [...new Set(scheduled.map((sw) => sw.weekNum))].sort((a, b) => a - b);
+  const weeks: CycleWeekSummary[] = weekNums.map((weekNum) => {
+    const workoutsInWeek = scheduled.filter((sw) => sw.weekNum === weekNum);
+    return {
+      week: weekNum as WeekNumber,
+      workoutDates: weekMap.get(weekNum) ?? [],
+      completed: workoutsInWeek.every((sw) => completedWorkoutNums.has(sw.workoutNum)),
+    };
+  });
+
+  return {
+    program: d.program,
+    cycleNum: d.cycleNum,
+    cycleStartDate: isoDate(d.cycleDate),
+    weeks,
+    currentWeekType: d.currentWeekType,
+  };
+}
 
 export const toCyclePlanResponse = (r: CyclePlanResult): CyclePlanResponse => ({
   proposedChanges: r.proposedChanges.map((c) => ({

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -6,7 +6,10 @@ import {
   NestFastifyApplication,
 } from '@nestjs/platform-fastify';
 import { AppModule } from '../app.module';
+import { InMemoryRepositoryFactory } from '../adapters/factory/in-memory-repository-factory';
+import { InMemoryUserSettingsRepository } from '../adapters/in-memory/user-settings.adapter';
 import { SEED_PROGRAM } from '../adapters/in-memory/fixtures';
+import { REPOSITORY_FACTORY } from '../ports/tokens';
 import { DomainNotFoundFilter } from './not-found.filter';
 
 describe('Programs HTTP (e2e, in-memory adapters)', () => {
@@ -949,6 +952,99 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
       expect(body.muscleGroups).toEqual([]);
       expect(body.substitutions).toEqual([]);
       expect(body.foundational).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Schedule mode: verify distributeWorkouts() integrates with cycle lifecycle
+  // Uses a fresh user ID to avoid interfering with the seeded dev-token state.
+  // ---------------------------------------------------------------------------
+
+  describe('schedule mode', () => {
+    const SCHEDULE_USER_TOKEN = 'schedule-e2e-user';
+    const AS_SCHEDULE_USER = { authorization: `Bearer ${SCHEDULE_USER_TOKEN}` };
+
+    const scheduleGet = (url: string) =>
+      app.getHttpAdapter().getInstance().inject({ method: 'GET', url, headers: AS_SCHEDULE_USER });
+
+    const schedulePost = (url: string, body?: unknown) =>
+      app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url,
+        headers: body
+          ? { 'content-type': 'application/json', ...AS_SCHEDULE_USER }
+          : AS_SCHEDULE_USER,
+        ...(body ? { payload: JSON.stringify(body) } : {}),
+      });
+
+    async function setScheduleForUser(userId: string): Promise<void> {
+      const factory = app.get<InMemoryRepositoryFactory>(REPOSITORY_FACTORY);
+      const bundle = await factory.forUser({ id: userId, email: '', provider: 'dev' });
+      (bundle.userSettings as InMemoryUserSettingsRepository).setSchedule({
+        type: 'fixed',
+        days: [0, 2, 4], // Mon, Wed, Fri
+      });
+    }
+
+    it('GET cycle dashboard returns weeks:[] when no schedule is set', async () => {
+      await schedulePost(`/programs/${SEED_PROGRAM}/cycles/initialize`, { cycleDate: '2026-05-19' });
+      const res = await scheduleGet(`/programs/${SEED_PROGRAM}/cycles/current`);
+      expect(res.statusCode).toBe(200);
+      expect(res.json().weeks).toEqual([]);
+    });
+
+    it('GET cycle dashboard returns populated weeks when schedule is set before cycle init', async () => {
+      const userId = 'schedule-e2e-with-schedule';
+      const token = `Bearer ${userId}`;
+      await setScheduleForUser(userId);
+
+      const initRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/cycles/initialize`,
+        headers: { 'content-type': 'application/json', authorization: token },
+        payload: JSON.stringify({ cycleDate: '2026-05-19' }),
+      });
+      expect(initRes.statusCode).toBe(201);
+
+      const dashRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'GET',
+        url: `/programs/${SEED_PROGRAM}/cycles/current`,
+        headers: { authorization: token },
+      });
+      expect(dashRes.statusCode).toBe(200);
+      const body = dashRes.json();
+      expect(Array.isArray(body.weeks)).toBe(true);
+      expect(body.weeks.length).toBeGreaterThan(0);
+      // Mon-Wed-Fri schedule: week 1 should have dates on Mon/Wed/Fri
+      const week1 = body.weeks[0];
+      expect(week1.week).toBe(1);
+      expect(week1.workoutDates.length).toBeGreaterThan(0);
+      expect(week1.completed).toBe(false);
+      // Each date should be a valid ISO date string
+      for (const d of week1.workoutDates) {
+        expect(d).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      }
+    });
+
+    it('GET cycle dashboard returns weeks:[] when no schedule is set (schedule user baseline)', async () => {
+      // A fresh user with no schedule should still see weeks:[]
+      const userId = 'schedule-e2e-no-schedule';
+      const token = `Bearer ${userId}`;
+
+      await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/cycles/initialize`,
+        headers: { 'content-type': 'application/json', authorization: token },
+        payload: JSON.stringify({ cycleDate: '2026-05-19' }),
+      });
+
+      const dashRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'GET',
+        url: `/programs/${SEED_PROGRAM}/cycles/current`,
+        headers: { authorization: token },
+      });
+      expect(dashRes.statusCode).toBe(200);
+      expect(dashRes.json().weeks).toEqual([]);
     });
   });
 });

--- a/apps/api/src/user-settings/user-settings.repository.ts
+++ b/apps/api/src/user-settings/user-settings.repository.ts
@@ -1,10 +1,10 @@
-import { Prisma } from '@prisma/client';
-import { PrismaService } from '../adapters/prisma/prisma.service';
+import { Prisma, PrismaClient } from '@prisma/client';
 import {
   UserSettingsResponse,
   UserWorkoutSchedule,
   isValidSchedule,
 } from '@lifting-logbook/types';
+import { IUserSettingsRepository } from '../ports/IUserSettingsRepository';
 
 export interface UpsertSettingsPatch {
   activeProgram?: string;
@@ -21,9 +21,9 @@ function parseSchedule(value: unknown): UserWorkoutSchedule | null {
   return isValidSchedule(value) ? value : null;
 }
 
-export class UserSettingsRepository {
+export class UserSettingsRepository implements IUserSettingsRepository {
   constructor(
-    private readonly prisma: PrismaService,
+    private readonly prisma: PrismaClient,
     private readonly userId: string,
   ) {}
 


### PR DESCRIPTION
## Summary

Wires `distributeWorkouts()` (Phase 2) into the cycle lifecycle so `GET /programs/:program/cycles/current` returns `weeks: CycleWeekSummary[]` populated with scheduled workout dates, override resolution, and completion status.

- Add `CycleScheduledWorkout` DB table storing system-assigned workout dates per (userId, program, cycleNum, workoutNum)
- Add `IUserSettingsRepository` and `ICycleScheduledWorkoutRepository` port interfaces
- Add in-memory adapters for both (used by E2E tests) and a Prisma adapter for `CycleScheduledWorkout`
- Wire both repos into all three factory implementations (in-memory, Prisma, system-db)
- At cycle creation, if the user has a `workoutSchedule`, call `distributeWorkouts()` and persist dates via `saveScheduledWorkouts()`
- Add `buildCycleDashboardResponse()` mapper with date override resolution (override > scheduled > none) and per-week completion tracking
- Dashboard endpoint now returns populated `weeks` when schedule is active; returns `weeks: []` in no-schedule mode (backward-compatible)

## Acceptance Criteria

- [x] `CycleDashboardResponse.weeks` populated with scheduled dates when user has a `workoutSchedule`
- [x] `distributeWorkouts()` called at cycle creation; dates persisted to `cycle_scheduled_workout`
- [x] Date resolution: `workoutDateOverride.newDate` > `cycleScheduledWorkout.scheduledDate`
- [x] `weeks: []` returned when no schedule is set (no-schedule mode unchanged)
- [x] Week `completed: true` when all workouts in that week have lift records
- [x] Unit tests for cycle generation with/without schedule
- [x] Unit tests for dashboard controller (no workouts, populated, override, completion)
- [x] E2E integration tests for schedule mode on/off

## Test Results

All 265 tests pass (19 test suites):
```
Test Suites: 1 skipped, 19 passed, 19 of 20 total
Tests:       51 skipped, 214 passed, 265 total
```

Build passes across all workspaces (`5 successful, 5 total`).

Closes #269 (Phase 3 of 5)