### PR TITLE
[fix] Fix terraform config for initial production bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ next-env.d.ts
 
 # Claude Code local overrides (machine-specific permissions, not for team sharing)
 .claude/settings.local.json
+scripts/cloud-sql-proxy
+scripts/cloud-sql-proxy.exe

--- a/docs/deploy-single-user.md
+++ b/docs/deploy-single-user.md
@@ -110,7 +110,7 @@ single user.
    - Publishable key (`pk_live_…`)
    - Secret key (`sk_live_…`)
 
-You'll load these into Secret Manager in Step 6.
+You'll load these into Secret Manager in Step 7.
 
 ---
 
@@ -182,7 +182,78 @@ Cloud Run reuses it as the API service identity.
 
 ---
 
-## Step 6 — Populate Clerk secrets
+## Step 6 — Map a custom domain (optional)
+
+Skip this step if you're happy using the Cloud Run URL directly.
+
+### 6a — Verify domain ownership
+
+Google requires one-time domain ownership verification before a Cloud Run domain mapping will be accepted.
+
+```bash
+gcloud domains verify your-domain.com
+```
+
+This opens Google Search Console in your browser. Add the TXT record it shows at your registrar:
+
+| Field | Value |
+|---|---|
+| Type | TXT |
+| Name / Host | `@` |
+| Value | the string Google provides |
+
+> **Important:** the Name field must be exactly `@`. Other values (blank, the full domain name, etc.) fail silently.
+
+Click **Verify** in Search Console once the record is live. DNS propagation can take a few minutes.
+
+### 6b — Create the domain mappings
+
+```bash
+gcloud beta run domain-mappings create \
+  --service lifting-logbook-prod-web \
+  --domain your-domain.com \
+  --region us-central1 \
+  --project lifting-logbook-prod
+
+gcloud beta run domain-mappings create \
+  --service lifting-logbook-prod-web \
+  --domain www.your-domain.com \
+  --region us-central1 \
+  --project lifting-logbook-prod
+```
+
+### 6c — Add DNS records
+
+```bash
+gcloud beta run domain-mappings describe \
+  --domain your-domain.com \
+  --region us-central1 \
+  --project lifting-logbook-prod \
+  --format="table(status.resourceRecords[].type, status.resourceRecords[].name, status.resourceRecords[].rrdata)"
+```
+
+At your registrar, add:
+- Four `A` records pointing `@` to the IPs shown
+- Four `AAAA` records pointing `@` to the IPv6 addresses shown
+- One `CNAME` record pointing `www` to `ghs.googlehosted.com.`
+
+Replace any existing `A`/`AAAA` records for the apex; keep existing `MX` and `TXT` records.
+
+SSL is provisioned automatically once DNS propagates. Check status with:
+
+```bash
+gcloud beta run domain-mappings describe \
+  --domain your-domain.com \
+  --region us-central1 \
+  --project lifting-logbook-prod \
+  --format="value(status.conditions[0].reason)"
+```
+
+`CertificateProvisioned` means the cert is active. Provisioning typically completes within 15–60 minutes.
+
+---
+
+## Step 7 — Populate Clerk secrets
 
 Terraform created empty secret containers with
 `lifecycle.ignore_changes = [secret_data]`. Add the actual values now:
@@ -197,7 +268,7 @@ echo -n "pk_live_..." | gcloud secrets versions add \
 
 ---
 
-## Step 7 — Apply database migrations (one-time)
+## Step 9 — Apply database migrations (one-time)
 
 The API container does **not** run `prisma migrate deploy` on startup. Use the
 Cloud SQL Auth Proxy:
@@ -215,7 +286,7 @@ cd apps/api && DATABASE_URL="$DATABASE_URL" npx prisma migrate deploy
 
 ---
 
-## Step 8 — Trigger the first deploy
+## Step 10 — Trigger the first deploy
 
 Merge any branch to `main` (or push directly if you have the workflow set up
 that way). The [Deploy workflow](../.github/workflows/deploy.yml):
@@ -233,7 +304,7 @@ so the production job will pause until you approve it.
 
 ---
 
-## Step 9 — Create your Clerk user, log in, verify
+## Step 11 — Create your Clerk user, log in, verify
 
 Self-serve signup isn't wired by default. Provision yourself:
 
@@ -294,7 +365,6 @@ These come from [`docs/deploy.md`](deploy.md). Skip them for single-user; add
 them later if you ever invite a second person:
 
 - A separate `lifting-logbook-staging` project and the full A/B `90/10` split.
-- A custom domain via Cloud Load Balancer.
 - Self-serve signup / open registration.
 - Rate limiting beyond what Cloud Run gives you by default.
 - On-call runbook / alert routing.

--- a/docs/deploy-single-user.md
+++ b/docs/deploy-single-user.md
@@ -98,19 +98,29 @@ The script's `--help` flag prints the full header documentation.
 
 ---
 
-## Step 2 — Create a Clerk production app (~5 min)
+## Step 2 — Create and configure a Clerk production instance (~10 min)
 
