### PR TITLE
[refactor] Remove currentWeekType placeholder from parser / CycleDashboard model

### DIFF
--- a/apps/api/prisma/migrations/20260527000000_remove_cycle_dashboard_current_week_type/migration.sql
+++ b/apps/api/prisma/migrations/20260527000000_remove_cycle_dashboard_current_week_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "cycle_dashboard" DROP COLUMN "currentWeekType";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -49,7 +49,6 @@ model CycleDashboard {
   cycleDate         DateTime
   sheetName         String
   cycleStartWeekday String
-  currentWeekType   String
   programType       String?
 
   @@unique([userId, program])

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -170,13 +170,11 @@ async function main() {
 
   // CycleDashboard — current cycle state
   const currentCycle = NUM_CYCLES;
-  const currentWeek = WEEK_TYPES[(currentCycle - 1) % 3]!;
   await prisma.cycleDashboard.upsert({
     where: { userId_program: { userId: SEED_USER_ID, program: PROGRAM } },
     update: {
       cycleNum: currentCycle,
       cycleDate: now,
-      currentWeekType: currentWeek.weekType,
     },
     create: {
       userId: SEED_USER_ID,
@@ -186,7 +184,6 @@ async function main() {
       cycleDate: now,
       sheetName: '531',
       cycleStartWeekday: 'Monday',
-      currentWeekType: currentWeek.weekType,
       programType: '531',
     },
   });

--- a/apps/api/src/adapters/in-memory/fixtures.ts
+++ b/apps/api/src/adapters/in-memory/fixtures.ts
@@ -21,7 +21,6 @@ export const seedCycleDashboard = (): CycleDashboard => ({
   cycleDate: new Date('2026-04-20T00:00:00.000Z'),
   sheetName: '',
   cycleStartWeekday: Weekday.Monday,
-  currentWeekType: 'training',
   programType: '5-3-1',
 });
 

--- a/apps/api/src/adapters/prisma/cycle-dashboard.repository.ts
+++ b/apps/api/src/adapters/prisma/cycle-dashboard.repository.ts
@@ -21,7 +21,6 @@ export class PrismaCycleDashboardRepository implements ICycleDashboardRepository
       cycleDate: row.cycleDate,
       sheetName: row.sheetName,
       cycleStartWeekday: row.cycleStartWeekday as Weekday,
-      currentWeekType: row.currentWeekType as CycleDashboard['currentWeekType'],
       ...(row.programType !== null && { programType: row.programType }),
     };
   }
@@ -37,7 +36,6 @@ export class PrismaCycleDashboardRepository implements ICycleDashboardRepository
         cycleDate: dashboard.cycleDate,
         sheetName: dashboard.sheetName,
         cycleStartWeekday: dashboard.cycleStartWeekday,
-        currentWeekType: dashboard.currentWeekType,
         programType: dashboard.programType ?? null,
       },
       update: {
@@ -46,7 +44,6 @@ export class PrismaCycleDashboardRepository implements ICycleDashboardRepository
         cycleDate: dashboard.cycleDate,
         sheetName: dashboard.sheetName,
         cycleStartWeekday: dashboard.cycleStartWeekday,
-        currentWeekType: dashboard.currentWeekType,
         programType: dashboard.programType ?? null,
       },
     });

--- a/apps/api/src/programs/cycle-dashboard.controller.spec.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.spec.ts
@@ -12,15 +12,13 @@ import { CycleDashboardController } from './cycle-dashboard.controller';
 
 const MOCK_USER = { id: 'test-user', email: 'test@example.com', provider: 'dev' };
 
