### PR TITLE
[fix] Fix seed.ts constraint values: source 'test', unit 'lbs'

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -116,7 +116,7 @@ async function main() {
             reps: 1,
             date: histDate,
             isPR: true,
-            source: 'training-max-update',
+            source: 'test',
             goalMet: false,
           },
         });
@@ -209,7 +209,7 @@ async function main() {
         program: PROGRAM,
         lift: lift.name,
         goalType: 'relative',
-        unit: 'lb',
+        unit: 'lbs',
         ratio: GOAL_RATIOS[lift.name] ?? null,
       },
     });


### PR DESCRIPTION
## Summary

Fixes `npx prisma db seed` failing at runtime with PostgreSQL check constraint violations.

## Root cause

The seed used invalid values for two columns with DB-level check constraints:

| Column | Seed value | Allowed values | Fix |
|---|---|---|---|
| `training_max_history.source` | `'training-max-update'` | `'test', 'program'` | `'test'` |
| `strength_goal.unit` | `'lb'` | `'lbs', 'kg'` | `'lbs'` |

## Testing

- Constraint values verified against migrations `20260505000001` and `20260505000004`
- Linting passes

Closes #339