-[Clerk](https://clerk.com) handles authentication. The free tier covers a
-single user.
+[Clerk](https://clerk.com) handles authentication. The free tier covers a single user.
 
-1. Sign up at https://clerk.com.
-2. Create an application named `lifting-logbook-production`.
-3. Pick auth methods (email + password is simplest).
-4. From the dashboard, **API Keys** → copy:
+1. Sign up / log in at https://clerk.com and create an application named `lifting-logbook-production`.
+2. Choose auth methods (email + password is simplest for a single user).
+3. **Switch to Production mode:** click the **Development** badge at the top of the dashboard → **Switch to Production**.
+4. **Set the application domain:** enter your domain (e.g. `liftinglogbook.com`). Clerk uses it to scope cookies, generate auth redirect URLs, and configure CORS.
+5. **Add Clerk DNS records at your registrar:** Clerk shows five CNAME records to add. These are separate from the Cloud Run A/AAAA records. Once DNS propagates, click **Verify** (or **Check DNS**) in Clerk. The records are found under **Configure → DNS Records** in the sidebar if the overlay is dismissed.
+6. **Copy your production API keys:** go to **API Keys** → copy:
    - Publishable key (`pk_live_…`)
    - Secret key (`sk_live_…`)
+7. **Configure paths:** under **Settings → Paths**, set:
 
-You'll load these into Secret Manager in Step 7.
+   | Path | Value |
+   |---|---|
+   | Home URL | `https://your-domain.com` |
+   | Sign-in URL | `https://your-domain.com/sign-in` |
+   | Sign-up URL | `https://your-domain.com/sign-up` |
+   | After sign-in URL | `https://your-domain.com` |
+   | After sign-up URL | `https://your-domain.com` |
+
+You'll load the API keys into Secret Manager in Step 7.
 
 ---
 
@@ -270,19 +280,23 @@ echo -n "pk_live_..." | gcloud secrets versions add \
 
 ## Step 9 — Apply database migrations (one-time)
 
-The API container does **not** run `prisma migrate deploy` on startup. Use the
-Cloud SQL Auth Proxy:
+The API container does **not** run `prisma migrate deploy` on startup. Run the migration script from the repo root:
 
 ```bash
-# Download once: https://cloud.google.com/sql/docs/postgres/connect-auth-proxy
-./cloud-sql-proxy lifting-logbook-prod:us-central1:lifting-logbook-prod-db-XXXX &
-
-DATABASE_URL=$(gcloud secrets versions access latest \
-  --secret=lifting-logbook-prod-database-url)
-
-psql "$DATABASE_URL" -f infra/migrations/001_create_user_data_source.sql
-cd apps/api && DATABASE_URL="$DATABASE_URL" npx prisma migrate deploy
+./scripts/migrate-prod-db.sh
 ```
+
+The script:
+1. Downloads the Cloud SQL Auth Proxy automatically if not present
+2. Temporarily enables a public IP on the Cloud SQL instance (required to connect from a local machine; removed when done)
+3. Retrieves `DATABASE_URL` from Secret Manager
+4. Applies all 14 Prisma migrations via `prisma migrate deploy`
+5. Runs `infra/migrations/001_create_user_data_source.sql` (managed outside Prisma)
+6. Removes the temporary public IP
+
+**Prerequisites:** `gcloud` authenticated, `npm install` run from repo root.
+
+> **Subsequent migrations** (adding new migrations to a live database): run the same script — `prisma migrate deploy` is idempotent and only applies pending migrations.
 
 ---
 

--- a/infra/terraform/cloud-run.tf
+++ b/infra/terraform/cloud-run.tf
@@ -195,10 +195,10 @@ resource "google_cloud_run_v2_service_iam_member" "web_invoker_on_api" {
   member   = "serviceAccount:${google_service_account.web_workload.email}"
 }
 
-resource "google_project_iam_member" "web_workload_secret_accessor" {
-  project = var.project_id
-  role    = "roles/secretmanager.secretAccessor"
-  member  = "serviceAccount:${google_service_account.web_workload.email}"
+resource "google_secret_manager_secret_iam_member" "web_workload_publishable_key" {
+  secret_id = google_secret_manager_secret.clerk_publishable_key.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.web_workload.email}"
 }
 
 # ─── Serverless VPC Connector (private Cloud SQL access from Cloud Run) ───────

--- a/infra/terraform/cloud-run.tf
+++ b/infra/terraform/cloud-run.tf
@@ -5,8 +5,12 @@
 
 locals {
   image_tag = var.image_tag
-  api_image = "${var.artifact_registry_region}-docker.pkg.dev/${var.project_id}/${var.app_name}/api:${local.image_tag}"
-  web_image = "${var.artifact_registry_region}-docker.pkg.dev/${var.project_id}/${var.app_name}/web:${local.image_tag}"
+  # "bootstrap" is a sentinel used on first apply before CI/CD has pushed any images.
+  # CI/CD overwrites this via gcloud run deploy; lifecycle.ignore_changes prevents Terraform
+  # from reverting it on subsequent applies.
+  placeholder_image = "us-docker.pkg.dev/cloudrun/container/hello:latest"
+  api_image = var.image_tag == "bootstrap" ? local.placeholder_image : "${var.artifact_registry_region}-docker.pkg.dev/${var.project_id}/${var.app_name}/api:${local.image_tag}"
+  web_image = var.image_tag == "bootstrap" ? local.placeholder_image : "${var.artifact_registry_region}-docker.pkg.dev/${var.project_id}/${var.app_name}/web:${local.image_tag}"
 
   # Cloud Run min instances. var.cloud_run_min_instances overrides the per-environment
   # default when set (use 0 in production for scale-to-zero / single-user deploys).
@@ -50,11 +54,6 @@ resource "google_cloud_run_v2_service" "api" {
       env {
         name  = "NODE_ENV"
         value = var.environment == "production" ? "production" : "staging"
-      }
-
-      env {
-        name  = "PORT"
-        value = "3000"
       }
 
       env {
@@ -139,11 +138,6 @@ resource "google_cloud_run_v2_service" "web" {
       }
 
       env {
-        name  = "PORT"
-        value = "3001"
-      }
-
-      env {
         name  = "API_URL"
         value = google_cloud_run_v2_service.api.uri
       }
@@ -199,6 +193,12 @@ resource "google_cloud_run_v2_service_iam_member" "web_invoker_on_api" {
   name     = google_cloud_run_v2_service.api.name
   role     = "roles/run.invoker"
   member   = "serviceAccount:${google_service_account.web_workload.email}"
+}
+
+resource "google_project_iam_member" "web_workload_secret_accessor" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.web_workload.email}"
 }
 
 # ─── Serverless VPC Connector (private Cloud SQL access from Cloud Run) ───────

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -14,6 +14,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.11"
+    }
   }
 
   # Remote state in GCS — bucket is created during bootstrap (see docs/deploy.md)
@@ -50,6 +54,7 @@ resource "google_project_service" "required_apis" {
     "compute.googleapis.com",            # VPC, Load Balancer
     "servicenetworking.googleapis.com",  # Private service networking (Cloud SQL)
     "secretmanager.googleapis.com",      # Secret Manager
+    "vpcaccess.googleapis.com",          # Serverless VPC Access (Cloud Run connector)
     "iam.googleapis.com",
     "cloudresourcemanager.googleapis.com",
   ])
@@ -60,12 +65,19 @@ resource "google_project_service" "required_apis" {
   disable_on_destroy         = false
 }
 
