### PR TITLE
[fix] Move GCP project IDs from secrets to variables to prevent output masking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,16 +9,20 @@ name: Deploy
 # deploy-production (production-only / single-user mode).
 #
 # Required GitHub repository secrets (see docs/deploy.md):
-#   GCP_PROD_PROJECT_ID
 #   GCP_PROD_WORKLOAD_IDENTITY_PROVIDER
 #   GCP_PROD_SERVICE_ACCOUNT
 #   TF_STATE_BUCKET
 #   GCP_BILLING_ACCOUNT   — never commit real value to tfvars; pass here instead
 #
+# Required GitHub repository variables (Settings → Variables, not Secrets):
+#   GCP_PROD_PROJECT_ID   — project IDs are not sensitive; vars.* is not masked in outputs
+#
 # Optional secrets (required only when staging environment is configured):
-#   GCP_STAGING_PROJECT_ID
 #   GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER
 #   GCP_STAGING_SERVICE_ACCOUNT
+#
+# Optional variables (required only when staging environment is configured):
+#   GCP_STAGING_PROJECT_ID
 
 on:
   push:
@@ -43,7 +47,7 @@ jobs:
       - id: check
         env:
           STAGING_WIF: ${{ secrets.GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER }}
-          PROD_PROJECT: ${{ secrets.GCP_PROD_PROJECT_ID }}
+          PROD_PROJECT: ${{ vars.GCP_PROD_PROJECT_ID }}
         run: |
           if [[ -n "$STAGING_WIF" ]]; then
             echo "staging_enabled=true" >> "$GITHUB_OUTPUT"
@@ -168,7 +172,7 @@ jobs:
             # Production-only mode: gcloud auth is already done above.
             URL=$(gcloud run services describe lifting-logbook-prod-api \
               --region="${{ env.REGION }}" \
-              --project="${{ secrets.GCP_PROD_PROJECT_ID }}" \
+              --project="${{ vars.GCP_PROD_PROJECT_ID }}" \
               --format="value(status.url)")
             echo "url=${URL}" >> "$GITHUB_OUTPUT"
           fi
@@ -233,7 +237,7 @@ jobs:
         with:
           cluster_name: ${{ needs.terraform-staging.outputs.gke_cluster_name }}
           location: ${{ env.REGION }}
-          project_id: ${{ secrets.GCP_STAGING_PROJECT_ID }}
+          project_id: ${{ vars.GCP_STAGING_PROJECT_ID }}
 
       - name: Set up Helm
         if: needs.terraform-staging.outputs.gke_enabled == 'true'
@@ -249,13 +253,13 @@ jobs:
         run: |
           DB_URL=$(gcloud secrets versions access latest \
             --secret="lifting-logbook-stg-database-url" \
-            --project="${{ secrets.GCP_STAGING_PROJECT_ID }}")
+            --project="${{ vars.GCP_STAGING_PROJECT_ID }}")
           SYS_DB_URL=$(gcloud secrets versions access latest \
             --secret="lifting-logbook-stg-system-database-url" \
-            --project="${{ secrets.GCP_STAGING_PROJECT_ID }}")
+            --project="${{ vars.GCP_STAGING_PROJECT_ID }}")
           CLERK_KEY=$(gcloud secrets versions access latest \
             --secret="lifting-logbook-stg-clerk-secret-key" \
-            --project="${{ secrets.GCP_STAGING_PROJECT_ID }}")
+            --project="${{ vars.GCP_STAGING_PROJECT_ID }}")
           kubectl create secret generic api-secrets \
             --namespace=staging \
             --from-literal=database-url="$DB_URL" \
@@ -268,7 +272,7 @@ jobs:
         run: |
           CLERK_PUB=$(gcloud secrets versions access latest \
             --secret="lifting-logbook-stg-clerk-publishable-key" \
-            --project="${{ secrets.GCP_STAGING_PROJECT_ID }}")
+            --project="${{ vars.GCP_STAGING_PROJECT_ID }}")
           kubectl create secret generic web-secrets \
             --namespace=staging \
             --from-literal=clerk-publishable-key="$CLERK_PUB" \
@@ -282,7 +286,7 @@ jobs:
             --values=infra/kubernetes/values/staging-api.yaml \
             --set image.repository="${{ needs.build-images.outputs.ar_repo }}/api" \
             --set image.tag="${{ github.sha }}" \
-            --set gcp.projectId="${{ secrets.GCP_STAGING_PROJECT_ID }}" \
+            --set gcp.projectId="${{ vars.GCP_STAGING_PROJECT_ID }}" \
             --set gcp.kmsKeyName="${{ needs.terraform-staging.outputs.kms_key_name }}" \
             --set gcp.serviceAccountEmail="${{ needs.terraform-staging.outputs.api_wi_sa }}" \
             --set env.NODE_ENV=staging \
