### PR TITLE
[fix] Include workspace packages in API runner

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -33,8 +33,16 @@ WORKDIR /app
 RUN addgroup --system --gid 1001 nodejs \
  && adduser  --system --uid 1001 --ingroup nodejs nestjs
 
-# Copy the hoisted root node_modules.
+# Copy the hoisted root node_modules. This contains symlinks like
+# @lifting-logbook/core -> ../../packages/core, so the linked workspace
+# packages need to be copied too (next block).
 COPY --from=builder --chown=nestjs:nodejs /app/node_modules ./node_modules
+
+# Copy workspace packages that api depends on. node_modules/@lifting-logbook/*
+# symlinks here, and require('@lifting-logbook/core') resolves to the linked
+# packages/core/dist files at runtime. Without these the symlinks are dangling.
+COPY --from=builder --chown=nestjs:nodejs /app/packages/core ./packages/core
+COPY --from=builder --chown=nestjs:nodejs /app/packages/types ./packages/types
 
 # Copy the api workspace tree under its real path so workspace-local
 # node_modules (e.g., @fastify/multipart) is visible to node's module


### PR DESCRIPTION
## Summary

Adds COPY of \`packages/core\` and \`packages/types\` to the API runner stage so the workspace symlinks at \`node_modules/@lifting-logbook/*\` resolve.

## Root cause

After PR #315, the runner had both root and workspace-local node_modules. \`@fastify/multipart\` resolved. Next error:

\`\`\`
Error: Cannot find module '@lifting-logbook/core'
\`\`\`

\`node_modules/@lifting-logbook/core\` is a symlink to \`packages/core\`. Without copying \`packages/core\` and \`packages/types\` into the runner, those symlinks are dangling at runtime.

## Test plan

- [ ] After merge: API container starts on PORT=3000; liftinglogbook.com serves the app

Closes #316