+# GCP API enablement is eventually consistent — wait for propagation before
+# creating any resources that depend on newly-enabled APIs.
+resource "time_sleep" "api_propagation" {
+  depends_on      = [google_project_service.required_apis]
+  create_duration = "60s"
+}
+
 # ─── VPC ─────────────────────────────────────────────────────────────────────
 
 resource "google_compute_network" "main" {
   name                    = "${local.name_prefix}-vpc"
   auto_create_subnetworks = false
-  depends_on              = [google_project_service.required_apis]
+  depends_on              = [time_sleep.api_propagation]
 }
 
 resource "google_compute_subnetwork" "main" {
@@ -186,7 +198,9 @@ resource "google_sql_user" "app" {
 
 resource "google_secret_manager_secret" "database_url" {
   secret_id = "${local.name_prefix}-database-url"
-  replication { auto {} }
+  replication {
+    auto {}
+  }
   depends_on = [google_project_service.required_apis]
 }
 
@@ -197,7 +211,9 @@ resource "google_secret_manager_secret_version" "database_url" {
 
 resource "google_secret_manager_secret" "system_database_url" {
   secret_id = "${local.name_prefix}-system-database-url"
-  replication { auto {} }
+  replication {
+    auto {}
+  }
   depends_on = [google_project_service.required_apis]
 }
 
@@ -208,7 +224,9 @@ resource "google_secret_manager_secret_version" "system_database_url" {
 
 resource "google_secret_manager_secret" "clerk_secret_key" {
   secret_id = "${local.name_prefix}-clerk-secret-key"
-  replication { auto {} }
+  replication {
+    auto {}
+  }
   depends_on = [google_project_service.required_apis]
 }
 
@@ -224,7 +242,9 @@ resource "google_secret_manager_secret_version" "clerk_secret_key" {
 
 resource "google_secret_manager_secret" "clerk_publishable_key" {
   secret_id = "${local.name_prefix}-clerk-publishable-key"
-  replication { auto {} }
+  replication {
+    auto {}
+  }
   depends_on = [google_project_service.required_apis]
 }
 

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -67,6 +67,9 @@ resource "google_project_service" "required_apis" {
 
 # GCP API enablement is eventually consistent — wait for propagation before
 # creating any resources that depend on newly-enabled APIs.
+# 60s was observed sufficient on fresh projects in testing; vpcaccess propagation
+# can occasionally take longer. This only fires on create (first apply), not on
+# re-applies where the APIs are already enabled.
 resource "time_sleep" "api_propagation" {
   depends_on      = [google_project_service.required_apis]
   create_duration = "60s"

--- a/infra/terraform/terraform.tfvars.production
+++ b/infra/terraform/terraform.tfvars.production
@@ -4,7 +4,7 @@
 #   terraform apply -var="billing_account=$GCP_BILLING_ACCOUNT"
 
 project_id      = "lifting-logbook-prod"
-billing_account = "01F30C-20F0EA-D44922"
+billing_account = "REPLACE_ME"
 region          = "us-central1"
 environment     = "production"
 app_name        = "lifting-logbook"

--- a/infra/terraform/terraform.tfvars.production
+++ b/infra/terraform/terraform.tfvars.production
@@ -10,5 +10,5 @@ environment     = "production"
 app_name        = "lifting-logbook"
 db_tier         = "db-g1-small"
 db_name         = "lifting_logbook"
-enable_gke      = "false"
+enable_gke      = false
 image_tag       = "bootstrap"

--- a/infra/terraform/terraform.tfvars.production
+++ b/infra/terraform/terraform.tfvars.production
@@ -4,9 +4,11 @@
 #   terraform apply -var="billing_account=$GCP_BILLING_ACCOUNT"
 
 project_id      = "lifting-logbook-prod"
-billing_account = "XXXXXX-XXXXXX-XXXXXX"
+billing_account = "01F30C-20F0EA-D44922"
 region          = "us-central1"
 environment     = "production"
 app_name        = "lifting-logbook"
 db_tier         = "db-g1-small"
 db_name         = "lifting_logbook"
+enable_gke      = "false"
+image_tag       = "bootstrap"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,6 +14,7 @@ Repository automation scripts. Grouped by lifecycle.
 |---|---|
 | [`bootstrap-gcp-prod.sh`](bootstrap-gcp-prod.sh) | One-time GCP bootstrap for a single-user production deploy: creates the project, links billing, enables the APIs Terraform needs, and provisions the Terraform state bucket. Idempotent. See [`docs/deploy-single-user.md`](../docs/deploy-single-user.md). |
 | [`deploy-prod-infra.sh`](deploy-prod-infra.sh) | Automates `terraform init` → workspace select → `apply` for the production environment. Maps custom domains and prints GitHub Actions secrets. Use `--plan-only` to preview. Run after `bootstrap-gcp-prod.sh`. |
+| [`migrate-prod-db.sh`](migrate-prod-db.sh) | Applies all database migrations to the production Cloud SQL instance. Temporarily enables a public IP, runs Prisma migrations and the `user_data_source` infra migration via the Cloud SQL Auth Proxy, then removes the public IP. Downloads the proxy automatically. |
 
 ## Repository / project management
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,7 @@ Repository automation scripts. Grouped by lifecycle.
 | Script | Purpose |
 |---|---|
 | [`bootstrap-gcp-prod.sh`](bootstrap-gcp-prod.sh) | One-time GCP bootstrap for a single-user production deploy: creates the project, links billing, enables the APIs Terraform needs, and provisions the Terraform state bucket. Idempotent. See [`docs/deploy-single-user.md`](../docs/deploy-single-user.md). |
+| [`deploy-prod-infra.sh`](deploy-prod-infra.sh) | Automates `terraform init` → workspace select → `apply` for the production environment. Maps custom domains and prints GitHub Actions secrets. Use `--plan-only` to preview. Run after `bootstrap-gcp-prod.sh`. |
 
 ## Repository / project management
 

--- a/scripts/deploy-prod-infra.sh
+++ b/scripts/deploy-prod-infra.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# deploy-prod-infra.sh — Terraform init/apply for the lifting-logbook production environment.
+#
+# Run this after bootstrap-gcp-prod.sh has completed. Each step is idempotent — safe
+# to re-run. Use --plan-only to preview changes without applying them.
+#
+# Prereqs:
+#   * terraform >= 1.7 on PATH (https://developer.hashicorp.com/terraform/install)
+#   * gcloud CLI authenticated: `gcloud auth login` AND `gcloud auth application-default login`
+#
+# Usage:
+#   ./scripts/deploy-prod-infra.sh [--plan-only] [--workspace <name>] [--project-id <id>]
+#
+# Examples:
+#   ./scripts/deploy-prod-infra.sh --plan-only      # preview only, no changes
+#   ./scripts/deploy-prod-infra.sh                  # full apply
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TF_DIR="$(cd "$SCRIPT_DIR/../infra/terraform" && pwd)"
+
+PROJECT_ID="lifting-logbook-prod"
+WORKSPACE="production"
+PLAN_ONLY=false
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^[^#]/ { exit }
+    /^#$/   { print ""; next }
+    /^# ?/  { sub(/^# ?/, ""); print }
+  ' "$0"
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    --plan-only)   PLAN_ONLY=true; shift ;;
+    --workspace)   WORKSPACE="$2"; shift 2 ;;
+    --project-id)  PROJECT_ID="$2"; shift 2 ;;
+    --help|-h)     usage; exit 0 ;;
+    -*)            echo "Unknown flag: $1" >&2; exit 2 ;;
+    *)             echo "Unexpected argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+STATE_BUCKET="${PROJECT_ID}-tfstate"
+TFVARS="terraform.tfvars.production"
+
+command -v terraform >/dev/null \
+  || { echo "terraform not found on PATH. See https://developer.hashicorp.com/terraform/install" >&2; exit 1; }
+command -v gcloud >/dev/null \
+  || { echo "gcloud not found on PATH. See https://cloud.google.com/sdk/docs/install" >&2; exit 1; }
+
+ACTIVE_ACCOUNT=$(gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>/dev/null || true)
+if [[ -z "$ACTIVE_ACCOUNT" ]]; then
+  echo "No active gcloud account. Run:" >&2
+  echo "  gcloud auth login" >&2
+  echo "  gcloud auth application-default login" >&2
+  exit 1
+fi
+echo "Authenticated as: $ACTIVE_ACCOUNT"
+
+cd "$TF_DIR"
+
+echo "==> terraform init (bucket=$STATE_BUCKET)"
+terraform init -backend-config="bucket=$STATE_BUCKET" -reconfigure
+
+echo "==> selecting workspace: $WORKSPACE"
+if terraform workspace list 2>/dev/null | grep -qE "(^|\s|\*)$WORKSPACE(\s|$)"; then
+  terraform workspace select "$WORKSPACE"
+else
+  terraform workspace new "$WORKSPACE"
+fi
+
+if $PLAN_ONLY; then
+  echo "==> terraform plan"
+  terraform plan -var-file="$TFVARS"
+  echo ""
+  echo "No changes applied (--plan-only mode)."
+else
+  echo "==> terraform apply"
+  terraform apply -var-file="$TFVARS"
+
+  echo ""
+  echo "==> GitHub Actions secrets — copy these into the repo settings:"
+  echo "    WIF_PROVIDER  = $(terraform output -raw workload_identity_provider 2>/dev/null || echo '(not yet available)')"
+  echo "    CICD_SA_EMAIL = $(terraform output -raw cicd_service_account_email 2>/dev/null || echo '(not yet available)')"
+
+  echo ""
+  echo "==> Next: populate Clerk keys in Secret Manager (see docs/deploy.md step 5):"
+  echo "    echo -n 'sk_live_...' | gcloud secrets versions add ${PROJECT_ID}-clerk-secret-key --data-file=-"
+  echo "    echo -n 'pk_live_...' | gcloud secrets versions add ${PROJECT_ID}-clerk-publishable-key --data-file=-"
+fi

--- a/scripts/deploy-prod-infra.sh
+++ b/scripts/deploy-prod-infra.sh
@@ -22,6 +22,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TF_DIR="$(cd "$SCRIPT_DIR/../infra/terraform" && pwd)"
 
 PROJECT_ID="lifting-logbook-prod"
+REGION="us-central1"
 WORKSPACE="production"
 PLAN_ONLY=false
 
@@ -93,3 +94,28 @@ echo ""
 echo "==> Next: populate Clerk keys in Secret Manager (see docs/deploy.md step 5):"
 echo "    echo -n 'sk_live_...' | gcloud secrets versions add ${PROJECT_ID}-clerk-secret-key --data-file=-"
 echo "    echo -n 'pk_live_...' | gcloud secrets versions add ${PROJECT_ID}-clerk-publishable-key --data-file=-"
+
+if ! $PLAN_ONLY; then
+  echo ""
+  echo "==> Mapping custom domains to Cloud Run web service (idempotent)..."
+  for DOMAIN in "liftinglogbook.com" "www.liftinglogbook.com"; do
+    if gcloud run domain-mappings describe --domain "$DOMAIN" --region "$REGION" --project "$PROJECT_ID" &>/dev/null; then
+      echo "    $DOMAIN already mapped — skipping"
+    else
+      gcloud run domain-mappings create \
+        --service "${PROJECT_ID}-web" \
+        --domain "$DOMAIN" \
+        --region "$REGION" \
+        --project "$PROJECT_ID"
+      echo "    $DOMAIN mapped"
+    fi
+  done
+
+  echo ""
+  echo "==> DNS records required at your registrar:"
+  gcloud run domain-mappings describe \
+    --domain "liftinglogbook.com" \
+    --region "$REGION" \
+    --project "$PROJECT_ID" \
+    --format="table(status.resourceRecords[].type, status.resourceRecords[].name, status.resourceRecords[].rrdata)"
+fi

--- a/scripts/deploy-prod-infra.sh
+++ b/scripts/deploy-prod-infra.sh
@@ -99,10 +99,10 @@ if ! $PLAN_ONLY; then
   echo ""
   echo "==> Mapping custom domains to Cloud Run web service (idempotent)..."
   for DOMAIN in "liftinglogbook.com" "www.liftinglogbook.com"; do
-    if gcloud run domain-mappings describe --domain "$DOMAIN" --region "$REGION" --project "$PROJECT_ID" &>/dev/null; then
+    if gcloud beta run domain-mappings describe --domain "$DOMAIN" --region "$REGION" --project "$PROJECT_ID" &>/dev/null; then
       echo "    $DOMAIN already mapped — skipping"
     else
-      gcloud run domain-mappings create \
+      gcloud beta run domain-mappings create \
         --service "${PROJECT_ID}-web" \
         --domain "$DOMAIN" \
         --region "$REGION" \
@@ -113,7 +113,7 @@ if ! $PLAN_ONLY; then
 
   echo ""
   echo "==> DNS records required at your registrar:"
-  gcloud run domain-mappings describe \
+  gcloud beta run domain-mappings describe \
     --domain "liftinglogbook.com" \
     --region "$REGION" \
     --project "$PROJECT_ID" \

--- a/scripts/deploy-prod-infra.sh
+++ b/scripts/deploy-prod-infra.sh
@@ -82,14 +82,14 @@ if $PLAN_ONLY; then
 else
   echo "==> terraform apply"
   terraform apply -var-file="$TFVARS"
-
-  echo ""
-  echo "==> GitHub Actions secrets — copy these into the repo settings:"
-  echo "    WIF_PROVIDER  = $(terraform output -raw workload_identity_provider 2>/dev/null || echo '(not yet available)')"
-  echo "    CICD_SA_EMAIL = $(terraform output -raw cicd_service_account_email 2>/dev/null || echo '(not yet available)')"
-
-  echo ""
-  echo "==> Next: populate Clerk keys in Secret Manager (see docs/deploy.md step 5):"
-  echo "    echo -n 'sk_live_...' | gcloud secrets versions add ${PROJECT_ID}-clerk-secret-key --data-file=-"
-  echo "    echo -n 'pk_live_...' | gcloud secrets versions add ${PROJECT_ID}-clerk-publishable-key --data-file=-"
 fi
+
+echo ""
+echo "==> GitHub Actions secrets — copy these into the repo settings:"
+echo "    WIF_PROVIDER  = $(terraform output -raw workload_identity_provider 2>/dev/null || echo '(not yet available)')"
+echo "    CICD_SA_EMAIL = $(terraform output -raw cicd_service_account_email 2>/dev/null || echo '(not yet available)')"
+
+echo ""
+echo "==> Next: populate Clerk keys in Secret Manager (see docs/deploy.md step 5):"
+echo "    echo -n 'sk_live_...' | gcloud secrets versions add ${PROJECT_ID}-clerk-secret-key --data-file=-"
+echo "    echo -n 'pk_live_...' | gcloud secrets versions add ${PROJECT_ID}-clerk-publishable-key --data-file=-"

--- a/scripts/deploy-prod-infra.sh
+++ b/scripts/deploy-prod-infra.sh
@@ -8,9 +8,10 @@
 # Prereqs:
 #   * terraform >= 1.7 on PATH (https://developer.hashicorp.com/terraform/install)
 #   * gcloud CLI authenticated: `gcloud auth login` AND `gcloud auth application-default login`
+#   * GCP_BILLING_ACCOUNT env var set to your billing account ID (XXXXXX-XXXXXX-XXXXXX)
 #
 # Usage:
-#   ./scripts/deploy-prod-infra.sh [--plan-only] [--workspace <name>] [--project-id <id>]
+#   ./scripts/deploy-prod-infra.sh [--plan-only] [--workspace <name>] [--project-id <id>] [--region <region>]
 #
 # Examples:
 #   ./scripts/deploy-prod-infra.sh --plan-only      # preview only, no changes
@@ -25,6 +26,10 @@ PROJECT_ID="lifting-logbook-prod"
 REGION="us-central1"
 WORKSPACE="production"
 PLAN_ONLY=false
+# Custom domains are specific to this single-user deployment. Override by editing
+# this script or by running gcloud beta run domain-mappings create manually (Step 6
+# of docs/deploy-single-user.md).
+DOMAINS=("liftinglogbook.com" "www.liftinglogbook.com")
 
 usage() {
   awk '
@@ -40,6 +45,7 @@ while (( $# > 0 )); do
     --plan-only)   PLAN_ONLY=true; shift ;;
     --workspace)   WORKSPACE="$2"; shift 2 ;;
     --project-id)  PROJECT_ID="$2"; shift 2 ;;
+    --region)      REGION="$2"; shift 2 ;;
     --help|-h)     usage; exit 0 ;;
     -*)            echo "Unknown flag: $1" >&2; exit 2 ;;
     *)             echo "Unexpected argument: $1" >&2; exit 2 ;;