@@ -297,7 +301,7 @@ jobs:
             --values=infra/kubernetes/values/staging-web.yaml \
             --set image.repository="${{ needs.build-images.outputs.ar_repo }}/web" \
             --set image.tag="${{ github.sha }}" \
-            --set gcp.projectId="${{ secrets.GCP_STAGING_PROJECT_ID }}" \
+            --set gcp.projectId="${{ vars.GCP_STAGING_PROJECT_ID }}" \
             --set env.NODE_ENV=staging \
             --set env.API_URL="$API_CLUSTER_URL" \
             --wait --timeout=5m
@@ -308,7 +312,7 @@ jobs:
           gcloud run deploy lifting-logbook-stg-api \
             --image="${{ needs.build-images.outputs.ar_repo }}/api:${{ github.sha }}" \
             --region="${{ env.REGION }}" \
-            --project="${{ secrets.GCP_STAGING_PROJECT_ID }}" \
+            --project="${{ vars.GCP_STAGING_PROJECT_ID }}" \
             --platform=managed \
             --no-allow-unauthenticated \
             --quiet
@@ -318,7 +322,7 @@ jobs:
           gcloud run deploy lifting-logbook-stg-web \
             --image="${{ needs.build-images.outputs.ar_repo }}/web:${{ github.sha }}" \
             --region="${{ env.REGION }}" \
-            --project="${{ secrets.GCP_STAGING_PROJECT_ID }}" \
+            --project="${{ vars.GCP_STAGING_PROJECT_ID }}" \
             --platform=managed \
             --allow-unauthenticated \
             --service-account="${{ needs.terraform-staging.outputs.web_workload_sa }}" \
@@ -428,7 +432,7 @@ jobs:
         with:
           cluster_name: ${{ steps.tf-prod.outputs.gke_cluster_name }}
           location: ${{ env.REGION }}
-          project_id: ${{ secrets.GCP_PROD_PROJECT_ID }}
+          project_id: ${{ vars.GCP_PROD_PROJECT_ID }}
 
       - name: Set up Helm
         if: steps.tf-prod.outputs.gke_enabled == 'true'
@@ -443,13 +447,13 @@ jobs:
         run: |
           DB_URL=$(gcloud secrets versions access latest \
             --secret="lifting-logbook-prod-database-url" \
-            --project="${{ secrets.GCP_PROD_PROJECT_ID }}")
+            --project="${{ vars.GCP_PROD_PROJECT_ID }}")
           SYS_DB_URL=$(gcloud secrets versions access latest \
             --secret="lifting-logbook-prod-system-database-url" \
-            --project="${{ secrets.GCP_PROD_PROJECT_ID }}")
+            --project="${{ vars.GCP_PROD_PROJECT_ID }}")
           CLERK_KEY=$(gcloud secrets versions access latest \
             --secret="lifting-logbook-prod-clerk-secret-key" \
-            --project="${{ secrets.GCP_PROD_PROJECT_ID }}")
+            --project="${{ vars.GCP_PROD_PROJECT_ID }}")
           kubectl create secret generic api-secrets \
             --namespace=production \
             --from-literal=database-url="$DB_URL" \
@@ -462,7 +466,7 @@ jobs:
         run: |
           CLERK_PUB=$(gcloud secrets versions access latest \
             --secret="lifting-logbook-prod-clerk-publishable-key" \
-            --project="${{ secrets.GCP_PROD_PROJECT_ID }}")
+            --project="${{ vars.GCP_PROD_PROJECT_ID }}")
           kubectl create secret generic web-secrets \
             --namespace=production \
             --from-literal=clerk-publishable-key="$CLERK_PUB" \
@@ -476,7 +480,7 @@ jobs:
             --values=infra/kubernetes/values/production-api.yaml \
             --set image.repository="${{ steps.tf-prod.outputs.ar_repo }}/api" \
             --set image.tag="${{ github.sha }}" \
-            --set gcp.projectId="${{ secrets.GCP_PROD_PROJECT_ID }}" \
+            --set gcp.projectId="${{ vars.GCP_PROD_PROJECT_ID }}" \
             --set gcp.kmsKeyName="${{ steps.tf-prod.outputs.kms_key_name }}" \
             --set gcp.serviceAccountEmail="${{ steps.tf-prod.outputs.api_wi_sa }}" \
             --set env.NODE_ENV=production \
@@ -491,7 +495,7 @@ jobs:
             --values=infra/kubernetes/values/production-web.yaml \
             --set image.repository="${{ steps.tf-prod.outputs.ar_repo }}/web" \
             --set image.tag="${{ github.sha }}" \
