### PR TITLE
[fix] Fix migrate-staging-db.sh: state bucket, secret names, and proxy SSL

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -178,7 +178,7 @@ the environment realistic data for testing cycle generation, reporting, and API 
 any real user PII.
 
 **When to run:** after `prisma migrate deploy` completes on the staging database (the deploy
-workflow runs migrations automatically; you can also run them manually via Cloud SQL Auth Proxy).
+workflow runs migrations automatically; for manual runs use `./scripts/migrate-staging-db.sh`).
 
 **What it creates:**
 
@@ -200,8 +200,10 @@ schema validation, API smoke tests, and query testing.
 
 ```bash
 # Via Cloud SQL Auth Proxy (connect to staging DB locally)
-cloud_sql_proxy lifting-logbook-staging:us-central1:lifting-logbook-stg-db-<suffix> &
-DATABASE_URL="postgresql://lifting-logbook-app:<password>@127.0.0.1:5432/lifting_logbook" \
+# Use port 5434 (avoids conflict with prod proxy on 5433)
+# sslmode=disable required: proxy handles TLS; Prisma must not negotiate SSL independently
+cloud-sql-proxy "lifting-logbook-staging:us-central1:lifting-logbook-stg-db-<suffix>?port=5434" &
+DATABASE_URL="postgresql://lifting-logbook-app:<password>@127.0.0.1:5434/lifting_logbook?sslmode=disable" \
   npx --prefix apps/api prisma db seed
 ```
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,7 +15,7 @@ Repository automation scripts. Grouped by lifecycle.
 | [`bootstrap-gcp-prod.sh`](bootstrap-gcp-prod.sh) | One-time GCP bootstrap for a single-user production deploy: creates the project, links billing, enables the APIs Terraform needs, and provisions the Terraform state bucket. Idempotent. See [`docs/deploy-single-user.md`](../docs/deploy-single-user.md). |
 | [`deploy-prod-infra.sh`](deploy-prod-infra.sh) | Automates `terraform init` → workspace select → `apply` for the production environment. Maps custom domains and prints GitHub Actions secrets. Use `--plan-only` to preview. Run after `bootstrap-gcp-prod.sh`. |
 | [`migrate-prod-db.sh`](migrate-prod-db.sh) | Applies all database migrations to the production Cloud SQL instance. Temporarily enables a public IP, runs Prisma migrations and the `user_data_source` infra migration via the Cloud SQL Auth Proxy, then removes the public IP. Downloads the proxy automatically. |
-| [`migrate-staging-db.sh`](migrate-staging-db.sh) | Applies all database migrations to the staging Cloud SQL instance. Mirrors `migrate-prod-db.sh` with staging overrides (`PROJECT_ID`, `PROXY_PORT=5434`, `terraform workspace select staging`). |
+| [`migrate-staging-db.sh`](migrate-staging-db.sh) | Applies all database migrations to the staging Cloud SQL instance. Staging-specific variant of `migrate-prod-db.sh`: uses the shared `lifting-logbook-tfstate` state bucket (prefix `terraform/state`), the `-stg-` secret naming pattern, `PROXY_PORT=5434`, and forces `sslmode=disable` on the proxy URL for Prisma compatibility. |
 
 ## Repository / project management
 

--- a/scripts/migrate-staging-db.sh
+++ b/scripts/migrate-staging-db.sh
@@ -145,7 +145,10 @@ fi
 
 echo "==> Getting Cloud SQL instance name from terraform output ..."
 cd "$TF_DIR"
-terraform init -backend-config="bucket=lifting-logbook-tfstate" \n               -backend-config="prefix=terraform/state" \n               -reconfigure -input=false >/dev/null 2>&1
+terraform init \r
+  -backend-config="bucket=lifting-logbook-tfstate" \r
+  -backend-config="prefix=terraform/state" \r
+  -reconfigure -input=false >/dev/null 2>&1
 terraform workspace select staging >/dev/null 2>&1
 INSTANCE_NAME=$(terraform output -raw database_instance_name)
 INSTANCE_CONNECTION_NAME="${PROJECT_ID}:${REGION}:${INSTANCE_NAME}"
@@ -158,7 +161,7 @@ echo "    Instance: $INSTANCE_CONNECTION_NAME"
 # The proxy still requires IAM auth — the public IP alone does not grant DB access.
 
 echo "==> Enabling temporary public IP on Cloud SQL instance ..."
-OPERATOR_IP=$(curl -fsSL ifconfig.me 2>/dev/null || curl -fsSL api.ipify.org 2>/dev/null || echo "")
+OPERATOR_IP=$(curl -fsSL api4.ipify.org 2>/dev/null || curl -fsSL ifconfig.me 2>/dev/null || echo "")
 if [[ -n "$OPERATOR_IP" ]]; then
   echo "    Scoping authorized_networks to operator IP: $OPERATOR_IP/32"
   gcloud sql instances patch "$INSTANCE_NAME" \

