### PR TITLE
[infra] Single-user prod deploy mode + bootstrap script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,7 @@ jobs:
       contents: read
       id-token: write
     outputs:
+      gke_enabled: ${{ steps.tf-outputs.outputs.gke_enabled }}
       gke_cluster_name: ${{ steps.tf-outputs.outputs.gke_cluster_name }}
       cloud_run_api_url: ${{ steps.tf-outputs.outputs.cloud_run_api_url }}
       cloud_run_web_url: ${{ steps.tf-outputs.outputs.cloud_run_web_url }}
@@ -76,6 +77,7 @@ jobs:
         id: tf-outputs
         working-directory: ${{ env.TF_DIR }}
         run: |
+          echo "gke_enabled=$(terraform output -raw gke_enabled)" >> "$GITHUB_OUTPUT"
           echo "gke_cluster_name=$(terraform output -raw gke_cluster_name)" >> "$GITHUB_OUTPUT"
           echo "cloud_run_api_url=$(terraform output -raw cloud_run_api_url)" >> "$GITHUB_OUTPUT"
           echo "cloud_run_web_url=$(terraform output -raw cloud_run_web_url)" >> "$GITHUB_OUTPUT"
@@ -153,7 +155,10 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_STAGING_SERVICE_ACCOUNT }}
 
+      # GKE-only steps below are skipped when terraform var enable_gke = false
+      # (single-user / Cloud-Run-only deployments).
       - name: Set up GKE credentials
+        if: needs.terraform-staging.outputs.gke_enabled == 'true'
         uses: google-github-actions/get-gke-credentials@v2
         with:
           cluster_name: ${{ needs.terraform-staging.outputs.gke_cluster_name }}
@@ -161,13 +166,16 @@ jobs:
           project_id: ${{ secrets.GCP_STAGING_PROJECT_ID }}
 
       - name: Set up Helm
+        if: needs.terraform-staging.outputs.gke_enabled == 'true'
         uses: azure/setup-helm@v4
 
       - name: Ensure staging namespace
+        if: needs.terraform-staging.outputs.gke_enabled == 'true'
         run: kubectl create namespace staging --dry-run=client -o yaml | kubectl apply -f -
 
       # Sync secrets from Secret Manager → Kubernetes Secrets
       - name: Sync API secrets to Kubernetes
