### PR TITLE
[fix] Grant cicd SA Owner; collapse role list; update recovery script

### DIFF
--- a/docs/deploy-single-user.md
+++ b/docs/deploy-single-user.md
@@ -201,17 +201,21 @@ placeholder secrets), KMS keyring, IAM, and the Cloud Run service shells. With
 skipped; the `api_workload` service account itself is still created because
 Cloud Run reuses it as the API service identity.
 
-The CI/CD service account is created with both **runtime** roles (Cloud Run
-deploy, Artifact Registry write, Secret Manager read, Cloud SQL client) and
-**admin** roles (Editor + projectIamAdmin) so that `terraform apply` running
-from GitHub Actions can manage every resource in this module. The state
-bucket gets a `storage.objectAdmin` binding for the same SA so the CI run
-can read/write Terraform state.
+The CI/CD service account is created with `roles/owner` on the project plus
+`roles/iam.serviceAccountTokenCreator` (for workload identity token issuance).
+Owner is the pragmatic choice for a single-user production project: it covers
+every `setIamPolicy` permission across Secret Manager, KMS, Storage, and
+other resources where Editor + projectIamAdmin still fall short. For
+multi-tenant environments, replace Owner with a narrower combination —
+see the comments in `infra/terraform/main.tf` for the trade-off.
+
+The state bucket also gets an explicit `storage.objectAdmin` binding so
+that revoking Owner later (when narrowing for multi-tenant) does not
+silently break CI access to Terraform state.
 
 > **Recovery for pre-existing setups.** If you ran the first `terraform apply`
-> before this section existed — i.e., the `cicd_roles` list in
-> `infra/terraform/main.tf` didn't yet include `roles/editor` and
-> `roles/resourcemanager.projectIamAdmin` — CI cannot grant these roles to
+> before the cicd SA was granted Owner — i.e., you set up using an older
+> version of this guide — CI cannot grant the missing permissions to
 > itself (chicken-and-egg: terraform needs the perms to manage the perms).
 > Run the recovery script once from your laptop as a project owner, then
 > push to main:
