### PR TITLE
[feat] Allow date edit on completed workouts

### DIFF
--- a/apps/api/prisma/migrations/20260517000003_add_workout_skip_override/migration.sql
+++ b/apps/api/prisma/migrations/20260517000003_add_workout_skip_override/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "workout_skip_override" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "program" TEXT NOT NULL,
+    "cycleNum" INTEGER NOT NULL,
+    "workoutNum" INTEGER NOT NULL,
+    "reason" TEXT,
+    "skippedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "workout_skip_override_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "workout_skip_override_userId_program_cycleNum_workoutNum_key" ON "workout_skip_override"("userId", "program", "cycleNum", "workoutNum");
+
+-- CreateIndex
+CREATE INDEX "workout_skip_override_userId_program_cycleNum_idx" ON "workout_skip_override"("userId", "program", "cycleNum");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -105,6 +105,20 @@ model WorkoutDateOverride {
   @@map("workout_date_override")
 }
 
+model WorkoutSkipOverride {
+  id         String   @id @default(uuid())
+  userId     String
+  program    String
+  cycleNum   Int
+  workoutNum Int
+  reason     String?
+  skippedAt  DateTime @default(now())
+
+  @@unique([userId, program, cycleNum, workoutNum])
+  @@index([userId, program, cycleNum])
+  @@map("workout_skip_override")
+}
+
 model WorkoutLiftOverride {
   id         String   @id @default(cuid())
   userId     String

--- a/apps/api/src/adapters/factory/in-memory-repository-factory.ts
+++ b/apps/api/src/adapters/factory/in-memory-repository-factory.ts
@@ -15,6 +15,7 @@ import { InMemoryUserSettingsRepository } from '../in-memory/user-settings.adapt
 import { InMemoryWorkoutDateOverrideRepository } from '../in-memory/workout-date-override.adapter';
 import { InMemoryWorkoutLiftOverrideRepository } from '../in-memory/workout-lift-override.adapter';
 import { InMemoryWorkoutRepository } from '../in-memory/workout.adapter';
+import { InMemoryWorkoutSkipOverrideRepository } from '../in-memory/workout-skip-override.adapter';
 import { SEED_PROGRAM, seedLiftRecords } from '../in-memory/fixtures';
 
 // The dev seed user gets pre-populated training maxes so existing tests that
@@ -47,6 +48,7 @@ export class InMemoryRepositoryFactory implements IRepositoryFactory {
         workout: new InMemoryWorkoutRepository(sharedRecords),
         workoutDateOverride: new InMemoryWorkoutDateOverrideRepository(),
         workoutLiftOverride: new InMemoryWorkoutLiftOverrideRepository(),
+        workoutSkipOverride: new InMemoryWorkoutSkipOverrideRepository(),
       });
     }
     return this.bundles.get(user.id)!;

--- a/apps/api/src/adapters/factory/system-db-repository-factory.ts
+++ b/apps/api/src/adapters/factory/system-db-repository-factory.ts
@@ -27,6 +27,8 @@ import { InMemoryWorkoutDateOverrideRepository } from '../in-memory/workout-date
 import { InMemoryWorkoutLiftOverrideRepository } from '../in-memory/workout-lift-override.adapter';
 import { InMemoryWorkoutRepository } from '../in-memory/workout.adapter';
 import { PrismaCycleScheduledWorkoutRepository } from '../prisma/cycle-scheduled-workout.repository';
+import { PrismaWorkoutSkipOverrideRepository } from '../prisma/workout-skip-override.repository';
+import { InMemoryWorkoutSkipOverrideRepository } from '../in-memory/workout-skip-override.adapter';
 import { UserSettingsRepository } from '../../user-settings/user-settings.repository';
 
 interface UserDataSourceRow {
@@ -95,6 +97,7 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
         workout: new PrismaWorkoutRepository(prisma, userId),
         workoutDateOverride: new PrismaWorkoutDateOverrideRepository(prisma, userId),
         workoutLiftOverride: new PrismaWorkoutLiftOverrideRepository(prisma, userId),
+        workoutSkipOverride: new PrismaWorkoutSkipOverrideRepository(prisma, userId),
         liftingProgramSpec: this.programSpecRepo,
       };
     }
@@ -117,6 +120,7 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
       workout: new InMemoryWorkoutRepository(sharedRecords),
       workoutDateOverride: new InMemoryWorkoutDateOverrideRepository(),
       workoutLiftOverride: new InMemoryWorkoutLiftOverrideRepository(),
+      workoutSkipOverride: new InMemoryWorkoutSkipOverrideRepository(),
     };
   }
 

--- a/apps/api/src/adapters/in-memory/workout-skip-override.adapter.ts
+++ b/apps/api/src/adapters/in-memory/workout-skip-override.adapter.ts
@@ -1,0 +1,24 @@
+import { IWorkoutSkipOverrideRepository } from '../../ports/IWorkoutSkipOverrideRepository';
+
+export class InMemoryWorkoutSkipOverrideRepository implements IWorkoutSkipOverrideRepository {
+  private readonly store = new Map<string, Set<number>>();
+
+  private key(program: string, cycleNum: number): string {
+    return `${program}:${cycleNum}`;
+  }
+
+  async getSkipsForCycle(program: string, cycleNum: number): Promise<Set<number>> {
+    return new Set(this.store.get(this.key(program, cycleNum)) ?? []);
+  }
+
+  async skipWorkout(program: string, cycleNum: number, workoutNum: number, _reason?: string): Promise<void> {
+    const k = this.key(program, cycleNum);
+    const set = this.store.get(k) ?? new Set<number>();
+    set.add(workoutNum);
+    this.store.set(k, set);
+  }
+
+  async unskipWorkout(program: string, cycleNum: number, workoutNum: number): Promise<void> {
+    this.store.get(this.key(program, cycleNum))?.delete(workoutNum);
+  }
+}

--- a/apps/api/src/adapters/prisma/prisma-repository-factory.ts
+++ b/apps/api/src/adapters/prisma/prisma-repository-factory.ts
@@ -11,6 +11,7 @@ import { PrismaTrainingMaxRepository } from './training-max.repository';
 import { PrismaTrainingMaxHistoryRepository } from './training-max-history.repository';
 import { PrismaWorkoutDateOverrideRepository } from './workout-date-override.repository';
 import { PrismaWorkoutLiftOverrideRepository } from './workout-lift-override.repository';
+import { PrismaWorkoutSkipOverrideRepository } from './workout-skip-override.repository';
 import { PrismaWorkoutRepository } from './workout.repository';
 import { HybridLiftingProgramSpecRepository } from './hybrid-program-spec.repository';
 import { InMemoryProgramPhilosophyRepository } from '../in-memory/program-philosophy.adapter';
@@ -40,6 +41,7 @@ export class PrismaRepositoryFactory implements IRepositoryFactory {
       workout: new PrismaWorkoutRepository(this.prisma, user.id),
       workoutDateOverride: new PrismaWorkoutDateOverrideRepository(this.prisma, user.id),
       workoutLiftOverride: new PrismaWorkoutLiftOverrideRepository(this.prisma, user.id),
+      workoutSkipOverride: new PrismaWorkoutSkipOverrideRepository(this.prisma, user.id),
       liftingProgramSpec: this.programSpecRepo,
     };
   }