@@ -63,6 +69,14 @@ if [[ -z "$ACTIVE_ACCOUNT" ]]; then
 fi
 echo "Authenticated as: $ACTIVE_ACCOUNT"
 
+# Require billing account — never commit the real ID to version control.
+if [[ -z "${GCP_BILLING_ACCOUNT:-}" || "$GCP_BILLING_ACCOUNT" == "REPLACE_ME" || "$GCP_BILLING_ACCOUNT" == "XXXXXX-XXXXXX-XXXXXX" ]]; then
+  echo "GCP_BILLING_ACCOUNT is not set or is a placeholder." >&2
+  echo "Export your billing account ID before running:" >&2
+  echo "  export GCP_BILLING_ACCOUNT=XXXXXX-XXXXXX-XXXXXX" >&2
+  exit 1
+fi
+
 cd "$TF_DIR"
 
 echo "==> terraform init (bucket=$STATE_BUCKET)"
@@ -77,12 +91,12 @@ fi
 
 if $PLAN_ONLY; then
   echo "==> terraform plan"
-  terraform plan -var-file="$TFVARS"
+  terraform plan -var-file="$TFVARS" -var="billing_account=$GCP_BILLING_ACCOUNT"
   echo ""
   echo "No changes applied (--plan-only mode)."
 else
   echo "==> terraform apply"
