### PR TITLE
[test] Remediate skewed tests + add fallback-coverage standard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,6 +343,10 @@ npm test -w @lifting-logbook/web
 
 **Blocking rule:** A PR that adds an API endpoint or frontend feature without satisfying the above is not mergeable.
 
+### Skewed-test rule
+
+When a PR adds or modifies a `.catch(() => default)`, `?? default`, or `try { … } catch { return neutral }` in a server component or API boundary, the test coverage for that code path must satisfy one of: (a) a data-level assertion the fallback would not produce, (b) a separate test that fails specifically when the upstream fails, or (c) an inline comment that names the swallowed-fallback source line and explains why structure-only is intentional. See [`docs/standards/error-fallback-test-coverage.md`](docs/standards/error-fallback-test-coverage.md) for the full rule and examples.
+
 ---
 
 ## Documentation and Citations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,7 @@ rationale, examples, and enforcement notes. Existing standards:
 | File | Applies to | Rule |
 |---|---|---|
 | [`docs/standards/fetch-cache-semantics.md`](docs/standards/fetch-cache-semantics.md) | `apps/web` Server Components | All `fetch()` calls must specify `{ cache: 'no-store' }` or `{ next: { revalidate: N } }` explicitly |
+| [`docs/standards/error-fallback-test-coverage.md`](docs/standards/error-fallback-test-coverage.md) | all packages and apps | Error-swallowing fallbacks (`.catch(() => default)`, `?? default`, try/catch returning neutral) require a data-level assertion, a paired success-path test, or a documented structure-only comment |
 
 When implementing `apps/web`, read the relevant standards before writing any `fetch()` calls.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,6 +343,15 @@ npm test -w @lifting-logbook/web
 
 **Blocking rule:** A PR that adds an API endpoint or frontend feature without satisfying the above is not mergeable.
 
+### Failure-tracking rule
+
+Every test failure reported in a pre-PR run must be resolved in one of two ways before `gh pr create`:
+
+1. **Fixed in this PR** (default).
+2. **Tracked by an open GitHub issue cited in the PR body** by number — prose explanation alone is not sufficient. If the failure does not yet have an issue, file one before opening the PR.
+
+A label of "pre-existing" without an open-issue link is not acceptable. The motivating incident is [#349 / PR #355](https://github.com/brownm09/lifting-logbook/pull/355), where four API suite-load failures were carried as "pre-existing" until a one-line `postinstall` hook fixed the entire class — the rule should have forced the investigation up front. The global equivalent of this rule is tracked in [dev-env#281](https://github.com/brownm09/dev-env/issues/281).
+
 ### Skewed-test rule
 
 When a PR adds or modifies a `.catch(() => default)`, `?? default`, or `try { … } catch { return neutral }` in a server component or API boundary, the test coverage for that code path must satisfy one of: (a) a data-level assertion the fallback would not produce, (b) a separate test that fails specifically when the upstream fails, or (c) an inline comment that names the swallowed-fallback source line and explains why structure-only is intentional. See [`docs/standards/error-fallback-test-coverage.md`](docs/standards/error-fallback-test-coverage.md) for the full rule and examples.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,8 @@
     "start": "node dist/main.js",
     "lint": "eslint src",
     "test": "jest",
-    "test:db": "jest --testPathPattern=db\\.e2e"
+    "test:db": "jest --testPathPattern=db\\.e2e",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.92.0",

--- a/apps/api/src/programs/workouts.controller.spec.ts
+++ b/apps/api/src/programs/workouts.controller.spec.ts
@@ -328,6 +328,13 @@ describe('WorkoutsController', () => {
       expect(result.lifts).toHaveLength(2);
       expect(result.lifts[0]).toMatchObject({ lift: 'Squat', planned: true });
     });
+
+    it('rethrows non-ProgramNotFoundError errors from getCycleDashboard', async () => {
+      dashboardRepo.getCycleDashboard.mockRejectedValue(new Error('db connection lost'));
+      specRepo.getProgramSpec.mockResolvedValue(twoLiftSpec);
+
+      await expect(controller.getWorkout('5-3-1', '1', MOCK_USER)).rejects.toThrow('db connection lost');
+    });
   });
 
   describe('skipped field', () => {
@@ -375,6 +382,24 @@ describe('WorkoutsController', () => {
       await controller.getWorkout('5-3-1', '1', MOCK_USER);
 
       expect(skipOverrideRepo.getSkipsForCycle).toHaveBeenCalledWith('5-3-1', 3);
+    });
+
+    it('treats getSkipsForCycle failure as empty skip set (does not propagate the error)', async () => {
+      // The controller swallows getSkipsForCycle errors and falls back to an
+      // empty Set so a transient skip-store failure cannot break the workout
+      // response. Verify the fallback branch separately from the success
+      // branch — see docs/standards/error-fallback-test-coverage.md.
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      dashboardRepo.getCycleDashboard.mockResolvedValue(dashboard);
+      specRepo.getProgramSpec.mockResolvedValue(spec);
+      workoutRepo.getWorkout.mockRejectedValue(new WorkoutNotFoundError('5-3-1', 3, 1));
+      skipOverrideRepo.getSkipsForCycle.mockRejectedValue(new Error('skip store unavailable'));
+
+      const result = await controller.getWorkout('5-3-1', '1', MOCK_USER);
+
+      expect(result.skipped).toBe(false);
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockRestore();
     });
   });
 });

