### PR TITLE
[fix] Enable Next.js standalone output and keep public/ tracked

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Produce a self-contained build under .next/standalone for the Docker
+  // runner stage to copy. Without this, .next/standalone is never created
+  // and the runner-stage COPY fails.
+  // https://nextjs.org/docs/app/api-reference/next-config-js/output
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/apps/web/public/.gitkeep
+++ b/apps/web/public/.gitkeep
@@ -1,0 +1,3 @@
+# Preserve the public/ directory in version control.
+# The Docker runner stage copies this directory; if it's empty/untracked,
+# turbo prune --docker omits it from out/full/ and the COPY fails.


### PR DESCRIPTION
## Summary

Two issues blocking the web Docker runner stage (fifth in the deploy-unblocking chain after #286, #290, #293, #295, #297):

1. **Add `output: \"standalone\"`** to `apps/web/next.config.ts`. Without this Next.js never produces `.next/standalone`, and the runner stage's `COPY --from=builder /app/apps/web/.next/standalone ./` fails with \"not found\".
2. **Add `apps/web/public/.gitkeep`** so the directory is tracked. `turbo prune --docker` omits empty directories from `out/full/`, breaking the runner stage's `COPY` of `public/`.

## Test plan

- [ ] After merge: Deploy workflow `build-images` succeeds for both API and web
- [ ] `deploy-production` deploys real images; liftinglogbook.com serves the app

No automated test added — Docker build is validated by CI.

Closes #298