-const stubDashboard = (overrides: Partial<{ currentWeekType: 'training' | 'test' | 'deload' }> = {}) => ({
+const stubDashboard = () => ({
   program: '5-3-1',
   cycleUnit: 'week' as const,
   cycleNum: 2,
   cycleDate: new Date('2026-04-20T00:00:00.000Z'),
   sheetName: '',
   cycleStartWeekday: Weekday.Monday,
-  currentWeekType: 'training' as const,
-  ...overrides,
 });
 
 const stubSpec = (weekType: 'training' | 'test' | 'deload' = 'training') => [{

--- a/apps/api/src/programs/cycle-dashboard.controller.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.ts
@@ -25,7 +25,7 @@ export class CycleDashboardController {
       cycleDashboard.getCycleDashboard(program),
       liftingProgramSpec.getProgramSpec(program),
     ]);
-    dashboard.currentWeekType = weekTypeForDate(dashboard.cycleDate, programSpec);
+    const currentWeekType = weekTypeForDate(dashboard.cycleDate, programSpec);
 
     const [scheduledWorkouts, liftRecords, overrideMap, skippedNums] = await Promise.all([
       cycleScheduledWorkout.getScheduledWorkouts(program, dashboard.cycleNum),
@@ -35,6 +35,6 @@ export class CycleDashboardController {
     ]);
     const completedWorkoutNums = new Set(liftRecords.map((r) => r.workoutNum));
 
-    return buildCycleDashboardResponse(dashboard, scheduledWorkouts, overrideMap, completedWorkoutNums, skippedNums);
+    return buildCycleDashboardResponse(dashboard, currentWeekType, scheduledWorkouts, overrideMap, completedWorkoutNums, skippedNums);
   }
 }

--- a/apps/api/src/programs/cycle-generation.controller.spec.ts
+++ b/apps/api/src/programs/cycle-generation.controller.spec.ts
@@ -24,9 +24,7 @@ const stubProgramSpec = () => [{
   weekType: 'training' as const,
 }];
 
-const MOCK_BUNDLE = {
-  liftingProgramSpec: { getProgramSpec: jest.fn().mockResolvedValue(stubProgramSpec()) },
-} as unknown as RepositoryBundle;
+const MOCK_BUNDLE = {} as RepositoryBundle;
 
 const stubCycleDashboard = () => ({
   program: PROGRAM,
@@ -65,7 +63,7 @@ describe('CycleGenerationController', () => {
 
   describe('startNewCycle', () => {
     it('calls service with repos, program, and dto, returns mapped response', async () => {
-      service.startNewCycle.mockResolvedValue(stubCycleDashboard());
+      service.startNewCycle.mockResolvedValue({ dashboard: stubCycleDashboard(), programSpec: stubProgramSpec() });
 
       const result = await controller.startNewCycle(PROGRAM, {}, MOCK_USER);
 
@@ -81,7 +79,7 @@ describe('CycleGenerationController', () => {
     });
 
     it('passes fromCycleNum and cycleDate through to service', async () => {
-      service.startNewCycle.mockResolvedValue(stubCycleDashboard());
+      service.startNewCycle.mockResolvedValue({ dashboard: stubCycleDashboard(), programSpec: stubProgramSpec() });
 
       await controller.startNewCycle(PROGRAM, {
         fromCycleNum: 1,
@@ -115,7 +113,7 @@ describe('CycleGenerationController', () => {
     });
 
     it('calls service with repos, program, and dto, returns mapped response', async () => {
-      service.initializeFirstCycle.mockResolvedValue(stubInitDashboard());
+      service.initializeFirstCycle.mockResolvedValue({ dashboard: stubInitDashboard(), programSpec: stubProgramSpec() });
 
       const result = await controller.initializeFirstCycle(PROGRAM, {}, MOCK_USER);
 
@@ -131,7 +129,7 @@ describe('CycleGenerationController', () => {
     });
 
     it('passes optional cycleDate through to service', async () => {
-      service.initializeFirstCycle.mockResolvedValue(stubInitDashboard());
+      service.initializeFirstCycle.mockResolvedValue({ dashboard: stubInitDashboard(), programSpec: stubProgramSpec() });
 
       await controller.initializeFirstCycle(PROGRAM, { cycleDate: '2026-05-12' }, MOCK_USER);
 

--- a/apps/api/src/programs/cycle-generation.controller.spec.ts
+++ b/apps/api/src/programs/cycle-generation.controller.spec.ts
@@ -6,9 +6,27 @@ import { CycleGenerationController } from './cycle-generation.controller';
 import { CycleGenerationService } from './cycle-generation.service';
 
 const MOCK_USER = { id: 'test-user', email: 'test@example.com', provider: 'dev' };
-const MOCK_BUNDLE = {} as RepositoryBundle;
 
 const PROGRAM = '5-3-1';
+
+const stubProgramSpec = () => [{
+  week: 1,
+  offset: 0,
+  lift: 'Squat',
+  increment: 5,
+  order: 1,
+  sets: 3,
+  reps: 5,
+  amrap: false,
+  warmUpPct: '40,50,60',
+  wtDecrementPct: 0,
+  activation: 'None',
+  weekType: 'training' as const,
+}];
+
+const MOCK_BUNDLE = {
+  liftingProgramSpec: { getProgramSpec: jest.fn().mockResolvedValue(stubProgramSpec()) },
+} as unknown as RepositoryBundle;
 
 const stubCycleDashboard = () => ({
   program: PROGRAM,
@@ -17,7 +35,6 @@ const stubCycleDashboard = () => ({
   cycleDate: new Date('2026-04-27T00:00:00.000Z'),
   sheetName: '5-3-1_Cycle_2_20260427',
   cycleStartWeekday: Weekday.Monday,
-  currentWeekType: 'training' as const,
 });
 
 describe('CycleGenerationController', () => {
@@ -94,7 +111,6 @@ describe('CycleGenerationController', () => {
       cycleDate: new Date('2026-05-12T00:00:00.000Z'),
       sheetName: '5-3-1_Cycle_1_20260512',
       cycleStartWeekday: Weekday.Monday,
-      currentWeekType: 'training' as const,
       programType: '5-3-1',
     });
 

--- a/apps/api/src/programs/cycle-generation.controller.ts
+++ b/apps/api/src/programs/cycle-generation.controller.ts
@@ -3,6 +3,7 @@ import {
   CycleDashboardResponse,
   RecalculateMaxesResponse,
 } from '@lifting-logbook/types';
+import { weekTypeForDate } from '@lifting-logbook/core';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../ports/auth';
 import { IRepositoryFactory } from '../ports/factory';
@@ -30,7 +31,9 @@ export class CycleGenerationController {
   ): Promise<CycleDashboardResponse> {
     const repos = await this.factory.forUser(user);
     const dashboard = await this.cycleGenerationService.initializeFirstCycle(repos, program, dto);
-    return toCycleDashboardResponse(dashboard);
+    const programSpec = await repos.liftingProgramSpec.getProgramSpec(program);
+    const currentWeekType = weekTypeForDate(dashboard.cycleDate, programSpec);
+    return toCycleDashboardResponse(dashboard, currentWeekType);
   }
 
   @Post('cycles')
@@ -41,7 +44,9 @@ export class CycleGenerationController {
   ): Promise<CycleDashboardResponse> {
     const repos = await this.factory.forUser(user);
     const newCycle = await this.cycleGenerationService.startNewCycle(repos, program, dto);
-    return toCycleDashboardResponse(newCycle);
+    const programSpec = await repos.liftingProgramSpec.getProgramSpec(program);
+    const currentWeekType = weekTypeForDate(newCycle.cycleDate, programSpec);
+    return toCycleDashboardResponse(newCycle, currentWeekType);
   }
 
   @Post('training-maxes/recalculate')

--- a/apps/api/src/programs/cycle-generation.controller.ts
+++ b/apps/api/src/programs/cycle-generation.controller.ts
@@ -30,8 +30,7 @@ export class CycleGenerationController {
     @CurrentUser() user: AuthUser,
   ): Promise<CycleDashboardResponse> {
     const repos = await this.factory.forUser(user);
-    const dashboard = await this.cycleGenerationService.initializeFirstCycle(repos, program, dto);
-    const programSpec = await repos.liftingProgramSpec.getProgramSpec(program);
+    const { dashboard, programSpec } = await this.cycleGenerationService.initializeFirstCycle(repos, program, dto);
     const currentWeekType = weekTypeForDate(dashboard.cycleDate, programSpec);
     return toCycleDashboardResponse(dashboard, currentWeekType);
   }
@@ -43,8 +42,7 @@ export class CycleGenerationController {
     @CurrentUser() user: AuthUser,
   ): Promise<CycleDashboardResponse> {
     const repos = await this.factory.forUser(user);
-    const newCycle = await this.cycleGenerationService.startNewCycle(repos, program, dto);
-    const programSpec = await repos.liftingProgramSpec.getProgramSpec(program);
+    const { dashboard: newCycle, programSpec } = await this.cycleGenerationService.startNewCycle(repos, program, dto);
     const currentWeekType = weekTypeForDate(newCycle.cycleDate, programSpec);
     return toCycleDashboardResponse(newCycle, currentWeekType);
   }

--- a/apps/api/src/programs/cycle-generation.service.spec.ts
+++ b/apps/api/src/programs/cycle-generation.service.spec.ts
@@ -127,7 +127,7 @@ describe('CycleGenerationService', () => {
       trainingMaxRepo.getTrainingMaxes.mockResolvedValue(stubTrainingMaxes());
       liftRecordRepo.getLiftRecords.mockResolvedValue(stubLiftRecords());
 
-      const result = await service.startNewCycle(repos, PROGRAM);
+      const { dashboard: result } = await service.startNewCycle(repos, PROGRAM);
 
       expect(result.cycleNum).toBe(2);
       expect(result.program).toBe(PROGRAM);
@@ -171,7 +171,7 @@ describe('CycleGenerationService', () => {
       trainingMaxRepo.getTrainingMaxes.mockResolvedValue(stubTrainingMaxes());
       liftRecordRepo.getLiftRecords.mockResolvedValue(stubLiftRecords());
 
-      const result = await service.startNewCycle(repos, PROGRAM, { fromCycleNum: 3 });
+      const { dashboard: result } = await service.startNewCycle(repos, PROGRAM, { fromCycleNum: 3 });
 
       expect(liftRecordRepo.getLiftRecords).toHaveBeenCalledWith(PROGRAM, 3);
       expect(result.cycleNum).toBe(4);
@@ -194,7 +194,7 @@ describe('CycleGenerationService', () => {
       trainingMaxRepo.getTrainingMaxes.mockResolvedValue(stubTrainingMaxes());
       liftRecordRepo.getLiftRecords.mockResolvedValue(stubLiftRecords());
 
-      const result = await service.startNewCycle(repos, PROGRAM, { cycleDate: '2026-06-01' });
+      const { dashboard: result } = await service.startNewCycle(repos, PROGRAM, { cycleDate: '2026-06-01' });
 
       expect(result.cycleDate).toEqual(new Date('2026-06-01T00:00:00.000Z'));
     });
@@ -238,7 +238,7 @@ describe('CycleGenerationService', () => {
         new ProgramNotFoundError(PROGRAM),
       );
 
-      const result = await service.initializeFirstCycle(
+      const { dashboard: result } = await service.initializeFirstCycle(
         repos,
         PROGRAM,
         { cycleDate: '2026-05-12' },
@@ -260,7 +260,7 @@ describe('CycleGenerationService', () => {
       );
 
       const before = new Date();
-      const result = await service.initializeFirstCycle(repos, PROGRAM);
+      const { dashboard: result } = await service.initializeFirstCycle(repos, PROGRAM);
       const after = new Date();
 
       expect(result.cycleDate.getTime()).toBeGreaterThanOrEqual(before.getTime() - 1000);

--- a/apps/api/src/programs/cycle-generation.service.spec.ts
+++ b/apps/api/src/programs/cycle-generation.service.spec.ts
@@ -21,7 +21,6 @@ const stubDashboard = () => ({
   cycleDate: new Date('2026-04-20T00:00:00.000Z'),
   sheetName: '',
   cycleStartWeekday: Weekday.Monday,
-  currentWeekType: 'training' as const,
 });
 
 const stubProgramSpec = () => [

--- a/apps/api/src/programs/cycle-generation.service.ts
+++ b/apps/api/src/programs/cycle-generation.service.ts
@@ -11,6 +11,7 @@ import {
   TrainingMaxHistoryEntry,
   updateCycle,
   updateMaxes,
+  weekTypeForDate,
   WEEKDAY_MAP,
   Weekday,
 } from '@lifting-logbook/core';
@@ -159,7 +160,7 @@ export class CycleGenerationService {
     }
     await repos.cycleDashboard.saveCycleDashboard(newCycle);
 
-    const source = dashboard.currentWeekType === 'test' ? 'test' : 'program';
+    const source = weekTypeForDate(dashboard.cycleDate, programSpec) === 'test' ? 'test' : 'program';
     const historyEntries = buildHistoryEntries(trainingMaxes, newMaxes, newCycle.cycleDate, source);
     if (historyEntries.length > 0) {
       await repos.trainingMaxHistory.appendHistoryEntries(program, historyEntries);
@@ -206,7 +207,6 @@ export class CycleGenerationService {
       cycleDate,
       sheetName: `${program}_Cycle_1_${formatDateYYYYMMDD(cycleDate)}`,
       cycleStartWeekday: weekdayName,
-      currentWeekType: 'training',
       programType: defaults.programType,
     };
 

--- a/apps/api/src/programs/cycle-generation.service.ts
+++ b/apps/api/src/programs/cycle-generation.service.ts
@@ -111,13 +111,18 @@ function buildHistoryEntries(
     }));
 }
 
+export interface CycleGenerationResult {
+  dashboard: CycleDashboard;
+  programSpec: LiftingProgramSpec[];
+}
+
 @Injectable()
 export class CycleGenerationService {
   async startNewCycle(
     repos: CycleRepos,
     program: string,
     dto: StartNewCycleDto = {},
-  ): Promise<CycleDashboard> {
+  ): Promise<CycleGenerationResult> {
     const dashboard = await repos.cycleDashboard.getCycleDashboard(program);
     const sourceCycleNum = dto.fromCycleNum ?? dashboard.cycleNum;
 
@@ -160,20 +165,23 @@ export class CycleGenerationService {
     }
     await repos.cycleDashboard.saveCycleDashboard(newCycle);
 
+    // Source reflects the week type of the cycle being closed (the previous
+    // dashboard), not the new cycle being opened — hence `dashboard.cycleDate`,
+    // not `newCycle.cycleDate`.
     const source = weekTypeForDate(dashboard.cycleDate, programSpec) === 'test' ? 'test' : 'program';
     const historyEntries = buildHistoryEntries(trainingMaxes, newMaxes, newCycle.cycleDate, source);
     if (historyEntries.length > 0) {
       await repos.trainingMaxHistory.appendHistoryEntries(program, historyEntries);
     }
 
-    return newCycle;
+    return { dashboard: newCycle, programSpec };
   }
 
   async initializeFirstCycle(
     repos: Pick<CycleRepos, 'cycleDashboard' | 'cycleScheduledWorkout' | 'liftingProgramSpec' | 'userSettings'>,
     program: string,
     dto: { cycleDate?: string } = {},
-  ): Promise<CycleDashboard> {
+  ): Promise<CycleGenerationResult> {
     // Guard: fail fast if a cycle already exists for this user+program
     try {
       await repos.cycleDashboard.getCycleDashboard(program);
@@ -210,13 +218,15 @@ export class CycleGenerationService {
       programType: defaults.programType,
     };
 
-    const settings = await repos.userSettings.getSettings();
+    const [settings, programSpec] = await Promise.all([
+      repos.userSettings.getSettings(),
+      repos.liftingProgramSpec.getProgramSpec(program),
+    ]);
     if (settings.workoutSchedule) {
-      const spec = await repos.liftingProgramSpec.getProgramSpec(program);
-      await saveScheduledDates(repos, program, dashboard.cycleNum, dashboard.cycleDate, spec, settings.workoutSchedule);
+      await saveScheduledDates(repos, program, dashboard.cycleNum, dashboard.cycleDate, programSpec, settings.workoutSchedule);
     }
     await repos.cycleDashboard.saveCycleDashboard(dashboard);
-    return dashboard;
+    return { dashboard, programSpec };
   }
 
   async recalculateMaxes(

--- a/apps/api/src/programs/lift-records.controller.spec.ts
+++ b/apps/api/src/programs/lift-records.controller.spec.ts
@@ -16,7 +16,6 @@ const SEED_DASHBOARD = {
   cycleDate: new Date('2026-04-20T00:00:00.000Z'),
   sheetName: '',
   cycleStartWeekday: Weekday.Monday,
-  currentWeekType: 'training' as const,
 };
 
 const SEED_RECORD = {

--- a/apps/api/src/programs/mappers.spec.ts
+++ b/apps/api/src/programs/mappers.spec.ts
@@ -180,11 +180,12 @@ describe('buildCycleDashboardResponse', () => {
     program: 'test-531',
     cycleNum: 1,
     cycleDate: new Date('2026-05-19T00:00:00.000Z'),
-    currentWeekType: 1,
     cycleUnit: 'week',
     sheetName: 'Sheet1',
     cycleStartWeekday: Weekday.Monday,
   };
+
+  const WEEK_TYPE = 'training' as const;
 
   const sw = (workoutNum: number, weekNum: number, date: string): ScheduledWorkout => ({
     workoutNum,
@@ -193,13 +194,13 @@ describe('buildCycleDashboardResponse', () => {
   });
 
   it('returns base response when scheduled array is empty', () => {
-    const result = buildCycleDashboardResponse(baseDashboard, [], new Map(), new Set());
+    const result = buildCycleDashboardResponse(baseDashboard, WEEK_TYPE, [], new Map(), new Set());
     expect(result.weeks).toEqual([]);
   });
 
   it('emits workouts[] with workoutNum and date per entry', () => {
     const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21'), sw(3, 2, '2026-05-26')];
-    const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), new Set());
+    const result = buildCycleDashboardResponse(baseDashboard, WEEK_TYPE, scheduled, new Map(), new Set());
     expect(result.weeks).toHaveLength(2);
     const week1 = result.weeks[0]!;
     expect(week1.week).toBe(1);
@@ -214,28 +215,28 @@ describe('buildCycleDashboardResponse', () => {
   it('applies override date when present', () => {
     const scheduled = [sw(1, 1, '2026-05-19')];
     const overrides = new Map([[1, new Date('2026-05-20T00:00:00.000Z')]]);
-    const result = buildCycleDashboardResponse(baseDashboard, scheduled, overrides, new Set());
+    const result = buildCycleDashboardResponse(baseDashboard, WEEK_TYPE, scheduled, overrides, new Set());
     expect(result.weeks[0]!.workouts[0]).toEqual({ workoutNum: 1, date: '2026-05-20', skipped: false });
   });
 
   it('marks week completed when all workouts have records', () => {
     const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21')];
     const completed = new Set([1, 2]);
-    const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), completed);
+    const result = buildCycleDashboardResponse(baseDashboard, WEEK_TYPE, scheduled, new Map(), completed);
     expect(result.weeks[0]!.completed).toBe(true);
   });
 
   it('week is incomplete when only some workouts have records', () => {
     const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21')];
     const completed = new Set([1]);
-    const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), completed);
+    const result = buildCycleDashboardResponse(baseDashboard, WEEK_TYPE, scheduled, new Map(), completed);
     expect(result.weeks[0]!.completed).toBe(false);
   });
 
   it('marks skipped workout as skipped:true in output', () => {
     const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21')];
     const skipped = new Set([1]);
-    const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), new Set(), skipped);
+    const result = buildCycleDashboardResponse(baseDashboard, WEEK_TYPE, scheduled, new Map(), new Set(), skipped);
     expect(result.weeks[0]!.workouts[0]!.skipped).toBe(true);
     expect(result.weeks[0]!.workouts[1]!.skipped).toBe(false);
   });
@@ -244,14 +245,14 @@ describe('buildCycleDashboardResponse', () => {
     const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21')];
     const completed = new Set([1]);
     const skipped = new Set([2]);
-    const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), completed, skipped);
+    const result = buildCycleDashboardResponse(baseDashboard, WEEK_TYPE, scheduled, new Map(), completed, skipped);
     expect(result.weeks[0]!.completed).toBe(true);
   });
 
   it('week is incomplete when a skipped workout still has an un-logged sibling', () => {
     const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21'), sw(3, 1, '2026-05-23')];
     const skipped = new Set([1]);
-    const result = buildCycleDashboardResponse(baseDashboard, scheduled, new Map(), new Set(), skipped);
+    const result = buildCycleDashboardResponse(baseDashboard, WEEK_TYPE, scheduled, new Map(), new Set(), skipped);
     expect(result.weeks[0]!.completed).toBe(false);
   });
 });

--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -18,6 +18,7 @@ import {
   TrainingMaxHistoryEntryResponse,
   TrainingMaxResponse,
   WeekNumber,
+  WeekType,
   WorkoutLiftResponse,
   WorkoutResponse,
   WorkoutSummary,
@@ -92,15 +93,20 @@ export const toLiftingProgramSpecResponse = (
 /**
  * Maps a CycleDashboard to a CycleDashboardResponse with no schedule data.
  * Used when no scheduled workouts exist (no-schedule mode).
+ *
+ * `currentWeekType` is passed explicitly because it is derived at request time
+ * via `weekTypeForDate(dashboard.cycleDate, programSpec)`, not stored on the
+ * dashboard model.
  */
 export const toCycleDashboardResponse = (
   d: CycleDashboard,
+  currentWeekType: WeekType,
 ): CycleDashboardResponse => ({
   program: d.program,
   cycleNum: d.cycleNum,
   cycleStartDate: isoDate(d.cycleDate),
   weeks: [],
-  currentWeekType: d.currentWeekType,
+  currentWeekType,
 });
 
 /**
@@ -111,13 +117,14 @@ export const toCycleDashboardResponse = (
  */
 export function buildCycleDashboardResponse(
   d: CycleDashboard,
+  currentWeekType: WeekType,
   scheduled: ScheduledWorkout[],
   overrides: Map<number, Date>,
   completedWorkoutNums: Set<number>,
   skippedNums: Set<number> = new Set(),
 ): CycleDashboardResponse {
   if (scheduled.length === 0) {
-    return toCycleDashboardResponse(d);
+    return toCycleDashboardResponse(d, currentWeekType);
   }
 
   const weekAcc = new Map<number, { workouts: WorkoutSummary[]; scheduled: ScheduledWorkout[] }>();
@@ -151,7 +158,7 @@ export function buildCycleDashboardResponse(
     cycleNum: d.cycleNum,
     cycleStartDate: isoDate(d.cycleDate),
     weeks,
-    currentWeekType: d.currentWeekType,
+    currentWeekType,
   };
 }
 

--- a/apps/api/src/programs/programs.db.e2e.spec.ts
+++ b/apps/api/src/programs/programs.db.e2e.spec.ts
@@ -126,7 +126,6 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
         cycleDate: dashboard.cycleDate,
         sheetName: dashboard.sheetName,
         cycleStartWeekday: dashboard.cycleStartWeekday,
-        currentWeekType: dashboard.currentWeekType,
         programType: dashboard.programType ?? null,
       },
     });
@@ -907,7 +906,6 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
           cycleDate: dash.cycleDate,
           sheetName: dash.sheetName,
           cycleStartWeekday: dash.cycleStartWeekday,
-          currentWeekType: dash.currentWeekType,
           programType: dash.programType ?? null,
         },
       });

--- a/apps/api/src/programs/switch-program.controller.ts
+++ b/apps/api/src/programs/switch-program.controller.ts
@@ -53,7 +53,7 @@ export class SwitchProgramController {
       cycleNum = existing.cycleNum;
     } catch (e) {
       if (e instanceof ProgramNotFoundError) {
-        const dashboard = await this.cycleGenerationService.initializeFirstCycle(repos, program);
+        const { dashboard } = await this.cycleGenerationService.initializeFirstCycle(repos, program);
         cycleNum = dashboard.cycleNum;
       } else {
         throw e;

--- a/apps/api/src/programs/workouts.controller.spec.ts
+++ b/apps/api/src/programs/workouts.controller.spec.ts
@@ -77,7 +77,6 @@ describe('WorkoutsController', () => {
       cycleDate: new Date('2026-04-20T00:00:00.000Z'),
       sheetName: '',
       cycleStartWeekday: Weekday.Monday,
-      currentWeekType: 'training' as const,
     });
     specRepo.getProgramSpec.mockResolvedValue([
       {
@@ -155,7 +154,6 @@ describe('WorkoutsController', () => {
       cycleDate: new Date('2026-04-20T00:00:00.000Z'),
       sheetName: '',
       cycleStartWeekday: Weekday.Monday,
-      currentWeekType: 'training' as const,
     });
     workoutRepo.getWorkout.mockResolvedValue([]);
 
@@ -178,7 +176,6 @@ describe('WorkoutsController', () => {
       cycleDate: new Date('2026-04-20T00:00:00.000Z'),
       sheetName: '',
       cycleStartWeekday: Weekday.Monday,
-      currentWeekType: 'training' as const,
     });
     specRepo.getProgramSpec.mockResolvedValue([
       {
@@ -209,7 +206,6 @@ describe('WorkoutsController', () => {
       cycleDate: new Date('2026-04-20T00:00:00.000Z'),
       sheetName: '',
       cycleStartWeekday: Weekday.Monday,
-      currentWeekType: 'training' as const,
     };
     const baseSpec = [
       {
@@ -269,7 +265,6 @@ describe('WorkoutsController', () => {
       cycleDate: new Date('2026-04-20T00:00:00.000Z'),
       sheetName: '',
       cycleStartWeekday: Weekday.Monday,
-      currentWeekType: 'training' as const,
     };
     const twoLiftSpec = [
       { week: 1, offset: 0, lift: 'Squat', increment: 5, order: 1, sets: 3, reps: 5, amrap: false, warmUpPct: '', wtDecrementPct: 0, activation: 'compound' },
@@ -350,7 +345,6 @@ describe('WorkoutsController', () => {
       cycleDate: new Date('2026-04-20T00:00:00.000Z'),
       sheetName: '',
       cycleStartWeekday: Weekday.Monday,
-      currentWeekType: 'training' as const,
     };
     const spec = [
       { week: 1, offset: 0, lift: 'Squat', increment: 5, order: 1, sets: 3, reps: 5, amrap: false, warmUpPct: '', wtDecrementPct: 0, activation: 'compound' },

--- a/docs/adr/ADR-017-training-max-history-table.md
+++ b/docs/adr/ADR-017-training-max-history-table.md
@@ -43,7 +43,7 @@ A heuristic derivation might cover the 80% case today, but every future schema c
 ### Why a new table is correct
 
 - **Explicit write path**: `CycleGenerationService` already knows which maxes changed (it diffs `prevMaxes` vs. `newMaxes`). Appending a history row is a one-liner at the call site with zero inference needed.
-- **Source is known at write time**: `dashboard.currentWeekType` is available before the write; storing it then is reliable. Reconstructing it later is not.
+- **Source is known at write time**: the current week type is derivable from `weekTypeForDate(dashboard.cycleDate, programSpec)` before the write; computing it then is reliable. Reconstructing it later is not.
 - **User overrides are first-class**: `isPR` and `goalMet` are mutable boolean columns. They cannot live on a derived view.
 - **Query simplicity**: Filtering history by lift, source, or isPR is a straightforward indexed query. A derived approach would require multi-table aggregation on every page load.
 - **Append-only semantics**: History rows are never updated on max changes — each change is a new row. Only `isPR` and `goalMet` are mutable (user corrections). This makes the table easy to reason about and audit.
@@ -78,7 +78,7 @@ model TrainingMaxHistory {
 }
 ```
 
-**Write path**: `CycleGenerationService.startNewCycle` and `recalculateMaxes` diff old vs. new maxes and call `ITrainingMaxHistoryRepository.appendHistoryEntries` for changed lifts. Source is `'test'` when `dashboard.currentWeekType === 'test'`, otherwise `'program'`.
+**Write path**: `CycleGenerationService.startNewCycle` and `recalculateMaxes` diff old vs. new maxes and call `ITrainingMaxHistoryRepository.appendHistoryEntries` for changed lifts. Source is `'test'` when `weekTypeForDate(dashboard.cycleDate, programSpec) === 'test'`, otherwise `'program'`. Historically the week type was read from a `currentWeekType` column on the dashboard, but that column was a placeholder — it was overwritten at request time and never authoritative — and was removed in [#361](https://github.com/brownm09/lifting-logbook/issues/361).
 
 **Read path**: `GET /programs/:program/training-maxes/history` with optional `?lift=`, `?source=`, `?isPR=` query params.
 

--- a/docs/proposals/2026-04-30-initial-training-max-discovery.md
+++ b/docs/proposals/2026-04-30-initial-training-max-discovery.md
@@ -34,8 +34,13 @@ Three coordinated changes:
 
 Add `WeekType` (`'training' | 'test' | 'deload'`) to `packages/types/src/domain.ts`. Add an
 optional `weekType?: WeekType` per-row field to `LiftingProgramSpec` (default: `'training'`).
-`CycleDashboard` gains `currentWeekType: WeekType` reflecting the week-level declared type
-(not a per-exercise aggregate). The Sheets parser reads an optional `Week Type` column
+The week-level declared type is derived at request time via
+`weekTypeForDate(cycleDate, programSpec)` and exposed on the
+`CycleDashboardResponse` as `currentWeekType` (not a per-exercise aggregate).
+Originally proposed as a stored `CycleDashboard.currentWeekType` field; that
+placeholder was removed in [#361](https://github.com/brownm09/lifting-logbook/issues/361)
+because the value is never authoritative — it is always re-derived from the program
+spec and date. The Sheets parser reads an optional `Week Type` column
 per-row; blank rows inherit the first non-blank value in the same week, defaulting to
 `'training'` if the entire week is blank. Simple programs use a uniform week type; advanced
 programs may override per exercise.
@@ -79,8 +84,9 @@ feature is implemented (deferred).
       blank rows inherit the first non-blank value in the same week; all-blank week defaults
       to `'training'`; simple programs use a uniform week type; advanced programs may override
       per exercise
-- [ ] `CycleDashboard.currentWeekType: WeekType` — the week-level declared type (first
-      non-blank `weekType` value in the active week's spec rows); not a per-exercise aggregate
+- [ ] `weekTypeForDate(cycleDate, programSpec)` derives the week-level declared type
+      (first non-blank `weekType` value in the active week's spec rows) at request time;
+      not a per-exercise aggregate, not stored on `CycleDashboard`
 - [ ] `estimateTrainingMax(weight, reps): number` in `packages/core` using Brzycki formula,
       rounded to nearest 5 lbs; valid rep range enforced (1–36); exported from package
       public API
@@ -107,7 +113,7 @@ feature is implemented (deferred).
 
 - [`packages/types/src/domain.ts`](../../packages/types/src/domain.ts) — where `WeekType` enum belongs
 - [`packages/core/src/models/LiftingProgramSpec.ts`](../../packages/core/src/models/LiftingProgramSpec.ts) — model to extend with `weekType`
-- [`packages/core/src/models/CycleDashboard.ts`](../../packages/core/src/models/CycleDashboard.ts) — model to extend with `currentWeekType`
+- [`packages/core/src/utils/jsUtil.ts`](../../packages/core/src/utils/jsUtil.ts) — `weekTypeForDate(cycleDate, programSpec)` derives `currentWeekType` at request time
 - [`packages/core/src/services/maxes/updateMaxes.ts`](../../packages/core/src/services/maxes/updateMaxes.ts) — progression gate to relax for test weeks
 - [`packages/core/src/services/workout/generateLiftPlan.ts`](../../packages/core/src/services/workout/generateLiftPlan.ts) — ramp-up protocol generation basis
 - PRD §Non-Goals — "Deload / missed-session recovery" originally deferred; deload is now in scope as a distinct week type with defined progression behavior

--- a/packages/core/src/models/CycleDashboard.ts
+++ b/packages/core/src/models/CycleDashboard.ts
@@ -18,6 +18,7 @@ export interface CycleDashboard {
   cycleDate: Date;
   sheetName: string;
   cycleStartWeekday: Weekday;
-  currentWeekType: WeekType;
+  // Derived at request time via weekTypeForDate(); not stored on the dashboard sheet.
+  currentWeekType?: WeekType;
   programType?: string;
 }

--- a/packages/core/src/utils/parser/parseCycleDashboard.ts
+++ b/packages/core/src/utils/parser/parseCycleDashboard.ts
@@ -1,4 +1,3 @@
-import { WeekType } from "@lifting-logbook/types";
 import { CycleDashboard, SpreadsheetCell, Weekday } from "@src/core/models";
 import {
   CYCLE_DATE_KEY,
@@ -76,7 +75,5 @@ export function parseCycleDashboard(data: SpreadsheetCell[][]): CycleDashboard {
     cycleDate,
     sheetName,
     cycleStartWeekday,
-    // currentWeekType is derived from the program spec at request time, not stored in the dashboard sheet
-    currentWeekType: 'training' as WeekType,
   };
 }

--- a/packages/core/tests/core/services/dashboard/updateCycle.test.ts
+++ b/packages/core/tests/core/services/dashboard/updateCycle.test.ts
@@ -9,7 +9,6 @@ describe("updateCycle", () => {
       cycleDate: new Date(2026, 0, 5, 0, 0, 0, 0),
       sheetName: "RPT_Cycle_1_20260105",
       cycleStartWeekday: Weekday.Monday,
-      currentWeekType: 'training',
     };
     const overrides = {
       targetWeekday: "Monday" as Weekday,
@@ -29,7 +28,6 @@ describe("updateCycle", () => {
       cycleDate: new Date(2026, 0, 5, 0, 0, 0, 0),
       sheetName: "RPT_Cycle_1_20260105",
       cycleStartWeekday: Weekday.Monday,
-      currentWeekType: 'training',
     };
     const overrides = {
       targetWeekday: "Friday" as Weekday,
@@ -52,7 +50,6 @@ describe("updateCycle", () => {
       cycleDate: new Date(2026, 0, 12, 0, 0, 0, 0), // Monday
       sheetName: "RPT_Cycle_2_20260112",
       cycleStartWeekday: Weekday.Monday,
-      currentWeekType: 'training',
     };
     const overrides = {
       today: new Date(2026, 0, 19, 0, 0, 0, 0),
@@ -72,7 +69,6 @@ describe("updateCycle", () => {
       cycleDate: new Date(2026, 0, 19, 0, 0, 0, 0), // Monday
       sheetName: "RPT_Cycle_3_20260119",
       cycleStartWeekday: Weekday.Monday,
-      currentWeekType: 'training',
     };
     const overrides = {
       targetWeekday: "friday" as Weekday,
@@ -93,7 +89,6 @@ describe("updateCycle", () => {
       cycleDate: new Date(2026, 0, 23, 0, 0, 0, 0), // Friday
       sheetName: "RPT_Cycle_4_20260123",
       cycleStartWeekday: Weekday.Friday,
-      currentWeekType: 'training',
     };
     // Today is before the next Friday
     const overrides = {
@@ -115,7 +110,6 @@ describe("updateCycle", () => {
       cycleDate: new Date(2026, 0, 25, 0, 0, 0, 0), // Sunday
       sheetName: "RPT_Cycle_5_20260125",
       cycleStartWeekday: Weekday.Sunday,
-      currentWeekType: 'training',
     };
     const overrides = {
       targetWeekday: "Sunday" as Weekday,

--- a/packages/core/tests/core/utils/mapper/mapCycleDashboard.test.ts
+++ b/packages/core/tests/core/utils/mapper/mapCycleDashboard.test.ts
@@ -19,7 +19,6 @@ describe("mapCycleDashboard", () => {
       cycleDate: new Date("2026-01-01"),
       sheetName: "Week 1",
       cycleStartWeekday: Weekday.Friday,
-      currentWeekType: 'training',
     };
     const result = mapCycleDashboard(obj);
     expect(result).toEqual([

--- a/packages/core/tests/core/utils/parser/parseCycleDashboard.test.ts
+++ b/packages/core/tests/core/utils/parser/parseCycleDashboard.test.ts
@@ -12,7 +12,6 @@ describe("parseCycleDashboard", () => {
       cycleDate: new Date("1/5/2026"),
       sheetName: "RPT_Cycle_1_20260105",
       cycleStartWeekday: Weekday.Monday,
-      currentWeekType: 'training',
     });
   });
 


### PR DESCRIPTION
## Summary

- `parseCycleDashboard` no longer emits the hardcoded `currentWeekType: 'training'` placeholder; the field is now optional on `CycleDashboard` with a comment that it is derived at request time via `weekTypeForDate(date, programSpec)`, not stored on the sheet.
- Drop the `currentWeekType` column from `cycle_dashboard` via Prisma migration. Nothing in production ever wrote `'test'` to it, so the only read that branched on its value (`CycleGenerationService.startNewCycle`) was effectively dead; that read is replaced with `weekTypeForDate(...)` against the program spec.
- Refactor mappers (`toCycleDashboardResponse`, `buildCycleDashboardResponse`) to take an explicit `currentWeekType: WeekType` parameter rather than relying on callers mutating the dashboard before mapping. `CycleDashboardResponse.currentWeekType` stays required on the API contract; the web UI is unaffected.

Audit chain: #354 → #356 → this PR. Surfaced during `/review` of #360.

Closes #361

## Acceptance Criteria

- [x] `parseCycleDashboard` no longer emits `currentWeekType`.
- [x] `CycleDashboard.currentWeekType` is optional with a doc comment that it is derived at request time.
- [x] `cycle-dashboard.controller.ts` still produces a correct `CycleDashboardResponse` with `currentWeekType` from `weekTypeForDate(...)`.
- [x] Prisma migration drops the column; schema and adapter updated.
- [x] Fixtures, tests, ADR-017, and the proposal updated.

## Test plan

- [x] `npm test` (via `turbo run test --force`): all workspaces pass — `Tests: 250 passed, 51 skipped, 0 failed (11.094 s)` for `@lifting-logbook/api`; `155 passed, 0 skipped, 0 failed` for `@lifting-logbook/core`; `28 passed` for `@lifting-logbook/web`; `0 tests` for `@lifting-logbook/types` and `@lifting-logbook/mobile`. The skipped count in api is pre-existing (DB-backed e2e suite gated on `DATABASE_URL`).
- [x] `nest build` passes for `apps/api`.
- [x] Pre-PR suppression grep: no new suppressions introduced. Matches are context lines around unchanged `?? null` and a removed `!` in `seed.ts`.
- [x] Pre-PR test-integrity grep: clean. No deleted tests, no lowered thresholds, no new skips.
- [ ] DB-backed e2e (`programs.db.e2e.spec.ts`) requires `DATABASE_URL`; pre-existing skipped in this environment — covered by CI.
- [ ] Manual smoke test against a running api: `GET /programs/:program/cycles/current` returns a correct `currentWeekType` derived from `weekTypeForDate(...)`. (Deferred — staging deploy on merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)