### PR TITLE
[docs] Close staging-bootstrap gaps surfaced by prod deploy chain

### DIFF
--- a/docs/deploy-single-user.md
+++ b/docs/deploy-single-user.md
@@ -316,7 +316,7 @@ echo -n "pk_live_..." | gcloud secrets versions add \
 
 ---
 
-## Step 9 — Apply database migrations (one-time)
+## Step 8 — Apply database migrations (one-time)
 
 The API container does **not** run `prisma migrate deploy` on startup. Run the migration script from the repo root:
 
@@ -338,7 +338,7 @@ The script:
 
 ---
 
-## Step 10 — Trigger the first deploy
+## Step 9 — Trigger the first deploy
 
 Merge any branch to `main` (or push directly if you have the workflow set up
 that way). The [Deploy workflow](../.github/workflows/deploy.yml):
@@ -356,7 +356,7 @@ so the production job will pause until you approve it.
 
 ---
 
-## Step 11 — Create your Clerk user, log in, verify
+## Step 10 — Create your Clerk user, log in, verify
 
 Self-serve signup is disabled by default — there is no public "Sign Up" flow. You
 provision yourself directly through the Clerk dashboard:

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -233,6 +233,11 @@ In the GitHub repository → **Settings → Secrets and variables → Actions**:
 > job-to-job data passing (e.g., the `ar_repo` output used to resolve the Artifact Registry
 > URL — a masked project ID produces `us-central1-docker.pkg.dev//lifting-logbook/api:tag`
 > with an empty path segment that fails buildx).
+>
+> **Migrating an existing deploy?** If you previously stored `GCP_STAGING_PROJECT_ID` or
+> `GCP_PROD_PROJECT_ID` as repository secrets, delete the secret entries after creating the
+> variables. A leftover masked secret with the same name is a foot-gun if any workflow is
+> ever changed to reference `secrets.GCP_*_PROJECT_ID` — the failure mode reappears silently.
 
 ---
 
@@ -261,6 +266,14 @@ the production URL will appear in the `deploy-production` job summary after appr
 ### Deploying a change
 
 Push or merge to `main`. The pipeline runs automatically.
+
+### Recovering from CI/CD IAM errors
+
+If a CI run fails with `Error 403 ... setIamPolicy denied` or `does not have
+storage.objects.list access`, the CI/CD service account is missing the `roles/owner`
+binding that subsequent applies depend on. Re-run the recovery script from your laptop
+as a project owner — see the [CI/CD IAM recovery callout under Step 3](#step-3--bootstrap-terraform-first-apply)
+for the full explanation and commands.
 
 ### Rolling back
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -153,6 +153,21 @@ terraform output workload_identity_provider
 terraform output cicd_service_account_email
 ```
 
+> **CI/CD IAM recovery.** Each `terraform apply` above grants the CI/CD service account
+> `roles/owner` on its project so subsequent CI-driven applies can manage IAM bindings on
+> Secret Manager, KMS, and the tfstate bucket (Editor + projectIamAdmin fall short on
+> `setIamPolicy` for several resource types). If you bootstrap with an older toolchain
+> that predates this binding — symptom: CI fails with `Error 403 ... setIamPolicy denied`
+> or `does not have storage.objects.list access` — run the recovery script once from your
+> laptop as a project owner, then push to main:
+>
+> ```bash
+> ./scripts/fix-cicd-sa-iam.sh --project-id lifting-logbook-staging
+> ./scripts/fix-cicd-sa-iam.sh --project-id lifting-logbook-prod
+> ```
+>
+> Bindings are idempotent and get re-asserted by Terraform on the next apply.
+
 ---
 
 ### Step 4 — Sign up for Clerk and create two apps
@@ -190,19 +205,34 @@ echo -n "pk_live_YOUR_KEY" | gcloud secrets versions add \
 
 ---
 
-### Step 5 — Add GitHub repository secrets
+### Step 5 — Add GitHub repository secrets and variables
 
-In the GitHub repository → **Settings → Secrets and variables → Actions**, add:
+In the GitHub repository → **Settings → Secrets and variables → Actions**:
+
+**Repository secrets** (Secrets tab):
 
 | Secret | Value |
 |---|---|
-| `GCP_STAGING_PROJECT_ID` | `lifting-logbook-staging` |
-| `GCP_PROD_PROJECT_ID` | `lifting-logbook-prod` |
 | `GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER` | staging `terraform output workload_identity_provider` |
 | `GCP_STAGING_SERVICE_ACCOUNT` | staging `terraform output cicd_service_account_email` |
 | `GCP_PROD_WORKLOAD_IDENTITY_PROVIDER` | production `terraform output workload_identity_provider` |
 | `GCP_PROD_SERVICE_ACCOUNT` | production `terraform output cicd_service_account_email` |
+| `GCP_BILLING_ACCOUNT` | your billing account ID (used by terraform apply in CI) |
 | `TF_STATE_BUCKET` | `lifting-logbook-tfstate` |
+
+**Repository variables** (Variables tab):
+
+| Variable | Value |
+|---|---|
+| `GCP_STAGING_PROJECT_ID` | `lifting-logbook-staging` |
+| `GCP_PROD_PROJECT_ID` | `lifting-logbook-prod` |
+
+> **Why variables, not secrets?** GCP project IDs are not sensitive — they appear in
+> Cloud Console URLs, API responses, and `gcloud` output. Storing them as secrets causes
+> GitHub Actions to mask any workflow output that contains the value, which silently breaks
+> job-to-job data passing (e.g., the `ar_repo` output used to resolve the Artifact Registry
+> URL — a masked project ID produces `us-central1-docker.pkg.dev//lifting-logbook/api:tag`
+> with an empty path segment that fails buildx).
 
 ---
 

