### PR TITLE
[fix] Grant CI/CD SA storage.objectAdmin on Terraform state bucket

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -309,6 +309,16 @@ resource "google_project_iam_member" "cicd_roles" {
   member  = "serviceAccount:${google_service_account.cicd.email}"
 }
 
+# Grant the CI/CD service account access to the Terraform state bucket so the
+# Deploy workflow's `terraform init`/`apply` calls can read and write state.
+# The bucket itself is created by scripts/bootstrap-gcp-prod.sh (outside
+# Terraform), so we bind by computed name rather than by resource reference.
+resource "google_storage_bucket_iam_member" "cicd_tfstate" {
+  bucket = "${var.project_id}-tfstate"
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.cicd.email}"
+}
+
 # ─── IAM — Workload Identity Federation (keyless auth for GitHub Actions) ────
 
 resource "google_iam_workload_identity_pool" "github" {


### PR DESCRIPTION
## Summary

Adds a `google_storage_bucket_iam_member` resource granting `roles/storage.objectAdmin` on the Terraform state bucket (`${var.project_id}-tfstate`) to the CI/CD service account.

## Root cause

After PR #299 the Deploy workflow's `Build & Push Images` job succeeded for both API and web. `deploy-production` → `Terraform apply` then failed at `terraform init`:

```
Error: Failed to get existing workspaces: querying Cloud Storage failed:
googleapi: Error 403: ...-cicd@... does not have storage.objects.list access
```

The six project-level roles granted to the CI/CD SA do not include Cloud Storage. The state bucket lives outside Terraform (bootstrap script creates it), so no binding existed.

## One-time manual step

This commit cannot grant itself state access. The user must run **once** before this merge takes effect:

```bash
gcloud storage buckets add-iam-policy-binding gs://lifting-logbook-prod-tfstate   --member=\"serviceAccount:lifting-logbook-prod-cicd@lifting-logbook-prod.iam.gserviceaccount.com\"   --role=\"roles/storage.objectAdmin\"   --project=lifting-logbook-prod
```

After that, the Deploy workflow can complete `terraform apply`, which then takes ownership of the binding via this resource so it persists across re-applies.

## Test plan

- [ ] User runs the gcloud command above
- [ ] After merge: Deploy workflow runs to completion; `deploy-production` deploys real images; liftinglogbook.com serves the app

Closes #300