### PR TITLE
[fix] Collapse terraform init to single line (CRLF continuation bug)

### DIFF
--- a/scripts/migrate-staging-db.sh
+++ b/scripts/migrate-staging-db.sh
@@ -145,10 +145,7 @@ fi
 
 echo "==> Getting Cloud SQL instance name from terraform output ..."
 cd "$TF_DIR"
-terraform init \r
-  -backend-config="bucket=lifting-logbook-tfstate" \r
-  -backend-config="prefix=terraform/state" \r
-  -reconfigure -input=false >/dev/null 2>&1
+terraform init -backend-config="bucket=lifting-logbook-tfstate" -backend-config="prefix=terraform/state" -reconfigure -input=false >/dev/null 2>&1
 terraform workspace select staging >/dev/null 2>&1
 INSTANCE_NAME=$(terraform output -raw database_instance_name)
 INSTANCE_CONNECTION_NAME="${PROJECT_ID}:${REGION}:${INSTANCE_NAME}"


### PR DESCRIPTION
## Summary

Fixes a bash CRLF line-continuation bug introduced in #330. The multi-line `terraform init` block produced `\r<CR><LF>` byte sequences (backslash + letter-r + CRLF) rather than valid bash line continuations, causing terraform to fail immediately with:

```
Error: Too many command line arguments. Did you mean to use -chdir?
```

Root cause: Python `b'\\\r\n'` bytes were mangled by git's autocrlf normalization on Windows during `git add`/checkout, inserting an extra `r` byte between the backslash and the CRLF line ending.

Fix: collapse the four-line form to a single `terraform init` invocation — the arguments fit on one line without needing continuation.

## Test plan

- [x] Reproduced: previous version caused "Too many command line arguments" from terraform
- [ ] `./scripts/migrate-staging-db.sh` runs to completion (terraform init → workspace select → output → migrations)

Closes #331