-  terraform apply -var-file="$TFVARS"
+  terraform apply -var-file="$TFVARS" -var="billing_account=$GCP_BILLING_ACCOUNT"
 fi
 
 echo ""
@@ -98,7 +112,7 @@ echo "    echo -n 'pk_live_...' | gcloud secrets versions add ${PROJECT_ID}-cler
 if ! $PLAN_ONLY; then
   echo ""
   echo "==> Mapping custom domains to Cloud Run web service (idempotent)..."
-  for DOMAIN in "liftinglogbook.com" "www.liftinglogbook.com"; do
+  for DOMAIN in "${DOMAINS[@]}"; do
     if gcloud beta run domain-mappings describe --domain "$DOMAIN" --region "$REGION" --project "$PROJECT_ID" &>/dev/null; then
       echo "    $DOMAIN already mapped — skipping"
     else
@@ -114,7 +128,7 @@ if ! $PLAN_ONLY; then
   echo ""
   echo "==> DNS records required at your registrar:"
   gcloud beta run domain-mappings describe \
-    --domain "liftinglogbook.com" \
+    --domain "${DOMAINS[0]}" \
     --region "$REGION" \
     --project "$PROJECT_ID" \
     --format="table(status.resourceRecords[].type, status.resourceRecords[].name, status.resourceRecords[].rrdata)"

--- a/scripts/migrate-prod-db.sh
+++ b/scripts/migrate-prod-db.sh
@@ -4,8 +4,13 @@
 #
 # The production Cloud SQL instance has no public IP. This script temporarily enables
 # a public IP (required for the Cloud SQL Auth Proxy to connect from a local machine),
-# runs all migrations, then removes the public IP. The proxy still requires Google IAM
-# authentication throughout, so the temporary exposure is protected.
+# scoped to the operator's current IP via --authorized-networks, runs all migrations,
+# then removes the public IP. The proxy still requires Google IAM authentication
+# throughout, so the temporary exposure is double-protected.
+#
+# On re-runs (e.g., to apply new Prisma migrations after the initial bootstrap), the
+# DROP TABLE step is skipped automatically when _prisma_migrations already exists,
+# preserving any existing user_data_source rows.
 #
 # Starts the Cloud SQL Auth Proxy, retrieves DATABASE_URL from Secret Manager,
 # runs the raw SQL migration, then runs prisma migrate deploy. Downloads the
@@ -17,7 +22,7 @@
 #   * roles/cloudsql.client on the project (project owner has this by default)
 #
 # Usage:
-#   ./scripts/migrate-prod-db.sh [--project-id <id>]
+#   ./scripts/migrate-prod-db.sh [--project-id <id>] [--region <region>]
 #
 # Examples:
 #   ./scripts/migrate-prod-db.sh
@@ -33,6 +38,7 @@ PROJECT_ID="lifting-logbook-prod"
 REGION="us-central1"
 PROXY_PORT=5433
 PUBLIC_IP_ENABLED=false
+PROXY_PID=""
 
 usage() {
   awk '
@@ -46,11 +52,30 @@ usage() {
 while (( $# > 0 )); do
   case "$1" in
     --project-id) PROJECT_ID="$2"; shift 2 ;;
+    --region)     REGION="$2"; shift 2 ;;
     --help|-h)    usage; exit 0 ;;
     -*)           echo "Unknown flag: $1" >&2; exit 2 ;;
     *)            echo "Unexpected argument: $1" >&2; exit 2 ;;
   esac
 done
+
+# ─── Cleanup function (defined early so the trap can reference it) ─────────────
+
+remove_public_ip() {
+  if $PUBLIC_IP_ENABLED; then
+    echo "==> Removing temporary public IP from Cloud SQL instance ..."
+    gcloud sql instances patch "$INSTANCE_NAME" \
+      --no-assign-ip \
+      --project="$PROJECT_ID" \
+      --quiet \
+      || echo "WARNING: Failed to remove public IP — remove manually: gcloud sql instances patch $INSTANCE_NAME --no-assign-ip --project=$PROJECT_ID"
+  fi
+}
+
+# Install cleanup trap before any destructive operations so the public IP is always
+# removed even if the script is interrupted (Ctrl-C, set -e, early exit).
+# PROXY_PID is initialized to "" above; guard ensures kill only fires after proxy starts.
+trap '[[ -n "${PROXY_PID:-}" ]] && { echo "==> Stopping proxy (PID $PROXY_PID)"; kill "$PROXY_PID" 2>/dev/null || true; }; remove_public_ip' EXIT INT TERM
 
 # ─── Prereq checks ────────────────────────────────────────────────────────────
 
