### PR TITLE
[fix] Replace seed.ts TypeScript suppressions with proper fixes

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -135,6 +135,8 @@ async function main() {
 
         for (let setNum = 1; setNum <= 3; setNum++) {
           const pct = weekType.pct[setNum - 1];
+          // Explicit undefined check — 0 would be a valid (if degenerate) percentage,
+          // so !pct would be incorrect here even though the other guards in this file use it.
           if (pct === undefined) throw new Error(`weekType.pct missing index ${setNum - 1}`);
           const weight = weightForSet(max, pct);
           const isAmrap = setNum === 3;

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -93,7 +93,8 @@ async function main() {
   const workoutDate = new Date(startDate);
 
   for (let cycle = 0; cycle < NUM_CYCLES; cycle++) {
-    const weekType = WEEK_TYPES[cycle % 3]!;
+    const weekType = WEEK_TYPES[cycle % 3];
+    if (!weekType) throw new Error(`WEEK_TYPES missing index ${cycle % 3}`);
     const cycleNum = cycle + 1;
 
     // TrainingMaxHistory — one entry per lift at cycle start (representing a PR test)
@@ -124,14 +125,17 @@ async function main() {
     }
 
     for (let workoutNum = 1; workoutNum <= 3; workoutNum++) {
-      const liftsThisWorkout = WORKOUT_LIFTS[workoutNum]!;
+      const liftsThisWorkout = WORKOUT_LIFTS[workoutNum];
+      if (!liftsThisWorkout) throw new Error(`WORKOUT_LIFTS missing entry for workout ${workoutNum}`);
 
       for (const liftName of liftsThisWorkout) {
-        const lift = LIFTS.find((l) => l.name === liftName)!;
+        const lift = LIFTS.find((l) => l.name === liftName);
+        if (!lift) throw new Error(`LIFTS missing entry for ${liftName}`);
         const max = trainingMaxAt(lift, cycle);
 
         for (let setNum = 1; setNum <= 3; setNum++) {
-          const pct = weekType.pct[setNum - 1]!;
+          const pct = weekType.pct[setNum - 1];
+          if (pct === undefined) throw new Error(`weekType.pct missing index ${setNum - 1}`);
           const weight = weightForSet(max, pct);
           const isAmrap = setNum === 3;
           const amrapReps = isAmrap ? 5 + ((cycle * workoutNum + setNum) % 4) : 5;
@@ -189,14 +193,14 @@ async function main() {
   });
 
   // StrengthGoals — one per lift (relative, bodyweight ratio targets)
-  const GOAL_RATIOS: Record<string, number> = {
-    squat: 1.5,
-    deadlift: 2.0,
-    'bench-press': 1.25,
-    'overhead-press': 0.75,
-    'barbell-row': 1.0,
-    'romanian-deadlift': 1.25,
-  };
+  const GOAL_RATIOS = new Map<string, number>([
+    ['squat', 1.5],
+    ['deadlift', 2.0],
+    ['bench-press', 1.25],
+    ['overhead-press', 0.75],
+    ['barbell-row', 1.0],
+    ['romanian-deadlift', 1.25],
+  ]);
   for (const lift of LIFTS) {
     await prisma.strengthGoal.upsert({
       where: { userId_program_lift: { userId: SEED_USER_ID, program: PROGRAM, lift: lift.name } },
@@ -207,7 +211,7 @@ async function main() {
         lift: lift.name,
         goalType: 'relative',
         unit: 'lbs',
-        ratio: GOAL_RATIOS[lift.name] ?? null,
+        ratio: GOAL_RATIOS.get(lift.name) ?? null,
       },
     });
   }


### PR DESCRIPTION
## Summary

Replaces the 5 remaining TypeScript suppressions in `apps/api/prisma/seed.ts` with guarded lookups and a `Map`-based goal ratio table.

- **Lines 96, 127, 130, 134** — bounded `!` assertions replaced with `if (!x) throw new Error(...)` guards. Throwing gives clearer diagnostics than `Cannot read property of undefined` if a future edit ever violates the invariant.
- **Line 210** — `GOAL_RATIOS` converted from `Record<string, number>` to `Map<string, number>`. `Map.get()` natively returns `T | undefined`, so the trailing `?? null` is a legitimate semantic coercion to the nullable DB column, not a suppression of an index-signature warning.

Note: the issue listed 6 suppressions, but the line-173 `WEEK_TYPES[(currentCycle - 1) % 3]!` was already removed in commit `0c0aaba` (PR #362) when the `currentWeekType` placeholder was dropped.

## Acceptance criteria

- [x] Every suppression in `seed.ts` either fixed or justified — all 5 replaced with proper fixes
- [x] No new suppressions introduced
- [x] `seed.ts` typechecks under strict + `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes`

## Testing

Standalone strict typecheck of `seed.ts` (clean):

```
npx tsc --noEmit --strict --noUncheckedIndexedAccess --exactOptionalPropertyTypes \
  --esModuleInterop --target ES2020 --module commonjs --moduleResolution node \
  --skipLibCheck apps/api/prisma/seed.ts
```

Full suite (`npm test`):

- `@lifting-logbook/core`: Tests: 160 passed, 0 skipped, 0 failed (~52s)
- `@lifting-logbook/api`: passed
- `@lifting-logbook/web`: Tests: 23 passed, 0 skipped, 1 suite failed to compile — `StepProgram.test.tsx` jest-dom matcher registration issue, **pre-existing** (not touched by this PR). Tracked in #363.

Tests: 183+ passed, 0 skipped, 1 suite-load failure (pre-existing, tracked #363).

## Suppression policy check

```bash
git diff origin/main -- apps/api/prisma/seed.ts | grep -E '(ts-ignore|ts-expect-error|eslint-disable|![.[]|!\s*[;,)]|\?\? null)'
```

Yields a single `?? null` match on the `GOAL_RATIOS.get(...)` line. Justification: `Map.get()` returns `T | undefined` natively, so this is type coercion at a DB nullable-column boundary, not silencing a strict-mode error. Net change: 5 suppressions removed, 0 added.

## Test integrity check

No skip markers added, no tests deleted, no coverage thresholds changed.