### PR TITLE
[fix] migrate-staging-db.sh: IPv4 validation, 30s proxy wait, sslmode regex

### DIFF
--- a/scripts/migrate-staging-db.sh
+++ b/scripts/migrate-staging-db.sh
@@ -159,6 +159,11 @@ echo "    Instance: $INSTANCE_CONNECTION_NAME"
 
 echo "==> Enabling temporary public IP on Cloud SQL instance ..."
 OPERATOR_IP=$(curl -fsSL api4.ipify.org 2>/dev/null || curl -fsSL ifconfig.me 2>/dev/null || echo "")
+# Validate IPv4 -- Cloud SQL authorized-networks rejects IPv6; the gcloud error is not obvious
+if [[ -n "$OPERATOR_IP" ]] && ! [[ "$OPERATOR_IP" =~ ^[0-9]+[.][0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+  echo "WARNING: Detected non-IPv4 address ($OPERATOR_IP) -- skipping authorized_networks restriction." >&2
+  OPERATOR_IP=""
+fi
 if [[ -n "$OPERATOR_IP" ]]; then
   echo "    Scoping authorized_networks to operator IP: $OPERATOR_IP/32"
   gcloud sql instances patch "$INSTANCE_NAME" \
@@ -182,8 +187,8 @@ until gcloud sql instances describe "$INSTANCE_NAME" \
   echo "    Instance not ready yet, retrying in 5s ..."
   sleep 5
 done
-echo "    Instance ready. Waiting an additional 15s for IP to become routable ..."
-sleep 15
+echo "    Instance ready. Waiting an additional 30s for proxy port 3307 to become routable ..."
+sleep 30
 
 # ─── Get DATABASE_URL from Secret Manager ────────────────────────────────────
 
@@ -194,8 +199,11 @@ RAW_DB_URL=$(gcloud secrets versions access latest \
 
 # Proxy listens on localhost:$PROXY_PORT — rewrite host/port in the URL
 PROXY_DB_URL=$(echo "$RAW_DB_URL" | sed -E "s|@[^/]+/|@127.0.0.1:${PROXY_PORT}/|")
-# Cloud SQL Auth Proxy handles TLS — strip any sslmode and force disable for Prisma
-PROXY_DB_URL=$(node -e "const u=process.argv[1].replace(/[?&]sslmode=[^&]*/g,''); console.log(u+(u.includes('?') ? '&' : '?')+'sslmode=disable')" "$PROXY_DB_URL")
+# Cloud SQL Auth Proxy handles TLS -- strip any existing sslmode, then force disable for Prisma.
+# Two-pass replace: first promote the next param to ? when sslmode is the leading param,
+# then strip any remaining sslmode= occurrence. This avoids a malformed URL when
+# sslmode is the first query param but not the only one (e.g. ?sslmode=require&sslrootcert=...).
+PROXY_DB_URL=$(node -e "var u=process.argv[1].replace(/[?]sslmode=[^&]*&/,'?').replace(/[?&]sslmode=[^&]*/g,''); console.log(u+(u.indexOf('?')>=0?'&':'?')+'sslmode=disable')" "$PROXY_DB_URL")
 
 # ─── Start proxy ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Addresses three non-blocking findings from PR #330 review and one new issue discovered during migration execution.

**1. IPv4 validation (finding: #330 review reliability)**
After detecting `OPERATOR_IP`, validate it matches `^[0-9]+.[0-9]+.[0-9]+.[0-9]+$` before using as an authorized-network. If IPv6 is detected (e.g. from the `ifconfig.me` fallback), skip the restriction with a clear warning rather than passing an IPv6 CIDR that Cloud SQL rejects with an unintuitive gcloud error.

**2. Extended post-RUNNABLE wait: 15s → 30s (new, from execution)**
After enabling public IP and waiting for RUNNABLE state, port 3307 (used by the Cloud SQL Auth Proxy) was not yet reachable during a migration run, causing a 22-second timeout. The instance enters RUNNABLE state before port 3307 is fully accessible externally.

**3. sslmode regex fix (finding: #330 review reliability)**
The original single-pass regex `[?&]sslmode=[^&]*` consumed the leading `?` when sslmode was the first query param, leaving subsequent params without a `?` anchor and producing a malformed URL (e.g. `db&sslrootcert=x?sslmode=disable`). Fixed with two-pass approach:
- Pass 1: `?sslmode=X&` → `?` (promote next param when sslmode leads)
- Pass 2: `[?&]sslmode=X` → `` (strip any remaining sslmode)
Verified against six URL patterns.

**4. Clarifying comment (finding: #330 review style)**
Added four-line comment above the sslmode node-e one-liner explaining the two-step intent.

## Test plan

- [x] sslmode regex verified against 6 URL patterns (all pass)
- [ ] `./scripts/migrate-staging-db.sh` runs to completion against staging Cloud SQL

Closes #333