### PR TITLE
[fix] Run prisma generate in api Dockerfile before TypeScript build

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -26,6 +26,11 @@ COPY --from=installer /app/out/full/ .
 # (packages/types, packages/core, apps/api) extends ../../tsconfig.base.json,
 # so the build fails with TS5083 without this explicit copy.
 COPY --from=installer /app/tsconfig.base.json ./tsconfig.base.json
+# Generate the Prisma client from the schema before TypeScript compilation.
+# Without this, tsc fails with TS2694 ("no exported member 'InputJsonValue'")
+# because the .prisma/client/default scaffold installed by `npm ci` is empty
+# until `prisma generate` runs against schema.prisma.
+RUN npx prisma generate --schema=apps/api/prisma/schema.prisma
 RUN npx turbo run build --filter=@lifting-logbook/api
 
 # Install production-only dependencies for the final image.


### PR DESCRIPTION
## Summary

- Adds `RUN npx prisma generate --schema=apps/api/prisma/schema.prisma` to `apps/api/Dockerfile`, after the full source copy and before `npx turbo run build`
- Without this, `tsc` fails with 11 TS2694 errors on `Prisma.InputJsonValue` and generated input types

## Root cause

`npm ci` installs `@prisma/client` but only scaffolds an empty `.prisma/client/default` directory. The actual generated types (input types, JSON helpers, model namespaces) appear only after `prisma generate` runs against `schema.prisma`. Local builds work because developers have invoked Prisma at some point; Docker builds have never done so.

## Why not `postinstall: prisma generate`?

`postinstall` runs during `npm ci`, but the Dockerfile copies the schema **after** `npm ci` (deliberate, for layer caching). A postinstall hook would fail because `schema.prisma` isn't yet on disk.

## Test plan

- [ ] After merge: Deploy workflow's `build-images` job successfully builds and pushes both API and web Docker images
- [ ] `deploy-production` completes; liftinglogbook.com serves the app

No automated test added — the Dockerfile build is validated by the CI build itself.

Closes #296