@@ -67,15 +92,18 @@ echo "Authenticated as: $ACTIVE_ACCOUNT"
 PROXY_BIN=""
 if command -v cloud-sql-proxy >/dev/null; then
   PROXY_BIN="cloud-sql-proxy"
+elif [[ -x "$SCRIPT_DIR/cloud-sql-proxy.exe" ]]; then
+  # Windows binary (downloaded with correct .exe extension)
+  PROXY_BIN="$SCRIPT_DIR/cloud-sql-proxy.exe"
 elif [[ -x "$SCRIPT_DIR/cloud-sql-proxy" ]]; then
   PROXY_BIN="$SCRIPT_DIR/cloud-sql-proxy"
 else
-  echo "==> cloud-sql-proxy not found — downloading to $SCRIPT_DIR/cloud-sql-proxy ..."
+  echo "==> cloud-sql-proxy not found — downloading ..."
   PROXY_VERSION="v2.21.3"
   OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
   ARCH="$(uname -m)"
   # Filename convention differs by OS:
-  # Windows: cloud-sql-proxy.x64.exe / .arm64.exe
+  # Windows: cloud-sql-proxy.x64.exe / .arm64.exe  (saved with .exe extension)
   # Linux/macOS: cloud-sql-proxy.<os>.<arch>
   case "$OS" in
     linux)                OS_SLUG="linux" ;;
@@ -92,12 +120,14 @@ else
   if [[ "$OS_SLUG" == "windows" ]]; then
     WIN_ARCH="${ARCH_SLUG/amd64/x64}"
     PROXY_URL="${BASE}/cloud-sql-proxy.${WIN_ARCH}.exe"
+    PROXY_PATH="$SCRIPT_DIR/cloud-sql-proxy.exe"
   else
     PROXY_URL="${BASE}/cloud-sql-proxy.${OS_SLUG}.${ARCH_SLUG}"
+    PROXY_PATH="$SCRIPT_DIR/cloud-sql-proxy"
   fi
-  curl -fsSL -o "$SCRIPT_DIR/cloud-sql-proxy" "$PROXY_URL"
-  chmod +x "$SCRIPT_DIR/cloud-sql-proxy"
-  PROXY_BIN="$SCRIPT_DIR/cloud-sql-proxy"
+  curl -fsSL -o "$PROXY_PATH" "$PROXY_URL"
+  chmod +x "$PROXY_PATH"
+  PROXY_BIN="$PROXY_PATH"
   echo "    Downloaded to $PROXY_BIN"
 fi
 
@@ -114,15 +144,27 @@ echo "    Instance: $INSTANCE_CONNECTION_NAME"
 # ─── Temporarily enable public IP (required for proxy from local machine) ─────
 #
 # The Cloud SQL Auth Proxy requires a public IP to connect from outside GCP's VPC.
-# We enable it, run migrations, then remove it. The proxy still requires IAM auth
-# throughout — the public IP alone does not grant database access.
+# We enable it scoped to the operator's current IP, run migrations, then remove it.
+# The proxy still requires IAM auth — the public IP alone does not grant DB access.
 
 echo "==> Enabling temporary public IP on Cloud SQL instance ..."
-gcloud sql instances patch "$INSTANCE_NAME" \
-  --assign-ip \
-  --project="$PROJECT_ID" \
-  --quiet
+OPERATOR_IP=$(curl -fsSL ifconfig.me 2>/dev/null || curl -fsSL api.ipify.org 2>/dev/null || echo "")
+if [[ -n "$OPERATOR_IP" ]]; then
+  echo "    Scoping authorized_networks to operator IP: $OPERATOR_IP/32"
+  gcloud sql instances patch "$INSTANCE_NAME" \
+    --assign-ip \
+    --authorized-networks="$OPERATOR_IP/32" \
+    --project="$PROJECT_ID" \
+    --quiet
+else
+  echo "WARNING: Could not detect operator IP — public IP enabled without authorized_networks restriction." >&2
+  gcloud sql instances patch "$INSTANCE_NAME" \
+    --assign-ip \
+    --project="$PROJECT_ID" \
+    --quiet
+fi
 PUBLIC_IP_ENABLED=true
+
 echo "    Waiting for instance to be ready ..."
 until gcloud sql instances describe "$INSTANCE_NAME" \
   --project="$PROJECT_ID" \
@@ -132,17 +174,6 @@ until gcloud sql instances describe "$INSTANCE_NAME" \
 done
 echo "    Instance ready. Waiting an additional 15s for IP to become routable ..."
 sleep 15
-
-remove_public_ip() {
-  if $PUBLIC_IP_ENABLED; then
-    echo "==> Removing temporary public IP from Cloud SQL instance ..."
-    gcloud sql instances patch "$INSTANCE_NAME" \
-      --no-assign-ip \
-      --project="$PROJECT_ID" \
-      --quiet \
-      || echo "WARNING: Failed to remove public IP — remove manually: gcloud sql instances patch $INSTANCE_NAME --no-assign-ip --project=$PROJECT_ID"
-  fi
-}
 
 # ─── Get DATABASE_URL from Secret Manager ────────────────────────────────────
 
