### PR TITLE
[feat] Workout Skip Override (Phase 4.5 of 5)

### DIFF
--- a/apps/api/prisma/migrations/20260517000003_add_workout_skip_override/migration.sql
+++ b/apps/api/prisma/migrations/20260517000003_add_workout_skip_override/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "workout_skip_override" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "program" TEXT NOT NULL,
+    "cycleNum" INTEGER NOT NULL,
+    "workoutNum" INTEGER NOT NULL,
+    "reason" TEXT,
+    "skippedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "workout_skip_override_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "workout_skip_override_userId_program_cycleNum_workoutNum_key" ON "workout_skip_override"("userId", "program", "cycleNum", "workoutNum");
+
+-- CreateIndex
+CREATE INDEX "workout_skip_override_userId_program_cycleNum_idx" ON "workout_skip_override"("userId", "program", "cycleNum");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -105,6 +105,20 @@ model WorkoutDateOverride {
   @@map("workout_date_override")
 }
 
+model WorkoutSkipOverride {
+  id         String   @id @default(uuid())
+  userId     String
+  program    String
+  cycleNum   Int
+  workoutNum Int
+  reason     String?
+  skippedAt  DateTime @default(now())
+
+  @@unique([userId, program, cycleNum, workoutNum])
+  @@index([userId, program, cycleNum])
+  @@map("workout_skip_override")
+}
+
 model WorkoutLiftOverride {
   id         String   @id @default(cuid())
   userId     String

--- a/apps/api/src/adapters/factory/in-memory-repository-factory.ts
+++ b/apps/api/src/adapters/factory/in-memory-repository-factory.ts
@@ -15,6 +15,7 @@ import { InMemoryUserSettingsRepository } from '../in-memory/user-settings.adapt
 import { InMemoryWorkoutDateOverrideRepository } from '../in-memory/workout-date-override.adapter';
 import { InMemoryWorkoutLiftOverrideRepository } from '../in-memory/workout-lift-override.adapter';
 import { InMemoryWorkoutRepository } from '../in-memory/workout.adapter';
+import { InMemoryWorkoutSkipOverrideRepository } from '../in-memory/workout-skip-override.adapter';
 import { SEED_PROGRAM, seedLiftRecords } from '../in-memory/fixtures';
 
 // The dev seed user gets pre-populated training maxes so existing tests that
@@ -47,6 +48,7 @@ export class InMemoryRepositoryFactory implements IRepositoryFactory {
         workout: new InMemoryWorkoutRepository(sharedRecords),
         workoutDateOverride: new InMemoryWorkoutDateOverrideRepository(),
         workoutLiftOverride: new InMemoryWorkoutLiftOverrideRepository(),
+        workoutSkipOverride: new InMemoryWorkoutSkipOverrideRepository(),
       });
     }
     return this.bundles.get(user.id)!;

--- a/apps/api/src/adapters/factory/system-db-repository-factory.ts
+++ b/apps/api/src/adapters/factory/system-db-repository-factory.ts
@@ -27,6 +27,8 @@ import { InMemoryWorkoutDateOverrideRepository } from '../in-memory/workout-date
 import { InMemoryWorkoutLiftOverrideRepository } from '../in-memory/workout-lift-override.adapter';
 import { InMemoryWorkoutRepository } from '../in-memory/workout.adapter';
 import { PrismaCycleScheduledWorkoutRepository } from '../prisma/cycle-scheduled-workout.repository';
+import { PrismaWorkoutSkipOverrideRepository } from '../prisma/workout-skip-override.repository';
+import { InMemoryWorkoutSkipOverrideRepository } from '../in-memory/workout-skip-override.adapter';
 import { UserSettingsRepository } from '../../user-settings/user-settings.repository';
 
 interface UserDataSourceRow {
@@ -95,6 +97,7 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
         workout: new PrismaWorkoutRepository(prisma, userId),
         workoutDateOverride: new PrismaWorkoutDateOverrideRepository(prisma, userId),
         workoutLiftOverride: new PrismaWorkoutLiftOverrideRepository(prisma, userId),
+        workoutSkipOverride: new PrismaWorkoutSkipOverrideRepository(prisma, userId),
         liftingProgramSpec: this.programSpecRepo,
       };
     }
@@ -117,6 +120,7 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
       workout: new InMemoryWorkoutRepository(sharedRecords),
       workoutDateOverride: new InMemoryWorkoutDateOverrideRepository(),
       workoutLiftOverride: new InMemoryWorkoutLiftOverrideRepository(),
+      workoutSkipOverride: new InMemoryWorkoutSkipOverrideRepository(),
     };
   }
 

--- a/apps/api/src/adapters/in-memory/workout-skip-override.adapter.ts
+++ b/apps/api/src/adapters/in-memory/workout-skip-override.adapter.ts
@@ -11,7 +11,7 @@ export class InMemoryWorkoutSkipOverrideRepository implements IWorkoutSkipOverri
     return new Set(this.store.get(this.key(program, cycleNum)) ?? []);
   }
 
