### PR TITLE
[fix] Fix pre-commit hook TURBO_BINARY_PATH propagation on Windows worktrees

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,21 +2,31 @@
 
 # When running in a git worktree whose path contains directories (e.g. .claude)
 # that prevent Windows from spawning executables, turbo.exe fails with EUNKNOWN.
-# Resolve the binary from the main repo root (git common dir) to sidestep this.
+# Fix: run node directly (no cmd.exe hop) and set TURBO_BINARY_PATH inside the node
+# process. Node is a Windows native process so process.env mutations propagate to its
+# children via the Windows NT env block — unlike MSYS2 sh `export`, which only updates
+# the POSIX env and is invisible to cmd.exe subprocesses in git's hook context.
 _COMMON=$(git rev-parse --git-common-dir 2>/dev/null)
 _MAIN_ROOT=${_COMMON%/.git}
-if [ -n "$_MAIN_ROOT" ] && [ -f "$_MAIN_ROOT/node_modules/@turbo/windows-64/bin/turbo.exe" ]; then
-  export TURBO_BINARY_PATH="$_MAIN_ROOT/node_modules/@turbo/windows-64/bin/turbo.exe"
-fi
-unset _COMMON _MAIN_ROOT
+_WIN_TURBO="$_MAIN_ROOT/node_modules/@turbo/windows-64/bin/turbo.exe"
+unset _COMMON
+
+_TURBO_INLINE="process.env.TURBO_BINARY_PATH=process.argv[1]; require('./node_modules/turbo/bin/turbo')"
 
 # Excluded until scaffolded/clean:
 #   @lifting-logbook/web  — no src/ yet (issue #9)
 #   @lifting-logbook/core — 51 pre-existing GAS-migration lint errors (issue #51)
-npx turbo run lint \
-  --filter=!@lifting-logbook/web \
-  --filter=!@lifting-logbook/core
+if [ -n "$_MAIN_ROOT" ] && [ -f "$_WIN_TURBO" ]; then
+  node -e "$_TURBO_INLINE" "$_WIN_TURBO" run lint \
+    --filter=!@lifting-logbook/web \
+    --filter=!@lifting-logbook/core
+else
+  npx turbo run lint \
+    --filter=!@lifting-logbook/web \
+    --filter=!@lifting-logbook/core
+fi
 RESULT=$?
+unset _MAIN_ROOT _WIN_TURBO _TURBO_INLINE
 if [ $RESULT -ne 0 ]; then
   echo "Lint failed. Commit aborted."
   exit 1


### PR DESCRIPTION
## Summary

Fixes `git commit` failing with `EUNKNOWN` from git worktrees whose path contains `.claude`.

**Root cause (three-layer):**

1. The worktree-specific `config.worktree` sets `hooksPath` to the **main repo's** `.husky/`, so all worktree commits run `C:/Users/brown/Git/lifting-logbook/.husky/pre-commit` — not the worktree's copy. This is the file changed in this PR.

2. That hook called `npx turbo`, which goes through `npx.cmd` → `cmd.exe`. `cmd.exe` inherits the Windows NT env block, not MSYS2's POSIX env block. So `export TURBO_BINARY_PATH` in the old worktree hook was invisible.

3. The previous workaround (`export TURBO_BINARY_PATH` + `npx turbo`) only ran from worktree-specific `.husky/` files that git was never actually executing.

**Fix:** Replace `npx turbo` with `node -e "process.env.TURBO_BINARY_PATH=process.argv[1]; require('./node_modules/turbo/bin/turbo')"` when the Windows-x64 binary is found in the main repo root. Node.js is a Windows native process — its `process.env` mutations propagate to child processes through the Windows NT env block. Setting the path inside Node before requiring the turbo wrapper means the wrapper's `process.env.TURBO_BINARY_PATH` check sees the correct binary.

Falls back to `npx turbo` on macOS/Linux (no `.exe` found → condition false).

## After merging

After `git pull` in the main repo, `C:/Users/brown/Git/lifting-logbook/.husky/pre-commit` will have the fix and all worktrees will commit without needing `TURBO_BINARY_PATH` pre-set in the shell.

## Test plan

- [x] `sh .husky/pre-commit` passes without `TURBO_BINARY_PATH` in env
- [x] `git commit` succeeds in a worktree with no `TURBO_BINARY_PATH` pre-set in shell (this commit was made using the fixed hook)
- [x] All 4 lint targets pass (cache hits confirmed)

Closes #326