### PR TITLE
[fix] Add non-null assertions and ?? null to satisfy strict TypeScript in seed.ts

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -93,7 +93,7 @@ async function main() {
   const workoutDate = new Date(startDate);
 
   for (let cycle = 0; cycle < NUM_CYCLES; cycle++) {
-    const weekType = WEEK_TYPES[cycle % 3];
+    const weekType = WEEK_TYPES[cycle % 3]!;
     const cycleNum = cycle + 1;
 
     // TrainingMaxHistory — one entry per lift at cycle start (representing a PR test)
@@ -124,14 +124,14 @@ async function main() {
     }
 
     for (let workoutNum = 1; workoutNum <= 3; workoutNum++) {
-      const liftsThisWorkout = WORKOUT_LIFTS[workoutNum];
+      const liftsThisWorkout = WORKOUT_LIFTS[workoutNum]!;
 
       for (const liftName of liftsThisWorkout) {
         const lift = LIFTS.find((l) => l.name === liftName)!;
         const max = trainingMaxAt(lift, cycle);
 
         for (let setNum = 1; setNum <= 3; setNum++) {
-          const pct = weekType.pct[setNum - 1];
+          const pct = weekType.pct[setNum - 1]!;
           const weight = weightForSet(max, pct);
           const isAmrap = setNum === 3;
           const amrapReps = isAmrap ? 5 + ((cycle * workoutNum + setNum) % 4) : 5;
@@ -170,7 +170,7 @@ async function main() {
 
   // CycleDashboard — current cycle state
   const currentCycle = NUM_CYCLES;
-  const currentWeek = WEEK_TYPES[(currentCycle - 1) % 3];
+  const currentWeek = WEEK_TYPES[(currentCycle - 1) % 3]!;
   await prisma.cycleDashboard.upsert({
     where: { userId_program: { userId: SEED_USER_ID, program: PROGRAM } },
     update: {
@@ -210,7 +210,7 @@ async function main() {
         lift: lift.name,
         goalType: 'relative',
         unit: 'lb',
-        ratio: GOAL_RATIOS[lift.name],
+        ratio: GOAL_RATIOS[lift.name] ?? null,
       },
     });
   }


### PR DESCRIPTION
## Summary

Fixes `npx prisma db seed` failing to compile under the project's strict TypeScript settings.

## Root cause

`tsconfig.base.json` sets `noUncheckedIndexedAccess: true` and `exactOptionalPropertyTypes: true`. The seed script used array index access patterns that TypeScript typed as `T | undefined` even though the indices are provably in-bounds, and passed `number | undefined` where Prisma expects `number | null`.

## Changes

- `WEEK_TYPES[cycle % 3]` → `!` (mod-3 index, always 0/1/2)
- `WORKOUT_LIFTS[workoutNum]` → `!` (keys are always 1/2/3 per loop bounds)
- `weekType.pct[setNum - 1]` → `!` (setNum 1–3, pct has exactly 3 elements)
- `WEEK_TYPES[(currentCycle - 1) % 3]` → `!` (same mod-3 guarantee)
- `ratio: GOAL_RATIOS[lift.name]` → `?? null` (matches `StrengthGoal.ratio: Float?` → `number | null`)

## Testing

- `tsc --noEmit --skipLibCheck` reports no `seed.ts` errors after change
- Linting passes (pre-commit hook)

Closes #337