--- a/apps/api/src/adapters/prisma/workout-skip-override.repository.ts
+++ b/apps/api/src/adapters/prisma/workout-skip-override.repository.ts
@@ -1,0 +1,31 @@
+import { PrismaClient } from '@prisma/client';
+import { IWorkoutSkipOverrideRepository } from '../../ports/IWorkoutSkipOverrideRepository';
+
+export class PrismaWorkoutSkipOverrideRepository implements IWorkoutSkipOverrideRepository {
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly userId: string,
+  ) {}
+
+  async getSkipsForCycle(program: string, cycleNum: number): Promise<Set<number>> {
+    const rows = await this.prisma.workoutSkipOverride.findMany({
+      where: { userId: this.userId, program, cycleNum },
+      select: { workoutNum: true },
+    });
+    return new Set(rows.map((r) => r.workoutNum));
+  }
+
+  async skipWorkout(program: string, cycleNum: number, workoutNum: number, reason?: string): Promise<void> {
+    await this.prisma.workoutSkipOverride.upsert({
+      where: { userId_program_cycleNum_workoutNum: { userId: this.userId, program, cycleNum, workoutNum } },
+      update: { reason: reason ?? null, skippedAt: new Date() },
+      create: { userId: this.userId, program, cycleNum, workoutNum, reason: reason ?? null },
+    });
+  }
+
+  async unskipWorkout(program: string, cycleNum: number, workoutNum: number): Promise<void> {
+    await this.prisma.workoutSkipOverride.deleteMany({
+      where: { userId: this.userId, program, cycleNum, workoutNum },
+    });
+  }
+}

--- a/apps/api/src/ports/IWorkoutSkipOverrideRepository.ts
+++ b/apps/api/src/ports/IWorkoutSkipOverrideRepository.ts
@@ -1,0 +1,5 @@
+export interface IWorkoutSkipOverrideRepository {
+  getSkipsForCycle(program: string, cycleNum: number): Promise<Set<number>>;
+  skipWorkout(program: string, cycleNum: number, workoutNum: number, reason?: string): Promise<void>;
+  unskipWorkout(program: string, cycleNum: number, workoutNum: number): Promise<void>;
+}

--- a/apps/api/src/ports/factory.ts
+++ b/apps/api/src/ports/factory.ts
@@ -12,6 +12,7 @@ import { IUserSettingsRepository } from './IUserSettingsRepository';
 import { IWorkoutDateOverrideRepository } from './IWorkoutDateOverrideRepository';
 import { IWorkoutLiftOverrideRepository } from './IWorkoutLiftOverrideRepository';
 import { IWorkoutRepository } from './IWorkoutRepository';
