### PR TITLE
[feat] Lift Record Scheduling (Phase 4 of 5)

### DIFF
--- a/apps/api/src/programs/cycle-dashboard.controller.spec.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.spec.ts
@@ -137,12 +137,15 @@ describe('CycleDashboardController', () => {
     expect(result.weeks).toHaveLength(2);
     expect(result.weeks[0]).toEqual({
       week: 1,
-      workoutDates: ['2026-04-21', '2026-04-23'],
+      workouts: [
+        { workoutNum: 1, date: '2026-04-21' },
+        { workoutNum: 2, date: '2026-04-23' },
+      ],
       completed: false,
     });
     expect(result.weeks[1]).toEqual({
       week: 2,
-      workoutDates: ['2026-04-28'],
+      workouts: [{ workoutNum: 3, date: '2026-04-28' }],
       completed: false,
     });
   });
@@ -157,7 +160,7 @@ describe('CycleDashboardController', () => {
 
     const result = await controller.getCurrentCycle('5-3-1', MOCK_USER);
 
-    expect(result.weeks[0]?.workoutDates).toEqual(['2026-04-25']);
+    expect(result.weeks[0]?.workouts).toEqual([{ workoutNum: 1, date: '2026-04-25' }]);
   });
 
   it('marks a week as completed when all its workouts have lift records', async () => {

--- a/apps/api/src/programs/lift-records.controller.ts
+++ b/apps/api/src/programs/lift-records.controller.ts
@@ -58,12 +58,22 @@ export class LiftRecordsController {
     @Body() body: CreateLiftRecordRequest,
     @CurrentUser() user: AuthUser,
   ): Promise<LiftRecordResponse> {
-    const { liftRecord } = await this.factory.forUser(user);
+    const { liftRecord, cycleScheduledWorkout } = await this.factory.forUser(user);
+
+    let effectiveDate: Date;
+    if (body.date) {
+      effectiveDate = new Date(body.date);
+    } else {
+      const scheduled = await cycleScheduledWorkout.getScheduledWorkouts(program, body.cycleNum);
+      const match = scheduled.find((s) => s.workoutNum === body.workoutNum);
+      effectiveDate = match?.scheduledDate ?? new Date();
+    }
+
     const record = {
       program,
       cycleNum: body.cycleNum,
       workoutNum: body.workoutNum,
-      date: new Date(body.date),
+      date: effectiveDate,
       lift: body.lift,
       setNum: body.setNum,
       weight: body.weight,

--- a/apps/api/src/programs/mappers.spec.ts
+++ b/apps/api/src/programs/mappers.spec.ts
@@ -1,6 +1,7 @@
-import { LiftingProgramSpec } from '@lifting-logbook/core';
-import { applyLiftOverrides, toWorkoutResponse, weekForWorkoutNum } from './mappers';
+import { CycleDashboard, LiftingProgramSpec, Weekday } from '@lifting-logbook/core';
+import { applyLiftOverrides, buildCycleDashboardResponse, toWorkoutResponse, weekForWorkoutNum } from './mappers';
 import { LiftOverride } from '../ports/IWorkoutLiftOverrideRepository';
+import { ScheduledWorkout } from '../ports/ICycleScheduledWorkoutRepository';
 
 const baseFields: Omit<LiftingProgramSpec, 'offset' | 'lift' | 'week'> = {
   increment: 5,
@@ -158,5 +159,76 @@ describe('toWorkoutResponse with plannedLifts', () => {
     const records = [record('Squat', 1, 200)];
     const result = toWorkoutResponse(program, cycleNum, workoutNum, week, records);
     expect(result.lifts[0]).toMatchObject({ lift: 'Squat', planned: false });
+  });
+
+  it('uses scheduledDate as date when no records exist', () => {
+    const scheduledDate = new Date('2026-06-02T00:00:00.000Z');
+    const result = toWorkoutResponse(program, cycleNum, workoutNum, week, [], undefined, undefined, scheduledDate);
+    expect(result.date).toBe('2026-06-02');
+  });
+
+  it('prefers first record date over scheduledDate when records exist', () => {
+    const records = [record('Squat', 1, 200)];
+    const scheduledDate = new Date('2026-06-02T00:00:00.000Z');
+    const result = toWorkoutResponse(program, cycleNum, workoutNum, week, records, undefined, undefined, scheduledDate);
+    expect(result.date).toBe(records[0]!.date.toISOString().slice(0, 10));
+  });
+});
+
+describe('buildCycleDashboardResponse', () => {
+  const baseDashboard: CycleDashboard = {
+    program: 'test-531',
+    cycleNum: 1,
+    cycleDate: new Date('2026-05-19T00:00:00.000Z'),
+    currentWeekType: 1,
+    cycleUnit: 'week',
+    sheetName: 'Sheet1',
+    cycleStartWeekday: Weekday.Monday,
+  };
+
+  const sw = (workoutNum: number, weekNum: number, date: string): ScheduledWorkout => ({
+    workoutNum,
+    weekNum,
+    scheduledDate: new Date(`${date}T00:00:00.000Z`),
+  });
+
+  it('returns base response when scheduled array is empty', () => {
+    const result = buildCycleDashboardResponse(baseDashboard, [], new Map(), new Set());
+    expect(result.weeks).toEqual([]);
+  });
+
+  it('emits workouts[] with workoutNum and date per entry', () => {
+    const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21'), sw(3, 2, '2026-05-26')];
+    const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), new Set());
+    expect(result.weeks).toHaveLength(2);
+    const week1 = result.weeks[0]!;
+    expect(week1.week).toBe(1);
+    expect(week1.workouts).toHaveLength(2);
+    expect(week1.workouts[0]).toEqual({ workoutNum: 1, date: '2026-05-19' });
+    expect(week1.workouts[1]).toEqual({ workoutNum: 2, date: '2026-05-21' });
+    expect(week1.completed).toBe(false);
+    const week2 = result.weeks[1]!;
+    expect(week2.workouts[0]).toEqual({ workoutNum: 3, date: '2026-05-26' });
+  });
+
+  it('applies override date when present', () => {
+    const scheduled = [sw(1, 1, '2026-05-19')];
+    const overrides = new Map([[1, new Date('2026-05-20T00:00:00.000Z')]]);
+    const result = buildCycleDashboardResponse(baseDashboard, scheduled, overrides, new Set());
+    expect(result.weeks[0]!.workouts[0]).toEqual({ workoutNum: 1, date: '2026-05-20' });
+  });
+
+  it('marks week completed when all workouts have records', () => {
+    const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21')];
+    const completed = new Set([1, 2]);
+    const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), completed);
+    expect(result.weeks[0]!.completed).toBe(true);
+  });
+
+  it('week is incomplete when only some workouts have records', () => {
+    const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21')];
+    const completed = new Set([1]);
+    const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), completed);
+    expect(result.weeks[0]!.completed).toBe(false);
   });
 });