--- a/scripts/migrate-staging-db.sh
+++ b/scripts/migrate-staging-db.sh
@@ -2,6 +2,16 @@
 #
 # migrate-staging-db.sh — Apply database migrations to the lifting-logbook staging Cloud SQL instance.
 #
+# Differences from migrate-prod-db.sh:
+#   * PROJECT_ID=lifting-logbook-staging
+#   * PROXY_PORT=5434 (avoids conflict if the prod proxy is also running on 5433)
+#   * terraform workspace select staging
+#   * State bucket: lifting-logbook-tfstate (prefix=terraform/state) — staging uses
+#     the shared tfstate bucket, unlike prod which has its own lifting-logbook-prod-tfstate
+#   * Secret names use the -stg- suffix pattern (lifting-logbook-stg-database-url)
+#     rather than the full project name (${PROJECT_ID}-database-url)
+#   * PROXY_DB_URL has sslmode=disable appended (required for Prisma via Cloud SQL Auth Proxy)
+#
 # The staging Cloud SQL instance has no public IP. This script temporarily enables
 # a public IP (required for the Cloud SQL Auth Proxy to connect from a local machine),
 # scoped to the operator's current IP via --authorized-networks, runs all migrations,
@@ -135,7 +145,7 @@ fi
 
 echo "==> Getting Cloud SQL instance name from terraform output ..."
 cd "$TF_DIR"
-terraform init -backend-config="bucket=${PROJECT_ID}-tfstate" -reconfigure -input=false >/dev/null 2>&1
+terraform init -backend-config="bucket=lifting-logbook-tfstate" \n               -backend-config="prefix=terraform/state" \n               -reconfigure -input=false >/dev/null 2>&1
 terraform workspace select staging >/dev/null 2>&1
 INSTANCE_NAME=$(terraform output -raw database_instance_name)
 INSTANCE_CONNECTION_NAME="${PROJECT_ID}:${REGION}:${INSTANCE_NAME}"
@@ -179,11 +189,13 @@ sleep 15
 
 echo "==> Retrieving DATABASE_URL from Secret Manager ..."
 RAW_DB_URL=$(gcloud secrets versions access latest \
-  --secret="${PROJECT_ID}-database-url" \
+  --secret="lifting-logbook-stg-database-url" \
   --project="$PROJECT_ID")
 
 # Proxy listens on localhost:$PROXY_PORT — rewrite host/port in the URL
 PROXY_DB_URL=$(echo "$RAW_DB_URL" | sed -E "s|@[^/]+/|@127.0.0.1:${PROXY_PORT}/|")
+# Cloud SQL Auth Proxy handles TLS — strip any sslmode and force disable for Prisma
+PROXY_DB_URL=$(node -e "const u=process.argv[1].replace(/[?&]sslmode=[^&]*/g,''); console.log(u+(u.includes('?') ? '&' : '?')+'sslmode=disable')" "$PROXY_DB_URL")
 
 # ─── Start proxy ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes three bugs in \`scripts/migrate-staging-db.sh\` discovered during the post-#323 staging deploy execution. All three caused the script to fail silently or partially.

**1. Wrong state bucket**
The script used \`bucket=${PROJECT_ID}-tfstate\` → \`lifting-logbook-staging-tfstate\`, but staging state lives in the shared \`lifting-logbook-tfstate\` bucket at \`prefix=terraform/state\` (as documented in \`docs/deploy.md\` line 139). This caused \`terraform output -raw database_instance_name\` to fail with "Output not found."

**2. Wrong secret name pattern**
The script used \`--secret="${PROJECT_ID}-database-url"\` → \`lifting-logbook-staging-database-url\`, but terraform's \`name_prefix\` uses the \`-stg-\` env_suffix (from \`locals { env_suffix = ... ? "prod" : "stg" }\`), making the actual secret \`lifting-logbook-stg-database-url\`.

**3. Prisma SSL failure via Cloud SQL Auth Proxy**
Prisma failed with P1001 ("Can't reach database server") even though the proxy was running and the \`pg\` node client connected successfully. Root cause: the DATABASE_URL from Secret Manager includes SSL parameters tuned for direct Cloud SQL connections. When routed through the Auth Proxy, these must be stripped and replaced with \`sslmode=disable\` — the proxy handles TLS; Prisma must not negotiate SSL independently.

## Documentation updated

- \`scripts/README.md\`: description updated to list all staging-specific differences from \`migrate-prod-db.sh\`
- \`docs/deploy.md\` Step 3.5: seed command updated to use port 5434, cloud-sql-proxy v2 syntax, and \`sslmode=disable\`

## Test plan

- [x] All three bugs reproduced and root-caused during staging deploy execution (2026-05-23)
- [ ] \`./scripts/migrate-staging-db.sh\` runs to completion against the staging Cloud SQL instance (part of issue #324 deploy verification)

Closes #328