### PR TITLE
[fix] Grant CI/CD SA Editor + projectIamAdmin; document recovery

### DIFF
--- a/docs/deploy-single-user.md
+++ b/docs/deploy-single-user.md
@@ -201,6 +201,30 @@ placeholder secrets), KMS keyring, IAM, and the Cloud Run service shells. With
 skipped; the `api_workload` service account itself is still created because
 Cloud Run reuses it as the API service identity.
 
+The CI/CD service account is created with both **runtime** roles (Cloud Run
+deploy, Artifact Registry write, Secret Manager read, Cloud SQL client) and
+**admin** roles (Editor + projectIamAdmin) so that `terraform apply` running
+from GitHub Actions can manage every resource in this module. The state
+bucket gets a `storage.objectAdmin` binding for the same SA so the CI run
+can read/write Terraform state.
+
+> **Recovery for pre-existing setups.** If you ran the first `terraform apply`
+> before this section existed — i.e., the `cicd_roles` list in
+> `infra/terraform/main.tf` didn't yet include `roles/editor` and
+> `roles/resourcemanager.projectIamAdmin` — CI cannot grant these roles to
+> itself (chicken-and-egg: terraform needs the perms to manage the perms).
+> Run the recovery script once from your laptop as a project owner, then
+> push to main:
+>
+> ```bash
+> ./scripts/fix-cicd-sa-iam.sh
+> ```
+>
+> It grants three roles: `storage.objectAdmin` on the tfstate bucket,
+> `editor` on the project, and `resourcemanager.projectIamAdmin` on the
+> project. All bindings are idempotent and will be taken over by Terraform
+> on the next CI apply, so they persist across re-applies.
+
 ---
 
 ## Step 6 — Map a custom domain (optional)

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -297,12 +297,21 @@ resource "google_service_account" "cicd" {
 
 resource "google_project_iam_member" "cicd_roles" {
   for_each = toset([
+    # ── Runtime roles (used by the workloads themselves) ─────────────────
     "roles/container.developer",          # GKE deploy
     "roles/run.admin",                    # Cloud Run deploy
     "roles/artifactregistry.writer",      # Push images
     "roles/secretmanager.secretAccessor", # Read secrets
     "roles/cloudsql.client",
     "roles/iam.serviceAccountTokenCreator",
+    # ── Terraform-from-CI admin roles ────────────────────────────────────
+    # Required so that `terraform apply` running as this SA from CI can
+    # manage every resource in this module. Editor covers Cloud SQL,
+    # Artifact Registry, Secret Manager, Compute (VPC), KMS, Cloud Run,
+    # and GKE admin. projectIamAdmin is needed separately because
+    # roles/editor explicitly excludes IAM binding management.
+    "roles/editor",
+    "roles/resourcemanager.projectIamAdmin",
   ])
   project = var.project_id
   role    = each.value

--- a/scripts/fix-cicd-sa-iam.sh
+++ b/scripts/fix-cicd-sa-iam.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# fix-cicd-sa-iam.sh — grant the CI/CD service account the IAM roles required
+# for `terraform apply` from GitHub Actions to succeed.
+#
+# This is a one-time recovery script for production projects that were
+# bootstrapped *before* infra/terraform/main.tf was updated to include these
+# roles in the `cicd_roles` list. Without these grants, the Deploy workflow
+# fails with one of:
+#
+#   * "does not have storage.objects.list access" (on tfstate bucket)
+#   * "Error retrieving IAM policy for project ... 403 forbidden"
+#   * Other 403s when terraform tries to read/manage project resources
+#
+# The chicken-and-egg: `terraform apply` from CI needs these permissions
+# before it can grant them to itself. Run this script once, as a user identity
+# with project-owner access (the same identity that ran the original local
+# `terraform apply` in Step 5 of docs/deploy-single-user.md).
+#
+# After this runs successfully, the next CI Deploy run will complete the
+# `terraform apply` step and take ownership of these bindings via the
+# `google_project_iam_member.cicd_roles` and
+# `google_storage_bucket_iam_member.cicd_tfstate` resources, so they persist
+# across re-applies.
+#
+# Prereqs:
+#   * gcloud authenticated as a project owner: `gcloud auth login`
+#   * jq is NOT required
+#
+# Usage:
+#   ./scripts/fix-cicd-sa-iam.sh [--project-id <id>]
+#
+# Examples:
+#   ./scripts/fix-cicd-sa-iam.sh
+#   ./scripts/fix-cicd-sa-iam.sh --project-id my-other-project
+
+set -euo pipefail
+
+PROJECT_ID="lifting-logbook-prod"
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^[^#]/ { exit }
+    /^#$/   { print ""; next }
+    /^# ?/  { sub(/^# ?/, ""); print }
+  ' "$0"
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    --project-id) PROJECT_ID="$2"; shift 2 ;;
+    --help|-h)    usage; exit 0 ;;
+    -*)           echo "Unknown flag: $1" >&2; exit 2 ;;
+    *)            echo "Unexpected argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+SA_EMAIL="${PROJECT_ID}-cicd@${PROJECT_ID}.iam.gserviceaccount.com"
+STATE_BUCKET="${PROJECT_ID}-tfstate"
+
+command -v gcloud >/dev/null \
+  || { echo "gcloud not found. See https://cloud.google.com/sdk/docs/install" >&2; exit 1; }
+
+ACTIVE_ACCOUNT=$(gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>/dev/null || true)
+[[ -n "$ACTIVE_ACCOUNT" ]] \
+  || { echo "No active gcloud account. Run: gcloud auth login" >&2; exit 1; }
+echo "Authenticated as: $ACTIVE_ACCOUNT"
+echo "Target project:   $PROJECT_ID"
+echo "Target SA:        $SA_EMAIL"
+echo "Target bucket:    gs://$STATE_BUCKET"
+echo ""
+
+# Confirm the SA exists. If it does not, terraform has not been applied yet —
+# this script is a no-op until the SA is created by the first terraform apply.
+if ! gcloud iam service-accounts describe "$SA_EMAIL" --project="$PROJECT_ID" >/dev/null 2>&1; then
+  echo "ERROR: service account $SA_EMAIL not found in project $PROJECT_ID." >&2
+  echo "Run Step 5 of docs/deploy-single-user.md first (the local terraform apply)." >&2
+  exit 1
+fi
+
+echo "==> Granting roles/storage.objectAdmin on gs://$STATE_BUCKET ..."
+gcloud storage buckets add-iam-policy-binding "gs://$STATE_BUCKET" \
+  --member="serviceAccount:$SA_EMAIL" \
+  --role="roles/storage.objectAdmin" \
+  --project="$PROJECT_ID" \
+  --condition=None >/dev/null
+
+echo "==> Granting roles/editor on project $PROJECT_ID ..."
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:$SA_EMAIL" \
+  --role="roles/editor" \
+  --condition=None >/dev/null
+
+echo "==> Granting roles/resourcemanager.projectIamAdmin on project $PROJECT_ID ..."
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:$SA_EMAIL" \
+  --role="roles/resourcemanager.projectIamAdmin" \
+  --condition=None >/dev/null
+
+echo ""
+echo "Done. The CI/CD service account now has the IAM roles required for"
+echo "terraform apply to run from GitHub Actions."
+echo ""
+echo "Push any commit to main (or re-run the most recent failed Deploy run)"
+echo "to trigger a fresh deploy."


### PR DESCRIPTION
## Summary

Three coordinated changes so the CI/CD service account has every IAM role Terraform needs to run from GitHub Actions:

1. **`infra/terraform/main.tf`** — add `roles/editor` and `roles/resourcemanager.projectIamAdmin` to `cicd_roles`. Combined with `storage.objectAdmin` on the tfstate bucket (already added in #301), this is everything CI needs.
2. **`scripts/fix-cicd-sa-iam.sh`** — idempotent recovery script for installs done before this PR (where the cicd SA was created with the old role list). Run once locally as project owner; then Terraform takes ownership.
3. **`docs/deploy-single-user.md` Step 5** — describes the full role set and references the recovery script.

## Root cause

After #301 unblocked terraform state access, `terraform apply` failed with 403s on every `google_project_iam_member` resource — the cicd SA couldn't even read the project IAM policy. Editor + projectIamAdmin fix this.

## Test plan

- [ ] Pre-existing user runs `./scripts/fix-cicd-sa-iam.sh` once (already done in this session — confirmed by the user)
- [ ] After merge: Deploy workflow's `terraform apply` completes; `gcloud run deploy` runs; liftinglogbook.com serves the app

Closes #302