### PR TITLE
[feat] Workout Scheduling Phase 5 — Skip UI + schedule-mode prompt

### DIFF
--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -234,6 +234,7 @@ export const toWorkoutResponse = (
   overrideDate?: Date,
   plannedLifts?: string[],
   scheduledDate?: Date,
+  skipped = false,
 ): WorkoutResponse => {
   const liftMap = new Map<string, SetResponse[]>();
   for (const r of records) {
@@ -282,6 +283,7 @@ export const toWorkoutResponse = (
     week,
     date,
     ...(overrideDate !== undefined && { overrideDate: isoDate(overrideDate) }),
+    skipped,
     lifts,
   };
 };

--- a/apps/api/src/programs/workout-skip.controller.ts
+++ b/apps/api/src/programs/workout-skip.controller.ts
@@ -9,7 +9,7 @@ import {
   Param,
   Post,
 } from '@nestjs/common';
-import { IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../ports/auth';
 import { IRepositoryFactory } from '../ports/factory';
@@ -19,6 +19,7 @@ import { isValidWorkoutNum } from './mappers';
 class SkipWorkoutDto {
   @IsOptional()
   @IsString()
+  @MaxLength(500)
   reason?: string;
 }
 

--- a/apps/api/src/programs/workouts.controller.spec.ts
+++ b/apps/api/src/programs/workouts.controller.spec.ts
@@ -7,6 +7,7 @@ import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepos
 import { IWorkoutDateOverrideRepository } from '../ports/IWorkoutDateOverrideRepository';
 import { IWorkoutLiftOverrideRepository } from '../ports/IWorkoutLiftOverrideRepository';
 import { IWorkoutRepository } from '../ports/IWorkoutRepository';
+import { IWorkoutSkipOverrideRepository } from '../ports/IWorkoutSkipOverrideRepository';
 import { ProgramNotFoundError, WorkoutNotFoundError } from '../ports/errors';
 import { IRepositoryFactory } from '../ports/factory';
 import { REPOSITORY_FACTORY } from '../ports/tokens';
@@ -22,6 +23,7 @@ describe('WorkoutsController', () => {
   let overrideRepo: jest.Mocked<IWorkoutDateOverrideRepository>;
   let liftOverrideRepo: jest.Mocked<IWorkoutLiftOverrideRepository>;
   let scheduledWorkoutRepo: jest.Mocked<ICycleScheduledWorkoutRepository>;
+  let skipOverrideRepo: jest.Mocked<IWorkoutSkipOverrideRepository>;
   let factory: jest.Mocked<IRepositoryFactory>;
 
   beforeEach(async () => {
@@ -44,6 +46,11 @@ describe('WorkoutsController', () => {
       getScheduledWorkouts: jest.fn().mockResolvedValue([]),
       saveScheduledWorkouts: jest.fn().mockResolvedValue(undefined),
     };
+    skipOverrideRepo = {
+      getSkipsForCycle: jest.fn().mockResolvedValue(new Set<number>()),
+      skipWorkout: jest.fn().mockResolvedValue(undefined),
+      unskipWorkout: jest.fn().mockResolvedValue(undefined),
+    };
     factory = {
       forUser: jest.fn().mockResolvedValue({
         workout: workoutRepo,
@@ -52,6 +59,7 @@ describe('WorkoutsController', () => {
         liftingProgramSpec: specRepo,
         workoutDateOverride: overrideRepo,
         workoutLiftOverride: liftOverrideRepo,
+        workoutSkipOverride: skipOverrideRepo,
       }),
     };
     const module: TestingModule = await Test.createTestingModule({
@@ -319,6 +327,54 @@ describe('WorkoutsController', () => {
 
       expect(result.lifts).toHaveLength(2);
       expect(result.lifts[0]).toMatchObject({ lift: 'Squat', planned: true });
+    });
+  });
+
+  describe('skipped field', () => {
+    const dashboard = {
+      program: '5-3-1',
+      cycleUnit: 'week',
+      cycleNum: 3,
+      cycleDate: new Date('2026-04-20T00:00:00.000Z'),
+      sheetName: '',
+      cycleStartWeekday: Weekday.Monday,
+      currentWeekType: 'training' as const,
+    };
+    const spec = [
+      { week: 1, offset: 0, lift: 'Squat', increment: 5, order: 1, sets: 3, reps: 5, amrap: false, warmUpPct: '', wtDecrementPct: 0, activation: 'compound' },
+    ];
+
+    it('returns skipped: false when the workout is not in the skip set', async () => {
+      dashboardRepo.getCycleDashboard.mockResolvedValue(dashboard);
+      specRepo.getProgramSpec.mockResolvedValue(spec);
+      workoutRepo.getWorkout.mockRejectedValue(new WorkoutNotFoundError('5-3-1', 3, 1));
+      skipOverrideRepo.getSkipsForCycle.mockResolvedValue(new Set<number>());
+
+      const result = await controller.getWorkout('5-3-1', '1', MOCK_USER);
+
+      expect(result.skipped).toBe(false);
+    });
+
+    it('returns skipped: true when the workout is in the skip set', async () => {
+      dashboardRepo.getCycleDashboard.mockResolvedValue(dashboard);
+      specRepo.getProgramSpec.mockResolvedValue(spec);
+      workoutRepo.getWorkout.mockRejectedValue(new WorkoutNotFoundError('5-3-1', 3, 1));
+      skipOverrideRepo.getSkipsForCycle.mockResolvedValue(new Set([1]));
+
+      const result = await controller.getWorkout('5-3-1', '1', MOCK_USER);
+
+      expect(result.skipped).toBe(true);
+    });
+
+    it('fetches skip set for the current cycle', async () => {
+      dashboardRepo.getCycleDashboard.mockResolvedValue(dashboard);
+      specRepo.getProgramSpec.mockResolvedValue(spec);
+      workoutRepo.getWorkout.mockRejectedValue(new WorkoutNotFoundError('5-3-1', 3, 1));
+      skipOverrideRepo.getSkipsForCycle.mockResolvedValue(new Set<number>());
+
+      await controller.getWorkout('5-3-1', '1', MOCK_USER);
+
+      expect(skipOverrideRepo.getSkipsForCycle).toHaveBeenCalledWith('5-3-1', 3);
     });
   });
 });

--- a/apps/api/src/programs/workouts.controller.ts
+++ b/apps/api/src/programs/workouts.controller.ts
@@ -65,7 +65,7 @@ export class WorkoutsController {
       workoutDateOverride.getOverride(program, dashboard.cycleNum, workoutNum),
       workoutLiftOverride.getOverrides(program, dashboard.cycleNum, workoutNum),
       cycleScheduledWorkout.getScheduledWorkouts(program, dashboard.cycleNum),
-      workoutSkipOverride.getSkipsForCycle(program, dashboard.cycleNum),
+      workoutSkipOverride.getSkipsForCycle(program, dashboard.cycleNum).catch(() => new Set<number>()),
     ]);
     const scheduledDate = scheduledWorkouts.find((s) => s.workoutNum === workoutNum)?.scheduledDate;
 

--- a/apps/api/src/programs/workouts.controller.ts
+++ b/apps/api/src/programs/workouts.controller.ts
@@ -35,7 +35,7 @@ export class WorkoutsController {
     if (!isValidWorkoutNum(workoutNum)) {
       throw new BadRequestException('workoutNum must be a positive integer');
     }
-    const { workout, cycleDashboard, cycleScheduledWorkout, liftingProgramSpec, workoutDateOverride, workoutLiftOverride } =
+    const { workout, cycleDashboard, cycleScheduledWorkout, liftingProgramSpec, workoutDateOverride, workoutLiftOverride, workoutSkipOverride } =
       await this.factory.forUser(user);
     const [dashboard, spec] = await Promise.all([
       cycleDashboard.getCycleDashboard(program).catch((err: unknown) => {
@@ -54,7 +54,7 @@ export class WorkoutsController {
     // Spec lifts for this workout's week — used to build the planned lift list.
     const specLifts = [...new Set(spec.filter((s) => s.week === week).map((s) => s.lift))];
 
-    const [records, overrideDate, liftOverrides, scheduledWorkouts] = await Promise.all([
+    const [records, overrideDate, liftOverrides, scheduledWorkouts, skippedNums] = await Promise.all([
       workout
         .getWorkout(program, dashboard.cycleNum, workoutNum)
         .catch((err: unknown) => {
@@ -65,6 +65,7 @@ export class WorkoutsController {
       workoutDateOverride.getOverride(program, dashboard.cycleNum, workoutNum),
       workoutLiftOverride.getOverrides(program, dashboard.cycleNum, workoutNum),
       cycleScheduledWorkout.getScheduledWorkouts(program, dashboard.cycleNum),
+      workoutSkipOverride.getSkipsForCycle(program, dashboard.cycleNum),
     ]);
     const scheduledDate = scheduledWorkouts.find((s) => s.workoutNum === workoutNum)?.scheduledDate;
 
@@ -94,6 +95,7 @@ export class WorkoutsController {
       overrideDate ?? undefined,
       plannedLifts,
       scheduledDate,
+      skippedNums.has(workoutNum),
     );
   }
 }

--- a/apps/api/src/programs/workouts.controller.ts
+++ b/apps/api/src/programs/workouts.controller.ts
@@ -65,7 +65,10 @@ export class WorkoutsController {
       workoutDateOverride.getOverride(program, dashboard.cycleNum, workoutNum),
       workoutLiftOverride.getOverrides(program, dashboard.cycleNum, workoutNum),
       cycleScheduledWorkout.getScheduledWorkouts(program, dashboard.cycleNum),
-      workoutSkipOverride.getSkipsForCycle(program, dashboard.cycleNum).catch(() => new Set<number>()),
+      workoutSkipOverride.getSkipsForCycle(program, dashboard.cycleNum).catch((err: unknown) => {
+        console.error('[WorkoutsController] getSkipsForCycle failed; defaulting to empty set', err);
+        return new Set<number>();
+      }),
     ]);
     const scheduledDate = scheduledWorkouts.find((s) => s.workoutNum === workoutNum)?.scheduledDate;
 

--- a/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.module.css
+++ b/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.module.css
@@ -90,6 +90,12 @@
   border-color: var(--color-missed-border);
 }
 
+.card_skipped {
+  background: var(--color-surface-alt);
+  border-color: var(--color-border);
+  opacity: 0.75;
+}
+
 .cardHeader {
   display: flex;
   justify-content: space-between;
@@ -124,6 +130,11 @@
 .badge_missed {
   background: var(--color-missed-bg);
   color: var(--color-upcoming-text);
+}
+
+.badge_skipped {
+  background: var(--color-surface-alt);
+  color: var(--color-text-muted);
 }
 
 .liftList {

--- a/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.tsx
+++ b/apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.tsx
@@ -14,16 +14,17 @@ function findCurrentWeek(weeks: WeekRow[]): number {
   return weeks[weeks.length - 1]?.week ?? 1;
 }
 
+const STATUS_LABELS: Record<WorkoutCell['status'], string> = {
+  completed: 'Completed',
+  upcoming: 'Upcoming',
+  missed: 'Missed',
+  skipped: 'Skipped',
+};
+
 function StatusBadge({ status }: { status: WorkoutCell['status'] }) {
-  const label =
-    status === 'completed'
-      ? 'Completed'
-      : status === 'upcoming'
-        ? 'Upcoming'
-        : 'Missed';
   return (
     <span className={`${styles.badge} ${styles[`badge_${status}`]}`}>
-      {label}
+      {STATUS_LABELS[status]}
     </span>
   );
 }

--- a/apps/web/app/cycle/[cycleNum]/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/page.tsx
@@ -44,9 +44,11 @@ export default async function CycleDashboardPage({
   // Build a flat workoutNum → scheduled date lookup from the cycle dashboard response.
   // This is populated when schedule mode is active; empty when no schedule is set.
   const scheduledDateMap = new Map<number, string>();
+  const skippedWorkoutNums = new Set<number>();
   for (const week of dashboard.weeks) {
     for (const ws of week.workouts) {
       scheduledDateMap.set(ws.workoutNum, ws.date);
+      if (ws.skipped) skippedWorkoutNums.add(ws.workoutNum);
     }
   }
 
@@ -66,9 +68,11 @@ export default async function CycleDashboardPage({
         const effectiveDate = response?.overrideDate ?? scheduledDateMap.get(w.workoutNum) ?? w.date;
         const status: WorkoutCell['status'] = logged
           ? 'completed'
-          : effectiveDate < today
-            ? 'missed'
-            : 'upcoming';
+          : skippedWorkoutNums.has(w.workoutNum)
+            ? 'skipped'
+            : effectiveDate < today
+              ? 'missed'
+              : 'upcoming';
         return {
           workoutNum: w.workoutNum,
           date: effectiveDate,

--- a/apps/web/app/cycle/[cycleNum]/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/page.tsx
@@ -63,7 +63,7 @@ export default async function CycleDashboardPage({
       .filter((w) => w.week === week)
       .map((w): WorkoutCell => {
         const response = workoutResponseMap.get(w.workoutNum);
-        const logged = response != null && response.lifts.length > 0;
+        const logged = response != null && response.lifts.some((l) => !l.planned);
         // Priority: user override date > API scheduled date > spec-computed date.
         const effectiveDate = response?.overrideDate ?? scheduledDateMap.get(w.workoutNum) ?? w.date;
         const status: WorkoutCell['status'] = logged

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/SkipForm.module.css
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/SkipForm.module.css
@@ -1,0 +1,134 @@
+.trigger {
+  padding: var(--space-2) var(--space-4);
+  background: transparent;
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.trigger:hover {
+  background: var(--color-surface-alt);
+}
+
+.form {
+  width: 100%;
+  padding: var(--space-4);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.infoBox {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.label {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+.optional {
+  font-weight: 400;
+  color: var(--color-text-muted);
+}
+
+.input {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  background: var(--color-surface);
+  color: var(--color-text);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.error {
+  font-size: var(--font-size-sm);
+  color: var(--color-error-text, red);
+  margin: 0;
+}
+
+.buttons {
+  display: flex;
+  gap: var(--space-3);
+  justify-content: flex-end;
+}
+
+.cancel {
+  padding: var(--space-2) var(--space-4);
+  background: transparent;
+  color: var(--color-text);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.cancel:not(:disabled):hover {
+  background: var(--color-surface-alt);
+}
+
+.cancel:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.skip {
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-warn-bg, #fef3c7);
+  color: var(--color-warn-text, #92400e);
+  border: 1px solid var(--color-warn-border, #fcd34d);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.skip:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.skip:not(:disabled):hover {
+  opacity: 0.88;
+}
+
+.undo {
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-accent);
+  color: var(--color-accent-text);
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.undo:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.undo:not(:disabled):hover {
+  opacity: 0.88;
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/SkipForm.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/SkipForm.tsx
@@ -30,7 +30,8 @@ export default function SkipForm({ program, cycleNum, workoutNum, skipped }: Pro
       }
       setOpen(false);
       router.refresh();
-    } catch {
+    } catch (e) {
+      console.error('[SkipForm] mutation failed', e);
       setError(skipped ? 'Failed to undo skip. Please try again.' : 'Failed to skip workout. Please try again.');
     } finally {
       setLoading(false);
@@ -67,6 +68,7 @@ export default function SkipForm({ program, cycleNum, workoutNum, skipped }: Pro
               onChange={(e) => setReason(e.target.value)}
               className={styles.input}
               placeholder="e.g. Travel, illness, rest day"
+              maxLength={500}
               aria-describedby={error ? 'skip-error' : undefined}
             />
           </div>

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/SkipForm.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/SkipForm.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { skipWorkout, unskipWorkout } from '@/lib/client-api';
+import styles from './SkipForm.module.css';
+
+interface Props {
+  program: string;
+  cycleNum: number;
+  workoutNum: number;
+  skipped: boolean;
+}
+
+export default function SkipForm({ program, cycleNum, workoutNum, skipped }: Props) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleConfirm() {
+    setLoading(true);
+    setError(null);
+    try {
+      if (skipped) {
+        await unskipWorkout(program, cycleNum, workoutNum);
+      } else {
+        await skipWorkout(program, cycleNum, workoutNum, reason || undefined);
+      }
+      setOpen(false);
+      router.refresh();
+    } catch {
+      setError(skipped ? 'Failed to undo skip. Please try again.' : 'Failed to skip workout. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button type="button" className={styles.trigger} onClick={() => setOpen(true)}>
+        {skipped ? '↩ Undo Skip' : '⊘ Mark as Skipped'}
+      </button>
+    );
+  }
+
+  return (
+    <div className={styles.form}>
+      {skipped ? (
+        <p className={styles.infoBox}>
+          Undo the skip for this workout. It will return to its previous status.
+        </p>
+      ) : (
+        <>
+          <p className={styles.infoBox}>
+            Mark this workout as skipped. It will count as done for the week.
+          </p>
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="skip-reason">
+              Reason <span className={styles.optional}>(optional)</span>
+            </label>
+            <input
+              id="skip-reason"
+              type="text"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              className={styles.input}
+              placeholder="e.g. Travel, illness, rest day"
+              aria-describedby={error ? 'skip-error' : undefined}
+            />
+          </div>
+        </>
+      )}
+      {error && (
+        <p id="skip-error" className={styles.error}>
+          {error}
+        </p>
+      )}
+      <div className={styles.buttons}>
+        <button
+          type="button"
+          className={styles.cancel}
+          onClick={() => {
+            setOpen(false);
+            setReason('');
+            setError(null);
+          }}
+          disabled={loading}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className={skipped ? styles.undo : styles.skip}
+          onClick={handleConfirm}
+          disabled={loading}
+        >
+          {loading
+            ? skipped ? 'Undoing…' : 'Skipping…'
+            : skipped ? 'Undo Skip' : 'Skip Workout'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/SkipForm.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/SkipForm.tsx
@@ -19,20 +19,31 @@ export default function SkipForm({ program, cycleNum, workoutNum, skipped }: Pro
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  async function handleConfirm() {
+  async function handleSkip() {
     setLoading(true);
     setError(null);
     try {
-      if (skipped) {
-        await unskipWorkout(program, cycleNum, workoutNum);
-      } else {
-        await skipWorkout(program, cycleNum, workoutNum, reason || undefined);
-      }
+      await skipWorkout(program, cycleNum, workoutNum, reason || undefined);
       setOpen(false);
       router.refresh();
     } catch (e) {
-      console.error('[SkipForm] mutation failed', e);
-      setError(skipped ? 'Failed to undo skip. Please try again.' : 'Failed to skip workout. Please try again.');
+      console.error('[SkipForm] skip failed', e);
+      setError('Failed to skip workout. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleUnskip() {
+    setLoading(true);
+    setError(null);
+    try {
+      await unskipWorkout(program, cycleNum, workoutNum);
+      setOpen(false);
+      router.refresh();
+    } catch (e) {
+      console.error('[SkipForm] unskip failed', e);
+      setError('Failed to undo skip. Please try again.');
     } finally {
       setLoading(false);
     }
@@ -92,16 +103,25 @@ export default function SkipForm({ program, cycleNum, workoutNum, skipped }: Pro
         >
           Cancel
         </button>
-        <button
-          type="button"
-          className={skipped ? styles.undo : styles.skip}
-          onClick={handleConfirm}
-          disabled={loading}
-        >
-          {loading
-            ? skipped ? 'Undoing…' : 'Skipping…'
-            : skipped ? 'Undo Skip' : 'Skip Workout'}
-        </button>
+        {skipped ? (
+          <button
+            type="button"
+            className={styles.undo}
+            onClick={handleUnskip}
+            disabled={loading}
+          >
+            {loading ? 'Undoing…' : 'Undo Skip'}
+          </button>
+        ) : (
+          <button
+            type="button"
+            className={styles.skip}
+            onClick={handleSkip}
+            disabled={loading}
+          >
+            {loading ? 'Skipping…' : 'Skip Workout'}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/detail.module.css
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/detail.module.css
@@ -69,6 +69,11 @@
   color: var(--color-upcoming-text);
 }
 
+.badge_skipped {
+  background: var(--color-surface-alt);
+  color: var(--color-text-muted);
+}
+
 .sectionHeading {
   font-size: var(--font-size-base);
   font-weight: 600;

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/page.tsx
@@ -5,14 +5,17 @@ import { getActiveProgram } from '@/lib/active-program';
 import { computePlannedSets } from '@/lib/workoutPlan';
 import CollapsibleLiftList from './CollapsibleLiftList';
 import RescheduleForm from './RescheduleForm';
+import SkipForm from './SkipForm';
 import styles from './detail.module.css';
 
 function workoutStatus(
   date: string,
   hasLogs: boolean,
-): 'completed' | 'upcoming' | 'missed' {
+  skipped: boolean,
+): 'completed' | 'upcoming' | 'missed' | 'skipped' {
   const today = new Date().toISOString().slice(0, 10);
   if (hasLogs) return 'completed';
+  if (skipped) return 'skipped';
   if (date < today) return 'missed';
   return 'upcoming';
 }
@@ -45,7 +48,7 @@ export default async function WorkoutDetailPage({
 
   const effectiveDate = workout.overrideDate ?? workout.date;
   const hasLogs = workout.lifts.some((l) => !l.planned);
-  const status = workoutStatus(effectiveDate, hasLogs);
+  const status = workoutStatus(effectiveDate, hasLogs, workout.skipped);
   const maxMap = new Map(maxes.map((m) => [m.lift, m.weight]));
 
   // For each lift, compute warm-up and work set counts from spec
@@ -63,7 +66,10 @@ export default async function WorkoutDetailPage({
   const displaySets = status === 'completed' ? actualSets : plannedSets;
 
   const statusLabel =
-    status === 'completed' ? '✓ Done' : status === 'upcoming' ? 'Upcoming' : 'Missed';
+    status === 'completed' ? '✓ Done'
+    : status === 'upcoming' ? 'Upcoming'
+    : status === 'skipped' ? '⊘ Skipped'
+    : 'Missed';
 
   return (
     <main className={styles.container}>
@@ -118,7 +124,7 @@ export default async function WorkoutDetailPage({
         >
           ✏️ Manage Lifts
         </Link>
-        {status !== 'completed' && (
+        {status !== 'completed' && status !== 'skipped' && (
           <Link
             href={`/cycle/${cycleNum}/workout/${workoutNum}`}
             className={styles.btnPrimary}
@@ -132,6 +138,14 @@ export default async function WorkoutDetailPage({
           workoutNum={workoutNum}
           currentDate={effectiveDate}
         />
+        {status !== 'completed' && (
+          <SkipForm
+            program={program}
+            cycleNum={cycleNum}
+            workoutNum={workoutNum}
+            skipped={workout.skipped}
+          />
+        )}
       </section>
     </main>
   );

--- a/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/page.tsx
+++ b/apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/page.tsx
@@ -48,6 +48,9 @@ export default async function WorkoutDetailPage({
 
   const effectiveDate = workout.overrideDate ?? workout.date;
   const hasLogs = workout.lifts.some((l) => !l.planned);
+  // completed wins over skipped intentionally: a partially-logged workout can also be
+  // marked skipped (the two states are independent records). When both are true the
+  // workout still shows as completed and SkipForm is hidden.
   const status = workoutStatus(effectiveDate, hasLogs, workout.skipped);
   const maxMap = new Map(maxes.map((m) => [m.lift, m.weight]));
 

--- a/apps/web/app/programs/BrowseTab.tsx
+++ b/apps/web/app/programs/BrowseTab.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import type { UserWorkoutSchedule } from '@lifting-logbook/types';
 import {
   PROGRAMS,
   type Experience,
@@ -32,9 +33,10 @@ const GOAL_OPTIONS: { label: string; value: 'all' | Goal }[] = [
 
 type Props = {
   activeProgram: string | null;
+  workoutSchedule: UserWorkoutSchedule | null;
 };
 
-export default function BrowseTab({ activeProgram }: Props) {
+export default function BrowseTab({ activeProgram, workoutSchedule }: Props) {
   const [experienceFilter, setExperienceFilter] = useState<Experience | 'all'>('all');
   const [goalFilter, setGoalFilter] = useState<'all' | Goal>('all');
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -209,6 +211,7 @@ export default function BrowseTab({ activeProgram }: Props) {
           programId={switchTarget.id}
           programName={switchTarget.name}
           currentProgramId={activeProgram}
+          workoutSchedule={workoutSchedule}
           onClose={() => setSwitchTarget(null)}
         />
       )}

--- a/apps/web/app/programs/ProgramsTabs.tsx
+++ b/apps/web/app/programs/ProgramsTabs.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import type { CustomProgramSummaryResponse } from '@lifting-logbook/types';
+import type { CustomProgramSummaryResponse, UserWorkoutSchedule } from '@lifting-logbook/types';
 import BrowseTab from './BrowseTab';
 import EditorTab from './EditorTab';
 import styles from './programs.module.css';
@@ -10,10 +10,11 @@ type Tab = 'browse' | 'editor';
 
 type Props = {
   activeProgram: string | null;
+  workoutSchedule: UserWorkoutSchedule | null;
   customPrograms: CustomProgramSummaryResponse[];
 };
 
-export default function ProgramsTabs({ activeProgram, customPrograms }: Props) {
+export default function ProgramsTabs({ activeProgram, workoutSchedule, customPrograms }: Props) {
   const [activeTab, setActiveTab] = useState<Tab>('browse');
   const [currentActive, _setCurrentActive] = useState(activeProgram);
 
@@ -44,7 +45,7 @@ export default function ProgramsTabs({ activeProgram, customPrograms }: Props) {
       </div>
 
       {activeTab === 'browse' && (
-        <BrowseTab activeProgram={currentActive} />
+        <BrowseTab activeProgram={currentActive} workoutSchedule={workoutSchedule} />
       )}
 
       {activeTab === 'editor' && (

--- a/apps/web/app/programs/SwitchProgramDialog.tsx
+++ b/apps/web/app/programs/SwitchProgramDialog.tsx
@@ -49,6 +49,7 @@ export default function SwitchProgramDialog({
         if (workoutSchedule) {
           setCycleNum(result.cycleNum);
           setStep('schedule-info');
+          router.refresh();
         } else {
           router.push(`/cycle/${result.cycleNum}`);
           router.refresh();
@@ -67,64 +68,61 @@ export default function SwitchProgramDialog({
   }
 
   const currentLabel = currentProgramId ? `your current program` : 'your dashboard';
-
-  if (step === 'schedule-info' && workoutSchedule && cycleNum !== null) {
-    const workoutsPerWeek = getScheduleWorkoutsPerWeek(workoutSchedule);
-    return (
-      <div
-        className={styles.dialogOverlay}
-        role="dialog"
-        aria-modal="true"
-      >
-        <div className={styles.dialog}>
-          <p className={styles.dialogTitle}>Schedule applied to {programName}</p>
-          <div className={styles.scheduleInfoBody}>
-            <p className={styles.scheduleInfoText}>
-              Workout dates have been distributed using your schedule.
-            </p>
-            <div className={styles.scheduleSummary}>
-              <span className={styles.scheduleDetail}>{formatSchedule(workoutSchedule)}</span>
-              <span className={styles.scheduleDetail}>
-                {workoutsPerWeek} workout{workoutsPerWeek !== 1 ? 's' : ''}/week
-              </span>
-            </div>
-          </div>
-          <div className={styles.dialogActions}>
-            <button
-              type="button"
-              className={styles.btnPrimary}
-              onClick={handleGoToCycle}
-            >
-              Go to Cycle
-            </button>
-          </div>
-        </div>
-      </div>
-    );
-  }
+  const workoutsPerWeek =
+    step === 'schedule-info' && workoutSchedule
+      ? getScheduleWorkoutsPerWeek(workoutSchedule)
+      : null;
 
   return (
     <div
       className={styles.dialogOverlay}
       role="dialog"
       aria-modal="true"
-      onKeyDown={(e) => { if (e.key === 'Escape' && !isPending) onClose(); }}
+      onKeyDown={(e) => { if (e.key === 'Escape' && !isPending && step === 'confirm') onClose(); }}
     >
       <div className={styles.dialog}>
-        <p className={styles.dialogTitle}>Switch to {programName}?</p>
-        <p className={styles.dialogBody}>
-          {programName} will become your active program. Your existing lift history and
-          training maxes for {currentLabel} are preserved and remain accessible.
-        </p>
-        {error && <p className={styles.errorNote}>{error}</p>}
-        <div className={styles.dialogActions}>
-          <button type="button" className={styles.btnSecondary} onClick={onClose} disabled={isPending}>
-            Cancel
-          </button>
-          <button type="button" className={styles.btnPrimary} onClick={handleConfirm} disabled={isPending}>
-            {isPending ? 'Switching…' : 'Confirm Switch'}
-          </button>
-        </div>
+        {step === 'schedule-info' && workoutSchedule && cycleNum !== null ? (
+          <>
+            <p className={styles.dialogTitle}>Schedule applied to {programName}</p>
+            <div className={styles.scheduleInfoBody}>
+              <p className={styles.scheduleInfoText}>
+                Workout dates have been distributed using your schedule.
+              </p>
+              <div className={styles.scheduleSummary}>
+                <span className={styles.scheduleDetail}>{formatSchedule(workoutSchedule)}</span>
+                <span className={styles.scheduleDetail}>
+                  {workoutsPerWeek} workout{workoutsPerWeek !== 1 ? 's' : ''}/week
+                </span>
+              </div>
+            </div>
+            <div className={styles.dialogActions}>
+              <button
+                type="button"
+                className={styles.btnPrimary}
+                onClick={handleGoToCycle}
+              >
+                Go to Cycle
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <p className={styles.dialogTitle}>Switch to {programName}?</p>
+            <p className={styles.dialogBody}>
+              {programName} will become your active program. Your existing lift history and
+              training maxes for {currentLabel} are preserved and remain accessible.
+            </p>
+            {error && <p className={styles.errorNote}>{error}</p>}
+            <div className={styles.dialogActions}>
+              <button type="button" className={styles.btnSecondary} onClick={onClose} disabled={isPending}>
+                Cancel
+              </button>
+              <button type="button" className={styles.btnPrimary} onClick={handleConfirm} disabled={isPending}>
+                {isPending ? 'Switching…' : 'Confirm Switch'}
+              </button>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/apps/web/app/programs/SwitchProgramDialog.tsx
+++ b/apps/web/app/programs/SwitchProgramDialog.tsx
@@ -2,13 +2,30 @@
 
 import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
+import { getScheduleWorkoutsPerWeek } from '@lifting-logbook/core';
+import type { UserWorkoutSchedule } from '@lifting-logbook/types';
 import { switchProgram } from './actions';
 import styles from './programs.module.css';
+
+const DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+function formatSchedule(schedule: UserWorkoutSchedule): string {
+  if (schedule.type === 'fixed' && schedule.days) {
+    return schedule.days.map((d) => DAY_NAMES[d]).join(' / ');
+  }
+  if (schedule.type === 'rotating' && schedule.weeks) {
+    return schedule.weeks
+      .map((week, i) => `Week ${i + 1}: ${week.map((d) => DAY_NAMES[d]).join('/')}`)
+      .join(' · ');
+  }
+  return 'Custom schedule';
+}
 
 type Props = {
   programId: string;
   programName: string;
   currentProgramId: string | null;
+  workoutSchedule: UserWorkoutSchedule | null;
   onClose: () => void;
 };
 
@@ -16,25 +33,75 @@ export default function SwitchProgramDialog({
   programId,
   programName,
   currentProgramId,
+  workoutSchedule,
   onClose,
 }: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+  const [step, setStep] = useState<'confirm' | 'schedule-info'>('confirm');
+  const [cycleNum, setCycleNum] = useState<number | null>(null);
 
   function handleConfirm() {
     startTransition(async () => {
       try {
         const result = await switchProgram(programId);
-        router.push(`/cycle/${result.cycleNum}`);
-        router.refresh();
+        if (workoutSchedule) {
+          setCycleNum(result.cycleNum);
+          setStep('schedule-info');
+        } else {
+          router.push(`/cycle/${result.cycleNum}`);
+          router.refresh();
+        }
       } catch (e) {
         setError(e instanceof Error ? e.message : 'Failed to switch program.');
       }
     });
   }
 
+  function handleGoToCycle() {
+    if (cycleNum !== null) {
+      router.push(`/cycle/${cycleNum}`);
+      router.refresh();
+    }
+  }
+
   const currentLabel = currentProgramId ? `your current program` : 'your dashboard';
+
+  if (step === 'schedule-info' && workoutSchedule && cycleNum !== null) {
+    const workoutsPerWeek = getScheduleWorkoutsPerWeek(workoutSchedule);
+    return (
+      <div
+        className={styles.dialogOverlay}
+        role="dialog"
+        aria-modal="true"
+      >
+        <div className={styles.dialog}>
+          <p className={styles.dialogTitle}>Schedule applied to {programName}</p>
+          <div className={styles.scheduleInfoBody}>
+            <p className={styles.scheduleInfoText}>
+              Workout dates have been distributed using your schedule.
+            </p>
+            <div className={styles.scheduleSummary}>
+              <span className={styles.scheduleDetail}>{formatSchedule(workoutSchedule)}</span>
+              <span className={styles.scheduleDetail}>
+                {workoutsPerWeek} workout{workoutsPerWeek !== 1 ? 's' : ''}/week
+              </span>
+            </div>
+          </div>
+          <div className={styles.dialogActions}>
+            <button
+              type="button"
+              className={styles.btnPrimary}
+              onClick={handleGoToCycle}
+            >
+              Go to Cycle
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/apps/web/app/programs/SwitchProgramDialog.tsx
+++ b/apps/web/app/programs/SwitchProgramDialog.tsx
@@ -49,7 +49,6 @@ export default function SwitchProgramDialog({
         if (workoutSchedule) {
           setCycleNum(result.cycleNum);
           setStep('schedule-info');
-          router.refresh();
         } else {
           router.push(`/cycle/${result.cycleNum}`);
         }
@@ -62,8 +61,14 @@ export default function SwitchProgramDialog({
   function handleGoToCycle() {
     if (cycleNum !== null) {
       router.push(`/cycle/${cycleNum}`);
-      router.refresh();
     }
+  }
+
+  function handleClose() {
+    setStep('confirm');
+    setCycleNum(null);
+    setError(null);
+    onClose();
   }
 
   const currentLabel = currentProgramId ? `your current program` : 'your dashboard';
@@ -77,7 +82,7 @@ export default function SwitchProgramDialog({
       className={styles.dialogOverlay}
       role="dialog"
       aria-modal="true"
-      onKeyDown={(e) => { if (e.key === 'Escape' && !isPending && step === 'confirm') onClose(); }}
+      onKeyDown={(e) => { if (e.key === 'Escape' && !isPending) handleClose(); }}
     >
       <div className={styles.dialog}>
         {step === 'schedule-info' && workoutSchedule && cycleNum !== null ? (
@@ -95,6 +100,9 @@ export default function SwitchProgramDialog({
               </div>
             </div>
             <div className={styles.dialogActions}>
+              <button type="button" className={styles.btnSecondary} onClick={handleClose}>
+                Close
+              </button>
               <button
                 type="button"
                 className={styles.btnPrimary}
@@ -113,7 +121,7 @@ export default function SwitchProgramDialog({
             </p>
             {error && <p className={styles.errorNote}>{error}</p>}
             <div className={styles.dialogActions}>
-              <button type="button" className={styles.btnSecondary} onClick={onClose} disabled={isPending}>
+              <button type="button" className={styles.btnSecondary} onClick={handleClose} disabled={isPending}>
                 Cancel
               </button>
               <button type="button" className={styles.btnPrimary} onClick={handleConfirm} disabled={isPending}>

--- a/apps/web/app/programs/SwitchProgramDialog.tsx
+++ b/apps/web/app/programs/SwitchProgramDialog.tsx
@@ -52,7 +52,6 @@ export default function SwitchProgramDialog({
           router.refresh();
         } else {
           router.push(`/cycle/${result.cycleNum}`);
-          router.refresh();
         }
       } catch (e) {
         setError(e instanceof Error ? e.message : 'Failed to switch program.');

--- a/apps/web/app/programs/page.tsx
+++ b/apps/web/app/programs/page.tsx
@@ -1,11 +1,13 @@
 import { fetchCustomPrograms, fetchUserSettings } from '@/lib/api';
-import type { UserWorkoutSchedule } from '@lifting-logbook/types';
+import type { UserSettingsResponse } from '@lifting-logbook/types';
 import ProgramsTabs from './ProgramsTabs';
 import styles from './programs.module.css';
 
+const DEFAULT_SETTINGS: UserSettingsResponse = { activeProgram: null, workoutSchedule: null };
+
 export default async function ProgramsPage() {
   const [settings, customPrograms] = await Promise.all([
-    fetchUserSettings().catch(() => ({ activeProgram: null, workoutSchedule: null as UserWorkoutSchedule | null })),
+    fetchUserSettings().catch(() => DEFAULT_SETTINGS),
     fetchCustomPrograms().catch(() => []),
   ]);
 

--- a/apps/web/app/programs/page.tsx
+++ b/apps/web/app/programs/page.tsx
@@ -1,10 +1,11 @@
 import { fetchCustomPrograms, fetchUserSettings } from '@/lib/api';
+import type { UserWorkoutSchedule } from '@lifting-logbook/types';
 import ProgramsTabs from './ProgramsTabs';
 import styles from './programs.module.css';
 
 export default async function ProgramsPage() {
   const [settings, customPrograms] = await Promise.all([
-    fetchUserSettings().catch(() => ({ activeProgram: null })),
+    fetchUserSettings().catch(() => ({ activeProgram: null, workoutSchedule: null as UserWorkoutSchedule | null })),
     fetchCustomPrograms().catch(() => []),
   ]);
 
@@ -13,6 +14,7 @@ export default async function ProgramsPage() {
       <h1 className={styles.heading}>Programs</h1>
       <ProgramsTabs
         activeProgram={settings.activeProgram}
+        workoutSchedule={settings.workoutSchedule ?? null}
         customPrograms={customPrograms}
       />
     </main>

--- a/apps/web/app/programs/programs.module.css
+++ b/apps/web/app/programs/programs.module.css
@@ -222,6 +222,11 @@
 .dialogBody { font-size: 0.9375rem; color: var(--color-text, #111827); margin-bottom: 1.25rem; }
 .dialogActions { display: flex; gap: 0.5rem; justify-content: flex-end; }
 
+.scheduleInfoBody { margin-bottom: 1.25rem; }
+.scheduleInfoText { font-size: 0.9375rem; color: var(--color-text-muted); margin: 0 0 0.75rem; }
+.scheduleSummary { display: flex; flex-direction: column; gap: 0.25rem; }
+.scheduleDetail { font-size: 0.9375rem; font-weight: 600; color: var(--color-text); }
+
 /* ----- Editor ----- */
 .subTabs {
   display: flex;

--- a/apps/web/e2e/mock-api.mjs
+++ b/apps/web/e2e/mock-api.mjs
@@ -31,6 +31,7 @@ const WORKOUT = {
   workoutNum: 1,
   week: 1,
   date: '2025-01-06',
+  skipped: false,
   lifts: [
     {
       lift: 'squat',
@@ -90,6 +91,8 @@ function createInitialState() {
     noCurrentCycle: false,
     trainingMaxes: structuredClone(INITIAL_TRAINING_MAXES),
     strengthGoals: [],
+    skippedWorkouts: new Set(),
+    workoutSchedule: null,
   };
 }
 
@@ -156,6 +159,9 @@ const server = createServer(async (req, res) => {
     if (url.searchParams.get('noCurrentCycle') === 'true') {
       state.noCurrentCycle = true;
     }
+    if (url.searchParams.get('withSchedule') === 'true') {
+      state.workoutSchedule = { type: 'fixed', days: [0, 2, 4] }; // Mon/Wed/Fri
+    }
     json(res, { ok: true });
     return;
   }
@@ -164,7 +170,7 @@ const server = createServer(async (req, res) => {
   // GET /users/me/settings
   // -------------------------------------------------------------------------
   if (method === 'GET' && url.pathname === '/users/me/settings') {
-    json(res, { activeProgram: '5-3-1', workoutSchedule: null });
+    json(res, { activeProgram: '5-3-1', workoutSchedule: state.workoutSchedule });
     return;
   }
 
@@ -187,7 +193,14 @@ const server = createServer(async (req, res) => {
       if (state.noCurrentCycle) {
         json(res, { statusCode: 404, message: 'No active cycle' }, 404);
       } else {
-        json(res, CYCLE_DASHBOARD);
+        const dashboard = structuredClone(CYCLE_DASHBOARD);
+        for (const week of dashboard.weeks) {
+          for (const wo of week.workouts) {
+            wo.skipped = state.skippedWorkouts.has(wo.workoutNum);
+          }
+          week.completed = week.workouts.every((wo) => wo.skipped);
+        }
+        json(res, dashboard);
       }
       return;
     }
@@ -200,7 +213,24 @@ const server = createServer(async (req, res) => {
 
     // GET /programs/:p/workouts/:workoutNum
     if (method === 'GET' && rest[0] === 'workouts' && rest.length === 2) {
-      json(res, WORKOUT);
+      const workoutNum = Number(rest[1]);
+      json(res, { ...WORKOUT, workoutNum, skipped: state.skippedWorkouts.has(workoutNum) });
+      return;
+    }
+
+    // POST /programs/:p/cycles/:cycleNum/workouts/:workoutNum/skip
+    if (method === 'POST' && rest[0] === 'cycles' && rest[2] === 'workouts' && rest[4] === 'skip') {
+      const workoutNum = Number(rest[3]);
+      state.skippedWorkouts.add(workoutNum);
+      noContent(res);
+      return;
+    }
+
+    // DELETE /programs/:p/cycles/:cycleNum/workouts/:workoutNum/skip
+    if (method === 'DELETE' && rest[0] === 'cycles' && rest[2] === 'workouts' && rest[4] === 'skip') {
+      const workoutNum = Number(rest[3]);
+      state.skippedWorkouts.delete(workoutNum);
+      noContent(res);
       return;
     }
 

--- a/apps/web/e2e/scheduling.spec.ts
+++ b/apps/web/e2e/scheduling.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from '@playwright/test';
+
+const MOCK_API = 'http://localhost:3004';
+
+test.beforeEach(async ({ request }) => {
+  await request.get(`${MOCK_API}/__reset`);
+});
+
+// ---------------------------------------------------------------------------
+// Skip / Unskip workout
+// ---------------------------------------------------------------------------
+
+test('skip a workout from detail page — Skipped badge shown', async ({ page }) => {
+  await page.goto('/cycle/1/workout/1/detail');
+
+  // SkipForm trigger is visible for an upcoming (non-completed) workout
+  const skipBtn = page.getByRole('button', { name: '⊘ Mark as Skipped' });
+  await expect(skipBtn).toBeVisible();
+  await skipBtn.click();
+
+  // Expanded form appears with confirm button
+  const confirmBtn = page.getByRole('button', { name: 'Skip Workout' });
+  await expect(confirmBtn).toBeVisible();
+  await confirmBtn.click();
+
+  // After refresh, page shows Skipped badge
+  await expect(page.getByText('⊘ Skipped')).toBeVisible();
+  // Start Logging link hidden for skipped workouts
+  await expect(page.getByRole('link', { name: 'Start Logging' })).not.toBeVisible();
+  // Undo button is now shown
+  await expect(page.getByRole('button', { name: '↩ Undo Skip' })).toBeVisible();
+});
+
+test('skip a workout — cycle dashboard card shows Skipped status', async ({ page, request }) => {
+  // Pre-skip workout 1 via API so the dashboard reflects it
+  await request.post(`${MOCK_API}/programs/5-3-1/cycles/1/workouts/1/skip`);
+
+  await page.goto('/cycle/1');
+  await expect(page).toHaveURL(/\/cycle\/1/);
+
+  // The workout card for workout 1 should show the Skipped badge
+  await expect(page.locator('text=Skipped').first()).toBeVisible();
+});
+
+test('undo skip — workout reverts to Upcoming/Missed status', async ({ page, request }) => {
+  // Pre-skip workout 1
+  await request.post(`${MOCK_API}/programs/5-3-1/cycles/1/workouts/1/skip`);
+
+  await page.goto('/cycle/1/workout/1/detail');
+
+  // Undo button visible for a skipped workout
+  const undoBtn = page.getByRole('button', { name: '↩ Undo Skip' });
+  await expect(undoBtn).toBeVisible();
+  await undoBtn.click();
+
+  // Confirm undo
+  const confirmBtn = page.getByRole('button', { name: 'Undo Skip' });
+  await expect(confirmBtn).toBeVisible();
+  await confirmBtn.click();
+
+  // After refresh, ⊘ Skipped is gone; Skip button is back
+  await expect(page.getByText('⊘ Skipped')).not.toBeVisible();
+  await expect(page.getByRole('button', { name: '⊘ Mark as Skipped' })).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// Schedule-mode confirmation prompt
+// ---------------------------------------------------------------------------
+
+test('selecting a program with schedule set shows schedule-info step', async ({ page, request }) => {
+  // Reset with a Mon/Wed/Fri schedule so the settings endpoint returns it
+  await request.get(`${MOCK_API}/__reset?withSchedule=true`);
+
+  await page.goto('/programs');
+
+  // Open the switch dialog
+  await page.getByRole('button', { name: 'Choose This Program' }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+
+  // Confirm switch
+  await page.getByRole('button', { name: 'Confirm Switch' }).click();
+
+  // Schedule-info step should appear
+  await expect(page.getByText(/Workout dates have been distributed/i)).toBeVisible();
+  await expect(page.getByText(/Mon \/ Wed \/ Fri/i)).toBeVisible();
+  await expect(page.getByText(/3 workouts\/week/i)).toBeVisible();
+
+  // Navigates to cycle when "Go to Cycle" is clicked
+  await page.getByRole('button', { name: 'Go to Cycle' }).click();
+  await expect(page).toHaveURL(/\/cycle\/1/);
+});
+
+test('selecting a program without schedule skips the schedule-info step', async ({ page }) => {
+  // Default reset has workoutSchedule: null
+  await page.goto('/programs');
+
+  await page.getByRole('button', { name: 'Choose This Program' }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Confirm Switch' }).click();
+
+  // Should navigate directly to cycle — no schedule-info step
+  await expect(page).toHaveURL(/\/cycle\/1/, { timeout: 10_000 });
+});

--- a/apps/web/lib/client-api.ts
+++ b/apps/web/lib/client-api.ts
@@ -81,6 +81,34 @@ export function rescheduleWorkout(
   );
 }
 
+export function skipWorkout(
+  program: string,
+  cycleNum: number,
+  workoutNum: number,
+  reason?: string,
+): Promise<void> {
+  return clientFetch<void>(
+    `/programs/${encodeURIComponent(program)}/cycles/${cycleNum}/workouts/${workoutNum}/skip`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(reason !== undefined ? { reason } : {}),
+      cache: 'no-store',
+    },
+  );
+}
+
+export function unskipWorkout(
+  program: string,
+  cycleNum: number,
+  workoutNum: number,
+): Promise<void> {
+  return clientFetch<void>(
+    `/programs/${encodeURIComponent(program)}/cycles/${cycleNum}/workouts/${workoutNum}/skip`,
+    { method: 'DELETE', cache: 'no-store' },
+  );
+}
+
 export function recordBodyWeight(
   program: string,
   body: RecordBodyWeightRequest,

--- a/apps/web/lib/client-api.ts
+++ b/apps/web/lib/client-api.ts
@@ -30,6 +30,7 @@ async function clientFetch<T>(path: string, init?: RequestInit): Promise<T> {
   if (!res.ok) {
     throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
   }
+  if (res.status === 204) return undefined as T;
   return res.json() as Promise<T>;
 }
 

--- a/apps/web/lib/workoutPlan.ts
+++ b/apps/web/lib/workoutPlan.ts
@@ -24,7 +24,7 @@ export interface WorkoutDay {
 export interface WorkoutCell {
   workoutNum: number;
   date: string; // YYYY-MM-DD
-  status: 'completed' | 'upcoming' | 'missed';
+  status: 'completed' | 'upcoming' | 'missed' | 'skipped';
   lifts: { name: string; sets: PlannedSet[] }[];
 }
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -92,6 +92,7 @@ export interface WorkoutResponse {
   week: WeekNumber;
   date: string; // ISO 8601 date string
   overrideDate?: string; // ISO 8601 date string; present when the user has rescheduled
+  skipped: boolean;
   lifts: WorkoutLiftResponse[];
   bodyWeightEntry?: Pick<BodyWeightEntry, 'weight' | 'unit'>;
 }


### PR DESCRIPTION
## Summary

- **Skip/Unskip UI**: New `SkipForm` component on the workout detail page lets users mark a workout as skipped (with optional reason) or undo a skip. The cycle dashboard now shows a Skipped badge for skipped workouts.
- **`WorkoutResponse.skipped`**: The GET workout endpoint now fetches the skip set from `workoutSkipOverride.getSkipsForCycle()` in parallel with other data and includes `skipped: boolean` in the response.
- **Schedule-mode confirmation prompt**: When a user with a `workoutSchedule` configured switches to a new program, `SwitchProgramDialog` now shows an informational second step after the switch confirming that workout dates have been distributed, displaying the schedule summary (e.g., "Mon / Wed / Fri") and estimated workouts per week.
- **Fix: "completed" status now requires actual logged lifts** — `WorkoutResponse.lifts` always includes planned entries for upcoming workouts. The cycle dashboard's `logged` check was changed from `lifts.length > 0` (which counted planned-only lifts, making every workout appear completed) to `lifts.some(l => !l.planned)` (actual logged sets only).

## Acceptance Criteria

- [x] Skip a workout from detail page — Skipped badge shown, Start Logging hidden, Undo Skip button visible
- [x] Undo skip — workout reverts to Upcoming/Missed status
- [x] Cycle dashboard card shows Skipped status for skipped workouts
- [x] Selecting a program with schedule set shows schedule-info step with schedule summary and workouts/week
- [x] Selecting a program without schedule skips the schedule-info step (navigates directly)

## Changes

| Area | Change |
|---|---|
| `packages/types/src/api.ts` | Add `skipped: boolean` to `WorkoutResponse` |
| `apps/api/src/programs/mappers.ts` | Accept `skipped` param in `toWorkoutResponse` |
| `apps/api/src/programs/workouts.controller.ts` | Fetch skip set in parallel, pass to mapper; log errors before skip-set fallback |
| `apps/web/lib/client-api.ts` | Add `skipWorkout`, `unskipWorkout`; handle 204 No Content in `clientFetch` |
| `apps/web/lib/workoutPlan.ts` | Add `'skipped'` to `WorkoutCell.status` |
| `apps/web/app/cycle/[cycleNum]/page.tsx` | Derive skipped status from dashboard; fix `logged` predicate |
| `apps/web/app/cycle/[cycleNum]/CycleDashboardGrid.tsx` | Skipped badge + card style |
| `apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/SkipForm.tsx` | **New** — skip/unskip toggle component |
| `apps/web/app/cycle/[cycleNum]/workout/[workoutNum]/detail/page.tsx` | Render SkipForm, hide Start Logging when skipped |
| `apps/web/app/programs/page.tsx` + `ProgramsTabs.tsx` + `BrowseTab.tsx` | Thread `workoutSchedule` to dialog |
| `apps/web/app/programs/SwitchProgramDialog.tsx` | Add schedule-info step with Close button and state reset |
| `apps/web/e2e/mock-api.mjs` | Skip state tracking + `withSchedule` reset param |
| `apps/web/e2e/scheduling.spec.ts` | **New** — 5 Playwright E2E tests |

## Design notes

- Skip is a label orthogonal to log data: a partially-logged workout can be marked skipped. No server-side guard prevents both states coexisting. The UI prevents reaching that state through normal paths (`completed` status hides SkipForm; `skipped` status hides Start Logging); this is documented with a comment in `detail/page.tsx`.

## Tests

**Unit tests:** `npm test -w @lifting-logbook/api` — 243 passed, 3 new tests covering `skipped: false`, `skipped: true`, and correct cycle scoping in the workouts controller.

**Web tests:** `npm test -w @lifting-logbook/web` — 28 passed (no regressions).

**E2E tests:** 5 new Playwright scenarios in `apps/web/e2e/scheduling.spec.ts` — skip flow, undo skip, dashboard badge, and schedule-mode prompt with and without a configured schedule.

Note: `npm run build` fails on the API package with pre-existing Prisma type errors unrelated to this PR (present on `main` before this branch).

Closes #281
