### PR TITLE
[fix] Preserve monorepo layout in API runner; include workspace node_modules

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -3,9 +3,9 @@
 # ── Stage 1: builder ─────────────────────────────────────────────────────────
 # Copy the full repo, install all deps, generate Prisma client, build with
 # turbo. We previously used `turbo prune --docker` to produce a minimal
-# subset, but observed (PRs #310/#311) that the resulting tree dropped some
-# transitive runtime deps (@fastify/multipart) — the most reliable behaviour
-# is to skip the prune entirely. Image-size optimization is tracked in #310.
+# subset, but observed that the resulting tree dropped some transitive
+# runtime deps — the most reliable behaviour is to skip the prune entirely.
+# Image-size optimization is tracked in #310.
 FROM node:20.11.1-alpine AS builder
 WORKDIR /app
 
@@ -21,7 +21,11 @@ RUN npx prisma generate --schema=apps/api/prisma/schema.prisma
 RUN npx turbo run build --filter=@lifting-logbook/api
 
 # ── Stage 2: runner ──────────────────────────────────────────────────────────
-# Minimal production image: compiled output + full node_modules.
+# Minimal production image: compiled output + node_modules at both root and
+# workspace level (npm workspaces hoists most deps to root, but some don't
+# hoist because of version conflicts — e.g., @fastify/multipart lives at
+# /app/apps/api/node_modules, not /app/node_modules). We preserve the full
+# monorepo directory layout so node's module resolution walks both paths.
 FROM node:20.11.1-alpine AS runner
 WORKDIR /app
 
@@ -29,24 +33,22 @@ WORKDIR /app
 RUN addgroup --system --gid 1001 nodejs \
  && adduser  --system --uid 1001 --ingroup nodejs nestjs
 
-# Copy compiled output, hoisted node_modules, and package metadata.
-#
-# Source for node_modules is /app/node_modules (the hoisted root tree). npm
-# workspaces hoists most dependencies to the repo root; the workspace-local
-# /app/apps/api/node_modules contains only conflict-resolution entries.
-# Copying the workspace-local path would leave the runtime missing every
-# hoisted dep (e.g., @opentelemetry/sdk-node).
-#
-# The Prisma client lives under /app/node_modules/.prisma/client and is
-# carried along with this COPY.
-COPY --from=builder --chown=nestjs:nodejs /app/apps/api/dist ./dist
+# Copy the hoisted root node_modules.
 COPY --from=builder --chown=nestjs:nodejs /app/node_modules ./node_modules
-COPY --from=builder --chown=nestjs:nodejs /app/apps/api/package.json ./package.json
-# The Prisma client looks for the schema file at runtime to bind to the
-# generated default-client. Include it so the client can self-locate.
-COPY --from=builder --chown=nestjs:nodejs /app/apps/api/prisma ./prisma
+
+# Copy the api workspace tree under its real path so workspace-local
+# node_modules (e.g., @fastify/multipart) is visible to node's module
+# resolution walking up from /app/apps/api.
+COPY --from=builder --chown=nestjs:nodejs /app/apps/api/dist ./apps/api/dist
+COPY --from=builder --chown=nestjs:nodejs /app/apps/api/node_modules ./apps/api/node_modules
+COPY --from=builder --chown=nestjs:nodejs /app/apps/api/package.json ./apps/api/package.json
+COPY --from=builder --chown=nestjs:nodejs /app/apps/api/prisma ./apps/api/prisma
 
 USER nestjs
 
 EXPOSE 3000
+
+# Run from the workspace directory so node's module resolution starts at
+# /app/apps/api/node_modules and walks up to /app/node_modules.
+WORKDIR /app/apps/api
 CMD ["node", "dist/main.js"]


### PR DESCRIPTION
## Real root cause (finally)

\`@fastify/multipart\` IS installed by \`npm ci\` — at \`apps/api/node_modules/@fastify/multipart\` (workspace-local), NOT at the hoisted root \`/app/node_modules\`. npm workspaces did not hoist it (likely a version-conflict resolution). Verified locally — \`ls node_modules/@fastify/\` does not include multipart, but \`ls apps/api/node_modules/@fastify/\` does.

The runner stage was copying only the hoisted root \`node_modules\`. Workspace-local deps were unreachable.

## Fix

Preserve the monorepo layout in the runner so node's module resolution can walk both:
1. \`/app/apps/api/node_modules\` (workspace-local, where @fastify/multipart lives)
2. \`/app/node_modules\` (root, where OTel etc. live)

WORKDIR moves to \`/app/apps/api\` so resolution starts in the right place.

## Test plan

- [ ] After merge: API container starts on PORT=3000; liftinglogbook.com serves the app

Closes #314