### PR TITLE
[fix] Copy tsconfig.base.json into Docker builder stages

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -21,6 +21,11 @@ RUN npm ci
 
 # Copy full source and build.
 COPY --from=installer /app/out/full/ .
+# tsconfig.base.json lives at the repo root and is not a workspace package, so
+# turbo prune --docker does not include it in out/full/. Every workspace tsconfig
+# (packages/types, packages/core, apps/api) extends ../../tsconfig.base.json,
+# so the build fails with TS5083 without this explicit copy.
+COPY --from=installer /app/tsconfig.base.json ./tsconfig.base.json
 RUN npx turbo run build --filter=@lifting-logbook/api
 
 # Install production-only dependencies for the final image.

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -21,6 +21,11 @@ RUN npm ci
 
 # Copy full source and build.
 COPY --from=installer /app/out/full/ .
+# tsconfig.base.json lives at the repo root and is not a workspace package, so
+# turbo prune --docker does not include it in out/full/. packages/types (a
+# dependency of web) extends ../../tsconfig.base.json and fails with TS5083
+# without this explicit copy.
+COPY --from=installer /app/tsconfig.base.json ./tsconfig.base.json
 ARG NEXT_PUBLIC_API_URL
 RUN npx turbo run build --filter=@lifting-logbook/web
 


### PR DESCRIPTION
## Summary

- Adds `COPY --from=installer /app/tsconfig.base.json ./tsconfig.base.json` to the builder stage of `apps/api/Dockerfile` and `apps/web/Dockerfile`
- `turbo prune --docker` only includes workspace packages in `out/full/`; the repo-root `tsconfig.base.json` is excluded but every workspace tsconfig extends it

## Root cause

The Docker build runs `npx turbo run build --filter=@lifting-logbook/api`, which transitively builds `packages/types`. That build invokes `tsc` with `packages/types/tsconfig.json`, which has:

```json
{ "extends": "../../tsconfig.base.json", ... }
```

Without the file present in the pruned source tree, tsc fails:

```
@lifting-logbook/types:build: error TS5083: Cannot read file '/app/tsconfig.base.json'.
```

## Why this surfaced now

The Deploy workflow has never successfully reached `build-images` before today. Before PR #290 it failed at `terraform-staging` (missing staging credentials). After PR #290 it failed at `build-images` resolving the AR repo URL (project ID secret-masking — fixed in PR #293). With both of those fixed, the Docker build was finally attempted and this preexisting Dockerfile bug surfaced.

## Test plan

- [ ] After merge: trigger the Deploy workflow; `build-images` builds both api and web images successfully and pushes to Artifact Registry
- [ ] `deploy-production` deploys real images; liftinglogbook.com serves the app instead of the Cloud Run placeholder

No automated test added — Dockerfile builds are validated by the CI build itself.

Closes #294