-  async skipWorkout(program: string, cycleNum: number, workoutNum: number): Promise<void> {
+  async skipWorkout(program: string, cycleNum: number, workoutNum: number, _reason?: string): Promise<void> {
     const k = this.key(program, cycleNum);
     const set = this.store.get(k) ?? new Set<number>();
     set.add(workoutNum);

--- a/apps/api/src/adapters/in-memory/workout-skip-override.adapter.ts
+++ b/apps/api/src/adapters/in-memory/workout-skip-override.adapter.ts
@@ -1,0 +1,24 @@
+import { IWorkoutSkipOverrideRepository } from '../../ports/IWorkoutSkipOverrideRepository';
+
+export class InMemoryWorkoutSkipOverrideRepository implements IWorkoutSkipOverrideRepository {
+  private readonly store = new Map<string, Set<number>>();
+
+  private key(program: string, cycleNum: number): string {
+    return `${program}:${cycleNum}`;
+  }
+
+  async getSkipsForCycle(program: string, cycleNum: number): Promise<Set<number>> {
+    return new Set(this.store.get(this.key(program, cycleNum)) ?? []);
+  }
+
+  async skipWorkout(program: string, cycleNum: number, workoutNum: number): Promise<void> {
+    const k = this.key(program, cycleNum);
+    const set = this.store.get(k) ?? new Set<number>();
+    set.add(workoutNum);
+    this.store.set(k, set);
+  }
+
+  async unskipWorkout(program: string, cycleNum: number, workoutNum: number): Promise<void> {
+    this.store.get(this.key(program, cycleNum))?.delete(workoutNum);
+  }
+}

--- a/apps/api/src/adapters/prisma/prisma-repository-factory.ts
+++ b/apps/api/src/adapters/prisma/prisma-repository-factory.ts
@@ -11,6 +11,7 @@ import { PrismaTrainingMaxRepository } from './training-max.repository';
 import { PrismaTrainingMaxHistoryRepository } from './training-max-history.repository';
 import { PrismaWorkoutDateOverrideRepository } from './workout-date-override.repository';
 import { PrismaWorkoutLiftOverrideRepository } from './workout-lift-override.repository';
+import { PrismaWorkoutSkipOverrideRepository } from './workout-skip-override.repository';
 import { PrismaWorkoutRepository } from './workout.repository';
 import { HybridLiftingProgramSpecRepository } from './hybrid-program-spec.repository';
 import { InMemoryProgramPhilosophyRepository } from '../in-memory/program-philosophy.adapter';
@@ -40,6 +41,7 @@ export class PrismaRepositoryFactory implements IRepositoryFactory {
       workout: new PrismaWorkoutRepository(this.prisma, user.id),
       workoutDateOverride: new PrismaWorkoutDateOverrideRepository(this.prisma, user.id),
       workoutLiftOverride: new PrismaWorkoutLiftOverrideRepository(this.prisma, user.id),
+      workoutSkipOverride: new PrismaWorkoutSkipOverrideRepository(this.prisma, user.id),
       liftingProgramSpec: this.programSpecRepo,
     };
   }

--- a/apps/api/src/adapters/prisma/workout-skip-override.repository.ts
+++ b/apps/api/src/adapters/prisma/workout-skip-override.repository.ts
@@ -1,0 +1,31 @@
+import { PrismaClient } from '@prisma/client';
+import { IWorkoutSkipOverrideRepository } from '../../ports/IWorkoutSkipOverrideRepository';
+
+export class PrismaWorkoutSkipOverrideRepository implements IWorkoutSkipOverrideRepository {
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly userId: string,
+  ) {}
+
+  async getSkipsForCycle(program: string, cycleNum: number): Promise<Set<number>> {
+    const rows = await this.prisma.workoutSkipOverride.findMany({
+      where: { userId: this.userId, program, cycleNum },
+      select: { workoutNum: true },
+    });
+    return new Set(rows.map((r) => r.workoutNum));
+  }
+
+  async skipWorkout(program: string, cycleNum: number, workoutNum: number, reason?: string): Promise<void> {
+    await this.prisma.workoutSkipOverride.upsert({
+      where: { userId_program_cycleNum_workoutNum: { userId: this.userId, program, cycleNum, workoutNum } },
+      update: { reason: reason ?? null, skippedAt: new Date() },
+      create: { userId: this.userId, program, cycleNum, workoutNum, reason: reason ?? null },
+    });
+  }
+
+  async unskipWorkout(program: string, cycleNum: number, workoutNum: number): Promise<void> {
+    await this.prisma.workoutSkipOverride.deleteMany({
+      where: { userId: this.userId, program, cycleNum, workoutNum },
+    });
+  }
+}

--- a/apps/api/src/ports/IWorkoutSkipOverrideRepository.ts
+++ b/apps/api/src/ports/IWorkoutSkipOverrideRepository.ts
@@ -1,0 +1,5 @@
+export interface IWorkoutSkipOverrideRepository {
+  getSkipsForCycle(program: string, cycleNum: number): Promise<Set<number>>;
+  skipWorkout(program: string, cycleNum: number, workoutNum: number, reason?: string): Promise<void>;
+  unskipWorkout(program: string, cycleNum: number, workoutNum: number): Promise<void>;
+}