--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -20,6 +20,7 @@ import {
   WeekNumber,
   WorkoutLiftResponse,
   WorkoutResponse,
+  WorkoutSummary,
 } from '@lifting-logbook/types';
 import { CyclePlanResult } from '../ports/ICyclePlanningAgent';
 import { ScheduledWorkout } from '../ports/ICycleScheduledWorkoutRepository';
@@ -118,23 +119,23 @@ export function buildCycleDashboardResponse(
     return toCycleDashboardResponse(d);
   }
 
-  const weekAcc = new Map<number, { dates: string[]; workouts: ScheduledWorkout[] }>();
+  const weekAcc = new Map<number, { workouts: WorkoutSummary[]; scheduled: ScheduledWorkout[] }>();
   for (const sw of scheduled) {
     const effectiveDate = overrides.get(sw.workoutNum) ?? sw.scheduledDate;
-    const acc = weekAcc.get(sw.weekNum) ?? { dates: [], workouts: [] };
-    acc.dates.push(isoDate(effectiveDate));
-    acc.workouts.push(sw);
+    const acc = weekAcc.get(sw.weekNum) ?? { workouts: [], scheduled: [] };
+    acc.workouts.push({ workoutNum: sw.workoutNum, date: isoDate(effectiveDate) });
+    acc.scheduled.push(sw);
     weekAcc.set(sw.weekNum, acc);
   }
 
   const weeks: CycleWeekSummary[] = [...weekAcc.keys()]
     .sort((a, b) => a - b)
     .map((weekNum) => {
-      const { dates, workouts } = weekAcc.get(weekNum)!;
+      const { workouts, scheduled } = weekAcc.get(weekNum)!;
       return {
         week: weekNum as WeekNumber,
-        workoutDates: dates,
-        completed: workouts.every((sw) => completedWorkoutNums.has(sw.workoutNum)),
+        workouts,
+        completed: scheduled.every((sw) => completedWorkoutNums.has(sw.workoutNum)),
       };
     });
 