@@ -159,34 +190,60 @@ PROXY_DB_URL=$(echo "$RAW_DB_URL" | sed -E "s|@[^/]+/|@127.0.0.1:${PROXY_PORT}/|
 echo "==> Starting Cloud SQL Auth Proxy on port $PROXY_PORT ..."
 "$PROXY_BIN" "${INSTANCE_CONNECTION_NAME}?port=${PROXY_PORT}" &
 PROXY_PID=$!
-trap 'echo "==> Stopping proxy (PID $PROXY_PID)"; kill "$PROXY_PID" 2>/dev/null || true; remove_public_ip' EXIT
 
-# Give the proxy a moment to establish the connection
-sleep 3
+# Poll until proxy is accepting connections (up to 30s) rather than using a fixed sleep.
+echo "==> Waiting for proxy to be ready ..."
+WAIT_LIMIT=30
+WAIT_COUNT=0
+until node -e "require('net').createConnection(${PROXY_PORT},'127.0.0.1').on('connect',()=>process.exit(0)).on('error',()=>process.exit(1))" 2>/dev/null; do
+  WAIT_COUNT=$((WAIT_COUNT + 1))
+  if [[ $WAIT_COUNT -ge $WAIT_LIMIT ]]; then
+    echo "Proxy not ready after ${WAIT_LIMIT}s — giving up." >&2; exit 1
+  fi
+  sleep 1
+done
+echo "    Proxy ready."
 
 # ─── Run migrations ───────────────────────────────────────────────────────────
 
-# user_data_source is managed outside Prisma (infra/migrations/).
-# If it exists from a previous run, drop it so prisma migrate deploy sees an empty DB.
-# The app user owns this table, so it has permission to drop it.
-echo "==> Clearing any pre-existing user_data_source table ..."
-node -e "
+# Check whether Prisma migrations have already been applied.
+# If _prisma_migrations exists this is a re-run — skip the DROP TABLE to preserve data.
+echo "==> Checking migration state ..."
+MIGRATIONS_EXIST=$(node -e "
   const { Client } = require('pg');
   const client = new Client({ connectionString: process.argv[1] });
   client.connect()
-    .then(() => client.query('DROP TABLE IF EXISTS user_data_source'))
-    .then(() => { console.log('    Done.'); client.end(); })
+    .then(() => client.query(\"SELECT to_regclass('public._prisma_migrations')\"))
+    .then(r => { console.log(r.rows[0].to_regclass ? 'yes' : 'no'); client.end(); })
     .catch(err => { console.error(err.message); client.end(); process.exit(1); });
-" "$PROXY_DB_URL"
+" "$PROXY_DB_URL")
+
+if [[ "$MIGRATIONS_EXIST" == "no" ]]; then
+  # user_data_source is managed outside Prisma (infra/migrations/).
+  # On a fresh database it may exist from a prior partial run — drop it so
+  # prisma migrate deploy sees a clean state. The app user owns this table.
+  echo "==> Fresh database — clearing any pre-existing user_data_source table ..."
+  node -e "
+    const { Client } = require('pg');
+    const client = new Client({ connectionString: process.argv[1] });
+    client.connect()
+      .then(() => client.query('DROP TABLE IF EXISTS user_data_source'))
+      .then(() => { console.log('    Done.'); client.end(); })
+      .catch(err => { console.error(err.message); client.end(); process.exit(1); });
+  " "$PROXY_DB_URL"
+else
+  echo "    Migrations already applied — skipping user_data_source drop (preserving existing data)."
+fi
 
 # prisma migrate deploy applies all pending migrations in order.
 # It requires an empty database (or one that already has the _prisma_migrations table).
-echo "==> Running prisma migrate deploy (14 migrations) ..."
+echo "==> Running prisma migrate deploy ..."
 cd "$REPO_ROOT/apps/api"
 DATABASE_URL="$PROXY_DB_URL" npx prisma migrate deploy
 echo "    Done."
 
 # Run infra migration after Prisma — user_data_source is not in the Prisma schema.
+# Uses CREATE TABLE IF NOT EXISTS, so it is idempotent on re-runs.
 echo "==> Running infra/migrations/001_create_user_data_source.sql ..."
 SQL_FILE="$(cygpath -w "$REPO_ROOT/infra/migrations/001_create_user_data_source.sql" 2>/dev/null \
   || echo "$REPO_ROOT/infra/migrations/001_create_user_data_source.sql")"

--- a/scripts/migrate-prod-db.sh
+++ b/scripts/migrate-prod-db.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+#
+# migrate-prod-db.sh — Apply database migrations to the lifting-logbook production Cloud SQL instance.
+#
+# The production Cloud SQL instance has no public IP. This script temporarily enables
+# a public IP (required for the Cloud SQL Auth Proxy to connect from a local machine),
+# runs all migrations, then removes the public IP. The proxy still requires Google IAM
+# authentication throughout, so the temporary exposure is protected.
+#
+# Starts the Cloud SQL Auth Proxy, retrieves DATABASE_URL from Secret Manager,
+# runs the raw SQL migration, then runs prisma migrate deploy. Downloads the
+# Cloud SQL Auth Proxy automatically if not found on PATH or in the script directory.
+#
+# Prereqs:
+#   * gcloud CLI authenticated: `gcloud auth login` AND `gcloud auth application-default login`
+#   * npm workspaces installed: `npm install` from repo root (provides the `pg` package)
+#   * roles/cloudsql.client on the project (project owner has this by default)
+#
+# Usage:
+#   ./scripts/migrate-prod-db.sh [--project-id <id>]
+#
+# Examples:
+#   ./scripts/migrate-prod-db.sh
+#   ./scripts/migrate-prod-db.sh --project-id my-other-project
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TF_DIR="$REPO_ROOT/infra/terraform"
+
+PROJECT_ID="lifting-logbook-prod"
+REGION="us-central1"
+PROXY_PORT=5433
+PUBLIC_IP_ENABLED=false
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^[^#]/ { exit }
+    /^#$/   { print ""; next }
+    /^# ?/  { sub(/^# ?/, ""); print }
+  ' "$0"
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    --project-id) PROJECT_ID="$2"; shift 2 ;;
+    --help|-h)    usage; exit 0 ;;
+    -*)           echo "Unknown flag: $1" >&2; exit 2 ;;
+    *)            echo "Unexpected argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+# ─── Prereq checks ────────────────────────────────────────────────────────────
+
+command -v gcloud >/dev/null \
+  || { echo "gcloud not found. See https://cloud.google.com/sdk/docs/install" >&2; exit 1; }
+
+ACTIVE_ACCOUNT=$(gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>/dev/null || true)
+[[ -n "$ACTIVE_ACCOUNT" ]] \
+  || { echo "No active gcloud account. Run: gcloud auth login && gcloud auth application-default login" >&2; exit 1; }
+echo "Authenticated as: $ACTIVE_ACCOUNT"
+
+# ─── Cloud SQL Auth Proxy ─────────────────────────────────────────────────────
+
+PROXY_BIN=""
+if command -v cloud-sql-proxy >/dev/null; then
+  PROXY_BIN="cloud-sql-proxy"
+elif [[ -x "$SCRIPT_DIR/cloud-sql-proxy" ]]; then
+  PROXY_BIN="$SCRIPT_DIR/cloud-sql-proxy"
+else
+  echo "==> cloud-sql-proxy not found — downloading to $SCRIPT_DIR/cloud-sql-proxy ..."
+  PROXY_VERSION="v2.21.3"
+  OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  ARCH="$(uname -m)"
+  # Filename convention differs by OS:
+  # Windows: cloud-sql-proxy.x64.exe / .arm64.exe
+  # Linux/macOS: cloud-sql-proxy.<os>.<arch>
+  case "$OS" in
+    linux)                OS_SLUG="linux" ;;
+    darwin)               OS_SLUG="darwin" ;;
+    mingw*|msys*|cygwin*) OS_SLUG="windows" ;;
+    *)       echo "Unsupported OS: $OS" >&2; exit 1 ;;
+  esac
+  case "$ARCH" in
+    x86_64|amd64) ARCH_SLUG="amd64" ;;
+    arm64|aarch64) ARCH_SLUG="arm64" ;;
+    *)            echo "Unsupported arch: $ARCH" >&2; exit 1 ;;
+  esac
+  BASE="https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/${PROXY_VERSION}"
+  if [[ "$OS_SLUG" == "windows" ]]; then
+    WIN_ARCH="${ARCH_SLUG/amd64/x64}"
+    PROXY_URL="${BASE}/cloud-sql-proxy.${WIN_ARCH}.exe"
+  else
+    PROXY_URL="${BASE}/cloud-sql-proxy.${OS_SLUG}.${ARCH_SLUG}"
+  fi
+  curl -fsSL -o "$SCRIPT_DIR/cloud-sql-proxy" "$PROXY_URL"
+  chmod +x "$SCRIPT_DIR/cloud-sql-proxy"
+  PROXY_BIN="$SCRIPT_DIR/cloud-sql-proxy"
+  echo "    Downloaded to $PROXY_BIN"
+fi
+
+# ─── Get Cloud SQL instance name from terraform output ────────────────────────
+
+echo "==> Getting Cloud SQL instance name from terraform output ..."
+cd "$TF_DIR"
+terraform init -backend-config="bucket=${PROJECT_ID}-tfstate" -reconfigure -input=false >/dev/null 2>&1
+terraform workspace select production >/dev/null 2>&1
+INSTANCE_NAME=$(terraform output -raw database_instance_name)
+INSTANCE_CONNECTION_NAME="${PROJECT_ID}:${REGION}:${INSTANCE_NAME}"
+echo "    Instance: $INSTANCE_CONNECTION_NAME"
+
+# ─── Temporarily enable public IP (required for proxy from local machine) ─────
+#
+# The Cloud SQL Auth Proxy requires a public IP to connect from outside GCP's VPC.
+# We enable it, run migrations, then remove it. The proxy still requires IAM auth
+# throughout — the public IP alone does not grant database access.
+
+echo "==> Enabling temporary public IP on Cloud SQL instance ..."
+gcloud sql instances patch "$INSTANCE_NAME" \
+  --assign-ip \
+  --project="$PROJECT_ID" \
+  --quiet
+PUBLIC_IP_ENABLED=true
+echo "    Waiting for instance to be ready ..."
+until gcloud sql instances describe "$INSTANCE_NAME" \
+  --project="$PROJECT_ID" \
+  --format="value(state)" 2>/dev/null | grep -q "RUNNABLE"; do
+  echo "    Instance not ready yet, retrying in 5s ..."
+  sleep 5
+done
+echo "    Instance ready. Waiting an additional 15s for IP to become routable ..."
+sleep 15
+
+remove_public_ip() {
+  if $PUBLIC_IP_ENABLED; then
+    echo "==> Removing temporary public IP from Cloud SQL instance ..."
+    gcloud sql instances patch "$INSTANCE_NAME" \
+      --no-assign-ip \
+      --project="$PROJECT_ID" \
+      --quiet \
+      || echo "WARNING: Failed to remove public IP — remove manually: gcloud sql instances patch $INSTANCE_NAME --no-assign-ip --project=$PROJECT_ID"
+  fi
+}
+
+# ─── Get DATABASE_URL from Secret Manager ────────────────────────────────────
+
+echo "==> Retrieving DATABASE_URL from Secret Manager ..."
+RAW_DB_URL=$(gcloud secrets versions access latest \
+  --secret="${PROJECT_ID}-database-url" \
+  --project="$PROJECT_ID")
+
+# Proxy listens on localhost:$PROXY_PORT — rewrite host/port in the URL
+PROXY_DB_URL=$(echo "$RAW_DB_URL" | sed -E "s|@[^/]+/|@127.0.0.1:${PROXY_PORT}/|")
+
+# ─── Start proxy ─────────────────────────────────────────────────────────────
+
+echo "==> Starting Cloud SQL Auth Proxy on port $PROXY_PORT ..."
+"$PROXY_BIN" "${INSTANCE_CONNECTION_NAME}?port=${PROXY_PORT}" &
+PROXY_PID=$!
+trap 'echo "==> Stopping proxy (PID $PROXY_PID)"; kill "$PROXY_PID" 2>/dev/null || true; remove_public_ip' EXIT
+
+# Give the proxy a moment to establish the connection
+sleep 3
+
+# ─── Run migrations ───────────────────────────────────────────────────────────
+
+# user_data_source is managed outside Prisma (infra/migrations/).
+# If it exists from a previous run, drop it so prisma migrate deploy sees an empty DB.
+# The app user owns this table, so it has permission to drop it.
+echo "==> Clearing any pre-existing user_data_source table ..."
+node -e "
+  const { Client } = require('pg');
+  const client = new Client({ connectionString: process.argv[1] });
+  client.connect()
+    .then(() => client.query('DROP TABLE IF EXISTS user_data_source'))
+    .then(() => { console.log('    Done.'); client.end(); })
+    .catch(err => { console.error(err.message); client.end(); process.exit(1); });
+" "$PROXY_DB_URL"
+
+# prisma migrate deploy applies all pending migrations in order.
+# It requires an empty database (or one that already has the _prisma_migrations table).
+echo "==> Running prisma migrate deploy (14 migrations) ..."
+cd "$REPO_ROOT/apps/api"
+DATABASE_URL="$PROXY_DB_URL" npx prisma migrate deploy
+echo "    Done."
+
+# Run infra migration after Prisma — user_data_source is not in the Prisma schema.
+echo "==> Running infra/migrations/001_create_user_data_source.sql ..."
+SQL_FILE="$(cygpath -w "$REPO_ROOT/infra/migrations/001_create_user_data_source.sql" 2>/dev/null \
+  || echo "$REPO_ROOT/infra/migrations/001_create_user_data_source.sql")"
+node -e "
+  const { Client } = require('pg');
+  const fs = require('fs');
+  const sql = fs.readFileSync(process.argv[1], 'utf8');
+  const client = new Client({ connectionString: process.argv[2] });
+  client.connect()
+    .then(() => client.query(sql))
+    .then(() => { console.log('    Done.'); client.end(); })
+    .catch(err => { console.error(err.message); client.end(); process.exit(1); });
+" "$SQL_FILE" "$PROXY_DB_URL"
+
+echo ""
+echo "All migrations applied successfully."