@@ -220,10 +224,9 @@ can read/write Terraform state.
 > ./scripts/fix-cicd-sa-iam.sh
 > ```
 >
-> It grants three roles: `storage.objectAdmin` on the tfstate bucket,
-> `editor` on the project, and `resourcemanager.projectIamAdmin` on the
-> project. All bindings are idempotent and will be taken over by Terraform
-> on the next CI apply, so they persist across re-applies.
+> It grants `roles/owner` on the project and `roles/storage.objectAdmin`
+> on the tfstate bucket. Bindings are idempotent and will be taken over
+> by Terraform on the next CI apply so they persist across re-applies.
 
 ---
 

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -297,21 +297,32 @@ resource "google_service_account" "cicd" {
 
 resource "google_project_iam_member" "cicd_roles" {
   for_each = toset([
-    # ── Runtime roles (used by the workloads themselves) ─────────────────
-    "roles/container.developer",          # GKE deploy
-    "roles/run.admin",                    # Cloud Run deploy
-    "roles/artifactregistry.writer",      # Push images
-    "roles/secretmanager.secretAccessor", # Read secrets
-    "roles/cloudsql.client",
+    # The CI/CD service account is the trusted automation identity for
+    # this project — it runs `terraform apply` and `gcloud run deploy`
+    # for every push to main. For a single-user production project,
+    # granting Owner is the pragmatic choice:
+    #
+    #   * Editor + projectIamAdmin still excludes `setIamPolicy` on
+    #     several resource types (Secret Manager secrets, KMS keys,
+    #     storage buckets) that Terraform's `*_iam_member` resources
+    #     need to manage. Closing each gap individually with a
+    #     resource-specific admin role is a whack-a-mole pattern that
+    #     this module has already iterated through twice (#301, #303).
+    #   * Owner gives the SA the same authority the human operator
+    #     already has when they run the first local terraform apply.
+    #     The only thing Owner adds beyond Editor+projectIamAdmin that
+    #     a deploy automation arguably should not have is the ability
+    #     to delete the project itself — acceptable here because access
+    #     to the SA is gated by WIF (only this repo's main branch).
+    #
+    # For multi-tenant production projects, replace `owner` with a
+    # narrower combination (e.g., editor + projectIamAdmin +
+    # secretmanager.admin + cloudkms.admin + storage.admin) and accept
+    # that adding new resource types may require adding more roles.
+    "roles/owner",
+
+    # Identity-token issuance for workload identity is not in `owner`.
     "roles/iam.serviceAccountTokenCreator",
-    # ── Terraform-from-CI admin roles ────────────────────────────────────
-    # Required so that `terraform apply` running as this SA from CI can
-    # manage every resource in this module. Editor covers Cloud SQL,
-    # Artifact Registry, Secret Manager, Compute (VPC), KMS, Cloud Run,
-    # and GKE admin. projectIamAdmin is needed separately because
-    # roles/editor explicitly excludes IAM binding management.
-    "roles/editor",
-    "roles/resourcemanager.projectIamAdmin",
   ])
   project = var.project_id
   role    = each.value

--- a/scripts/fix-cicd-sa-iam.sh
+++ b/scripts/fix-cicd-sa-iam.sh
@@ -4,13 +4,13 @@
 # for `terraform apply` from GitHub Actions to succeed.
 #
 # This is a one-time recovery script for production projects that were
-# bootstrapped *before* infra/terraform/main.tf was updated to include these
-# roles in the `cicd_roles` list. Without these grants, the Deploy workflow
-# fails with one of:
+# bootstrapped *before* infra/terraform/main.tf was updated to grant the
+# cicd SA roles/owner. Without it, the Deploy workflow fails with one of:
 #
 #   * "does not have storage.objects.list access" (on tfstate bucket)
 #   * "Error retrieving IAM policy for project ... 403 forbidden"
-#   * Other 403s when terraform tries to read/manage project resources
+#   * "Permission 'secretmanager.secrets.setIamPolicy' denied"
+#   * Other 403s when terraform tries to manage resource IAM policies
 #
 # The chicken-and-egg: `terraform apply` from CI needs these permissions
 # before it can grant them to itself. Run this script once, as a user identity
@@ -79,23 +79,27 @@ if ! gcloud iam service-accounts describe "$SA_EMAIL" --project="$PROJECT_ID" >/
   exit 1
 fi
 
+# Granting Owner covers every permission Terraform needs across Cloud SQL,
+# Secret Manager, KMS, Cloud Storage, Compute, Cloud Run, GKE, Artifact
+# Registry, and project IAM management — including the setIamPolicy
+# permissions that Editor + projectIamAdmin exclude on several resource
+# types. See infra/terraform/main.tf for the rationale on choosing Owner
+# over a narrower combination for a single-user production project.
+echo "==> Granting roles/owner on project $PROJECT_ID ..."
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:$SA_EMAIL" \
+  --role="roles/owner" \
+  --condition=None >/dev/null
+
+# storage.objectAdmin on the tfstate bucket is technically redundant once
+# Owner is granted at the project level, but we keep it as an explicit
+# binding so that revoking Owner later (when moving to multi-tenant) does
+# not silently break CI's access to terraform state.
 echo "==> Granting roles/storage.objectAdmin on gs://$STATE_BUCKET ..."
 gcloud storage buckets add-iam-policy-binding "gs://$STATE_BUCKET" \
   --member="serviceAccount:$SA_EMAIL" \
   --role="roles/storage.objectAdmin" \
   --project="$PROJECT_ID" \
-  --condition=None >/dev/null
-
-echo "==> Granting roles/editor on project $PROJECT_ID ..."
-gcloud projects add-iam-policy-binding "$PROJECT_ID" \
-  --member="serviceAccount:$SA_EMAIL" \
-  --role="roles/editor" \
-  --condition=None >/dev/null
-
-echo "==> Granting roles/resourcemanager.projectIamAdmin on project $PROJECT_ID ..."
-gcloud projects add-iam-policy-binding "$PROJECT_ID" \
-  --member="serviceAccount:$SA_EMAIL" \
-  --role="roles/resourcemanager.projectIamAdmin" \
   --condition=None >/dev/null
 
 echo ""


### PR DESCRIPTION
## Summary

Replaces the seven-role cicd_roles list with `[owner, serviceAccountTokenCreator]`, updates the recovery script and docs to match.

## Why

\`roles/editor\` excludes `setIamPolicy` on Secret Manager secrets, KMS keys, and storage buckets. After PR #303 (which added Editor + projectIamAdmin), terraform apply still fails:

```
Error 403: Permission 'secretmanager.secrets.setIamPolicy' denied
```

Owner is the smallest single role that covers every IAM operation Terraform needs to manage the resources in this module. For a single-user prod project where the cicd SA is the trusted WIF-gated deploy identity, Owner is appropriate; for multi-tenant, replace with a narrower combination (Terraform comments document the trade-off).

## One-time manual step

User needs to grant Owner once before next CI run:

```bash
gcloud projects add-iam-policy-binding lifting-logbook-prod   --member=\"serviceAccount:lifting-logbook-prod-cicd@lifting-logbook-prod.iam.gserviceaccount.com\"   --role=\"roles/owner\"
```

Or re-run `./scripts/fix-cicd-sa-iam.sh` (the updated script in this PR grants Owner).

## Test plan

- [ ] User grants Owner (or runs updated recovery script)
- [ ] After merge: terraform apply completes; gcloud run deploy runs; liftinglogbook.com serves the app

Closes #304