### PR TITLE
[fix] API container start — copy hoisted node_modules + re-generate Prisma

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -33,8 +33,13 @@ COPY --from=installer /app/tsconfig.base.json ./tsconfig.base.json
 RUN npx prisma generate --schema=apps/api/prisma/schema.prisma
 RUN npx turbo run build --filter=@lifting-logbook/api
 
-# Install production-only dependencies for the final image.
+# Install production-only dependencies for the final image. This is a fresh
+# `npm ci` which destroys /app/node_modules and reinstalls — including the
+# Prisma client generated above. We re-run `prisma generate` after to repopulate
+# /app/node_modules/.prisma/client; without it, runtime fails with
+# "Cannot find module '.prisma/client/default'".
 RUN npm ci --omit=dev --workspace=@lifting-logbook/api
+RUN npx prisma generate --schema=apps/api/prisma/schema.prisma
 
 # ── Stage 3: runner ──────────────────────────────────────────────────────────
 # Minimal production image: compiled output + production node_modules only.
@@ -46,9 +51,19 @@ RUN addgroup --system --gid 1001 nodejs \
  && adduser  --system --uid 1001 --ingroup nodejs nestjs
 
 # Copy compiled output and production dependencies.
+#
+# Source for node_modules is /app/node_modules (the hoisted root tree), NOT
+# /app/apps/api/node_modules. npm workspaces hoists most dependencies to the
+# repo root; the workspace-local node_modules contains only conflict-resolution
+# entries and is typically near-empty. Copying the workspace-local path leaves
+# the runtime missing every hoisted dependency (e.g., @opentelemetry/sdk-node)
+# and the container fails to start with "Cannot find module ...".
 COPY --from=builder --chown=nestjs:nodejs /app/apps/api/dist ./dist
-COPY --from=builder --chown=nestjs:nodejs /app/apps/api/node_modules ./node_modules
+COPY --from=builder --chown=nestjs:nodejs /app/node_modules ./node_modules
 COPY --from=builder --chown=nestjs:nodejs /app/apps/api/package.json ./package.json
+# The Prisma client looks for the schema file at runtime to bind to the
+# generated default-client. Include it so the client can self-locate.
+COPY --from=builder --chown=nestjs:nodejs /app/apps/api/prisma ./prisma
 
 USER nestjs
 


### PR DESCRIPTION
## Summary

Fixes two related Dockerfile bugs that prevented the API container from starting on Cloud Run.

## Root cause

After PR #305 unblocked terraform apply, \`gcloud run deploy\` finally ran. The container failed to start with:

\`\`\`
Error: Cannot find module '@opentelemetry/sdk-node'
  Require stack:
    - /app/dist/otel.js
    - /app/dist/main.js
\`\`\`

The package IS in dependencies, but the Dockerfile copies the wrong \`node_modules\` path. npm workspaces hoists shared dependencies to \`/app/node_modules\`; the runner stage was copying \`/app/apps/api/node_modules\` (workspace-local, near-empty).

A secondary bug would have surfaced next: the builder runs \`npm ci --omit=dev --workspace=...\` which wipes the just-generated Prisma client, so even with the right COPY path Prisma would fail.

## Fix

1. Re-run \`npx prisma generate\` after the prod-only \`npm ci\` (prisma CLI is in dependencies, so it survives \`--omit=dev\`).
2. Change runner COPY source from workspace-local to hoisted root path.
3. Copy \`apps/api/prisma/\` schema into runner for Prisma client self-location.

## Test plan

- [ ] After merge: gcloud run deploy succeeds for API; liftinglogbook.com serves the app (web service uses Next.js standalone which doesn't have this issue)

Closes #306