+        if: needs.terraform-staging.outputs.gke_enabled == 'true'
         run: |
           DB_URL=$(gcloud secrets versions access latest \
             --secret="lifting-logbook-stg-database-url" \
@@ -186,6 +194,7 @@ jobs:
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Sync web secrets to Kubernetes
+        if: needs.terraform-staging.outputs.gke_enabled == 'true'
         run: |
           CLERK_PUB=$(gcloud secrets versions access latest \
             --secret="lifting-logbook-stg-clerk-publishable-key" \
@@ -196,6 +205,7 @@ jobs:
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Helm deploy API (GKE staging)
+        if: needs.terraform-staging.outputs.gke_enabled == 'true'
         run: |
           helm upgrade --install api ./infra/kubernetes/charts/api \
             --namespace=staging \
@@ -209,6 +219,7 @@ jobs:
             --wait --timeout=5m
 
       - name: Helm deploy web (GKE staging)
+        if: needs.terraform-staging.outputs.gke_enabled == 'true'
         run: |
           API_CLUSTER_URL="http://api.staging.svc.cluster.local:3000"
           helm upgrade --install web ./infra/kubernetes/charts/web \
@@ -319,6 +330,7 @@ jobs:
         id: tf-prod
         working-directory: ${{ env.TF_DIR }}
         run: |
+          echo "gke_enabled=$(terraform output -raw gke_enabled)" >> "$GITHUB_OUTPUT"
           echo "gke_cluster_name=$(terraform output -raw gke_cluster_name)" >> "$GITHUB_OUTPUT"
           echo "cloud_run_api_url=$(terraform output -raw cloud_run_api_url)" >> "$GITHUB_OUTPUT"
           echo "cloud_run_web_url=$(terraform output -raw cloud_run_web_url)" >> "$GITHUB_OUTPUT"
@@ -327,7 +339,10 @@ jobs:
           echo "api_wi_sa=$(terraform output -raw cicd_service_account_email)" >> "$GITHUB_OUTPUT"
           echo "web_workload_sa=$(terraform output -raw web_workload_sa)" >> "$GITHUB_OUTPUT"
 
+      # GKE-only steps below are skipped when terraform var enable_gke = false
+      # (single-user / Cloud-Run-only deployments).
       - name: Set up GKE credentials (production)
+        if: steps.tf-prod.outputs.gke_enabled == 'true'
         uses: google-github-actions/get-gke-credentials@v2
         with:
           cluster_name: ${{ steps.tf-prod.outputs.gke_cluster_name }}
@@ -335,12 +350,15 @@ jobs:
           project_id: ${{ secrets.GCP_PROD_PROJECT_ID }}
 
       - name: Set up Helm
+        if: steps.tf-prod.outputs.gke_enabled == 'true'
         uses: azure/setup-helm@v4
 
       - name: Ensure production namespace
+        if: steps.tf-prod.outputs.gke_enabled == 'true'
         run: kubectl create namespace production --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Sync API secrets to Kubernetes (production)
+        if: steps.tf-prod.outputs.gke_enabled == 'true'
         run: |
           DB_URL=$(gcloud secrets versions access latest \
             --secret="lifting-logbook-prod-database-url" \
@@ -359,6 +377,7 @@ jobs:
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Sync web secrets to Kubernetes (production)
+        if: steps.tf-prod.outputs.gke_enabled == 'true'
         run: |
           CLERK_PUB=$(gcloud secrets versions access latest \
             --secret="lifting-logbook-prod-clerk-publishable-key" \
@@ -369,6 +388,7 @@ jobs:
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Helm deploy API (GKE production)
+        if: steps.tf-prod.outputs.gke_enabled == 'true'
         run: |
           helm upgrade --install api ./infra/kubernetes/charts/api \
             --namespace=production \
@@ -382,6 +402,7 @@ jobs:
             --wait --timeout=5m
 
       - name: Helm deploy web (GKE production)
+        if: steps.tf-prod.outputs.gke_enabled == 'true'
         run: |
           API_CLUSTER_URL="http://api.production.svc.cluster.local:3000"
           helm upgrade --install web ./infra/kubernetes/charts/web \

--- a/docs/deploy-single-user.md
+++ b/docs/deploy-single-user.md
@@ -1,0 +1,300 @@
+# Single-User Production Deploy
+
+This guide walks one person through standing up lifting-logbook on their own GCP
+project for personal use. It is a slimmed-down counterpart to the canonical
+[`docs/deploy.md`](deploy.md) — same building blocks (Terraform, Cloud Run, Cloud SQL,
+GitHub Actions), but **GKE Autopilot is skipped** via the `enable_gke = false`
+Terraform variable, removing the ~\$30/mo cluster cost and the entire Helm /
+kubectl pipeline. Cloud Run also runs at `min_instance_count = 0` so the API and
+web services scale to zero when idle.
+
+> The default deploy in `docs/deploy.md` provisions both GKE and Cloud Run to
+> satisfy the 90/10 A/B comparison in [ADR-009](adr/ADR-009-infrastructure.md).
+> Single-user mode is an opt-out, not a replacement: the same Terraform module
+> and the same workflow run, with the GKE-only resources gated off.
+
+Target cost: **~\$15–30/mo** (Cloud SQL + small Cloud Run usage + Artifact
+Registry). New GCP accounts get \$300 in free credit, which covers ~10 months.
+
+---
+
+## Step 0 — Get a GCP account and billing account (one-time, ~15 min)
+
+If you have never used GCP:
+
+1. Sign in to https://console.cloud.google.com with the Google account you want
+   to own the project. Accept terms.
+2. **Free credit:** new users get \$300 / 90 days. Google will not auto-charge
+   when the credit runs out — you have to opt in to a paid account first.
+3. **Create a billing account:**
+   - https://console.cloud.google.com/billing → **Create account**
+   - Enter a credit card (required even for the free credit; Google will not
+     charge until you opt in to a paid account)
+   - Pick **Individual** account type
+4. **Find your billing account ID:**
+   - https://console.cloud.google.com/billing → click the billing account →
+     **Account management** — the ID is at the top, formatted
+     `XXXXXX-XXXXXX-XXXXXX`
+   - Or from CLI after installing `gcloud`: `gcloud billing accounts list`
+5. **Install the `gcloud` CLI:**
+   - Windows installer: https://cloud.google.com/sdk/docs/install#windows
+   - macOS / Linux: see the same install page for your platform
+6. **Authenticate (two separate logins are required):**
+   ```bash
+   gcloud auth login                       # for gcloud CLI itself
+   gcloud auth application-default login   # for Terraform / SDKs
+   ```
+7. **Verify:**
+   ```bash
+   gcloud auth list                        # shows the logged-in account
+   gcloud projects list                    # confirms API access
+   ```
+
+### Git Bash on Windows — gotchas
+
+- The installer puts `gcloud` on the Windows `PATH`, but **Git Bash needs a
+  restart** to pick it up. Close all Git Bash windows and reopen.
+- Verify with `which gcloud`. If empty, add this to `~/.bashrc`:
+  ```bash
+  export PATH="$PATH:/c/Users/$USER/AppData/Local/Google/Cloud SDK/google-cloud-sdk/bin"
+  ```
+  then `source ~/.bashrc`.
+- `gcloud` on Windows is `gcloud.cmd` under the hood. If a command parses its
+  arguments oddly in Git Bash, prefix it with `winpty`:
+  ```bash
+  winpty gcloud auth login
+  ```
+
+### Cost guardrail
+
+Set a budget alert before running the bootstrap:
+
+- https://console.cloud.google.com/billing → **Budgets & alerts** → **Create
+  budget** → threshold \$50/mo → alert at 50%, 90%, 100%. You'll get email
+  before any surprise bill.
+
+---
+
+## Step 1 — Run the bootstrap script (~5 min)
+
+[`scripts/bootstrap-gcp-prod.sh`](../scripts/bootstrap-gcp-prod.sh) creates the
+project, links your billing account, enables the two APIs Terraform itself
+needs, and creates the Terraform state bucket. Every step is idempotent — re-run
+it if anything fails partway.
+
+```bash
+./scripts/bootstrap-gcp-prod.sh XXXXXX-XXXXXX-XXXXXX
+```
+
+To use a different project ID or region:
+
+```bash
+./scripts/bootstrap-gcp-prod.sh XXXXXX-XXXXXX-XXXXXX \
+  --project-id my-lifting-prod \
+  --region us-east1
+```
+
+The script's `--help` flag prints the full header documentation.
+
+---
+
+## Step 2 — Create a Clerk production app (~5 min)
+
+[Clerk](https://clerk.com) handles authentication. The free tier covers a
+single user.
+
+1. Sign up at https://clerk.com.
+2. Create an application named `lifting-logbook-production`.
+3. Pick auth methods (email + password is simplest).
+4. From the dashboard, **API Keys** → copy:
+   - Publishable key (`pk_live_…`)
+   - Secret key (`sk_live_…`)
+
+You'll load these into Secret Manager in Step 6.
+
+---
+
+## Step 3 — Configure Terraform for single-user mode
+
+Open [`infra/terraform/terraform.tfvars.production`](../infra/terraform/terraform.tfvars.production)
+and set, at minimum:
+
+```hcl
+project_id              = "lifting-logbook-prod"   # or whatever you passed to bootstrap
+environment             = "production"
+enable_gke              = false                    # skips the GKE Autopilot cluster
+cloud_run_min_instances = 0                        # scale Cloud Run to zero when idle
+# db_tier               = "db-f1-micro"            # optional: cheapest Cloud SQL tier
+```
+
+The `billing_account` variable is supplied on the command line (Step 5), not
+written to a file — billing IDs are sensitive.
+
+---
+
+## Step 4 — Add GitHub Actions secrets
+
+In the repo → **Settings → Secrets and variables → Actions** →
+**Repository secrets** (not the **Environments** tab):
+
+| Secret | Value |
+|---|---|
+| `GCP_PROD_PROJECT_ID` | `lifting-logbook-prod` |
+| `TF_STATE_BUCKET` | `lifting-logbook-prod-tfstate` |
+| `GCP_BILLING_ACCOUNT` | your billing account ID |
+| `GCP_PROD_WORKLOAD_IDENTITY_PROVIDER` | filled in **after** Step 5 |
+| `GCP_PROD_SERVICE_ACCOUNT` | filled in **after** Step 5 |
+
+If you also intend to deploy a staging environment later, also add the
+`GCP_STAGING_*` secrets per [`docs/deploy.md`](deploy.md#step-5--add-github-repository-secrets).
+
+> **Hardening (optional, for later):** move `GCP_PROD_*` into a GitHub
+> `production` environment so they're only readable from the production job
+> (which is already gated behind the required-reviewer rule). Not required for
+> a working single-user deploy. See
+> [Using secrets in GitHub Actions — Creating secrets for an environment](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-an-environment).
+
+---
+
+## Step 5 — First Terraform apply (local, not CI)
+
+CI needs the Workload Identity outputs as secrets before it can authenticate,
+so the very first apply runs from your laptop:
+
+```bash
+cd infra/terraform
+terraform init -backend-config="bucket=lifting-logbook-prod-tfstate"
+terraform workspace new production
+terraform apply \
+  -var-file=terraform.tfvars.production \
+  -var="billing_account=XXXXXX-XXXXXX-XXXXXX"
+
+# Capture the values for the two GitHub secrets above
+terraform output workload_identity_provider
+terraform output cicd_service_account_email
+```
+
+This creates: VPC, Cloud SQL, Artifact Registry, Secret Manager (empty
+placeholder secrets), KMS keyring, IAM, and the Cloud Run service shells. With
+`enable_gke = false`, the GKE cluster and its Workload Identity binding are
+skipped; the `api_workload` service account itself is still created because
+Cloud Run reuses it as the API service identity.
+
+---
+
+## Step 6 — Populate Clerk secrets
+
+Terraform created empty secret containers with
+`lifecycle.ignore_changes = [secret_data]`. Add the actual values now:
+
+```bash
+echo -n "sk_live_..." | gcloud secrets versions add \
+  lifting-logbook-prod-clerk-secret-key --data-file=-
+
+echo -n "pk_live_..." | gcloud secrets versions add \
+  lifting-logbook-prod-clerk-publishable-key --data-file=-
+```
+
+---
+
+## Step 7 — Apply database migrations (one-time)
+
+The API container does **not** run `prisma migrate deploy` on startup. Use the
+Cloud SQL Auth Proxy:
+
+```bash
+# Download once: https://cloud.google.com/sql/docs/postgres/connect-auth-proxy
+./cloud-sql-proxy lifting-logbook-prod:us-central1:lifting-logbook-prod-db-XXXX &
+
+DATABASE_URL=$(gcloud secrets versions access latest \
+  --secret=lifting-logbook-prod-database-url)
+
+psql "$DATABASE_URL" -f infra/migrations/001_create_user_data_source.sql
+cd apps/api && DATABASE_URL="$DATABASE_URL" npx prisma migrate deploy
+```
+
+---
+
+## Step 8 — Trigger the first deploy
+
+Merge any branch to `main` (or push directly if you have the workflow set up
+that way). The [Deploy workflow](../.github/workflows/deploy.yml):
+
+1. Builds the api and web Docker images, pushes to Artifact Registry.
+2. Runs `terraform apply` (idempotent — no-op since you just applied locally).
+3. Runs `gcloud run deploy` for both services.
+4. **Skips** all GKE / Helm / kubectl steps because `enable_gke=false`
+   propagates from the Terraform output `gke_enabled` into a step-level
+   `if:` condition.
+
+The `production` GitHub environment has a required-reviewer protection rule
+(set up in [`docs/deploy.md` Step 6](deploy.md#step-6--configure-github-environment-protection-rules)),
+so the production job will pause until you approve it.
+
+---
+
+## Step 9 — Create your Clerk user, log in, verify
+
+Self-serve signup isn't wired by default. Provision yourself:
+
+1. Clerk dashboard → **Users** → **Create user**.
+2. Get the web URL:
+   ```bash
+   gcloud run services describe lifting-logbook-prod-web \
+     --region=us-central1 --format='value(status.url)'
+   ```
+3. Open the URL, log in, complete onboarding, generate a cycle, log a workout.
+
+---
+
+## Flipping `enable_gke` on an existing environment
+
+You can move between modes after the initial deploy, but **uninstall Helm
+releases before disabling GKE** so any cluster-managed cloud resources (load
+balancer IPs, attached disks, etc.) get torn down cleanly. Terraform will
+destroy the cluster but does not know about the in-cluster Helm state.
+
+**To go from GKE-enabled → Cloud-Run-only:**
+
+```bash
+# 1. Remove Helm releases first (run for each namespace you deployed to)
+helm uninstall api -n production
+helm uninstall web -n production
+
+# 2. Set enable_gke = false in terraform.tfvars.production, then apply
+cd infra/terraform
+terraform apply \
+  -var-file=terraform.tfvars.production \
+  -var="billing_account=XXXXXX-XXXXXX-XXXXXX"
+```
+
+The apply will destroy `google_container_cluster.main[0]` and its Workload
+Identity binding; the `api_workload` service account and its IAM roles stay
+because Cloud Run still uses them.
+
+**To go from Cloud-Run-only → GKE-enabled:**
+
+```bash
+# 1. Set enable_gke = true in terraform.tfvars.production
+# 2. Apply
+terraform apply -var-file=terraform.tfvars.production \
+  -var="billing_account=XXXXXX-XXXXXX-XXXXXX"
+
+# 3. Push to main; GitHub Actions will deploy via Helm on the next run.
+```
+
+No Helm cleanup needed in this direction — the cluster comes up empty and the
+workflow deploys to it.
+
+---
+
+## What's intentionally not in this guide
+
+These come from [`docs/deploy.md`](deploy.md). Skip them for single-user; add
+them later if you ever invite a second person:
+
+- A separate `lifting-logbook-staging` project and the full A/B `90/10` split.
+- A custom domain via Cloud Load Balancer.
+- Self-serve signup / open registration.
+- Rate limiting beyond what Cloud Run gives you by default.
+- On-call runbook / alert routing.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -4,6 +4,11 @@ This project deploys to Google Cloud Platform using Terraform (infrastructure) a
 GitHub Actions (CI/CD). The deployment topology follows [ADR-009](adr/ADR-009-infrastructure.md):
 GKE Autopilot receives 90% of traffic; Cloud Run receives 10% as an A/B comparison target.
 
+> **Just deploying for yourself?** See [`deploy-single-user.md`](deploy-single-user.md)
+> for a slimmer walkthrough that sets `enable_gke = false` and skips the entire
+> Helm/kubectl pipeline. The remainder of this document is the canonical
+> two-deploy-target setup that satisfies ADR-009.
+
 ---
 
 ## Architecture overview
@@ -27,6 +32,46 @@ GitHub Actions (push to main)
 Two GCP projects are used for environment isolation:
 - `lifting-logbook-staging` — staging environment
 - `lifting-logbook-prod` — production environment
+
+---
+
+## Deploy modes
+
+The Terraform module supports two modes via the `enable_gke` variable
+([`infra/terraform/variables.tf`](../infra/terraform/variables.tf)):
+
+| Mode | `enable_gke` | What runs | When to use |
+|---|---|---|---|
+| Default / ADR-009 A/B | `true` (default) | GKE Autopilot **and** Cloud Run | Multi-user or portfolio deploy; preserves the A/B comparison this project is built around. |
+| Single-user / Cloud-Run-only | `false` | Cloud Run only | One-person deploys where ~\$30/mo of GKE Autopilot cost has no benefit. Full walkthrough: [`deploy-single-user.md`](deploy-single-user.md). |
+
+The `cloud_run_min_instances` variable controls Cloud Run scale-to-zero
+(`null` = environment default; `0` = always scale to zero for personal
+deployments; `1` = production-grade warm start).
+
+In default mode, this guide applies as written. In single-user mode, follow
+[`deploy-single-user.md`](deploy-single-user.md) instead — the bootstrap is
+scripted (`scripts/bootstrap-gcp-prod.sh`), only one GCP project is needed,
+and the GKE-only Helm/kubectl steps in the CI workflow are skipped via an
+`if: <ctx>.gke_enabled == 'true'` guard.
+
+### Flipping between modes on an existing environment
+
+You can move an environment from one mode to the other by toggling
+`enable_gke` and re-applying. **Uninstall Helm releases before disabling GKE**
+so any cluster-managed cloud resources (load balancer IPs, attached PVCs)
+are torn down before Terraform destroys the cluster:
+
+```bash
+# GKE-enabled → Cloud-Run-only
+helm uninstall api -n production
+helm uninstall web -n production
+# then set enable_gke = false and run terraform apply
+```
+
+Going the other direction (Cloud-Run-only → GKE-enabled) needs no cleanup —
+flip the variable, `terraform apply`, then push to `main` to let CI deploy
+the Helm releases onto the freshly created cluster.
 
 ---
 
@@ -228,13 +273,13 @@ gcloud logging read "resource.type=cloud_run_revision AND \
 
 ## Cost estimates
 
-| Resource | Staging | Production |
-|---|---|---|
-| GKE Autopilot (1 replica × 250m CPU × 256Mi) | ~$15/mo | ~$30/mo (2 replicas) |
-| Cloud SQL (db-f1-micro / db-g1-small) | ~$8/mo | ~$25/mo |
-| Cloud Run (low traffic) | ~$0–2/mo | ~$0–5/mo |
-| Artifact Registry | <$1/mo | <$1/mo |
-| **Total** | **~$24/mo** | **~$61/mo** |
+| Resource | Staging | Production | Production (single-user, `enable_gke=false`) |
+|---|---|---|---|
+| GKE Autopilot (1 replica × 250m CPU × 256Mi) | ~$15/mo | ~$30/mo (2 replicas) | — (skipped) |
+| Cloud SQL (db-f1-micro / db-g1-small) | ~$8/mo | ~$25/mo | ~$10–25/mo (tier-dependent) |
+| Cloud Run (low traffic) | ~$0–2/mo | ~$0–5/mo | ~$0–5/mo |
+| Artifact Registry | <$1/mo | <$1/mo | <$1/mo |
+| **Total** | **~$24/mo** | **~$61/mo** | **~$15–30/mo** |
 
 > GKE Autopilot charges for requested pod resources, not node capacity.
 > Idle pods with minimal resource requests keep costs low.

--- a/infra/terraform/cloud-run.tf
+++ b/infra/terraform/cloud-run.tf
@@ -7,6 +7,10 @@ locals {
   image_tag = var.image_tag
   api_image = "${var.artifact_registry_region}-docker.pkg.dev/${var.project_id}/${var.app_name}/api:${local.image_tag}"
   web_image = "${var.artifact_registry_region}-docker.pkg.dev/${var.project_id}/${var.app_name}/web:${local.image_tag}"
+
+  # Cloud Run min instances. var.cloud_run_min_instances overrides the per-environment
+  # default when set (use 0 in production for scale-to-zero / single-user deploys).
+  cloud_run_min_instances = var.cloud_run_min_instances != null ? var.cloud_run_min_instances : (var.environment == "production" ? 1 : 0)
 }
 
 # ─── API ──────────────────────────────────────────────────────────────────────
@@ -19,7 +23,7 @@ resource "google_cloud_run_v2_service" "api" {
     service_account = google_service_account.api_workload.email
 
     scaling {
-      min_instance_count = var.environment == "production" ? 1 : 0
+      min_instance_count = local.cloud_run_min_instances
       max_instance_count = var.environment == "production" ? 10 : 3
     }
 
@@ -110,7 +114,7 @@ resource "google_cloud_run_v2_service" "web" {
     service_account = google_service_account.web_workload.email
 
     scaling {
-      min_instance_count = var.environment == "production" ? 1 : 0
+      min_instance_count = local.cloud_run_min_instances
       max_instance_count = var.environment == "production" ? 10 : 3
     }
 

--- a/infra/terraform/gke.tf
+++ b/infra/terraform/gke.tf
@@ -4,6 +4,8 @@
 # Per ADR-009: GKE receives 90% of traffic; Cloud Run receives 10%.
 
 resource "google_container_cluster" "main" {
+  count = var.enable_gke ? 1 : 0
+
   provider = google-beta
 
   name     = "${local.name_prefix}-cluster"
@@ -72,6 +74,8 @@ resource "google_project_iam_member" "api_workload_roles" {
 # Allow the Kubernetes service account (in the app namespace) to impersonate
 # this GCP service account via Workload Identity.
 resource "google_service_account_iam_member" "api_workload_k8s_binding" {
+  count = var.enable_gke ? 1 : 0
+
   service_account_id = google_service_account.api_workload.name
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.environment}/api]"

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,11 +1,16 @@
+output "gke_enabled" {
+  description = "Whether GKE is provisioned for this environment"
+  value       = var.enable_gke
+}
+
 output "gke_cluster_name" {
-  description = "GKE cluster name (used by helm deploy step in CI/CD)"
-  value       = google_container_cluster.main.name
+  description = "GKE cluster name (used by helm deploy step in CI/CD). Empty when enable_gke = false."
+  value       = var.enable_gke ? google_container_cluster.main[0].name : ""
 }
 
 output "gke_cluster_location" {
-  description = "GKE cluster region"
-  value       = google_container_cluster.main.location
+  description = "GKE cluster region. Empty when enable_gke = false."
+  value       = var.enable_gke ? google_container_cluster.main[0].location : ""
 }
 
 output "cloud_run_api_url" {

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -58,3 +58,15 @@ variable "image_tag" {
   type        = string
   default     = "latest"
 }
+
+variable "enable_gke" {
+  description = "Provision the GKE Autopilot cluster (per ADR-009 A/B comparison). Set false for single-user / Cloud-Run-only deployments to skip ~$30/mo of cluster cost."
+  type        = bool
+  default     = true
+}
+
+variable "cloud_run_min_instances" {
+  description = "Minimum Cloud Run instances per service. null = use environment default (1 in production, 0 in staging). Set 0 in production for scale-to-zero (adds ~2s cold start to first request, near-zero idle cost)."
+  type        = number
+  default     = null
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -60,7 +60,17 @@ variable "image_tag" {
 }
 
 variable "enable_gke" {
-  description = "Provision the GKE Autopilot cluster (per ADR-009 A/B comparison). Set false for single-user / Cloud-Run-only deployments to skip ~$30/mo of cluster cost."
+  description = <<-EOT
+    Provision the GKE Autopilot cluster (per ADR-009 A/B comparison).
+    Set false for single-user / Cloud-Run-only deployments to skip ~$30/mo of cluster cost.
+
+    Flipping on an existing environment:
+      * true → false: `helm uninstall` every release in the cluster namespaces FIRST
+        (otherwise cluster-managed cloud resources like LB IPs and PVCs are orphaned
+        when terraform destroys the cluster), then apply. See docs/deploy.md.
+      * false → true: no cleanup needed; apply, then push to main so CI deploys Helm
+        releases onto the freshly created cluster.
+  EOT
   type        = bool
   default     = true
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,50 @@
+# scripts/
+
+Repository automation scripts. Grouped by lifecycle.
+
+## Local development setup
+
+| Script | Purpose |
+|---|---|
+| [`dev-setup.sh`](dev-setup.sh) | One-shot local bootstrap: installs Node deps, validates `.nvmrc`, sets up env files for `apps/api` and `apps/web`. Run after cloning. |
+
+## Production deploy
+
+| Script | Purpose |
+|---|---|
+| [`bootstrap-gcp-prod.sh`](bootstrap-gcp-prod.sh) | One-time GCP bootstrap for a single-user production deploy: creates the project, links billing, enables the APIs Terraform needs, and provisions the Terraform state bucket. Idempotent. See [`docs/deploy-single-user.md`](../docs/deploy-single-user.md). |
+
+## Repository / project management
+
+| Script | Purpose |
+|---|---|
+| [`create-github-project.sh`](create-github-project.sh) | Creates and configures the GitHub Project (v2) — fields, options, links repo, seeds Foundation issues. Run once per fresh fork. |
+| [`create-foundation-issues.sh`](create-foundation-issues.sh) | Creates labels, the `v0.1 — Foundation` milestone, and the 17 Foundation issues. Run from the target repo root. |
+
+## Build helpers (Apps Script legacy / build pipeline)
+
+| Script | Purpose |
+|---|---|
+| [`check-clasp-login.js`](check-clasp-login.js) | Verifies `clasp` (Google Apps Script CLI) is installed and authenticated. Used by legacy GAS builds. |
+| [`clean-index.js`](clean-index.js) | Removes `dist/**/index.js` files after bundling — part of the Apps Script build chain. |
+| [`flatten-dist.js`](flatten-dist.js) | Moves all `dist/**/*.js` files into a flat `dist/` for GAS upload. |
+| [`mkdir-dist.js`](mkdir-dist.js) | Ensures `dist/` exists before a build. |
+| [`watch.js`](watch.js) | esbuild watch mode for `src/{core,api}/*/index.ts` entry points. |
+
+## Verification / testing
+
+| Script | Purpose |
+|---|---|
+| [`smoke-test-observability.sh`](smoke-test-observability.sh) | End-to-end smoke test of the observability docker-compose stack: sends a synthetic OTLP trace and polls Tempo. Requires Docker Compose V2. |
+| [`validate-analytics-taxonomy.mjs`](validate-analytics-taxonomy.mjs) | Verifies `AnalyticsConstants.kt` is in sync with `packages/types/src/analytics.ts`. Exits 0 if the Kotlin file is absent (future work). |
+
+---
+
+When adding a new script:
+
+1. Drop a one-paragraph header comment at the top of the script (purpose,
+   prerequisites, usage).
+2. Add a row to the appropriate table above — keep tables sorted alphabetically
+   within each group.
+3. If the script is part of a workflow documented in `docs/`, link to it from
+   the relevant doc.

--- a/scripts/bootstrap-gcp-prod.sh
+++ b/scripts/bootstrap-gcp-prod.sh
@@ -26,6 +26,17 @@ PROJECT_NAME="Lifting Logbook Prod"
 REGION="us-central1"
 BILLING=""
 
+usage() {
+  # Print the leading comment block (everything from line 2 up to the first
+  # non-comment line). Resilient to header growth, unlike a fixed sed range.
+  awk '
+    NR == 1 { next }                    # skip shebang
+    /^[^#]/ { exit }                    # stop at first non-comment line
+    /^#$/   { print ""; next }          # blank-comment line → blank
+    /^# ?/  { sub(/^# ?/, ""); print }  # strip "# " prefix
+  ' "$0"
+}
+
 while (( $# > 0 )); do
   case "$1" in
     --project-id)
@@ -37,7 +48,7 @@ while (( $# > 0 )); do
       shift 2
       ;;
     --help|-h)
-      sed -n '2,20p' "$0"
+      usage
       exit 0
       ;;
     -*)
@@ -64,11 +75,15 @@ if [[ -z "$BILLING" ]]; then
   exit 2
 fi
 
-if ! [[ "$BILLING" =~ ^[A-Z0-9]{6}-[A-Z0-9]{6}-[A-Z0-9]{6}$ ]]; then
+# Shape check only — `gcloud billing accounts describe` below is the real validator.
+# Accept any case; gcloud normalizes to uppercase.
+if ! [[ "$BILLING" =~ ^[A-Za-z0-9]{6}-[A-Za-z0-9]{6}-[A-Za-z0-9]{6}$ ]]; then
   echo "Billing account ID '$BILLING' does not look right." >&2
-  echo "Expected format: XXXXXX-XXXXXX-XXXXXX (uppercase letters/digits)." >&2
+  echo "Expected format: XXXXXX-XXXXXX-XXXXXX (alphanumeric, three 6-char groups)." >&2
+  echo "Find your billing account ID with: gcloud billing accounts list" >&2
   exit 2
 fi
+BILLING=$(echo "$BILLING" | tr '[:lower:]' '[:upper:]')
 
 command -v gcloud >/dev/null \
   || { echo "gcloud not found on PATH. See https://cloud.google.com/sdk/docs/install" >&2; exit 1; }

--- a/scripts/bootstrap-gcp-prod.sh
+++ b/scripts/bootstrap-gcp-prod.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# bootstrap-gcp-prod.sh — one-time GCP bootstrap for lifting-logbook production deploy.
+#
+# Creates the GCP project, links a billing account, enables the bootstrap APIs that
+# Terraform itself needs in order to enable the rest of the APIs, and provisions the
+# Terraform remote-state bucket. Each step is idempotent — safe to re-run if a previous
+# attempt failed partway.
+#
+# Prereqs:
+#   * gcloud CLI installed and on PATH (https://cloud.google.com/sdk/docs/install)
+#   * Authenticated: `gcloud auth login` AND `gcloud auth application-default login`
+#
+# Usage:
+#   ./scripts/bootstrap-gcp-prod.sh <billing-account-id> [--project-id <id>] [--region <region>]
+#
+# Example:
+#   ./scripts/bootstrap-gcp-prod.sh 0X0X0X-0X0X0X-0X0X0X
+#
+# Find your billing account ID with: gcloud billing accounts list
+
+set -euo pipefail
+
+PROJECT_ID="lifting-logbook-prod"
+PROJECT_NAME="Lifting Logbook Prod"
+REGION="us-central1"
+BILLING=""
+
+while (( $# > 0 )); do
+  case "$1" in
+    --project-id)
+      PROJECT_ID="$2"
+      shift 2
+      ;;
+    --region)
+      REGION="$2"
+      shift 2
+      ;;
+    --help|-h)
+      sed -n '2,20p' "$0"
+      exit 0
+      ;;
+    -*)
+      echo "Unknown flag: $1" >&2
+      exit 2
+      ;;
+    *)
+      if [[ -z "$BILLING" ]]; then
+        BILLING="$1"
+        shift
+      else
+        echo "Unexpected positional arg: $1" >&2
+        exit 2
+      fi
+      ;;
+  esac
+done
+
+STATE_BUCKET="${PROJECT_ID}-tfstate"
+
+if [[ -z "$BILLING" ]]; then
+  echo "Usage: $0 <billing-account-id> [--project-id <id>] [--region <region>]" >&2
+  echo "Find your billing account ID with: gcloud billing accounts list" >&2
+  exit 2
+fi
+
+if ! [[ "$BILLING" =~ ^[A-Z0-9]{6}-[A-Z0-9]{6}-[A-Z0-9]{6}$ ]]; then
+  echo "Billing account ID '$BILLING' does not look right." >&2
+  echo "Expected format: XXXXXX-XXXXXX-XXXXXX (uppercase letters/digits)." >&2
+  exit 2
+fi
+
+command -v gcloud >/dev/null \
+  || { echo "gcloud not found on PATH. See https://cloud.google.com/sdk/docs/install" >&2; exit 1; }
+command -v gsutil >/dev/null \
+  || { echo "gsutil not found on PATH (usually installed alongside gcloud)." >&2; exit 1; }
+
+ACTIVE_ACCOUNT=$(gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>/dev/null || true)
+if [[ -z "$ACTIVE_ACCOUNT" ]]; then
+  echo "No active gcloud account. Run:" >&2
+  echo "  gcloud auth login" >&2
+  echo "  gcloud auth application-default login" >&2
+  exit 1
+fi
+echo "Authenticated as: $ACTIVE_ACCOUNT"
+
+echo "==> Validating billing account $BILLING is accessible"
+gcloud billing accounts describe "$BILLING" >/dev/null \
+  || { echo "Billing account $BILLING is not accessible to $ACTIVE_ACCOUNT." >&2; exit 1; }
+
+echo "==> Creating project $PROJECT_ID (skip if it already exists)"
+if gcloud projects describe "$PROJECT_ID" >/dev/null 2>&1; then
+  echo "    project $PROJECT_ID already exists"
+else
+  gcloud projects create "$PROJECT_ID" --name="$PROJECT_NAME"
+fi
+
+echo "==> Linking billing account to $PROJECT_ID"
+gcloud billing projects link "$PROJECT_ID" --billing-account="$BILLING"
+
+echo "==> Setting $PROJECT_ID as active gcloud project"
+gcloud config set project "$PROJECT_ID"
+
+echo "==> Enabling bootstrap APIs (cloudresourcemanager, iam)"
+gcloud services enable \
+  cloudresourcemanager.googleapis.com \
+  iam.googleapis.com \
+  --project="$PROJECT_ID"
+
+echo "==> Creating Terraform state bucket gs://$STATE_BUCKET (skip if it already exists)"
+if gsutil ls -b "gs://$STATE_BUCKET" >/dev/null 2>&1; then
+  echo "    bucket gs://$STATE_BUCKET already exists"
+else
+  gsutil mb -p "$PROJECT_ID" -l "$REGION" "gs://$STATE_BUCKET"
+fi
+
+echo "==> Enabling versioning on the state bucket"
+gsutil versioning set on "gs://$STATE_BUCKET"
+
+cat <<EOF
+
+Bootstrap complete for project '$PROJECT_ID'.
+
+Next steps (from docs/deploy.md and the production deploy plan):
+  1. Create the Clerk production app at https://clerk.com and copy pk_live_… / sk_live_…
+  2. Update infra/terraform/terraform.tfvars.production with project_id="$PROJECT_ID"
+     and (for single-user) enable_gke=false
+  3. Run the first Terraform apply locally:
+       cd infra/terraform
+       terraform init -backend-config="bucket=$STATE_BUCKET"
+       terraform workspace new production
+       terraform apply -var-file=terraform.tfvars.production \\
+         -var="billing_account=$BILLING"
+  4. Capture Workload Identity outputs and paste into GitHub Actions secrets:
+       terraform output workload_identity_provider
+       terraform output cicd_service_account_email
+  5. Populate Clerk secrets in Secret Manager:
+       echo -n "sk_live_..." | gcloud secrets versions add \\
+         ${PROJECT_ID}-clerk-secret-key --data-file=-
+       echo -n "pk_live_..." | gcloud secrets versions add \\
+         ${PROJECT_ID}-clerk-publishable-key --data-file=-
+  6. Apply database migrations via Cloud SQL Auth Proxy (see docs/deploy.md).
+  7. Merge to main — GitHub Actions will deploy.
+
+EOF


### PR DESCRIPTION
## Summary

- Adds `scripts/bootstrap-gcp-prod.sh` — idempotent one-time GCP project + Terraform state bucket bootstrap, run as `./scripts/bootstrap-gcp-prod.sh <billing-account-id>`.
- Adds `enable_gke` Terraform variable (default `true`, preserving the [ADR-009](docs/adr/009-api-deployment-comparison.md) A/B comparison). Set to `false` for single-user / Cloud-Run-only deployments to skip ~\$30/mo of GKE Autopilot cost.
- Adds `cloud_run_min_instances` variable — overrides the per-environment default so production can scale to zero for single-user deploys.
- Gates the GKE cluster, the Kubernetes Workload Identity binding, and all Helm/kubectl steps in `.github/workflows/deploy.yml` on `gke_enabled`. The `api_workload` service account and its IAM roles stay ungated because Cloud Run reuses them.

The full step-by-step deploy walkthrough (GCP account, Clerk, secrets, first apply, migrations, verification) lives in the plan file: `~/.claude/plans/does-the-app-work-ticklish-sparrow.md`.

## Test plan

- [x] `npm test` — 243 passed / 51 skipped / 1 suite skipped across all workspaces (after `npx prisma generate` to refresh pre-existing stale client types)
- [x] `bash -n scripts/bootstrap-gcp-prod.sh` — script syntax valid
- [x] Script arg validation tested (`./scripts/bootstrap-gcp-prod.sh` with no args → usage; with malformed ID → validation error)
- [x] deploy.yml structurally verified: 14 GKE-only steps now guarded by `if: <ctx>.gke_enabled == 'true'`, all 4 `Helm deploy` steps gated, both Set-up-GKE-credentials steps gated
- [ ] Live Terraform apply with `enable_gke = false` against a real project — deferred to first single-user deploy (validated as part of executing the plan)

## Coverage gate

No new application behavior — pure infra/CI plumbing. Existing test suite covers the API/web behavior that Cloud Run serves.

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)