--- a/apps/api/src/ports/factory.ts
+++ b/apps/api/src/ports/factory.ts
@@ -12,6 +12,7 @@ import { IUserSettingsRepository } from './IUserSettingsRepository';
 import { IWorkoutDateOverrideRepository } from './IWorkoutDateOverrideRepository';
 import { IWorkoutLiftOverrideRepository } from './IWorkoutLiftOverrideRepository';
 import { IWorkoutRepository } from './IWorkoutRepository';
+import { IWorkoutSkipOverrideRepository } from './IWorkoutSkipOverrideRepository';
 
 export interface RepositoryBundle {
   cycleDashboard: ICycleDashboardRepository;
@@ -27,6 +28,7 @@ export interface RepositoryBundle {
   workout: IWorkoutRepository;
   workoutDateOverride: IWorkoutDateOverrideRepository;
   workoutLiftOverride: IWorkoutLiftOverrideRepository;
+  workoutSkipOverride: IWorkoutSkipOverrideRepository;
 }
 
 export interface IRepositoryFactory {

--- a/apps/api/src/ports/ports.compile-test.ts
+++ b/apps/api/src/ports/ports.compile-test.ts
@@ -23,6 +23,7 @@ import { IUserSettingsRepository } from './IUserSettingsRepository';
 import { IWorkoutDateOverrideRepository } from './IWorkoutDateOverrideRepository';
 import { IWorkoutLiftOverrideRepository } from './IWorkoutLiftOverrideRepository';
 import { IWorkoutRepository } from './IWorkoutRepository';
+import { IWorkoutSkipOverrideRepository } from './IWorkoutSkipOverrideRepository';
 
 // ---------------------------------------------------------------------------
 // IAuthProvider
@@ -149,6 +150,12 @@ const _cycleScheduledWorkoutRepo: ICycleScheduledWorkoutRepository = {
   saveScheduledWorkouts: () => Promise.resolve(),
 };
 
+const _workoutSkipOverrideRepo: IWorkoutSkipOverrideRepository = {
+  getSkipsForCycle: () => Promise.resolve(new Set<number>()),
+  skipWorkout: () => Promise.resolve(),
+  unskipWorkout: () => Promise.resolve(),
+};
+
 const _userSettingsRepo: IUserSettingsRepository = {
   getSettings: () => Promise.resolve({ activeProgram: null, workoutSchedule: null }),
 };
@@ -167,6 +174,7 @@ const _repositoryBundle: RepositoryBundle = {
   workout: _workoutRepo,
   workoutDateOverride: _workoutDateOverrideRepo,
   workoutLiftOverride: _workoutLiftOverrideRepo,
+  workoutSkipOverride: _workoutSkipOverrideRepo,
 };
 
 const _repositoryFactory: IRepositoryFactory = {

--- a/apps/api/src/programs/cycle-dashboard.controller.spec.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.spec.ts
@@ -5,6 +5,7 @@ import { ICycleScheduledWorkoutRepository, ScheduledWorkout } from '../ports/ICy
 import { ILiftRecordRepository } from '../ports/ILiftRecordRepository';
 import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
 import { IWorkoutDateOverrideRepository } from '../ports/IWorkoutDateOverrideRepository';
+import { IWorkoutSkipOverrideRepository } from '../ports/IWorkoutSkipOverrideRepository';
 import { IRepositoryFactory } from '../ports/factory';
 import { REPOSITORY_FACTORY } from '../ports/tokens';
 import { CycleDashboardController } from './cycle-dashboard.controller';
@@ -50,6 +51,7 @@ describe('CycleDashboardController', () => {
   let scheduledRepo: jest.Mocked<ICycleScheduledWorkoutRepository>;
   let liftRecordRepo: jest.Mocked<ILiftRecordRepository>;
   let overrideRepo: jest.Mocked<IWorkoutDateOverrideRepository>;
+  let skipRepo: jest.Mocked<IWorkoutSkipOverrideRepository>;
   let factory: jest.Mocked<IRepositoryFactory>;
 
   beforeEach(async () => {
@@ -73,6 +75,11 @@ describe('CycleDashboardController', () => {
       getOverridesForCycle: jest.fn().mockResolvedValue(new Map()),
       upsertOverride: jest.fn(),
     };
+    skipRepo = {
+      getSkipsForCycle: jest.fn().mockResolvedValue(new Set<number>()),
+      skipWorkout: jest.fn(),
+      unskipWorkout: jest.fn(),
+    };
     factory = {
       forUser: jest.fn().mockResolvedValue({
         cycleDashboard: repo,
@@ -80,6 +87,7 @@ describe('CycleDashboardController', () => {
         liftingProgramSpec: specRepo,
         liftRecord: liftRecordRepo,
         workoutDateOverride: overrideRepo,
+        workoutSkipOverride: skipRepo,
       }),
     };
 
@@ -138,14 +146,14 @@ describe('CycleDashboardController', () => {
     expect(result.weeks[0]).toEqual({
       week: 1,
       workouts: [
-        { workoutNum: 1, date: '2026-04-21' },
-        { workoutNum: 2, date: '2026-04-23' },
+        { workoutNum: 1, date: '2026-04-21', skipped: false },
+        { workoutNum: 2, date: '2026-04-23', skipped: false },
       ],
       completed: false,
     });
     expect(result.weeks[1]).toEqual({
       week: 2,
-      workouts: [{ workoutNum: 3, date: '2026-04-28' }],
+      workouts: [{ workoutNum: 3, date: '2026-04-28', skipped: false }],
       completed: false,
     });
   });
@@ -160,7 +168,7 @@ describe('CycleDashboardController', () => {
 
     const result = await controller.getCurrentCycle('5-3-1', MOCK_USER);
 
-    expect(result.weeks[0]?.workouts).toEqual([{ workoutNum: 1, date: '2026-04-25' }]);
+    expect(result.weeks[0]?.workouts).toEqual([{ workoutNum: 1, date: '2026-04-25', skipped: false }]);
   });
 
   it('marks a week as completed when all its workouts have lift records', async () => {

--- a/apps/api/src/programs/cycle-dashboard.controller.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.ts
@@ -18,7 +18,7 @@ export class CycleDashboardController {
     @Param('program') program: string,
     @CurrentUser() user: AuthUser,
   ): Promise<CycleDashboardResponse> {
-    const { cycleDashboard, cycleScheduledWorkout, liftingProgramSpec, liftRecord, workoutDateOverride } =
+    const { cycleDashboard, cycleScheduledWorkout, liftingProgramSpec, liftRecord, workoutDateOverride, workoutSkipOverride } =
       await this.factory.forUser(user);
 
     const [dashboard, programSpec] = await Promise.all([
@@ -27,13 +27,14 @@ export class CycleDashboardController {
     ]);
     dashboard.currentWeekType = weekTypeForDate(dashboard.cycleDate, programSpec);
 
-    const [scheduledWorkouts, liftRecords, overrideMap] = await Promise.all([
+    const [scheduledWorkouts, liftRecords, overrideMap, skippedNums] = await Promise.all([
       cycleScheduledWorkout.getScheduledWorkouts(program, dashboard.cycleNum),
       liftRecord.getLiftRecords(program, dashboard.cycleNum),
       workoutDateOverride.getOverridesForCycle(program, dashboard.cycleNum),
+      workoutSkipOverride.getSkipsForCycle(program, dashboard.cycleNum),
     ]);
     const completedWorkoutNums = new Set(liftRecords.map((r) => r.workoutNum));
 
-    return buildCycleDashboardResponse(dashboard, scheduledWorkouts, overrideMap, completedWorkoutNums);
+    return buildCycleDashboardResponse(dashboard, scheduledWorkouts, overrideMap, completedWorkoutNums, skippedNums);
   }
 }

--- a/apps/api/src/programs/mappers.spec.ts
+++ b/apps/api/src/programs/mappers.spec.ts
@@ -204,18 +204,18 @@ describe('buildCycleDashboardResponse', () => {
     const week1 = result.weeks[0]!;
     expect(week1.week).toBe(1);
     expect(week1.workouts).toHaveLength(2);
-    expect(week1.workouts[0]).toEqual({ workoutNum: 1, date: '2026-05-19' });
-    expect(week1.workouts[1]).toEqual({ workoutNum: 2, date: '2026-05-21' });
+    expect(week1.workouts[0]).toEqual({ workoutNum: 1, date: '2026-05-19', skipped: false });
+    expect(week1.workouts[1]).toEqual({ workoutNum: 2, date: '2026-05-21', skipped: false });
     expect(week1.completed).toBe(false);
     const week2 = result.weeks[1]!;
-    expect(week2.workouts[0]).toEqual({ workoutNum: 3, date: '2026-05-26' });
+    expect(week2.workouts[0]).toEqual({ workoutNum: 3, date: '2026-05-26', skipped: false });
   });
 
   it('applies override date when present', () => {
     const scheduled = [sw(1, 1, '2026-05-19')];
     const overrides = new Map([[1, new Date('2026-05-20T00:00:00.000Z')]]);
     const result = buildCycleDashboardResponse(baseDashboard, scheduled, overrides, new Set());
-    expect(result.weeks[0]!.workouts[0]).toEqual({ workoutNum: 1, date: '2026-05-20' });
+    expect(result.weeks[0]!.workouts[0]).toEqual({ workoutNum: 1, date: '2026-05-20', skipped: false });
   });
 
   it('marks week completed when all workouts have records', () => {
@@ -229,6 +229,29 @@ describe('buildCycleDashboardResponse', () => {
     const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21')];
     const completed = new Set([1]);
     const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), completed);
+    expect(result.weeks[0]!.completed).toBe(false);
+  });
+
+  it('marks skipped workout as skipped:true in output', () => {
+    const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21')];
+    const skipped = new Set([1]);
+    const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), new Set(), skipped);
+    expect(result.weeks[0]!.workouts[0]!.skipped).toBe(true);
+    expect(result.weeks[0]!.workouts[1]!.skipped).toBe(false);
+  });
+
+  it('week is completed when all workouts are either logged or skipped', () => {
+    const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21')];
+    const completed = new Set([1]);
+    const skipped = new Set([2]);
+    const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), completed, skipped);
+    expect(result.weeks[0]!.completed).toBe(true);
+  });
+
+  it('week is incomplete when a skipped workout still has an un-logged sibling', () => {
+    const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21'), sw(3, 1, '2026-05-23')];
+    const skipped = new Set([1]);
+    const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), new Set(), skipped);
     expect(result.weeks[0]!.completed).toBe(false);
   });
 });

--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -107,13 +107,14 @@ export const toCycleDashboardResponse = (
  * Builds a CycleDashboardResponse with per-week summaries derived from scheduled
  * workout dates. When an override date exists for a workout it wins over the
  * system-assigned scheduled date. A week is marked completed when every workout
- * in that week has at least one lift record for the current cycle.
+ * in that week has at least one lift record or is explicitly skipped.
  */
 export function buildCycleDashboardResponse(
   d: CycleDashboard,
   scheduled: ScheduledWorkout[],
   overrides: Map<number, Date>,
   completedWorkoutNums: Set<number>,
+  skippedNums: Set<number> = new Set(),
 ): CycleDashboardResponse {
   if (scheduled.length === 0) {
     return toCycleDashboardResponse(d);
@@ -123,7 +124,11 @@ export function buildCycleDashboardResponse(
   for (const sw of scheduled) {
     const effectiveDate = overrides.get(sw.workoutNum) ?? sw.scheduledDate;
     const acc = weekAcc.get(sw.weekNum) ?? { workouts: [], scheduled: [] };
-    acc.workouts.push({ workoutNum: sw.workoutNum, date: isoDate(effectiveDate) });
+    acc.workouts.push({
+      workoutNum: sw.workoutNum,
+      date: isoDate(effectiveDate),
+      skipped: skippedNums.has(sw.workoutNum),
+    });
     acc.scheduled.push(sw);
     weekAcc.set(sw.weekNum, acc);
   }
@@ -135,7 +140,9 @@ export function buildCycleDashboardResponse(
       return {
         week: weekNum as WeekNumber,
         workouts,
-        completed: scheduled.every((sw) => completedWorkoutNums.has(sw.workoutNum)),
+        completed: scheduled.every(
+          (sw) => completedWorkoutNums.has(sw.workoutNum) || skippedNums.has(sw.workoutNum),
+        ),
       };
     });
 

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -1122,4 +1122,116 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
       expect(dashRes.json().weeks).toEqual([]);
     });
   });
+
+  describe('workout skip override', () => {
+    async function setupSkipUser(userId: string): Promise<string> {
+      const token = `Bearer ${userId}`;
+      // Set Mon/Wed/Fri schedule via factory (mirrors setScheduleForUser in schedule mode tests)
+      const factory = app.get<InMemoryRepositoryFactory>(REPOSITORY_FACTORY);
+      const bundle = await factory.forUser({ id: userId, email: '', provider: 'dev' });
+      (bundle.userSettings as InMemoryUserSettingsRepository).setSchedule({ type: 'fixed', days: [0, 2, 4] });
+      await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/cycles/initialize`,
+        headers: { 'content-type': 'application/json', authorization: token },
+        payload: JSON.stringify({ cycleDate: '2026-05-19' }),
+      });
+      return token;
+    }
+
+    it('POST skip marks workout as skipped:true in dashboard', async () => {
+      const token = await setupSkipUser('skip-e2e-skip-marks');
+
+      const skipRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/cycles/1/workouts/1/skip`,
+        headers: { 'content-type': 'application/json', authorization: token },
+        payload: JSON.stringify({}),
+      });
+      expect(skipRes.statusCode).toBe(204);
+
+      const dashRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'GET',
+        url: `/programs/${SEED_PROGRAM}/cycles/current`,
+        headers: { authorization: token },
+      });
+      expect(dashRes.statusCode).toBe(200);
+      const allWorkouts = dashRes.json().weeks.flatMap((w: { workouts: { workoutNum: number; skipped: boolean }[] }) => w.workouts);
+      const w1 = allWorkouts.find((ws: { workoutNum: number }) => ws.workoutNum === 1);
+      expect(w1).toBeDefined();
+      expect(w1!.skipped).toBe(true);
+    });
+
+    it('DELETE skip clears the skip mark (skipped:false)', async () => {
+      const token = await setupSkipUser('skip-e2e-unskip');
+
+      await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/cycles/1/workouts/1/skip`,
+        headers: { 'content-type': 'application/json', authorization: token },
+        payload: JSON.stringify({}),
+      });
+
+      const unskipRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'DELETE',
+        url: `/programs/${SEED_PROGRAM}/cycles/1/workouts/1/skip`,
+        headers: { authorization: token },
+      });
+      expect(unskipRes.statusCode).toBe(204);
+
+      const dashRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'GET',
+        url: `/programs/${SEED_PROGRAM}/cycles/current`,
+        headers: { authorization: token },
+      });
+      const allWorkouts = dashRes.json().weeks.flatMap((w: { workouts: { workoutNum: number; skipped: boolean }[] }) => w.workouts);
+      const w1 = allWorkouts.find((ws: { workoutNum: number }) => ws.workoutNum === 1);
+      expect(w1!.skipped).toBe(false);
+    });
+
+    it('week is completed when all workouts are either logged or skipped', async () => {
+      const token = await setupSkipUser('skip-e2e-completion');
+
+      // Get week 1 workouts
+      const dashRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'GET',
+        url: `/programs/${SEED_PROGRAM}/cycles/current`,
+        headers: { authorization: token },
+      });
+      const week1 = dashRes.json().weeks[0];
+      const workoutNums: number[] = week1.workouts.map((ws: { workoutNum: number }) => ws.workoutNum);
+
+      // Log all but the last; skip the last
+      for (let i = 0; i < workoutNums.length - 1; i++) {
+        await app.getHttpAdapter().getInstance().inject({
+          method: 'POST',
+          url: `/programs/${SEED_PROGRAM}/lift-records`,
+          headers: { 'content-type': 'application/json', authorization: token },
+          payload: JSON.stringify({
+            program: SEED_PROGRAM,
+            cycleNum: 1,
+            workoutNum: workoutNums[i],
+            lift: 'Squat',
+            setNum: 1,
+            weight: 135,
+            reps: 5,
+          }),
+        });
+      }
+      const lastWorkoutNum = workoutNums[workoutNums.length - 1];
+      await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/cycles/1/workouts/${lastWorkoutNum}/skip`,
+        headers: { 'content-type': 'application/json', authorization: token },
+        payload: JSON.stringify({}),
+      });
+
+      const finalDash = await app.getHttpAdapter().getInstance().inject({
+        method: 'GET',
+        url: `/programs/${SEED_PROGRAM}/cycles/current`,
+        headers: { authorization: token },
+      });
+      expect(finalDash.json().weeks[0].completed).toBe(true);
+    });
+  });
 });