--- a/apps/api/src/programs/workouts.controller.spec.ts
+++ b/apps/api/src/programs/workouts.controller.spec.ts
@@ -333,6 +333,11 @@ describe('WorkoutsController', () => {
       dashboardRepo.getCycleDashboard.mockRejectedValue(new Error('db connection lost'));
       specRepo.getProgramSpec.mockResolvedValue(twoLiftSpec);
 
+      // Assert the controller did NOT narrow this into the ProgramNotFoundError
+      // fallback path — if a future refactor broadens the catch, this test fails.
+      await expect(controller.getWorkout('5-3-1', '1', MOCK_USER)).rejects.not.toBeInstanceOf(
+        ProgramNotFoundError,
+      );
       await expect(controller.getWorkout('5-3-1', '1', MOCK_USER)).rejects.toThrow('db connection lost');
     });
   });
@@ -390,16 +395,19 @@ describe('WorkoutsController', () => {
       // response. Verify the fallback branch separately from the success
       // branch — see docs/standards/error-fallback-test-coverage.md.
       const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
-      dashboardRepo.getCycleDashboard.mockResolvedValue(dashboard);
-      specRepo.getProgramSpec.mockResolvedValue(spec);
-      workoutRepo.getWorkout.mockRejectedValue(new WorkoutNotFoundError('5-3-1', 3, 1));
-      skipOverrideRepo.getSkipsForCycle.mockRejectedValue(new Error('skip store unavailable'));
+      try {
+        dashboardRepo.getCycleDashboard.mockResolvedValue(dashboard);
+        specRepo.getProgramSpec.mockResolvedValue(spec);
+        workoutRepo.getWorkout.mockRejectedValue(new WorkoutNotFoundError('5-3-1', 3, 1));
+        skipOverrideRepo.getSkipsForCycle.mockRejectedValue(new Error('skip store unavailable'));
 
-      const result = await controller.getWorkout('5-3-1', '1', MOCK_USER);
+        const result = await controller.getWorkout('5-3-1', '1', MOCK_USER);
 
-      expect(result.skipped).toBe(false);
-      expect(errorSpy).toHaveBeenCalled();
-      errorSpy.mockRestore();
+        expect(result.skipped).toBe(false);
+        expect(errorSpy).toHaveBeenCalled();
+      } finally {
+        errorSpy.mockRestore();
+      }
     });
   });
 });