@@ -225,6 +226,7 @@ export const toWorkoutResponse = (
   records: LiftRecord[],
   overrideDate?: Date,
   plannedLifts?: string[],
+  scheduledDate?: Date,
 ): WorkoutResponse => {
   const liftMap = new Map<string, SetResponse[]>();
   for (const r of records) {
@@ -261,7 +263,11 @@ export const toWorkoutResponse = (
     }));
   }
 
-  const date = records[0] ? isoDate(records[0].date) : isoDate(new Date());
+  const date = records[0]
+    ? isoDate(records[0].date)
+    : scheduledDate
+      ? isoDate(scheduledDate)
+      : isoDate(new Date());
   return {
     program,
     cycleNum,

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -1018,12 +1018,87 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
       // Mon-Wed-Fri schedule: week 1 should have dates on Mon/Wed/Fri
       const week1 = body.weeks[0];
       expect(week1.week).toBe(1);
-      expect(week1.workoutDates.length).toBeGreaterThan(0);
+      expect(Array.isArray(week1.workouts)).toBe(true);
+      expect(week1.workouts.length).toBeGreaterThan(0);
       expect(week1.completed).toBe(false);
-      // Each date should be a valid ISO date string
-      for (const d of week1.workoutDates) {
-        expect(d).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      // Each workout entry should have workoutNum and a valid ISO date string
+      for (const ws of week1.workouts) {
+        expect(typeof ws.workoutNum).toBe('number');
+        expect(ws.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
       }
+    });
+
+    it('GET workout returns scheduled date as date when no records exist and schedule is active', async () => {
+      const userId = 'schedule-e2e-workout-date';
+      const token = `Bearer ${userId}`;
+      await setScheduleForUser(userId);
+
+      await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/cycles/initialize`,
+        headers: { 'content-type': 'application/json', authorization: token },
+        payload: JSON.stringify({ cycleDate: '2026-05-19' }),
+      });
+
+      // Get the scheduled date for workout 1 from the dashboard
+      const dashRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'GET',
+        url: `/programs/${SEED_PROGRAM}/cycles/current`,
+        headers: { authorization: token },
+      });
+      const dashBody = dashRes.json();
+      const allWorkouts = dashBody.weeks.flatMap((w: { workouts: { workoutNum: number; date: string }[] }) => w.workouts);
+      const scheduled = allWorkouts.find((ws: { workoutNum: number }) => ws.workoutNum === 1);
+      expect(scheduled).toBeDefined();
+
+      // GET workout 1 — should return the scheduled date as `date`
+      const workoutRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'GET',
+        url: `/programs/${SEED_PROGRAM}/workouts/1`,
+        headers: { authorization: token },
+      });
+      expect(workoutRes.statusCode).toBe(200);
+      expect(workoutRes.json().date).toBe(scheduled!.date);
+    });
+
+    it('POST lift-records without date uses scheduled date', async () => {
+      const userId = 'schedule-e2e-lift-record-date';
+      const token = `Bearer ${userId}`;
+      await setScheduleForUser(userId);
+
+      await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/cycles/initialize`,
+        headers: { 'content-type': 'application/json', authorization: token },
+        payload: JSON.stringify({ cycleDate: '2026-05-19' }),
+      });
+
+      // Get the scheduled date for workout 1
+      const dashRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'GET',
+        url: `/programs/${SEED_PROGRAM}/cycles/current`,
+        headers: { authorization: token },
+      });
+      const allWorkouts = dashRes.json().weeks.flatMap((w: { workouts: { workoutNum: number; date: string }[] }) => w.workouts);
+      const scheduledDate = allWorkouts.find((ws: { workoutNum: number }) => ws.workoutNum === 1)!.date;
+
+      // POST lift record without date
+      const recordRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/lift-records`,
+        headers: { 'content-type': 'application/json', authorization: token },
+        payload: JSON.stringify({
+          program: SEED_PROGRAM,
+          cycleNum: 1,
+          workoutNum: 1,
+          lift: 'Squat',
+          setNum: 1,
+          weight: 135,
+          reps: 5,
+        }),
+      });
+      expect(recordRes.statusCode).toBe(201);
+      expect(recordRes.json().date).toBe(scheduledDate);
     });
 
     it('GET cycle dashboard returns weeks:[] when no schedule is set (schedule user baseline)', async () => {

--- a/apps/api/src/programs/workouts.controller.spec.ts
+++ b/apps/api/src/programs/workouts.controller.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Weekday } from '@lifting-logbook/core';
 import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
+import { ICycleScheduledWorkoutRepository } from '../ports/ICycleScheduledWorkoutRepository';
 import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
 import { IWorkoutDateOverrideRepository } from '../ports/IWorkoutDateOverrideRepository';
 import { IWorkoutLiftOverrideRepository } from '../ports/IWorkoutLiftOverrideRepository';
@@ -20,6 +21,7 @@ describe('WorkoutsController', () => {
   let specRepo: jest.Mocked<ILiftingProgramSpecRepository>;
   let overrideRepo: jest.Mocked<IWorkoutDateOverrideRepository>;
   let liftOverrideRepo: jest.Mocked<IWorkoutLiftOverrideRepository>;
+  let scheduledWorkoutRepo: jest.Mocked<ICycleScheduledWorkoutRepository>;
   let factory: jest.Mocked<IRepositoryFactory>;
 
   beforeEach(async () => {
@@ -38,10 +40,15 @@ describe('WorkoutsController', () => {
       upsertOverride: jest.fn().mockResolvedValue(undefined),
       deleteOverride: jest.fn().mockResolvedValue(undefined),
     };
+    scheduledWorkoutRepo = {
+      getScheduledWorkouts: jest.fn().mockResolvedValue([]),
+      saveScheduledWorkouts: jest.fn().mockResolvedValue(undefined),
+    };
     factory = {
       forUser: jest.fn().mockResolvedValue({
         workout: workoutRepo,
         cycleDashboard: dashboardRepo,
+        cycleScheduledWorkout: scheduledWorkoutRepo,
         liftingProgramSpec: specRepo,
         workoutDateOverride: overrideRepo,
         workoutLiftOverride: liftOverrideRepo,

--- a/apps/api/src/programs/workouts.controller.ts
+++ b/apps/api/src/programs/workouts.controller.ts
@@ -35,7 +35,7 @@ export class WorkoutsController {
     if (!isValidWorkoutNum(workoutNum)) {
       throw new BadRequestException('workoutNum must be a positive integer');
     }
-    const { workout, cycleDashboard, liftingProgramSpec, workoutDateOverride, workoutLiftOverride } =
+    const { workout, cycleDashboard, cycleScheduledWorkout, liftingProgramSpec, workoutDateOverride, workoutLiftOverride } =
       await this.factory.forUser(user);
     const [dashboard, spec] = await Promise.all([
       cycleDashboard.getCycleDashboard(program).catch((err: unknown) => {
@@ -54,7 +54,7 @@ export class WorkoutsController {
     // Spec lifts for this workout's week — used to build the planned lift list.
     const specLifts = [...new Set(spec.filter((s) => s.week === week).map((s) => s.lift))];
 
-    const [records, overrideDate, liftOverrides] = await Promise.all([
+    const [records, overrideDate, liftOverrides, scheduledWorkouts] = await Promise.all([
       workout
         .getWorkout(program, dashboard.cycleNum, workoutNum)
         .catch((err: unknown) => {
@@ -64,7 +64,9 @@ export class WorkoutsController {
         }),
       workoutDateOverride.getOverride(program, dashboard.cycleNum, workoutNum),
       workoutLiftOverride.getOverrides(program, dashboard.cycleNum, workoutNum),
+      cycleScheduledWorkout.getScheduledWorkouts(program, dashboard.cycleNum),
     ]);
+    const scheduledDate = scheduledWorkouts.find((s) => s.workoutNum === workoutNum)?.scheduledDate;
 
     const plannedLifts = applyLiftOverrides(specLifts, liftOverrides);
 
@@ -91,6 +93,7 @@ export class WorkoutsController {
       adjustedRecords,
       overrideDate ?? undefined,
       plannedLifts,
+      scheduledDate,
     );
   }
 }

--- a/apps/web/app/cycle/[cycleNum]/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/page.tsx
@@ -41,6 +41,15 @@ export default async function CycleDashboardPage({
     workoutDays.map((w, i) => [w.workoutNum, workoutResponseList[i]]),
   );
 
+  // Build a flat workoutNum → scheduled date lookup from the cycle dashboard response.
+  // This is populated when schedule mode is active; empty when no schedule is set.
+  const scheduledDateMap = new Map<number, string>();
+  for (const week of dashboard.weeks) {
+    for (const ws of week.workouts) {
+      scheduledDateMap.set(ws.workoutNum, ws.date);
+    }
+  }
+
   const today = new Date().toISOString().slice(0, 10);
   const maxMap = new Map(maxes.map((m) => [m.lift, m.weight]));
 
@@ -53,9 +62,8 @@ export default async function CycleDashboardPage({
       .map((w): WorkoutCell => {
         const response = workoutResponseMap.get(w.workoutNum);
         const logged = response != null && response.lifts.length > 0;
-        // Prefer the user's overridden date when one exists; fall back to the computed schedule date.
-        // Status comparison uses UTC date strings (ISO YYYY-MM-DD) consistently across dashboard and detail page.
-        const effectiveDate = response?.overrideDate ?? w.date;
+        // Priority: user override date > API scheduled date > spec-computed date.
+        const effectiveDate = response?.overrideDate ?? scheduledDateMap.get(w.workoutNum) ?? w.date;
         const status: WorkoutCell['status'] = logged
           ? 'completed'
           : effectiveDate < today

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.module.css
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.module.css
@@ -47,6 +47,32 @@
 }
 
 /* ---------------------------------------------------------------------------
+   Date override row
+   --------------------------------------------------------------------------- */
+
+.dateRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) 0 var(--space-3);
+}
+
+.dateLabel {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.dateInput {
+  font-size: var(--font-size-sm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+/* ---------------------------------------------------------------------------
    Navigation dots
    --------------------------------------------------------------------------- */
 

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { LiftRecordResponse } from '@lifting-logbook/types';
 import {
   createLiftRecord,
@@ -480,6 +480,7 @@ export default function WorkoutLogger({
 
   // Editable date — initialized from the server-provided scheduled date, user can override.
   const [effectiveDate, setEffectiveDate] = useState(date);
+  useEffect(() => { setEffectiveDate(date); }, [date]);
 
   // Initialize loggedSets from any pre-existing records passed via server props
   const [loggedSets, setLoggedSets] = useState<Map<string, LiftRecordResponse>>(

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
@@ -478,6 +478,9 @@ export default function WorkoutLogger({
 }: WorkoutLoggerProps) {
   const router = useRouter();
 
+  // Editable date — initialized from the server-provided scheduled date, user can override.
+  const [effectiveDate, setEffectiveDate] = useState(date);
+
   // Initialize loggedSets from any pre-existing records passed via server props
   const [loggedSets, setLoggedSets] = useState<Map<string, LiftRecordResponse>>(
     () => {
@@ -503,7 +506,7 @@ export default function WorkoutLogger({
 
   async function handleBodyWeightSubmit(weight: number) {
     await recordBodyWeight(program, {
-      date,
+      date: effectiveDate,
       weight,
       unit: 'lbs',
     });
@@ -594,6 +597,21 @@ export default function WorkoutLogger({
         </button>
       </header>
 
+      {!isReadOnly && (
+        <div className={styles.dateRow}>
+          <label className={styles.dateLabel} htmlFor="workout-date">
+            Date
+          </label>
+          <input
+            id="workout-date"
+            className={styles.dateInput}
+            type="date"
+            value={effectiveDate}
+            onChange={(e) => setEffectiveDate(e.target.value)}
+          />
+        </div>
+      )}
+
       {/* Navigation dots */}
       <nav className={styles.navDots} aria-label="Exercise navigation">
         {lifts.map((lift, i) => {
@@ -624,7 +642,7 @@ export default function WorkoutLogger({
           program={program}
           cycleNum={cycleNum}
           workoutNum={workoutNum}
-          date={date}
+          date={effectiveDate}
           onLogged={handleLogged}
           onEditStart={handleEditStart}
           onEditSave={handleEditSave}

--- a/apps/web/lib/__tests__/programPlan.test.ts
+++ b/apps/web/lib/__tests__/programPlan.test.ts
@@ -3,9 +3,13 @@ import { deriveProgramPhases, deriveProgramSummary } from '../programPlan';
 
 const makeWeek = (
   week: number,
-  workoutDates: string[],
+  dates: string[],
   completed: boolean,
-): CycleWeekSummary => ({ week, workoutDates, completed });
+): CycleWeekSummary => ({
+  week,
+  workouts: dates.map((date, i) => ({ workoutNum: i + 1, date })),
+  completed,
+});
 
 const makeSpec = (
   overrides: Partial<LiftingProgramSpecResponse>,

--- a/apps/web/lib/programPlan.ts
+++ b/apps/web/lib/programPlan.ts
@@ -44,7 +44,7 @@ function phaseStatus(
   const summaries = weeks.map((w) => weekMap.get(w));
   if (summaries.every((s) => s?.completed)) return 'completed';
   const hasStarted = summaries.some((s) =>
-    s?.workoutDates.some((d) => d <= today),
+    s?.workouts.some((w) => w.date <= today),
   );
   return hasStarted ? 'in-progress' : 'upcoming';
 }

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -119,7 +119,8 @@ export interface CreateLiftRecordRequest {
   program: string;
   cycleNum: CycleNumber;
   workoutNum: number;
-  date: string; // ISO 8601 date string
+  /** ISO 8601 date string. When omitted the server uses the scheduled date for this workout, falling back to today. */
+  date?: string;
   lift: LiftName;
   setNum: number;
   weight: number;
@@ -178,10 +179,16 @@ export interface UpsertStrengthGoalRequest {
 // Cycle Dashboard
 // ---------------------------------------------------------------------------
 
+/** Per-workout entry within a cycle week summary. */
+export interface WorkoutSummary {
+  workoutNum: number;
+  date: string; // ISO 8601 scheduled date
+}
+
 /** Per-week summary within a cycle dashboard. */
 export interface CycleWeekSummary {
   week: WeekNumber;
-  workoutDates: string[]; // ISO 8601 date strings
+  workouts: WorkoutSummary[];
   completed: boolean;
 }
 


### PR DESCRIPTION
## Summary

- Replaces `CycleWeekSummary.workoutDates: string[]` with `workouts: WorkoutSummary[]` — each entry carries `{ workoutNum, date }` so per-workout date lookups are no longer positionally coupled
- `GET /programs/:program/workouts/:workoutNum` now returns the scheduled date as `date` for upcoming workouts (no records) when schedule mode is active; falls back to today
- `POST /programs/:program/lift-records` accepts an optional `date` field; when omitted the server looks up the scheduled date from `cycleScheduledWorkout` and falls back to today
- Cycle dashboard page uses `dashboard.weeks[*].workouts[*].date` (scheduled dates) over spec-computed dates when schedule mode is active
- `WorkoutLogger` converts the `date` prop to local state and renders an inline date input so users can override the pre-populated scheduled date before logging; a `useEffect` keeps the state in sync when the prop changes on re-render

## Testing

All 274 tests pass (51 skipped); the API build errors are pre-existing Prisma type mismatches unrelated to this change (confirmed by verifying they exist on `main` before any edits).

New tests:
- **`mappers.spec.ts`**: `buildCycleDashboardResponse` emits `workouts[]` with `{ workoutNum, date }` per entry; `toWorkoutResponse` uses `scheduledDate` when no records exist
- **`programs.e2e.spec.ts`**: `GET /workouts/1` returns scheduled date when schedule active; `POST /lift-records` without `date` uses scheduled date; dashboard shape updated to `workouts[]`

## Manual Test Plan (date input — Playwright deferred until #259)

1. **Schedule-active, new workout**: activate a Mon/Wed/Fri schedule, initialize a cycle, open an upcoming workout — the date input should be pre-populated with the scheduled date (not today's date unless they coincide)
2. **Date override propagates to records**: on an in-progress workout, change the date input, then log a set — the saved lift record's date should match the overridden date, not the original scheduled date
3. **Date override propagates to body weight**: if the workout has a bodyweight component, change the date input, then record body weight — the saved entry's date should match the overridden date
4. **No-schedule fallback**: open a workout for a user with no schedule configured — the date input should default to today's date
5. **Re-render sync**: navigate away and back to the workout — the date input resets to the server-provided scheduled date (not a stale client value)

## Acceptance Criteria

- [x] `GET /programs/:program/workouts/:workoutNum` returns scheduled date as `date` when no records and schedule active
- [x] `GET /programs/:program/cycles/current` returns `weeks[].workouts[{ workoutNum, date }]`
- [x] `POST /programs/:program/lift-records` without `date` uses scheduled date
- [x] Cycle dashboard grid shows correct scheduled dates per workout card
- [x] Lift logging UI pre-populates date with scheduled date and allows override
- [x] Date state stays in sync with server-provided date on re-render

Closes #273