--- a/apps/api/src/programs/programs.module.ts
+++ b/apps/api/src/programs/programs.module.ts
@@ -15,6 +15,7 @@ import { TrainingMaxesController } from './training-maxes.controller';
 import { TrainingMaxHistoryController } from './training-max-history.controller';
 import { RescheduleController } from './reschedule.controller';
 import { SwitchProgramController } from './switch-program.controller';
+import { WorkoutSkipController } from './workout-skip.controller';
 import { WorkoutsController } from './workouts.controller';
 
 @Module({
@@ -25,6 +26,7 @@ import { WorkoutsController } from './workouts.controller';
     CyclePlanController,
     RescheduleController,
     SwitchProgramController,
+    WorkoutSkipController,
     WorkoutsController,
     StrengthGoalsController,
     TrainingMaxesController,

--- a/apps/api/src/programs/workout-skip.controller.spec.ts
+++ b/apps/api/src/programs/workout-skip.controller.spec.ts
@@ -1,0 +1,84 @@
+import { BadRequestException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { IWorkoutSkipOverrideRepository } from '../ports/IWorkoutSkipOverrideRepository';
+import { IRepositoryFactory } from '../ports/factory';
+import { REPOSITORY_FACTORY } from '../ports/tokens';
+import { WorkoutSkipController } from './workout-skip.controller';
+
+const MOCK_USER = { id: 'u1', email: 'test@example.com', provider: 'dev' };
+
+describe('WorkoutSkipController', () => {
+  let controller: WorkoutSkipController;
+  let skipRepo: jest.Mocked<IWorkoutSkipOverrideRepository>;
+
+  beforeEach(async () => {
+    skipRepo = {
+      getSkipsForCycle: jest.fn(),
+      skipWorkout: jest.fn().mockResolvedValue(undefined),
+      unskipWorkout: jest.fn().mockResolvedValue(undefined),
+    };
+    const factory: jest.Mocked<IRepositoryFactory> = {
+      forUser: jest.fn().mockResolvedValue({ workoutSkipOverride: skipRepo }),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WorkoutSkipController],
+      providers: [{ provide: REPOSITORY_FACTORY, useValue: factory }],
+    }).compile();
+    controller = module.get(WorkoutSkipController);
+  });
+
+  describe('skipWorkout', () => {
+    it('throws 400 for non-numeric cycleNum', async () => {
+      await expect(
+        controller.skipWorkout('5-3-1', 'abc', '1', {}, MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws 400 for cycleNum < 1', async () => {
+      await expect(
+        controller.skipWorkout('5-3-1', '0', '1', {}, MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws 400 for non-numeric workoutNum', async () => {
+      await expect(
+        controller.skipWorkout('5-3-1', '1', 'abc', {}, MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws 400 for workoutNum < 1', async () => {
+      await expect(
+        controller.skipWorkout('5-3-1', '1', '0', {}, MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('calls skipWorkout with parsed params and optional reason', async () => {
+      await controller.skipWorkout('5-3-1', '2', '3', { reason: 'sick' }, MOCK_USER);
+      expect(skipRepo.skipWorkout).toHaveBeenCalledWith('5-3-1', 2, 3, 'sick');
+    });
+
+    it('calls skipWorkout without reason when dto has none', async () => {
+      await controller.skipWorkout('5-3-1', '2', '3', {}, MOCK_USER);
+      expect(skipRepo.skipWorkout).toHaveBeenCalledWith('5-3-1', 2, 3, undefined);
+    });
+  });
+
+  describe('unskipWorkout', () => {
+    it('throws 400 for non-numeric cycleNum', async () => {
+      await expect(
+        controller.unskipWorkout('5-3-1', 'abc', '1', MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws 400 for workoutNum < 1', async () => {
+      await expect(
+        controller.unskipWorkout('5-3-1', '1', '0', MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('calls unskipWorkout with parsed params', async () => {
+      await controller.unskipWorkout('5-3-1', '2', '3', MOCK_USER);
+      expect(skipRepo.unskipWorkout).toHaveBeenCalledWith('5-3-1', 2, 3);
+    });
+  });
+});

--- a/apps/api/src/programs/workout-skip.controller.spec.ts
+++ b/apps/api/src/programs/workout-skip.controller.spec.ts
@@ -70,6 +70,18 @@ describe('WorkoutSkipController', () => {
       ).rejects.toThrow(BadRequestException);
     });
 
+    it('throws 400 for cycleNum < 1', async () => {
+      await expect(
+        controller.unskipWorkout('5-3-1', '0', '1', MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws 400 for non-numeric workoutNum', async () => {
+      await expect(
+        controller.unskipWorkout('5-3-1', '1', 'abc', MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+    });
+
     it('throws 400 for workoutNum < 1', async () => {
       await expect(
         controller.unskipWorkout('5-3-1', '1', '0', MOCK_USER),

--- a/apps/api/src/programs/workout-skip.controller.ts
+++ b/apps/api/src/programs/workout-skip.controller.ts
@@ -9,6 +9,7 @@ import {
   Param,
   Post,
 } from '@nestjs/common';
+import { IsOptional, IsString } from 'class-validator';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../ports/auth';
 import { IRepositoryFactory } from '../ports/factory';
@@ -16,6 +17,8 @@ import { REPOSITORY_FACTORY } from '../ports/tokens';
 import { isValidWorkoutNum } from './mappers';
 
 class SkipWorkoutDto {
+  @IsOptional()
+  @IsString()
   reason?: string;
 }
 

--- a/apps/api/src/programs/workout-skip.controller.ts
+++ b/apps/api/src/programs/workout-skip.controller.ts
@@ -1,0 +1,72 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  Param,
+  Post,
+} from '@nestjs/common';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { AuthUser } from '../ports/auth';
+import { IRepositoryFactory } from '../ports/factory';
+import { REPOSITORY_FACTORY } from '../ports/tokens';
+import { isValidWorkoutNum } from './mappers';
+
+class SkipWorkoutDto {
+  reason?: string;
+}
+
+@Controller('programs/:program')
+export class WorkoutSkipController {
+  constructor(
+    @Inject(REPOSITORY_FACTORY) private readonly factory: IRepositoryFactory,
+  ) {}
+
+  @Post('cycles/:cycleNum/workouts/:workoutNum/skip')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async skipWorkout(
+    @Param('program') program: string,
+    @Param('cycleNum') cycleNumParam: string,
+    @Param('workoutNum') workoutNumParam: string,
+    @Body() dto: SkipWorkoutDto,
+    @CurrentUser() user: AuthUser,
+  ): Promise<void> {
+    const cycleNum = Number.parseInt(cycleNumParam, 10);
+    const workoutNum = Number.parseInt(workoutNumParam, 10);
+
+    if (!Number.isInteger(cycleNum) || cycleNum < 1) {
+      throw new BadRequestException('cycleNum must be a positive integer');
+    }
+    if (!isValidWorkoutNum(workoutNum)) {
+      throw new BadRequestException('workoutNum must be a positive integer');
+    }
+
+    const { workoutSkipOverride } = await this.factory.forUser(user);
+    await workoutSkipOverride.skipWorkout(program, cycleNum, workoutNum, dto.reason);
+  }
+
+  @Delete('cycles/:cycleNum/workouts/:workoutNum/skip')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async unskipWorkout(
+    @Param('program') program: string,
+    @Param('cycleNum') cycleNumParam: string,
+    @Param('workoutNum') workoutNumParam: string,
+    @CurrentUser() user: AuthUser,
+  ): Promise<void> {
+    const cycleNum = Number.parseInt(cycleNumParam, 10);
+    const workoutNum = Number.parseInt(workoutNumParam, 10);
+
+    if (!Number.isInteger(cycleNum) || cycleNum < 1) {
+      throw new BadRequestException('cycleNum must be a positive integer');
+    }
+    if (!isValidWorkoutNum(workoutNum)) {
+      throw new BadRequestException('workoutNum must be a positive integer');
+    }
+
+    const { workoutSkipOverride } = await this.factory.forUser(user);
+    await workoutSkipOverride.unskipWorkout(program, cycleNum, workoutNum);
+  }
+}

--- a/apps/web/lib/__tests__/programPlan.test.ts
+++ b/apps/web/lib/__tests__/programPlan.test.ts
@@ -7,7 +7,7 @@ const makeWeek = (
   completed: boolean,
 ): CycleWeekSummary => ({
   week,
-  workouts: dates.map((date, i) => ({ workoutNum: i + 1, date })),
+  workouts: dates.map((date, i) => ({ workoutNum: i + 1, date, skipped: false })),
   completed,
 });
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -183,6 +183,7 @@ export interface UpsertStrengthGoalRequest {
 export interface WorkoutSummary {
   workoutNum: number;
   date: string; // ISO 8601 scheduled date
+  skipped: boolean;
 }
 
 /** Per-week summary within a cycle dashboard. */


### PR DESCRIPTION
## Summary

Implements Phase 4.5 of the Workout Scheduling Override feature (#269). Users can now mark a workout as skipped; a skipped workout counts as complete for week/cycle completion logic.

This PR stacks on Phase 4 ([#274](https://github.com/brownm09/lifting-logbook/pull/274)) — base branch is set accordingly.

## Acceptance Criteria

- [x] `WorkoutSkipOverride` Prisma model added to schema; migration file created
- [x] `IWorkoutSkipOverrideRepository` port with `getSkipsForCycle`, `skipWorkout`, `unskipWorkout`
- [x] In-memory adapter (tests) and Prisma adapter (production)
- [x] `workoutSkipOverride` wired into `RepositoryBundle` and all three factory implementations
- [x] `WorkoutSummary.skipped: boolean` added (extends Phase 4 type)
- [x] `buildCycleDashboardResponse` accepts `skippedNums: Set<number>`; completion: logged OR skipped
- [x] `CycleDashboardController` fetches skips alongside existing parallel loads
- [x] `POST /programs/:program/cycles/:cycleNum/workouts/:workoutNum/skip` → 204
- [x] `DELETE /programs/:program/cycles/:cycleNum/workouts/:workoutNum/skip` → 204
- [x] Unit tests: 4 new mapper cases covering skip/unskip completion logic
- [x] Integration tests: 3 new e2e scenarios (skip marks, unskip clears, mixed log+skip completes week)

## Files Changed

- `apps/api/prisma/schema.prisma` — `WorkoutSkipOverride` model
- `apps/api/prisma/migrations/20260517000003_add_workout_skip_override/` — migration SQL
- `apps/api/src/ports/IWorkoutSkipOverrideRepository.ts` — new port
- `apps/api/src/adapters/in-memory/workout-skip-override.adapter.ts` — in-memory adapter
- `apps/api/src/adapters/prisma/workout-skip-override.repository.ts` — Prisma adapter
- `apps/api/src/ports/factory.ts` — `workoutSkipOverride` in `RepositoryBundle`
- `apps/api/src/ports/ports.compile-test.ts` — compile-time contract test updated
- `apps/api/src/adapters/factory/in-memory-repository-factory.ts` — wired
- `apps/api/src/adapters/factory/system-db-repository-factory.ts` — wired
- `apps/api/src/adapters/prisma/prisma-repository-factory.ts` — wired
- `packages/types/src/api.ts` — `WorkoutSummary.skipped: boolean`
- `apps/api/src/programs/mappers.ts` — `buildCycleDashboardResponse` with `skippedNums`
- `apps/api/src/programs/cycle-dashboard.controller.ts` — fetches skip set
- `apps/api/src/programs/workout-skip.controller.ts` — new POST/DELETE endpoints
- `apps/api/src/programs/programs.module.ts` — `WorkoutSkipController` registered
- `apps/api/src/programs/mappers.spec.ts` — 4 new skip test cases
- `apps/api/src/programs/cycle-dashboard.controller.spec.ts` — updated mock + `skipped` assertions
- `apps/api/src/programs/programs.e2e.spec.ts` — 3 new skip e2e tests
- `apps/web/lib/__tests__/programPlan.test.ts` — `skipped: false` in fixture

## Test Results

All 229 API tests pass, 28 web tests pass (51 skipped — same as before Phase 4.5).

Pre-existing build errors in `apps/api` (`implicit any` Prisma types, `UserSettingsUncheckedUpdateInput`) exist on `main` before this change and are unrelated.

Closes #275