+import { IWorkoutSkipOverrideRepository } from './IWorkoutSkipOverrideRepository';
 
 export interface RepositoryBundle {
   cycleDashboard: ICycleDashboardRepository;
@@ -27,6 +28,7 @@ export interface RepositoryBundle {
   workout: IWorkoutRepository;
   workoutDateOverride: IWorkoutDateOverrideRepository;
   workoutLiftOverride: IWorkoutLiftOverrideRepository;
+  workoutSkipOverride: IWorkoutSkipOverrideRepository;
 }
 
 export interface IRepositoryFactory {

--- a/apps/api/src/ports/ports.compile-test.ts
+++ b/apps/api/src/ports/ports.compile-test.ts
@@ -23,6 +23,7 @@ import { IUserSettingsRepository } from './IUserSettingsRepository';
 import { IWorkoutDateOverrideRepository } from './IWorkoutDateOverrideRepository';
 import { IWorkoutLiftOverrideRepository } from './IWorkoutLiftOverrideRepository';
 import { IWorkoutRepository } from './IWorkoutRepository';
+import { IWorkoutSkipOverrideRepository } from './IWorkoutSkipOverrideRepository';
 
 // ---------------------------------------------------------------------------
 // IAuthProvider
@@ -149,6 +150,12 @@ const _cycleScheduledWorkoutRepo: ICycleScheduledWorkoutRepository = {
   saveScheduledWorkouts: () => Promise.resolve(),
 };
 
+const _workoutSkipOverrideRepo: IWorkoutSkipOverrideRepository = {
+  getSkipsForCycle: () => Promise.resolve(new Set<number>()),
+  skipWorkout: () => Promise.resolve(),
+  unskipWorkout: () => Promise.resolve(),
+};
+
 const _userSettingsRepo: IUserSettingsRepository = {
   getSettings: () => Promise.resolve({ activeProgram: null, workoutSchedule: null }),
 };
@@ -167,6 +174,7 @@ const _repositoryBundle: RepositoryBundle = {
   workout: _workoutRepo,
   workoutDateOverride: _workoutDateOverrideRepo,
   workoutLiftOverride: _workoutLiftOverrideRepo,
+  workoutSkipOverride: _workoutSkipOverrideRepo,
 };
 
 const _repositoryFactory: IRepositoryFactory = {

--- a/apps/api/src/programs/cycle-dashboard.controller.spec.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.spec.ts
@@ -5,6 +5,7 @@ import { ICycleScheduledWorkoutRepository, ScheduledWorkout } from '../ports/ICy
 import { ILiftRecordRepository } from '../ports/ILiftRecordRepository';
 import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
 import { IWorkoutDateOverrideRepository } from '../ports/IWorkoutDateOverrideRepository';
+import { IWorkoutSkipOverrideRepository } from '../ports/IWorkoutSkipOverrideRepository';
 import { IRepositoryFactory } from '../ports/factory';
 import { REPOSITORY_FACTORY } from '../ports/tokens';
 import { CycleDashboardController } from './cycle-dashboard.controller';
@@ -50,6 +51,7 @@ describe('CycleDashboardController', () => {
   let scheduledRepo: jest.Mocked<ICycleScheduledWorkoutRepository>;
   let liftRecordRepo: jest.Mocked<ILiftRecordRepository>;
   let overrideRepo: jest.Mocked<IWorkoutDateOverrideRepository>;
+  let skipRepo: jest.Mocked<IWorkoutSkipOverrideRepository>;
   let factory: jest.Mocked<IRepositoryFactory>;
 
   beforeEach(async () => {
@@ -73,6 +75,11 @@ describe('CycleDashboardController', () => {
       getOverridesForCycle: jest.fn().mockResolvedValue(new Map()),
       upsertOverride: jest.fn(),
     };
+    skipRepo = {
+      getSkipsForCycle: jest.fn().mockResolvedValue(new Set<number>()),
+      skipWorkout: jest.fn(),
+      unskipWorkout: jest.fn(),
+    };
     factory = {
       forUser: jest.fn().mockResolvedValue({
         cycleDashboard: repo,
@@ -80,6 +87,7 @@ describe('CycleDashboardController', () => {
         liftingProgramSpec: specRepo,
         liftRecord: liftRecordRepo,
         workoutDateOverride: overrideRepo,
+        workoutSkipOverride: skipRepo,
       }),
     };
 
@@ -138,14 +146,14 @@ describe('CycleDashboardController', () => {
     expect(result.weeks[0]).toEqual({
       week: 1,
       workouts: [
-        { workoutNum: 1, date: '2026-04-21' },
-        { workoutNum: 2, date: '2026-04-23' },
+        { workoutNum: 1, date: '2026-04-21', skipped: false },
+        { workoutNum: 2, date: '2026-04-23', skipped: false },
       ],
       completed: false,
     });
     expect(result.weeks[1]).toEqual({
       week: 2,
-      workouts: [{ workoutNum: 3, date: '2026-04-28' }],
+      workouts: [{ workoutNum: 3, date: '2026-04-28', skipped: false }],
       completed: false,
     });
   });
@@ -160,7 +168,7 @@ describe('CycleDashboardController', () => {
 
     const result = await controller.getCurrentCycle('5-3-1', MOCK_USER);
 
-    expect(result.weeks[0]?.workouts).toEqual([{ workoutNum: 1, date: '2026-04-25' }]);
+    expect(result.weeks[0]?.workouts).toEqual([{ workoutNum: 1, date: '2026-04-25', skipped: false }]);
   });
 
   it('marks a week as completed when all its workouts have lift records', async () => {

--- a/apps/api/src/programs/cycle-dashboard.controller.spec.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.spec.ts
@@ -137,12 +137,15 @@ describe('CycleDashboardController', () => {
     expect(result.weeks).toHaveLength(2);
     expect(result.weeks[0]).toEqual({
       week: 1,
-      workoutDates: ['2026-04-21', '2026-04-23'],
+      workouts: [
+        { workoutNum: 1, date: '2026-04-21' },
+        { workoutNum: 2, date: '2026-04-23' },
+      ],
       completed: false,
     });
     expect(result.weeks[1]).toEqual({
       week: 2,
-      workoutDates: ['2026-04-28'],
+      workouts: [{ workoutNum: 3, date: '2026-04-28' }],
       completed: false,
     });
   });
@@ -157,7 +160,7 @@ describe('CycleDashboardController', () => {
 
     const result = await controller.getCurrentCycle('5-3-1', MOCK_USER);
 
-    expect(result.weeks[0]?.workoutDates).toEqual(['2026-04-25']);
+    expect(result.weeks[0]?.workouts).toEqual([{ workoutNum: 1, date: '2026-04-25' }]);
   });
 
   it('marks a week as completed when all its workouts have lift records', async () => {

--- a/apps/api/src/programs/cycle-dashboard.controller.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.ts
@@ -18,7 +18,7 @@ export class CycleDashboardController {
     @Param('program') program: string,
     @CurrentUser() user: AuthUser,
   ): Promise<CycleDashboardResponse> {
-    const { cycleDashboard, cycleScheduledWorkout, liftingProgramSpec, liftRecord, workoutDateOverride } =
+    const { cycleDashboard, cycleScheduledWorkout, liftingProgramSpec, liftRecord, workoutDateOverride, workoutSkipOverride } =
       await this.factory.forUser(user);
 
     const [dashboard, programSpec] = await Promise.all([
@@ -27,13 +27,14 @@ export class CycleDashboardController {
     ]);
     dashboard.currentWeekType = weekTypeForDate(dashboard.cycleDate, programSpec);
 
-    const [scheduledWorkouts, liftRecords, overrideMap] = await Promise.all([
+    const [scheduledWorkouts, liftRecords, overrideMap, skippedNums] = await Promise.all([
       cycleScheduledWorkout.getScheduledWorkouts(program, dashboard.cycleNum),
       liftRecord.getLiftRecords(program, dashboard.cycleNum),
       workoutDateOverride.getOverridesForCycle(program, dashboard.cycleNum),
+      workoutSkipOverride.getSkipsForCycle(program, dashboard.cycleNum),
     ]);
     const completedWorkoutNums = new Set(liftRecords.map((r) => r.workoutNum));
 
-    return buildCycleDashboardResponse(dashboard, scheduledWorkouts, overrideMap, completedWorkoutNums);
+    return buildCycleDashboardResponse(dashboard, scheduledWorkouts, overrideMap, completedWorkoutNums, skippedNums);
   }
 }

--- a/apps/api/src/programs/lift-records.controller.ts
+++ b/apps/api/src/programs/lift-records.controller.ts
@@ -58,12 +58,22 @@ export class LiftRecordsController {
     @Body() body: CreateLiftRecordRequest,
     @CurrentUser() user: AuthUser,
   ): Promise<LiftRecordResponse> {
-    const { liftRecord } = await this.factory.forUser(user);
+    const { liftRecord, cycleScheduledWorkout } = await this.factory.forUser(user);
+
+    let effectiveDate: Date;
+    if (body.date) {
+      effectiveDate = new Date(body.date);
+    } else {
+      const scheduled = await cycleScheduledWorkout.getScheduledWorkouts(program, body.cycleNum);
+      const match = scheduled.find((s) => s.workoutNum === body.workoutNum);
+      effectiveDate = match?.scheduledDate ?? new Date();
+    }
+
     const record = {
       program,
       cycleNum: body.cycleNum,
       workoutNum: body.workoutNum,
-      date: new Date(body.date),
+      date: effectiveDate,
       lift: body.lift,
       setNum: body.setNum,
       weight: body.weight,

--- a/apps/api/src/programs/mappers.spec.ts
+++ b/apps/api/src/programs/mappers.spec.ts
@@ -204,18 +204,18 @@ describe('buildCycleDashboardResponse', () => {
     const week1 = result.weeks[0]!;
     expect(week1.week).toBe(1);
     expect(week1.workouts).toHaveLength(2);
-    expect(week1.workouts[0]).toEqual({ workoutNum: 1, date: '2026-05-19' });
-    expect(week1.workouts[1]).toEqual({ workoutNum: 2, date: '2026-05-21' });
+    expect(week1.workouts[0]).toEqual({ workoutNum: 1, date: '2026-05-19', skipped: false });
+    expect(week1.workouts[1]).toEqual({ workoutNum: 2, date: '2026-05-21', skipped: false });
     expect(week1.completed).toBe(false);
     const week2 = result.weeks[1]!;
-    expect(week2.workouts[0]).toEqual({ workoutNum: 3, date: '2026-05-26' });
+    expect(week2.workouts[0]).toEqual({ workoutNum: 3, date: '2026-05-26', skipped: false });
   });
 
   it('applies override date when present', () => {
     const scheduled = [sw(1, 1, '2026-05-19')];
     const overrides = new Map([[1, new Date('2026-05-20T00:00:00.000Z')]]);
     const result = buildCycleDashboardResponse(baseDashboard, scheduled, overrides, new Set());
-    expect(result.weeks[0]!.workouts[0]).toEqual({ workoutNum: 1, date: '2026-05-20' });
+    expect(result.weeks[0]!.workouts[0]).toEqual({ workoutNum: 1, date: '2026-05-20', skipped: false });
   });
 
   it('marks week completed when all workouts have records', () => {
@@ -229,6 +229,29 @@ describe('buildCycleDashboardResponse', () => {
     const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21')];
     const completed = new Set([1]);
     const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), completed);
+    expect(result.weeks[0]!.completed).toBe(false);
+  });
+
+  it('marks skipped workout as skipped:true in output', () => {
+    const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21')];
+    const skipped = new Set([1]);
+    const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), new Set(), skipped);
+    expect(result.weeks[0]!.workouts[0]!.skipped).toBe(true);
+    expect(result.weeks[0]!.workouts[1]!.skipped).toBe(false);
+  });
+
+  it('week is completed when all workouts are either logged or skipped', () => {
+    const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21')];
+    const completed = new Set([1]);
+    const skipped = new Set([2]);
+    const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), completed, skipped);
+    expect(result.weeks[0]!.completed).toBe(true);
+  });
+
+  it('week is incomplete when a skipped workout still has an un-logged sibling', () => {
+    const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21'), sw(3, 1, '2026-05-23')];
+    const skipped = new Set([1]);
+    const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), new Set(), skipped);
     expect(result.weeks[0]!.completed).toBe(false);
   });
 });

--- a/apps/api/src/programs/mappers.spec.ts
+++ b/apps/api/src/programs/mappers.spec.ts
@@ -1,6 +1,7 @@
-import { LiftingProgramSpec } from '@lifting-logbook/core';
-import { applyLiftOverrides, toWorkoutResponse, weekForWorkoutNum } from './mappers';
+import { CycleDashboard, LiftingProgramSpec, Weekday } from '@lifting-logbook/core';
+import { applyLiftOverrides, buildCycleDashboardResponse, toWorkoutResponse, weekForWorkoutNum } from './mappers';
 import { LiftOverride } from '../ports/IWorkoutLiftOverrideRepository';
+import { ScheduledWorkout } from '../ports/ICycleScheduledWorkoutRepository';
 
 const baseFields: Omit<LiftingProgramSpec, 'offset' | 'lift' | 'week'> = {
   increment: 5,
@@ -158,5 +159,76 @@ describe('toWorkoutResponse with plannedLifts', () => {
     const records = [record('Squat', 1, 200)];
     const result = toWorkoutResponse(program, cycleNum, workoutNum, week, records);
     expect(result.lifts[0]).toMatchObject({ lift: 'Squat', planned: false });
+  });
+
+  it('uses scheduledDate as date when no records exist', () => {
+    const scheduledDate = new Date('2026-06-02T00:00:00.000Z');
+    const result = toWorkoutResponse(program, cycleNum, workoutNum, week, [], undefined, undefined, scheduledDate);
+    expect(result.date).toBe('2026-06-02');
+  });
+
+  it('prefers first record date over scheduledDate when records exist', () => {
+    const records = [record('Squat', 1, 200)];
+    const scheduledDate = new Date('2026-06-02T00:00:00.000Z');
+    const result = toWorkoutResponse(program, cycleNum, workoutNum, week, records, undefined, undefined, scheduledDate);
+    expect(result.date).toBe(records[0]!.date.toISOString().slice(0, 10));
+  });
+});
+
+describe('buildCycleDashboardResponse', () => {
+  const baseDashboard: CycleDashboard = {
+    program: 'test-531',
+    cycleNum: 1,
+    cycleDate: new Date('2026-05-19T00:00:00.000Z'),
+    currentWeekType: 1,
+    cycleUnit: 'week',
+    sheetName: 'Sheet1',
+    cycleStartWeekday: Weekday.Monday,
+  };
+
+  const sw = (workoutNum: number, weekNum: number, date: string): ScheduledWorkout => ({
+    workoutNum,
+    weekNum,
+    scheduledDate: new Date(`${date}T00:00:00.000Z`),
+  });
+
+  it('returns base response when scheduled array is empty', () => {
+    const result = buildCycleDashboardResponse(baseDashboard, [], new Map(), new Set());
+    expect(result.weeks).toEqual([]);
+  });
+
+  it('emits workouts[] with workoutNum and date per entry', () => {
+    const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21'), sw(3, 2, '2026-05-26')];
+    const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), new Set());
+    expect(result.weeks).toHaveLength(2);
+    const week1 = result.weeks[0]!;
+    expect(week1.week).toBe(1);
+    expect(week1.workouts).toHaveLength(2);
+    expect(week1.workouts[0]).toEqual({ workoutNum: 1, date: '2026-05-19' });
+    expect(week1.workouts[1]).toEqual({ workoutNum: 2, date: '2026-05-21' });
+    expect(week1.completed).toBe(false);
+    const week2 = result.weeks[1]!;
+    expect(week2.workouts[0]).toEqual({ workoutNum: 3, date: '2026-05-26' });
+  });
+
+  it('applies override date when present', () => {
+    const scheduled = [sw(1, 1, '2026-05-19')];
+    const overrides = new Map([[1, new Date('2026-05-20T00:00:00.000Z')]]);
+    const result = buildCycleDashboardResponse(baseDashboard, scheduled, overrides, new Set());
+    expect(result.weeks[0]!.workouts[0]).toEqual({ workoutNum: 1, date: '2026-05-20' });
+  });
+
+  it('marks week completed when all workouts have records', () => {
+    const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21')];
+    const completed = new Set([1, 2]);
+    const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), completed);
+    expect(result.weeks[0]!.completed).toBe(true);
+  });
+
+  it('week is incomplete when only some workouts have records', () => {
+    const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21')];
+    const completed = new Set([1]);
+    const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), completed);
+    expect(result.weeks[0]!.completed).toBe(false);
   });
 });

--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -107,13 +107,14 @@ export const toCycleDashboardResponse = (
  * Builds a CycleDashboardResponse with per-week summaries derived from scheduled
  * workout dates. When an override date exists for a workout it wins over the
  * system-assigned scheduled date. A week is marked completed when every workout
- * in that week has at least one lift record for the current cycle.
+ * in that week has at least one lift record or is explicitly skipped.
  */
 export function buildCycleDashboardResponse(
   d: CycleDashboard,
   scheduled: ScheduledWorkout[],
   overrides: Map<number, Date>,
   completedWorkoutNums: Set<number>,
+  skippedNums: Set<number> = new Set(),
 ): CycleDashboardResponse {
   if (scheduled.length === 0) {
     return toCycleDashboardResponse(d);
@@ -123,7 +124,11 @@ export function buildCycleDashboardResponse(
   for (const sw of scheduled) {
     const effectiveDate = overrides.get(sw.workoutNum) ?? sw.scheduledDate;
     const acc = weekAcc.get(sw.weekNum) ?? { workouts: [], scheduled: [] };
-    acc.workouts.push({ workoutNum: sw.workoutNum, date: isoDate(effectiveDate) });
+    acc.workouts.push({
+      workoutNum: sw.workoutNum,
+      date: isoDate(effectiveDate),
+      skipped: skippedNums.has(sw.workoutNum),
+    });
     acc.scheduled.push(sw);
     weekAcc.set(sw.weekNum, acc);
   }
@@ -135,7 +140,9 @@ export function buildCycleDashboardResponse(
       return {
         week: weekNum as WeekNumber,
         workouts,
-        completed: scheduled.every((sw) => completedWorkoutNums.has(sw.workoutNum)),
+        completed: scheduled.every(
+          (sw) => completedWorkoutNums.has(sw.workoutNum) || skippedNums.has(sw.workoutNum),
+        ),
       };
     });
 

--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -20,6 +20,7 @@ import {
   WeekNumber,
   WorkoutLiftResponse,
   WorkoutResponse,
+  WorkoutSummary,
 } from '@lifting-logbook/types';
 import { CyclePlanResult } from '../ports/ICyclePlanningAgent';
 import { ScheduledWorkout } from '../ports/ICycleScheduledWorkoutRepository';
@@ -118,23 +119,23 @@ export function buildCycleDashboardResponse(
     return toCycleDashboardResponse(d);
   }
 
-  const weekAcc = new Map<number, { dates: string[]; workouts: ScheduledWorkout[] }>();
+  const weekAcc = new Map<number, { workouts: WorkoutSummary[]; scheduled: ScheduledWorkout[] }>();
   for (const sw of scheduled) {
     const effectiveDate = overrides.get(sw.workoutNum) ?? sw.scheduledDate;
-    const acc = weekAcc.get(sw.weekNum) ?? { dates: [], workouts: [] };
-    acc.dates.push(isoDate(effectiveDate));
-    acc.workouts.push(sw);
+    const acc = weekAcc.get(sw.weekNum) ?? { workouts: [], scheduled: [] };
+    acc.workouts.push({ workoutNum: sw.workoutNum, date: isoDate(effectiveDate) });
+    acc.scheduled.push(sw);
     weekAcc.set(sw.weekNum, acc);
   }
 
   const weeks: CycleWeekSummary[] = [...weekAcc.keys()]
     .sort((a, b) => a - b)
     .map((weekNum) => {
-      const { dates, workouts } = weekAcc.get(weekNum)!;
+      const { workouts, scheduled } = weekAcc.get(weekNum)!;
       return {
         week: weekNum as WeekNumber,
-        workoutDates: dates,
-        completed: workouts.every((sw) => completedWorkoutNums.has(sw.workoutNum)),
+        workouts,
+        completed: scheduled.every((sw) => completedWorkoutNums.has(sw.workoutNum)),
       };
     });
 
@@ -225,6 +226,7 @@ export const toWorkoutResponse = (
   records: LiftRecord[],
   overrideDate?: Date,
   plannedLifts?: string[],
+  scheduledDate?: Date,
 ): WorkoutResponse => {
   const liftMap = new Map<string, SetResponse[]>();
   for (const r of records) {
@@ -261,7 +263,11 @@ export const toWorkoutResponse = (
     }));
   }
 
-  const date = records[0] ? isoDate(records[0].date) : isoDate(new Date());
+  const date = records[0]
+    ? isoDate(records[0].date)
+    : scheduledDate
+      ? isoDate(scheduledDate)
+      : isoDate(new Date());
   return {
     program,
     cycleNum,

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -1018,12 +1018,87 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
       // Mon-Wed-Fri schedule: week 1 should have dates on Mon/Wed/Fri
       const week1 = body.weeks[0];
       expect(week1.week).toBe(1);
-      expect(week1.workoutDates.length).toBeGreaterThan(0);
+      expect(Array.isArray(week1.workouts)).toBe(true);
+      expect(week1.workouts.length).toBeGreaterThan(0);
       expect(week1.completed).toBe(false);
-      // Each date should be a valid ISO date string
-      for (const d of week1.workoutDates) {
-        expect(d).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      // Each workout entry should have workoutNum and a valid ISO date string
+      for (const ws of week1.workouts) {
+        expect(typeof ws.workoutNum).toBe('number');
+        expect(ws.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
       }
+    });
+
+    it('GET workout returns scheduled date as date when no records exist and schedule is active', async () => {
+      const userId = 'schedule-e2e-workout-date';
+      const token = `Bearer ${userId}`;
+      await setScheduleForUser(userId);
+
+      await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/cycles/initialize`,
+        headers: { 'content-type': 'application/json', authorization: token },
+        payload: JSON.stringify({ cycleDate: '2026-05-19' }),
+      });
+
+      // Get the scheduled date for workout 1 from the dashboard
+      const dashRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'GET',
+        url: `/programs/${SEED_PROGRAM}/cycles/current`,
+        headers: { authorization: token },
+      });
+      const dashBody = dashRes.json();
+      const allWorkouts = dashBody.weeks.flatMap((w: { workouts: { workoutNum: number; date: string }[] }) => w.workouts);
+      const scheduled = allWorkouts.find((ws: { workoutNum: number }) => ws.workoutNum === 1);
+      expect(scheduled).toBeDefined();
+
+      // GET workout 1 — should return the scheduled date as `date`
+      const workoutRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'GET',
+        url: `/programs/${SEED_PROGRAM}/workouts/1`,
+        headers: { authorization: token },
+      });
+      expect(workoutRes.statusCode).toBe(200);
+      expect(workoutRes.json().date).toBe(scheduled!.date);
+    });
+
+    it('POST lift-records without date uses scheduled date', async () => {
+      const userId = 'schedule-e2e-lift-record-date';
+      const token = `Bearer ${userId}`;
+      await setScheduleForUser(userId);
+
+      await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/cycles/initialize`,
+        headers: { 'content-type': 'application/json', authorization: token },
+        payload: JSON.stringify({ cycleDate: '2026-05-19' }),
+      });
+
+      // Get the scheduled date for workout 1
+      const dashRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'GET',
+        url: `/programs/${SEED_PROGRAM}/cycles/current`,
+        headers: { authorization: token },
+      });
+      const allWorkouts = dashRes.json().weeks.flatMap((w: { workouts: { workoutNum: number; date: string }[] }) => w.workouts);
+      const scheduledDate = allWorkouts.find((ws: { workoutNum: number }) => ws.workoutNum === 1)!.date;
+
+      // POST lift record without date
+      const recordRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/lift-records`,
+        headers: { 'content-type': 'application/json', authorization: token },
+        payload: JSON.stringify({
+          program: SEED_PROGRAM,
+          cycleNum: 1,
+          workoutNum: 1,
+          lift: 'Squat',
+          setNum: 1,
+          weight: 135,
+          reps: 5,
+        }),
+      });
+      expect(recordRes.statusCode).toBe(201);
+      expect(recordRes.json().date).toBe(scheduledDate);
     });
 
     it('GET cycle dashboard returns weeks:[] when no schedule is set (schedule user baseline)', async () => {

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -1122,4 +1122,116 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
       expect(dashRes.json().weeks).toEqual([]);
     });
   });
+
+  describe('workout skip override', () => {
+    async function setupSkipUser(userId: string): Promise<string> {
+      const token = `Bearer ${userId}`;
+      // Set Mon/Wed/Fri schedule via factory (mirrors setScheduleForUser in schedule mode tests)
+      const factory = app.get<InMemoryRepositoryFactory>(REPOSITORY_FACTORY);
+      const bundle = await factory.forUser({ id: userId, email: '', provider: 'dev' });
+      (bundle.userSettings as InMemoryUserSettingsRepository).setSchedule({ type: 'fixed', days: [0, 2, 4] });
+      await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/cycles/initialize`,
+        headers: { 'content-type': 'application/json', authorization: token },
+        payload: JSON.stringify({ cycleDate: '2026-05-19' }),
+      });
+      return token;
+    }
+
+    it('POST skip marks workout as skipped:true in dashboard', async () => {
+      const token = await setupSkipUser('skip-e2e-skip-marks');
+
+      const skipRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/cycles/1/workouts/1/skip`,
+        headers: { 'content-type': 'application/json', authorization: token },
+        payload: JSON.stringify({}),
+      });
+      expect(skipRes.statusCode).toBe(204);
+
+      const dashRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'GET',
+        url: `/programs/${SEED_PROGRAM}/cycles/current`,
+        headers: { authorization: token },
+      });
+      expect(dashRes.statusCode).toBe(200);
+      const allWorkouts = dashRes.json().weeks.flatMap((w: { workouts: { workoutNum: number; skipped: boolean }[] }) => w.workouts);
+      const w1 = allWorkouts.find((ws: { workoutNum: number }) => ws.workoutNum === 1);
+      expect(w1).toBeDefined();
+      expect(w1!.skipped).toBe(true);
+    });
+
+    it('DELETE skip clears the skip mark (skipped:false)', async () => {
+      const token = await setupSkipUser('skip-e2e-unskip');
+
+      await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/cycles/1/workouts/1/skip`,
+        headers: { 'content-type': 'application/json', authorization: token },
+        payload: JSON.stringify({}),
+      });
+
+      const unskipRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'DELETE',
+        url: `/programs/${SEED_PROGRAM}/cycles/1/workouts/1/skip`,
+        headers: { authorization: token },
+      });
+      expect(unskipRes.statusCode).toBe(204);
+
+      const dashRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'GET',
+        url: `/programs/${SEED_PROGRAM}/cycles/current`,
+        headers: { authorization: token },
+      });
+      const allWorkouts = dashRes.json().weeks.flatMap((w: { workouts: { workoutNum: number; skipped: boolean }[] }) => w.workouts);
+      const w1 = allWorkouts.find((ws: { workoutNum: number }) => ws.workoutNum === 1);
+      expect(w1!.skipped).toBe(false);
+    });
+
+    it('week is completed when all workouts are either logged or skipped', async () => {
+      const token = await setupSkipUser('skip-e2e-completion');
+
+      // Get week 1 workouts
+      const dashRes = await app.getHttpAdapter().getInstance().inject({
+        method: 'GET',
+        url: `/programs/${SEED_PROGRAM}/cycles/current`,
+        headers: { authorization: token },
+      });
+      const week1 = dashRes.json().weeks[0];
+      const workoutNums: number[] = week1.workouts.map((ws: { workoutNum: number }) => ws.workoutNum);
+
+      // Log all but the last; skip the last
+      for (let i = 0; i < workoutNums.length - 1; i++) {
+        await app.getHttpAdapter().getInstance().inject({
+          method: 'POST',
+          url: `/programs/${SEED_PROGRAM}/lift-records`,
+          headers: { 'content-type': 'application/json', authorization: token },
+          payload: JSON.stringify({
+            program: SEED_PROGRAM,
+            cycleNum: 1,
+            workoutNum: workoutNums[i],
+            lift: 'Squat',
+            setNum: 1,
+            weight: 135,
+            reps: 5,
+          }),
+        });
+      }
+      const lastWorkoutNum = workoutNums[workoutNums.length - 1];
+      await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/cycles/1/workouts/${lastWorkoutNum}/skip`,
+        headers: { 'content-type': 'application/json', authorization: token },
+        payload: JSON.stringify({}),
+      });
+
+      const finalDash = await app.getHttpAdapter().getInstance().inject({
+        method: 'GET',
+        url: `/programs/${SEED_PROGRAM}/cycles/current`,
+        headers: { authorization: token },
+      });
+      expect(finalDash.json().weeks[0].completed).toBe(true);
+    });
+  });
 });

--- a/apps/api/src/programs/programs.module.ts
+++ b/apps/api/src/programs/programs.module.ts
@@ -15,6 +15,7 @@ import { TrainingMaxesController } from './training-maxes.controller';
 import { TrainingMaxHistoryController } from './training-max-history.controller';
 import { RescheduleController } from './reschedule.controller';
 import { SwitchProgramController } from './switch-program.controller';
+import { WorkoutSkipController } from './workout-skip.controller';
 import { WorkoutsController } from './workouts.controller';
 
 @Module({
@@ -25,6 +26,7 @@ import { WorkoutsController } from './workouts.controller';
     CyclePlanController,
     RescheduleController,
     SwitchProgramController,
+    WorkoutSkipController,
     WorkoutsController,
     StrengthGoalsController,
     TrainingMaxesController,

--- a/apps/api/src/programs/workout-skip.controller.spec.ts
+++ b/apps/api/src/programs/workout-skip.controller.spec.ts
@@ -1,0 +1,96 @@
+import { BadRequestException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { IWorkoutSkipOverrideRepository } from '../ports/IWorkoutSkipOverrideRepository';
+import { IRepositoryFactory } from '../ports/factory';
+import { REPOSITORY_FACTORY } from '../ports/tokens';
+import { WorkoutSkipController } from './workout-skip.controller';
+
+const MOCK_USER = { id: 'u1', email: 'test@example.com', provider: 'dev' };
+
+describe('WorkoutSkipController', () => {
+  let controller: WorkoutSkipController;
+  let skipRepo: jest.Mocked<IWorkoutSkipOverrideRepository>;
+
+  beforeEach(async () => {
+    skipRepo = {
+      getSkipsForCycle: jest.fn(),
+      skipWorkout: jest.fn().mockResolvedValue(undefined),
+      unskipWorkout: jest.fn().mockResolvedValue(undefined),
+    };
+    const factory: jest.Mocked<IRepositoryFactory> = {
+      forUser: jest.fn().mockResolvedValue({ workoutSkipOverride: skipRepo }),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WorkoutSkipController],
+      providers: [{ provide: REPOSITORY_FACTORY, useValue: factory }],
+    }).compile();
+    controller = module.get(WorkoutSkipController);
+  });
+
+  describe('skipWorkout', () => {
+    it('throws 400 for non-numeric cycleNum', async () => {
+      await expect(
+        controller.skipWorkout('5-3-1', 'abc', '1', {}, MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws 400 for cycleNum < 1', async () => {
+      await expect(
+        controller.skipWorkout('5-3-1', '0', '1', {}, MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws 400 for non-numeric workoutNum', async () => {
+      await expect(
+        controller.skipWorkout('5-3-1', '1', 'abc', {}, MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws 400 for workoutNum < 1', async () => {
+      await expect(
+        controller.skipWorkout('5-3-1', '1', '0', {}, MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('calls skipWorkout with parsed params and optional reason', async () => {
+      await controller.skipWorkout('5-3-1', '2', '3', { reason: 'sick' }, MOCK_USER);
+      expect(skipRepo.skipWorkout).toHaveBeenCalledWith('5-3-1', 2, 3, 'sick');
+    });
+
+    it('calls skipWorkout without reason when dto has none', async () => {
+      await controller.skipWorkout('5-3-1', '2', '3', {}, MOCK_USER);
+      expect(skipRepo.skipWorkout).toHaveBeenCalledWith('5-3-1', 2, 3, undefined);
+    });
+  });
+
+  describe('unskipWorkout', () => {
+    it('throws 400 for non-numeric cycleNum', async () => {
+      await expect(
+        controller.unskipWorkout('5-3-1', 'abc', '1', MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws 400 for cycleNum < 1', async () => {
+      await expect(
+        controller.unskipWorkout('5-3-1', '0', '1', MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws 400 for non-numeric workoutNum', async () => {
+      await expect(
+        controller.unskipWorkout('5-3-1', '1', 'abc', MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws 400 for workoutNum < 1', async () => {
+      await expect(
+        controller.unskipWorkout('5-3-1', '1', '0', MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('calls unskipWorkout with parsed params', async () => {
+      await controller.unskipWorkout('5-3-1', '2', '3', MOCK_USER);
+      expect(skipRepo.unskipWorkout).toHaveBeenCalledWith('5-3-1', 2, 3);
+    });
+  });
+});

--- a/apps/api/src/programs/workout-skip.controller.ts
+++ b/apps/api/src/programs/workout-skip.controller.ts
@@ -1,0 +1,75 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  Param,
+  Post,
+} from '@nestjs/common';
+import { IsOptional, IsString } from 'class-validator';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { AuthUser } from '../ports/auth';
+import { IRepositoryFactory } from '../ports/factory';
+import { REPOSITORY_FACTORY } from '../ports/tokens';
+import { isValidWorkoutNum } from './mappers';
+
+class SkipWorkoutDto {
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}
+
+@Controller('programs/:program')
+export class WorkoutSkipController {
+  constructor(
+    @Inject(REPOSITORY_FACTORY) private readonly factory: IRepositoryFactory,
+  ) {}
+
+  @Post('cycles/:cycleNum/workouts/:workoutNum/skip')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async skipWorkout(
+    @Param('program') program: string,
+    @Param('cycleNum') cycleNumParam: string,
+    @Param('workoutNum') workoutNumParam: string,
+    @Body() dto: SkipWorkoutDto,
+    @CurrentUser() user: AuthUser,
+  ): Promise<void> {
+    const cycleNum = Number.parseInt(cycleNumParam, 10);
+    const workoutNum = Number.parseInt(workoutNumParam, 10);
+
+    if (!Number.isInteger(cycleNum) || cycleNum < 1) {
+      throw new BadRequestException('cycleNum must be a positive integer');
+    }
+    if (!isValidWorkoutNum(workoutNum)) {
+      throw new BadRequestException('workoutNum must be a positive integer');
+    }
+
+    const { workoutSkipOverride } = await this.factory.forUser(user);
+    await workoutSkipOverride.skipWorkout(program, cycleNum, workoutNum, dto.reason);
+  }
+
+  @Delete('cycles/:cycleNum/workouts/:workoutNum/skip')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async unskipWorkout(
+    @Param('program') program: string,
+    @Param('cycleNum') cycleNumParam: string,
+    @Param('workoutNum') workoutNumParam: string,
+    @CurrentUser() user: AuthUser,
+  ): Promise<void> {
+    const cycleNum = Number.parseInt(cycleNumParam, 10);
+    const workoutNum = Number.parseInt(workoutNumParam, 10);
+
+    if (!Number.isInteger(cycleNum) || cycleNum < 1) {
+      throw new BadRequestException('cycleNum must be a positive integer');
+    }
+    if (!isValidWorkoutNum(workoutNum)) {
+      throw new BadRequestException('workoutNum must be a positive integer');
+    }
+
+    const { workoutSkipOverride } = await this.factory.forUser(user);
+    await workoutSkipOverride.unskipWorkout(program, cycleNum, workoutNum);
+  }
+}

--- a/apps/api/src/programs/workouts.controller.spec.ts
+++ b/apps/api/src/programs/workouts.controller.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Weekday } from '@lifting-logbook/core';
 import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
+import { ICycleScheduledWorkoutRepository } from '../ports/ICycleScheduledWorkoutRepository';
 import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
 import { IWorkoutDateOverrideRepository } from '../ports/IWorkoutDateOverrideRepository';
 import { IWorkoutLiftOverrideRepository } from '../ports/IWorkoutLiftOverrideRepository';
@@ -20,6 +21,7 @@ describe('WorkoutsController', () => {
   let specRepo: jest.Mocked<ILiftingProgramSpecRepository>;
   let overrideRepo: jest.Mocked<IWorkoutDateOverrideRepository>;
   let liftOverrideRepo: jest.Mocked<IWorkoutLiftOverrideRepository>;
+  let scheduledWorkoutRepo: jest.Mocked<ICycleScheduledWorkoutRepository>;
   let factory: jest.Mocked<IRepositoryFactory>;
 
   beforeEach(async () => {
@@ -38,10 +40,15 @@ describe('WorkoutsController', () => {
       upsertOverride: jest.fn().mockResolvedValue(undefined),
       deleteOverride: jest.fn().mockResolvedValue(undefined),
     };
+    scheduledWorkoutRepo = {
+      getScheduledWorkouts: jest.fn().mockResolvedValue([]),
+      saveScheduledWorkouts: jest.fn().mockResolvedValue(undefined),
+    };
     factory = {
       forUser: jest.fn().mockResolvedValue({
         workout: workoutRepo,
         cycleDashboard: dashboardRepo,
+        cycleScheduledWorkout: scheduledWorkoutRepo,
         liftingProgramSpec: specRepo,
         workoutDateOverride: overrideRepo,
         workoutLiftOverride: liftOverrideRepo,

--- a/apps/api/src/programs/workouts.controller.ts
+++ b/apps/api/src/programs/workouts.controller.ts
@@ -35,7 +35,7 @@ export class WorkoutsController {
     if (!isValidWorkoutNum(workoutNum)) {
       throw new BadRequestException('workoutNum must be a positive integer');
     }
-    const { workout, cycleDashboard, liftingProgramSpec, workoutDateOverride, workoutLiftOverride } =
+    const { workout, cycleDashboard, cycleScheduledWorkout, liftingProgramSpec, workoutDateOverride, workoutLiftOverride } =
       await this.factory.forUser(user);
     const [dashboard, spec] = await Promise.all([
       cycleDashboard.getCycleDashboard(program).catch((err: unknown) => {
@@ -54,7 +54,7 @@ export class WorkoutsController {
     // Spec lifts for this workout's week — used to build the planned lift list.
     const specLifts = [...new Set(spec.filter((s) => s.week === week).map((s) => s.lift))];
 
-    const [records, overrideDate, liftOverrides] = await Promise.all([
+    const [records, overrideDate, liftOverrides, scheduledWorkouts] = await Promise.all([
       workout
         .getWorkout(program, dashboard.cycleNum, workoutNum)
         .catch((err: unknown) => {
@@ -64,7 +64,9 @@ export class WorkoutsController {
         }),
       workoutDateOverride.getOverride(program, dashboard.cycleNum, workoutNum),
       workoutLiftOverride.getOverrides(program, dashboard.cycleNum, workoutNum),
+      cycleScheduledWorkout.getScheduledWorkouts(program, dashboard.cycleNum),
     ]);
+    const scheduledDate = scheduledWorkouts.find((s) => s.workoutNum === workoutNum)?.scheduledDate;
 
     const plannedLifts = applyLiftOverrides(specLifts, liftOverrides);
 
@@ -91,6 +93,7 @@ export class WorkoutsController {
       adjustedRecords,
       overrideDate ?? undefined,
       plannedLifts,
+      scheduledDate,
     );
   }
 }

--- a/apps/web/app/cycle/[cycleNum]/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/page.tsx
@@ -41,6 +41,15 @@ export default async function CycleDashboardPage({
     workoutDays.map((w, i) => [w.workoutNum, workoutResponseList[i]]),
   );
 
+  // Build a flat workoutNum → scheduled date lookup from the cycle dashboard response.
+  // This is populated when schedule mode is active; empty when no schedule is set.
+  const scheduledDateMap = new Map<number, string>();
+  for (const week of dashboard.weeks) {
+    for (const ws of week.workouts) {
+      scheduledDateMap.set(ws.workoutNum, ws.date);
+    }
+  }
+
   const today = new Date().toISOString().slice(0, 10);
   const maxMap = new Map(maxes.map((m) => [m.lift, m.weight]));
 
@@ -53,9 +62,8 @@ export default async function CycleDashboardPage({
       .map((w): WorkoutCell => {
         const response = workoutResponseMap.get(w.workoutNum);
         const logged = response != null && response.lifts.length > 0;
-        // Prefer the user's overridden date when one exists; fall back to the computed schedule date.
-        // Status comparison uses UTC date strings (ISO YYYY-MM-DD) consistently across dashboard and detail page.
-        const effectiveDate = response?.overrideDate ?? w.date;
+        // Priority: user override date > API scheduled date > spec-computed date.
+        const effectiveDate = response?.overrideDate ?? scheduledDateMap.get(w.workoutNum) ?? w.date;
         const status: WorkoutCell['status'] = logged
           ? 'completed'
           : effectiveDate < today

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.module.css
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.module.css
@@ -47,6 +47,32 @@
 }
 
 /* ---------------------------------------------------------------------------
+   Date override row
+   --------------------------------------------------------------------------- */
+
+.dateRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) 0 var(--space-3);
+}
+
+.dateLabel {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.dateInput {
+  font-size: var(--font-size-sm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+/* ---------------------------------------------------------------------------
    Navigation dots
    --------------------------------------------------------------------------- */
 

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
@@ -610,9 +610,13 @@ export default function WorkoutLogger({
           value={effectiveDate}
           onChange={(e) => {
             const newDate = e.target.value;
+            const prevDate = effectiveDate;
             setEffectiveDate(newDate);
             if (isReadOnly) {
-              rescheduleWorkout(program, cycleNum, workoutNum, newDate).catch(console.error);
+              rescheduleWorkout(program, cycleNum, workoutNum, newDate).catch((err) => {
+                console.error(err);
+                setEffectiveDate(prevDate);
+              });
             }
           }}
         />

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
@@ -6,6 +6,7 @@ import type { LiftRecordResponse } from '@lifting-logbook/types';
 import {
   createLiftRecord,
   recordBodyWeight,
+  rescheduleWorkout,
   updateLiftRecord,
 } from '@/lib/client-api';
 import styles from './WorkoutLogger.module.css';
@@ -598,20 +599,24 @@ export default function WorkoutLogger({
         </button>
       </header>
 
-      {!isReadOnly && (
-        <div className={styles.dateRow}>
-          <label className={styles.dateLabel} htmlFor="workout-date">
-            Date
-          </label>
-          <input
-            id="workout-date"
-            className={styles.dateInput}
-            type="date"
-            value={effectiveDate}
-            onChange={(e) => setEffectiveDate(e.target.value)}
-          />
-        </div>
-      )}
+      <div className={styles.dateRow}>
+        <label className={styles.dateLabel} htmlFor="workout-date">
+          Date
+        </label>
+        <input
+          id="workout-date"
+          className={styles.dateInput}
+          type="date"
+          value={effectiveDate}
+          onChange={(e) => {
+            const newDate = e.target.value;
+            setEffectiveDate(newDate);
+            if (isReadOnly) {
+              rescheduleWorkout(program, cycleNum, workoutNum, newDate).catch(console.error);
+            }
+          }}
+        />
+      </div>
 
       {/* Navigation dots */}
       <nav className={styles.navDots} aria-label="Exercise navigation">

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { LiftRecordResponse } from '@lifting-logbook/types';
 import {
   createLiftRecord,
@@ -478,6 +478,10 @@ export default function WorkoutLogger({
 }: WorkoutLoggerProps) {
   const router = useRouter();
 
+  // Editable date — initialized from the server-provided scheduled date, user can override.
+  const [effectiveDate, setEffectiveDate] = useState(date);
+  useEffect(() => { setEffectiveDate(date); }, [date]);
+
   // Initialize loggedSets from any pre-existing records passed via server props
   const [loggedSets, setLoggedSets] = useState<Map<string, LiftRecordResponse>>(
     () => {
@@ -503,7 +507,7 @@ export default function WorkoutLogger({
 
   async function handleBodyWeightSubmit(weight: number) {
     await recordBodyWeight(program, {
-      date,
+      date: effectiveDate,
       weight,
       unit: 'lbs',
     });
@@ -594,6 +598,21 @@ export default function WorkoutLogger({
         </button>
       </header>
 
+      {!isReadOnly && (
+        <div className={styles.dateRow}>
+          <label className={styles.dateLabel} htmlFor="workout-date">
+            Date
+          </label>
+          <input
+            id="workout-date"
+            className={styles.dateInput}
+            type="date"
+            value={effectiveDate}
+            onChange={(e) => setEffectiveDate(e.target.value)}
+          />
+        </div>
+      )}
+
       {/* Navigation dots */}
       <nav className={styles.navDots} aria-label="Exercise navigation">
         {lifts.map((lift, i) => {
@@ -624,7 +643,7 @@ export default function WorkoutLogger({
           program={program}
           cycleNum={cycleNum}
           workoutNum={workoutNum}
-          date={date}
+          date={effectiveDate}
           onLogged={handleLogged}
           onEditStart={handleEditStart}
           onEditSave={handleEditSave}

--- a/apps/web/lib/__tests__/programPlan.test.ts
+++ b/apps/web/lib/__tests__/programPlan.test.ts
@@ -3,9 +3,13 @@ import { deriveProgramPhases, deriveProgramSummary } from '../programPlan';
 
 const makeWeek = (
   week: number,
-  workoutDates: string[],
+  dates: string[],
   completed: boolean,
-): CycleWeekSummary => ({ week, workoutDates, completed });
+): CycleWeekSummary => ({
+  week,
+  workouts: dates.map((date, i) => ({ workoutNum: i + 1, date })),
+  completed,
+});
 
 const makeSpec = (
   overrides: Partial<LiftingProgramSpecResponse>,

--- a/apps/web/lib/__tests__/programPlan.test.ts
+++ b/apps/web/lib/__tests__/programPlan.test.ts
@@ -7,7 +7,7 @@ const makeWeek = (
   completed: boolean,
 ): CycleWeekSummary => ({
   week,
-  workouts: dates.map((date, i) => ({ workoutNum: i + 1, date })),
+  workouts: dates.map((date, i) => ({ workoutNum: i + 1, date, skipped: false })),
   completed,
 });
 

--- a/apps/web/lib/programPlan.ts
+++ b/apps/web/lib/programPlan.ts
@@ -44,7 +44,7 @@ function phaseStatus(
   const summaries = weeks.map((w) => weekMap.get(w));
   if (summaries.every((s) => s?.completed)) return 'completed';
   const hasStarted = summaries.some((s) =>
-    s?.workoutDates.some((d) => d <= today),
+    s?.workouts.some((w) => w.date <= today),
   );
   return hasStarted ? 'in-progress' : 'upcoming';
 }

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -119,7 +119,8 @@ export interface CreateLiftRecordRequest {
   program: string;
   cycleNum: CycleNumber;
   workoutNum: number;
-  date: string; // ISO 8601 date string
+  /** ISO 8601 date string. When omitted the server uses the scheduled date for this workout, falling back to today. */
+  date?: string;
   lift: LiftName;
   setNum: number;
   weight: number;
@@ -178,10 +179,16 @@ export interface UpsertStrengthGoalRequest {
 // Cycle Dashboard
 // ---------------------------------------------------------------------------
 
+/** Per-workout entry within a cycle week summary. */
+export interface WorkoutSummary {
+  workoutNum: number;
+  date: string; // ISO 8601 scheduled date
+}
+
 /** Per-week summary within a cycle dashboard. */
 export interface CycleWeekSummary {
   week: WeekNumber;
-  workoutDates: string[]; // ISO 8601 date strings
+  workouts: WorkoutSummary[];
   completed: boolean;
 }
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -183,6 +183,7 @@ export interface UpsertStrengthGoalRequest {
 export interface WorkoutSummary {
   workoutNum: number;
   date: string; // ISO 8601 scheduled date
+  skipped: boolean;
 }
 
 /** Per-week summary within a cycle dashboard. */


### PR DESCRIPTION
## Summary

- Removes the `!isReadOnly` guard from the date input in `WorkoutLogger`
- Date input is now visible for all workouts, including completed (read-only) ones
- For completed workouts: `onChange` calls `PATCH .../reschedule` to persist the new date via `WorkoutDateOverride`; local state updates immediately for responsive UI
- For in-progress workouts: behavior unchanged — date flows through `effectiveDate` state to new records

This PR stacks on Phase 4 ([#274](https://github.com/brownm09/lifting-logbook/pull/274)).

## Acceptance Criteria

- [x] Date input visible on completed (read-only) workouts
- [x] Changing the date on a completed workout calls the reschedule endpoint and persists across navigation
- [x] Date input on in-progress workouts behaves as before

## Test Plan

1. Log a full workout to completion (all sets recorded)
2. Return to the completed workout detail page — date input should appear
3. Change the date — no explicit save needed; the reschedule call fires on change
4. Navigate away and return — the updated date persists
5. Start a new workout, pre-populated with scheduled date — changing the date does not call reschedule; new records use the changed date

## Testing

All 28 web tests pass.

Closes #278