### PR TITLE
[fix] Add GCP identity token for Cloud Run service-to-service auth

### DIFF
--- a/apps/api/src/auth/auth.guard.spec.ts
+++ b/apps/api/src/auth/auth.guard.spec.ts
@@ -1,0 +1,87 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+import { AuthGuard } from './auth.guard';
+import { AUTH_PROVIDER } from '../ports/tokens';
+import type { AuthUser } from '../ports/auth';
+
+const mockUser: AuthUser = { id: 'user_1', email: 'test@example.com', provider: 'clerk' };
+const mockAuthProvider = { verifyToken: jest.fn().mockResolvedValue(mockUser) };
+
+function makeContext(headers: Record<string, string>, isPublic = false): ExecutionContext {
+  return {
+    getHandler: () => ({}),
+    getClass: () => ({}),
+    switchToHttp: () => ({
+      getRequest: () => ({ headers, user: undefined }),
+    }),
+    // Reflector.getAllAndOverride is stubbed via the module; this lets the guard
+    // read IS_PUBLIC_KEY without a real Reflector call.
+    _isPublic: isPublic,
+  } as unknown as ExecutionContext;
+}
+
+describe('AuthGuard', () => {
+  let guard: AuthGuard;
+  let reflector: Reflector;
+
+  beforeEach(async () => {
+    mockAuthProvider.verifyToken.mockClear();
+    const module = await Test.createTestingModule({
+      providers: [
+        AuthGuard,
+        {
+          provide: Reflector,
+          useValue: { getAllAndOverride: jest.fn().mockReturnValue(false) },
+        },
+        { provide: AUTH_PROVIDER, useValue: mockAuthProvider },
+      ],
+    }).compile();
+
+    guard = module.get(AuthGuard);
+    reflector = module.get(Reflector);
+  });
+
+  it('allows @Public() routes without a token', async () => {
+    (reflector.getAllAndOverride as jest.Mock).mockReturnValue(true);
+    const ctx = makeContext({});
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(mockAuthProvider.verifyToken).not.toHaveBeenCalled();
+  });
+
+  it('throws UnauthorizedException when no token header is present', async () => {
+    const ctx = makeContext({});
+    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('prefers x-clerk-authorization over authorization when both are present', async () => {
+    const clerkJwt = 'clerk-jwt-token';
+    const gcpToken = 'gcp-identity-token';
+    const request = { headers: { 'x-clerk-authorization': `Bearer ${clerkJwt}`, authorization: `Bearer ${gcpToken}` }, user: undefined };
+    const ctx = {
+      getHandler: () => ({}),
+      getClass: () => ({}),
+      switchToHttp: () => ({ getRequest: () => request }),
+    } as unknown as ExecutionContext;
+
+    await guard.canActivate(ctx);
+
+    expect(mockAuthProvider.verifyToken).toHaveBeenCalledWith(clerkJwt);
+    expect(request.user).toEqual(mockUser);
+  });
+
+  it('falls back to authorization when x-clerk-authorization is absent', async () => {
+    const clerkJwt = 'clerk-jwt-token';
+    const request = { headers: { authorization: `Bearer ${clerkJwt}` }, user: undefined };
+    const ctx = {
+      getHandler: () => ({}),
+      getClass: () => ({}),
+      switchToHttp: () => ({ getRequest: () => request }),
+    } as unknown as ExecutionContext;
+
+    await guard.canActivate(ctx);
+
+    expect(mockAuthProvider.verifyToken).toHaveBeenCalledWith(clerkJwt);
+    expect(request.user).toEqual(mockUser);
+  });
+});

--- a/apps/api/src/auth/auth.guard.ts
+++ b/apps/api/src/auth/auth.guard.ts
@@ -25,9 +25,14 @@ export class AuthGuard implements CanActivate {
     if (isPublic) return true;
 
     const request = context.switchToHttp().getRequest();
-    const authHeader: string | undefined = request.headers['authorization'];
-    const token = authHeader?.startsWith('Bearer ')
-      ? authHeader.slice(7)
+    // Server-to-server calls (apps/web) put the Clerk JWT in X-Clerk-Authorization to
+    // avoid colliding with the GCP identity token in Authorization (required for Cloud
+    // Run IAM). Browser clients and local dev continue using Authorization.
+    const headerValue: string | undefined =
+      (request.headers['x-clerk-authorization'] as string | undefined) ??
+      (request.headers['authorization'] as string | undefined);
+    const token = headerValue?.startsWith('Bearer ')
+      ? headerValue.slice(7)
       : undefined;
 
     if (!token) throw new UnauthorizedException();

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,29 +1,8 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
+import { getGcpIdentityToken } from '@/lib/gcp-identity-token';
 
 const API_URL = process.env.API_URL ?? 'http://localhost:3004';
-
-// Fetches a GCP identity token from the metadata service for service-to-service auth.
-// The staging API Cloud Run service requires Cloud Run IAM authentication — only the
-// web workload service account has roles/run.invoker on the API service (see
-// infra/terraform/cloud-run.tf: web_invoker_on_api). Unauthenticated requests to the
-// API are rejected with 403 by Cloud Run infrastructure before reaching NestJS.
-//
-// Returns null outside GCP environments (local dev, CI runners without the metadata
-// service). In those cases the API call is skipped and auth().userId is the sole check.
-async function getGcpIdentityToken(audience: string): Promise<string | null> {
-  const url = `http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=${encodeURIComponent(audience)}`;
-  try {
-    const res = await fetch(url, {
-      headers: { 'Metadata-Flavor': 'Google' },
-      signal: AbortSignal.timeout(2000),
-    });
-    if (!res.ok) return null;
-    return res.text();
-  } catch {
-    return null;
-  }
-}
 
 // Deployment health check — verifies two deployment properties independently:
 //

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { auth } from '@clerk/nextjs/server';
+import { getGcpIdentityToken } from './gcp-identity-token';
 import type {
   BodyWeightResponse,
   CreateCustomProgramRequest,
@@ -33,18 +34,34 @@ async function getAuthHeaders(): Promise<Record<string, string>> {
     const devToken = process.env.DEV_AUTH_TOKEN;
     return devToken ? { Authorization: `Bearer ${devToken}` } : {};
   }
+
+  let clerkToken: string | null = null;
   try {
     const { getToken } = await auth();
-    const token = await getToken();
-    if (!token) {
+    clerkToken = await getToken();
+    if (!clerkToken) {
       console.warn('[getAuthHeaders] No Clerk session token in Cloud Run — request will be unauthenticated');
-      return {};
     }
-    return { Authorization: `Bearer ${token}` };
   } catch (e) {
     console.error('[getAuthHeaders] Clerk token acquisition failed:', e);
-    return {};
   }
+
+  // Cloud Run IAM requires the identity token in Authorization; pass the Clerk JWT
+  // in a custom header so the NestJS AuthGuard can read it without collision.
+  // See infra/terraform/cloud-run.tf (web_invoker_on_api binding).
+  const identityToken = await getGcpIdentityToken(API_URL);
+
+  if (identityToken && clerkToken) {
+    return {
+      Authorization: `Bearer ${identityToken}`,
+      'X-Clerk-Authorization': `Bearer ${clerkToken}`,
+    };
+  }
+  if (clerkToken) {
+    console.warn('[getAuthHeaders] GCP identity token unavailable — falling back to Clerk JWT in Authorization, expect Cloud Run IAM 403');
+    return { Authorization: `Bearer ${clerkToken}` };
+  }
+  return {};
 }
 
 // NestJS ValidationPipe returns { statusCode, message: string | string[], error }.

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -35,27 +35,36 @@ async function getAuthHeaders(): Promise<Record<string, string>> {
     return devToken ? { Authorization: `Bearer ${devToken}` } : {};
   }
 
-  let clerkToken: string | null = null;
-  try {
-    const { getToken } = await auth();
-    clerkToken = await getToken();
-    if (!clerkToken) {
-      console.warn('[getAuthHeaders] No Clerk session token in Cloud Run — request will be unauthenticated');
-    }
-  } catch (e) {
-    console.error('[getAuthHeaders] Clerk token acquisition failed:', e);
-  }
-
   // Cloud Run IAM requires the identity token in Authorization; pass the Clerk JWT
   // in a custom header so the NestJS AuthGuard can read it without collision.
   // See infra/terraform/cloud-run.tf (web_invoker_on_api binding).
-  const identityToken = await getGcpIdentityToken(API_URL);
+  // Both fetches are independent — run them in parallel.
+  const [clerkToken, identityToken] = await Promise.all([
+    (async (): Promise<string | null> => {
+      try {
+        const { getToken } = await auth();
+        const token = await getToken();
+        if (!token) {
+          console.warn('[getAuthHeaders] No Clerk session token in Cloud Run — request will be unauthenticated');
+        }
+        return token;
+      } catch (e) {
+        console.error('[getAuthHeaders] Clerk token acquisition failed:', e);
+        return null;
+      }
+    })(),
+    getGcpIdentityToken(API_URL),
+  ]);
 
   if (identityToken && clerkToken) {
     return {
       Authorization: `Bearer ${identityToken}`,
       'X-Clerk-Authorization': `Bearer ${clerkToken}`,
     };
+  }
+  if (identityToken) {
+    // No Clerk session — passes Cloud Run IAM gate; NestJS returns 401 for protected endpoints
+    return { Authorization: `Bearer ${identityToken}` };
   }
   if (clerkToken) {
     console.warn('[getAuthHeaders] GCP identity token unavailable — falling back to Clerk JWT in Authorization, expect Cloud Run IAM 403');

--- a/apps/web/lib/gcp-identity-token.ts
+++ b/apps/web/lib/gcp-identity-token.ts
@@ -1,0 +1,23 @@
+import 'server-only';
+
+// Fetches a GCP identity token from the metadata service for service-to-service auth.
+// The staging API Cloud Run service requires Cloud Run IAM authentication — only the
+// web workload service account has roles/run.invoker on the API service (see
+// infra/terraform/cloud-run.tf: web_invoker_on_api). Unauthenticated requests to the
+// API are rejected with 403 by Cloud Run infrastructure before reaching NestJS.
+//
+// Returns null outside GCP environments (local dev, CI without the metadata service).
+// The audience must be the fully-qualified Cloud Run service URL.
+export async function getGcpIdentityToken(audience: string): Promise<string | null> {
+  const url = `http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=${encodeURIComponent(audience)}`;
+  try {
+    const res = await fetch(url, {
+      headers: { 'Metadata-Flavor': 'Google' },
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) return null;
+    return res.text();
+  } catch {
+    return null;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -567,7 +567,6 @@
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -668,7 +667,6 @@
       "version": "1.28.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
       "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -714,6 +712,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -723,6 +722,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -747,14 +747,12 @@
     "apps/web/node_modules/cjs-module-lexer": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
-      "peer": true
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="
     },
     "apps/web/node_modules/import-in-the-middle": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
       "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.14.0",
         "acorn-import-attributes": "^1.9.5",
@@ -766,6 +764,7 @@
       "version": "16.2.4",
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
       "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.4",
         "@swc/helpers": "0.5.15",
@@ -845,6 +844,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -853,6 +853,7 @@
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -864,7 +865,6 @@
       "version": "7.5.2",
       "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
       "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
-      "peer": true,
       "dependencies": {
         "debug": "^4.3.5",
         "module-details-from-path": "^1.0.3",
@@ -1155,6 +1155,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2627,16 +2628,6 @@
         }
       }
     },
-    "node_modules/@clerk/backend/node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@clerk/testing": {
       "version": "2.0.33",
       "resolved": "https://registry.npmjs.org/@clerk/testing/-/testing-2.0.33.tgz",
@@ -2704,17 +2695,6 @@
         "url": "https://dotenvx.com"
       }
     },
-    "node_modules/@clerk/testing/node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@clerk/types": {
       "version": "4.101.24",
       "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.24.tgz",
@@ -2759,16 +2739,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-    },
-    "node_modules/@clerk/types/node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -2886,6 +2856,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2908,6 +2879,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6053,6 +6025,7 @@
       "version": "10.4.22",
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.22.tgz",
       "integrity": "sha512-fxJ4v85nDHaqT1PmfNCQ37b/jcv2OojtXTaK1P2uAXhzLf9qq6WNUOFvxBrV4fhQek1EQoT1o9oj5xAZmv3NRw==",
+      "peer": true,
       "dependencies": {
         "file-type": "20.4.1",
         "iterare": "1.2.1",
@@ -6083,6 +6056,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.22.tgz",
       "integrity": "sha512-6IX9+VwjiKtCjx+mXVPncpkQ5ZjKfmssOZPFexmT+6T9H9wZ3svpYACAo7+9e7Nr9DZSoRZw3pffkJP7Z0UjaA==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
@@ -6320,6 +6294,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6427,6 +6402,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -7687,6 +7663,7 @@
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
       "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "playwright": "1.60.0"
       },
@@ -8133,7 +8110,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8143,7 +8119,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8156,7 +8131,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8170,8 +8144,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -8350,8 +8323,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.161",
@@ -8629,6 +8601,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -8765,6 +8738,7 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -9458,6 +9432,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9507,6 +9482,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -10135,6 +10111,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10450,12 +10427,14 @@
     "node_modules/class-transformer": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
-      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
       "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -11183,8 +11162,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/dotenv": {
       "version": "16.4.7",
@@ -11407,6 +11385,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11799,6 +11778,7 @@
       "version": "54.0.33",
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
       "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.23",
@@ -11886,6 +11866,7 @@
       "version": "14.0.11",
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
       "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
+      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -13590,6 +13571,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -14423,6 +14405,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -15041,7 +15024,6 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -16485,6 +16467,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -16613,6 +16596,7 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-11.0.0.tgz",
       "integrity": "sha512-wqg5XIAGRRIWtTk8qPGxkbrfiwEWz1lgedVLvhLALudKXvg1/L2lTFgTGPJ4Z2e3qcRmxoFxDuSdMdMGNM6I1g==",
+      "peer": true,
       "dependencies": {
         "get-caller-file": "^2.0.5",
         "pino": "^10.0.0",
@@ -16986,6 +16970,7 @@
       "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
       "devOptional": true,
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },
@@ -17757,6 +17742,7 @@
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17823,7 +17809,8 @@
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
-      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "peer": true
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -18150,6 +18137,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -18242,6 +18230,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -19738,6 +19727,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20063,6 +20053,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
       "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -20382,6 +20373,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },


### PR DESCRIPTION
## Summary

- Extracts `getGcpIdentityToken()` from the health route into a shared `apps/web/lib/gcp-identity-token.ts` utility
- Updates `getAuthHeaders()` in `api.ts` to inject the GCP identity token as `Authorization: Bearer` (Cloud Run IAM) and the Clerk JWT as `X-Clerk-Authorization: Bearer` (NestJS AuthGuard) when running on Cloud Run
- Updates the NestJS `AuthGuard` to prefer `X-Clerk-Authorization` over `Authorization`, falling back to `Authorization` for browser clients and local dev (backward-compatible)

## Root cause

Cloud Run IAM rejects requests where `Authorization: Bearer` is not a valid GCP identity token. Server-side `apiFetch()` calls were sending a Clerk JWT there, getting 403 before NestJS was ever reached.

## Acceptance criteria

- [x] `lib/gcp-identity-token.ts` wraps the metadata service fetch and is imported by both `api.ts` and the health route
- [x] All server components and route handlers use the shared utility via `getAuthHeaders()`
- [x] Local dev unchanged (no metadata service → falls through to DEV_AUTH_TOKEN)
- [x] Staging integration test 5 (`/api/health`) passes once deployed — this test was failing with `{"error":"api health returned 403"}` before this fix

## Test results

```
@lifting-logbook/api  — Test Suites: 20 passed  |  Tests: 243 passed (all passing)
@lifting-logbook/web  — Test Suites: 3 passed   |  Tests: 28 passed
@lifting-logbook/core — all passing
```

Note: `@lifting-logbook/api` TypeScript build fails with Prisma type errors — pre-existing issue on `main`, not introduced by this PR.

## Compatibility matrix

| Caller | Authorization | X-Clerk-Authorization | Cloud Run IAM | NestJS Guard |
|---|---|---|---|---|
| Browser (Clerk JWT) | Bearer \<clerk-jwt\> | — | n/a | ✅ via Authorization |
| Local dev | Bearer dev-token | — | n/a | ✅ via Authorization |
| Server component (Cloud Run) | Bearer \<identity-token\> | Bearer \<clerk-jwt\> | ✅ | ✅ via X-Clerk-Authorization |
| No Clerk session | Bearer \<identity-token\> | — | ✅ | 401 (correct) |
| `GET /health` (public) | Bearer \<identity-token\> | — | ✅ | @Public(), skipped |

Closes #350