### PR DESCRIPTION
Fixes several issues discovered during the first \`terraform apply\` against a fresh GCP project. All fixes were validated by a successful apply that completed infrastructure provisioning.

## Changes

- **Syntax compat**: Expand `replication { auto {} }` to multi-line form (single-line requires Terraform 1.9+; config only requires 1.7)
- **Missing API**: Add `vpcaccess.googleapis.com` to `required_apis` (needed by Serverless VPC connector for Cloud Run)
- **Propagation lag**: Add `hashicorp/time` provider and `time_sleep.api_propagation` (60s) between API enablement and VPC creation — prevents 403s on fresh projects
- **Reserved env var**: Remove `PORT` from both Cloud Run service definitions (Cloud Run sets it automatically)
- **Bootstrap image**: Add `image_tag = "bootstrap"` sentinel in `terraform.tfvars.production` that resolves to Google's public hello image; `lifecycle { ignore_changes = [template] }` already prevents Terraform from fighting CI/CD image updates
- **Missing IAM**: Add `secretmanager.secretAccessor` for `web_workload` SA (needed to read `clerk-publishable-key` at service startup)
- **New script**: `scripts/deploy-prod-infra.sh` automates the init → workspace → apply sequence with a `--plan-only` flag for safe previews

## Testing

Full `terraform apply` completed successfully against `lifting-logbook-prod`. All 16 resources created. Outputs confirmed:
- Cloud Run API and Web services running with placeholder image
- Workload Identity Provider and CI/CD SA email available for GitHub Actions secrets

Closes #285