--- a/infra/terraform/terraform.tfvars.staging
+++ b/infra/terraform/terraform.tfvars.staging
@@ -15,5 +15,9 @@ db_name         = "lifting_logbook"
 # Staging runs the full ADR-009 A/B (GKE Autopilot + Cloud Run) so the comparison
 # this project is built around is exercised on every push to main. Production
 # (terraform.tfvars.production) flips enable_gke=false for single-user cost savings.
-enable_gke              = true
+enable_gke = true
+
+# cloud_run_min_instances=0 keeps idle cost at zero (staging gets no real traffic).
+# Cold-start latency is acceptable here — the A/B harness measures steady-state
+# performance, not first-request response time. Prod sets this to 1 for warm starts.
 cloud_run_min_instances = 0

--- a/infra/terraform/terraform.tfvars.staging
+++ b/infra/terraform/terraform.tfvars.staging
@@ -10,3 +10,10 @@ environment     = "staging"
 app_name        = "lifting-logbook"
 db_tier         = "db-f1-micro"
 db_name         = "lifting_logbook"
+
+# Topology — set explicitly so the staging/prod difference is visible at a glance.
+# Staging runs the full ADR-009 A/B (GKE Autopilot + Cloud Run) so the comparison
+# this project is built around is exercised on every push to main. Production
+# (terraform.tfvars.production) flips enable_gke=false for single-user cost savings.
+enable_gke              = true
+cloud_run_min_instances = 0


### PR DESCRIPTION
## Summary

The 13-PR production unblock chain (#290–#317) taught four lessons that were documented for prod but would re-bite a fresh staging bootstrap. Capturing them now so #291 (staging environment) starts on a clean path instead of rediscovering each one live.

## Changes

- **`docs/deploy-single-user.md`** — renumbered Steps 9→8, 10→9, 11→10 (closes a numbering hole between Clerk secrets and migrations).
- **`infra/terraform/terraform.tfvars.staging`** — sets `enable_gke = true` and `cloud_run_min_instances = 0` explicitly with a comment explaining the staging-vs-prod topology choice (staging runs the full ADR-009 A/B; prod is single-user Cloud-Run-only).
- **`docs/deploy.md` Step 5** — splits secrets/variables table; moves `GCP_STAGING_PROJECT_ID` and `GCP_PROD_PROJECT_ID` from Repository secrets to Repository variables, with the masking-breaks-string-interpolation explanation from `deploy-single-user.md` Step 4. Also adds `GCP_BILLING_ACCOUNT` to the secrets table (it's referenced by the CI terraform apply but wasn't listed).
- **`docs/deploy.md` Step 3** — adds a recovery-script callout pointing to `scripts/fix-cicd-sa-iam.sh --project-id <id>` for both staging and prod, so the chicken-and-egg IAM situation has a documented remedy in the canonical guide (not just single-user).

## Test plan

- [x] Pre-push lint: `turbo run lint` passed (cached) across all 4 workspaces
- [x] No code paths touched — docs + tfvars only; coverage gate not applicable
- [ ] Visual: PR diff shows no other unintended changes

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)