-            --set gcp.projectId="${{ secrets.GCP_PROD_PROJECT_ID }}" \
+            --set gcp.projectId="${{ vars.GCP_PROD_PROJECT_ID }}" \
             --set env.NODE_ENV=production \
             --set env.API_URL="$API_CLUSTER_URL" \
             --wait --timeout=5m
@@ -501,7 +505,7 @@ jobs:
           gcloud run deploy lifting-logbook-prod-api \
             --image="${{ steps.tf-prod.outputs.ar_repo }}/api:${{ github.sha }}" \
             --region="${{ env.REGION }}" \
-            --project="${{ secrets.GCP_PROD_PROJECT_ID }}" \
+            --project="${{ vars.GCP_PROD_PROJECT_ID }}" \
             --platform=managed \
             --no-allow-unauthenticated \
             --quiet
@@ -511,7 +515,7 @@ jobs:
           gcloud run deploy lifting-logbook-prod-web \
             --image="${{ steps.tf-prod.outputs.ar_repo }}/web:${{ github.sha }}" \
             --region="${{ env.REGION }}" \
-            --project="${{ secrets.GCP_PROD_PROJECT_ID }}" \
+            --project="${{ vars.GCP_PROD_PROJECT_ID }}" \
             --platform=managed \
             --allow-unauthenticated \
             --service-account="${{ steps.tf-prod.outputs.web_workload_sa }}" \

--- a/docs/deploy-single-user.md
+++ b/docs/deploy-single-user.md
@@ -144,16 +144,27 @@ written to a file — billing IDs are sensitive.
 
 ## Step 4 — Add GitHub Actions secrets
 
-In the repo → **Settings → Secrets and variables → Actions** →
+In the repo → **Settings → Secrets and variables → Actions**:
+
 **Repository secrets** (not the **Environments** tab):
 
 | Secret | Value |
 |---|---|
-| `GCP_PROD_PROJECT_ID` | `lifting-logbook-prod` |
 | `TF_STATE_BUCKET` | `lifting-logbook-prod-tfstate` |
 | `GCP_BILLING_ACCOUNT` | your billing account ID |
 | `GCP_PROD_WORKLOAD_IDENTITY_PROVIDER` | filled in **after** Step 5 |
 | `GCP_PROD_SERVICE_ACCOUNT` | filled in **after** Step 5 |
+
+**Repository variables** (same page → **Variables** tab):
+
+| Variable | Value |
+|---|---|
+| `GCP_PROD_PROJECT_ID` | `lifting-logbook-prod` |
+
+> **Why a variable, not a secret?** GCP project IDs are not sensitive — they appear in
+> Cloud Console URLs, API responses, and `gcloud` output. Storing them as secrets causes
+> GitHub Actions to mask any workflow output that contains the value, which silently breaks
+> job-to-job data passing (the `ar_repo` output used to resolve the Artifact Registry URL).
 
 If you also intend to deploy a staging environment later, also add the
 `GCP_STAGING_*` secrets per [`docs/deploy.md`](deploy.md#step-5--add-github-repository-secrets).


### PR DESCRIPTION
## Summary

- Moves `GCP_PROD_PROJECT_ID` and `GCP_STAGING_PROJECT_ID` from repository **Secrets** to repository **Variables** in the deploy workflow
- Updates `docs/deploy-single-user.md` Step 4 to document the secrets vs variables split with an explanatory note

## Root cause

GitHub Actions masks any job output containing a secret value. `GCP_PROD_PROJECT_ID` was stored as a secret (`lifting-logbook-prod`). The `preflight` job constructed `ar_repo=us-central1-docker.pkg.dev/lifting-logbook-prod/lifting-logbook` as an output — GitHub detected the secret value embedded in it and suppressed the output:

```
##[warning]Skip output 'ar_repo' since it may contain secret.
```

`build-images` received an empty `ar_repo`, producing the invalid Docker tag `/api:<sha>` and failing the entire pipeline.

## Fix

Project IDs are not sensitive (they appear in Cloud Console URLs and `gcloud` output). Moving them to `vars.*` prevents masking while preserving all other credential security.

## User action required after merge

1. Repo → **Settings → Secrets and variables → Actions**
2. **Delete** the `GCP_PROD_PROJECT_ID` **secret**
3. Switch to the **Variables** tab → **New repository variable**
4. Add `GCP_PROD_PROJECT_ID` = `lifting-logbook-prod`

Then re-trigger the Deploy workflow (push anything to main, or re-run the last failed run).

## Test plan

- [ ] After merge and the variable/secret swap above: Deploy workflow runs, `preflight` outputs `ar_repo` without the masking warning, `build-images` builds with a valid tag, deploy-production completes, liftinglogbook.com serves the app

Closes #292