### PR TITLE
[fix] Ignore gcloud-set client/client_version drift on Cloud Run services

### DIFF
--- a/infra/terraform/cloud-run.tf
+++ b/infra/terraform/cloud-run.tf
@@ -96,8 +96,17 @@ resource "google_cloud_run_v2_service" "api" {
   # Image and template updates are managed exclusively by gcloud run deploy in CI/CD.
   # Terraform creates the service on first apply; subsequent image/env/scale changes
   # are applied by the deploy-staging / deploy-production jobs, not Terraform.
+  #
+  # `client` and `client_version` are set by `gcloud run deploy` (e.g.,
+  # "gcloud" / "568.0.0"). Without ignoring them, terraform sees them as drift
+  # and tries to revert to null on the next apply. The revert triggers an
+  # in-place Service modification, which Cloud Run validates by re-attempting
+  # to start the current template's image. If that image is broken (e.g., a
+  # bad deploy that pre-dates the current commit), the modification fails
+  # with "container failed to start", blocking every subsequent terraform
+  # apply even though the live image issue is unrelated to terraform.
   lifecycle {
-    ignore_changes = [template]
+    ignore_changes = [template, client, client_version]
   }
 
   depends_on = [google_project_service.required_apis]


### PR DESCRIPTION
## Summary

Adds \`client\` and \`client_version\` to \`lifecycle.ignore_changes\` on both Cloud Run services in \`infra/terraform/cloud-run.tf\`.

## Root cause

After PR #307 fixed the API container start bugs, the next \`terraform apply\` failed because it tried to revert client/client_version (set by the previous \`gcloud run deploy\`) back to null. The revert triggered a Service modification, which Cloud Run validated by trying to spin up the existing (still-broken from before #307) revision. That start failed and blocked terraform entirely — even though the new image fix had already merged.

## Fix

\`\`\`hcl
lifecycle {
  ignore_changes = [template, client, client_version]
}
\`\`\`

Matches the existing pattern for \`template\` (also gcloud-managed). Comment explains the failure mode.

## Test plan

- [ ] After merge: terraform apply succeeds (no spurious modification); gcloud run deploy applies the #307 image to a fresh revision; API container starts on PORT=3000; liftinglogbook.com serves the app.

Closes #308