### PR TITLE
[fix] Move ts-node compilerOptions to config block to fix Windows seed quoting

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -37,8 +37,13 @@
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.0"
   },
+  "ts-node": {
+    "compilerOptions": {
+      "module": "CommonJS"
+    }
+  },
   "prisma": {
-    "seed": "ts-node --compiler-options '{\"module\":\"CommonJS\"}' prisma/seed.ts"
+    "seed": "ts-node prisma/seed.ts"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",


### PR DESCRIPTION
## Summary

Fixes `npx prisma db seed` failing on Windows due to shell quoting of the `--compiler-options` flag.

## Root cause

On Windows, `cmd.exe` does not strip single quotes — ts-node received literal `'` characters as part of the JSON option value, producing:
```
SyntaxError: Unexpected token ''', "'{"module""... is not valid JSON
```

## Fix

Moved the compiler options from a `--compiler-options` CLI flag to a `"ts-node"` config block in `package.json`. ts-node v10+ reads this block automatically — no flag needed, no shell quoting involved, fully cross-platform.

## Changes

- `apps/api/package.json`: Added `"ts-node": { "compilerOptions": { "module": "CommonJS" } }` block; simplified `prisma.seed` to `"ts-node prisma/seed.ts"`

## Testing

- Linting passes (confirmed by pre-commit hook)
- Seed command verified on Windows (this was the active blocker for staging seeding)

Closes #335