--- a/apps/web/e2e/staging.spec.ts
+++ b/apps/web/e2e/staging.spec.ts
@@ -21,6 +21,14 @@ test('home page renders with primary navigation', async ({ page }) => {
 
 // ---------------------------------------------------------------------------
 // 2. Programs catalog loads
+//
+// Structure-only assertion is intentional: the program catalog is rendered
+// from static data in apps/web/lib/programs.ts, so the page renders even
+// when the `.catch(() => DEFAULT_SETTINGS)` and `.catch(() => [])` fallbacks
+// in apps/web/app/programs/page.tsx:10-11 are exercised. The staging test
+// user has no custom programs, so no real-data assertion would distinguish
+// the success and fallback paths here. API-success detection is delegated
+// to test 5 (auth/API propagation against /api/health).
 // ---------------------------------------------------------------------------
 
 test('programs page catalog loads', async ({ page }) => {
@@ -31,6 +39,12 @@ test('programs page catalog loads', async ({ page }) => {
 
 // ---------------------------------------------------------------------------
 // 3. History page tabs render
+//
+// Structure-only assertion is intentional: the staging test user has no
+// records, so neither real data nor the fallback `[]` from
+// apps/web/app/history/page.tsx:37-38 produces visible content. The API
+// success path for history fetches is covered indirectly by test 5
+// (auth/API propagation against /api/health).
 // ---------------------------------------------------------------------------
 
 test('history page renders both tabs', async ({ page }) => {
@@ -46,6 +60,12 @@ test('history page renders both tabs', async ({ page }) => {
 
 // ---------------------------------------------------------------------------
 // 4. Cycle dashboard renders (or onboarding if no cycle exists)
+//
+// The URL-or-onboarding tolerance is intentional: the staging test user
+// has no active cycle, so the try/catch in apps/web/app/cycle/page.tsx:10-16
+// redirects to /onboarding on both "no cycle" and "API failed". This test
+// cannot distinguish the two; API-failure detection is delegated to test 5
+// which calls /api/health and asserts a specific HTTP 200.
 // ---------------------------------------------------------------------------
 
 test('cycle resolves to dashboard or onboarding', async ({ page }) => {

--- a/docs/standards/error-fallback-test-coverage.md
+++ b/docs/standards/error-fallback-test-coverage.md
@@ -1,0 +1,74 @@
+# Coding Standard: Test Coverage for Error-Swallowing Fallbacks
+
+**Applies to:** all packages and apps — anywhere a server component or API boundary swallows an error with a fallback value
+**Status:** Active
+**Related issue:** [#349 — Audit and remediate skewed tests across the codebase](https://github.com/brownm09/lifting-logbook/issues/349)
+**Related ADR:** [ADR-023 — Staging Integration Test Design](../adr/ADR-023-staging-integration-test-design.md)
+
+---
+
+## Rule
+
+When code swallows an error with a fallback value — `.catch(() => default)`, `?? default`, or a `try { … } catch { return neutral }` — the test coverage for that code path must do **one** of:
+
+1. **Assert a data-level value** that the success path produces and the fallback does not. This requires a predictable non-empty upstream (e.g., a catalog endpoint that always returns rows, or seeded test data).
+2. **Add a separate test that fails specifically when the upstream fails.** For UI tests, the canonical example is calling a backend health endpoint and asserting HTTP 200 (see `apps/web/e2e/staging.spec.ts` test 5 — "authenticated API call succeeds"). For controller / service unit tests, add a paired test that asserts the fallback branch with a rejected mock so success and failure paths are both exercised.
+3. **Document the intentional structure-only assertion with an inline comment** that names the source file and line of the swallowed fallback and explains why a data-level assertion is not appropriate (e.g., test user has no data, fallback shape is identical to the empty success case).
+
+A test that asserts only structure or presence — heading visible, tab visible, page renders — gives a false-green signal when paired with an error-swallowing source path: the assertion passes whether the upstream succeeded or its fallback was silently substituted.
+
+---
+
+## Why
+
+PR [#346](https://github.com/brownm09/lifting-logbook/pull/346) introduced graceful-degradation wrappers on three Next.js Server Components (`ProgramsPage`, `HistoryPage`, `CyclePage`) without updating the staging suite. The Playwright assertions checked only structure — headings, tab elements, URL patterns — so the staging suite continued to pass even when the backend API was unreachable. The graceful degradation itself is correct product behavior (per ADR-023), but the test surface no longer distinguished success from silent failure.
+
+This pattern can recur anywhere an error boundary returns a neutral value: empty arrays, default settings, redirects to a recovery page. The standard ensures every new occurrence is paired with a deliberate decision about test coverage.
+
+---
+
+## Examples
+
+### Good: explicit success-path test
+
+`apps/web/e2e/staging.spec.ts` test 5 calls `/api/health` directly and asserts HTTP 200, with diagnostic text differentiating 401 (auth) from 503 (API down). The test fails specifically when the upstream that the other tests rely on is broken — no fallback hides the error.
+
+### Good: paired controller branches
+
+`apps/api/src/programs/workouts.controller.spec.ts` exercises both the success and the fallback branches of every `.catch()` in `workouts.controller.ts`:
+
+- `getCycleDashboard.catch(ProgramNotFoundError → cycleNum 1)` — paired success and fallback tests, plus a rethrow test for non-typed errors.
+- `getWorkout.catch(WorkoutNotFoundError → [])` — paired success, fallback, and rethrow tests.
+- `getSkipsForCycle.catch(_ → Set())` — paired success and fallback tests; the fallback test also asserts the error was logged.
+
+### Bad: structure-only test against an error-swallowing source
+
+```ts
+// apps/web/app/history/page.tsx
+const records = await fetchLiftRecords().catch(() => []);
+
+// Test — passes whether records is real data OR the [] fallback
+test('history page renders both tabs', async ({ page }) => {
+  await page.goto('/history');
+  await expect(page.getByRole('tab', { name: 'Lift History' })).toBeVisible();
+});
+```
+
+When the staging test user genuinely has no records, this is acceptable **only if** the comment block above the test names the swallowed fallback location and explains why a data-level assertion is not appropriate. See the comment style in `apps/web/e2e/staging.spec.ts` tests 2–4.
+
+---
+
+## Enforcement
+
+- **Reviewer checklist.** When a PR adds or modifies a `.catch()`, `?? default`, or try/catch that returns a neutral value in a server component or API boundary, the reviewer must verify that one of the three options above is satisfied. The PR-body Testing section should make this explicit.
+- **CLAUDE.md `## Testing` rule.** A short subsection of the project CLAUDE.md points at this standard and applies the rule at PR creation time.
+- **Future static check.** A lint or CI gate that detects new skewed-test instances automatically is tracked in [#353](https://github.com/brownm09/lifting-logbook/issues/353).
+- **Audit coverage.** The initial audit (issue #349) covered `apps/web` and `apps/api`. A follow-up audit for `packages/core` and `packages/types` is tracked in [#354](https://github.com/brownm09/lifting-logbook/issues/354).
+
+---
+
+## References
+
+- [Issue #349 — Audit and remediate skewed tests](https://github.com/brownm09/lifting-logbook/issues/349) — the audit that produced this standard
+- [PR #346 — staging deploy with Playwright integration test gate](https://github.com/brownm09/lifting-logbook/pull/346) — the incident that surfaced the pattern, and the first explicit success-path test (test 5)
+- [ADR-023 — Staging Integration Test Design](../adr/ADR-023-staging-integration-test-design.md) — Consequences section names this limitation

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
     "apps/api": {
       "name": "@lifting-logbook/api",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
         "@clerk/backend": "^3.4.4",
@@ -7679,6 +7680,7 @@
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz",
       "integrity": "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=16.13"
       },


### PR DESCRIPTION
## Summary

Audits and remediates the skewed-test pattern surfaced by PR #346 — tests that pass under both the success path of an upstream call and the silent-fallback path of its `.catch(() => default)` wrapper, giving a false-green signal.

- `apps/web/e2e/staging.spec.ts` — Programs / History / Cycle tests now carry explanatory comments naming the swallowed-fallback source lines and explain why structure-only assertion is intentional for the staging test user. Auth/API success-path detection remains delegated to test 5 (`/api/health`).
- `apps/api/src/programs/workouts.controller.spec.ts` — adds two paired tests covering the previously untested fallback branches: `getCycleDashboard` rethrows non-`ProgramNotFoundError` errors (asserts the error is not narrowed into the fallback), and `getSkipsForCycle` treats failure as an empty skip set (and logs).
- `docs/standards/error-fallback-test-coverage.md` — new standard codifying the rule (data-level assertion, separate success-path test, or documented structure-only intent) with good/bad examples and enforcement notes. Added as a row to the Coding Standards table in `CLAUDE.md`.
- `CLAUDE.md` `## Testing` — new "Skewed-test rule" subsection pointing at the standard, plus a "Failure-tracking rule" subsection requiring every reported test failure to be fixed in the PR or tracked by an open GitHub issue cited in the body (prose alone no longer acceptable). Global equivalent tracked in [dev-env#281](https://github.com/brownm09/dev-env/issues/281).
- `apps/api/package.json` — adds `"postinstall": "prisma generate"` to fix a worktree-only ambient-failure class (4 API suite-load failures from an ungenerated `@prisma/client`). CI was already clean because the workflow generates the client explicitly; this closes the local/CI parity gap.

Closes #349

## Acceptance criteria

- [x] Audit all existing tests for the skewed pattern — see audit summary in the issue
- [x] For each instance, apply the right fix (data assertion / separate success-path test / documented structure-only)
- [x] Update `CLAUDE.md` `## Testing` with a rule that prevents new skewed tests from landing, backed by `docs/standards/error-fallback-test-coverage.md`

## Out of scope (filed as follow-ups)

- [#353](https://github.com/brownm09/lifting-logbook/issues/353) — Add static-analysis check to detect skewed tests
- [#354](https://github.com/brownm09/lifting-logbook/issues/354) — Audit `packages/core` / `packages/types` for analogous neutral-return patterns
- [dev-env#281](https://github.com/brownm09/dev-env/issues/281) — Tighten the global test-before-PR rule + optional `tests-baseline.json` extension to ADR-029

## Testing

After the `postinstall: prisma generate` script was added, a fresh worktree install yields:

```
npm test -w @lifting-logbook/api
Tests: 250 passed, 51 skipped, 0 failed
```

The 51 skipped are `apps/api/src/programs/programs.db.e2e.spec.ts`, intentionally gated on `DATABASE_URL` per ADR-029 Rule 2 — they run in CI's `db-integration` job. Documented at the top of that file.

Per-workspace verification:

```
npm test -w @lifting-logbook/api -- --testPathPatterns=workouts.controller.spec
Tests: 16 passed, 0 skipped, 0 failed (1.2s)

npm test -w @lifting-logbook/core
Tests: 145 passed, 0 skipped, 0 failed (11.4s)

npm test -w @lifting-logbook/web
Tests: 28 passed, 0 skipped, 0 failed (7.3s)
```

Suppression and test-integrity greps both clean — no new `ts-ignore`, `eslint-disable`, `it.skip`, `passWithNoTests`, or deleted test files.

Playwright `apps/web/e2e/staging.spec.ts` changes are comment-only for tests 2/3/4 (no behavior change). No new browser execution required to validate this PR.

## Coverage gate

This PR adds testable behavior (`WorkoutsController` fallback branches). Tests for both new branches are included in `workouts.controller.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
