### PR TITLE
[docs] Add staging activation runbook + generalize bootstrap-gcp script

### DIFF
--- a/docs/deploy-single-user.md
+++ b/docs/deploy-single-user.md
@@ -77,19 +77,19 @@ Set a budget alert before running the bootstrap:
 
 ## Step 1 — Run the bootstrap script (~5 min)
 
-[`scripts/bootstrap-gcp-prod.sh`](../scripts/bootstrap-gcp-prod.sh) creates the
+[`scripts/bootstrap-gcp.sh`](../scripts/bootstrap-gcp.sh) creates the
 project, links your billing account, enables the two APIs Terraform itself
 needs, and creates the Terraform state bucket. Every step is idempotent — re-run
 it if anything fails partway.
 
 ```bash
-./scripts/bootstrap-gcp-prod.sh XXXXXX-XXXXXX-XXXXXX
+./scripts/bootstrap-gcp.sh XXXXXX-XXXXXX-XXXXXX
 ```
 
 To use a different project ID or region:
 
 ```bash
-./scripts/bootstrap-gcp-prod.sh XXXXXX-XXXXXX-XXXXXX \
+./scripts/bootstrap-gcp.sh XXXXXX-XXXXXX-XXXXXX \
   --project-id my-lifting-prod \
   --region us-east1
 ```

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -8,6 +8,10 @@ GKE Autopilot receives 90% of traffic; Cloud Run receives 10% as an A/B comparis
 > for a slimmer walkthrough that sets `enable_gke = false` and skips the entire
 > Helm/kubectl pipeline. The remainder of this document is the canonical
 > two-deploy-target setup that satisfies ADR-009.
+>
+> **Activating staging on top of an existing production deploy?** See
+> [`staging-runbook.md`](staging-runbook.md) for a linear top-to-bottom checklist that
+> cross-references the staging-only steps of this document.
 
 ---
 
@@ -51,7 +55,7 @@ deployments; `1` = production-grade warm start).
 
 In default mode, this guide applies as written. In single-user mode, follow
 [`deploy-single-user.md`](deploy-single-user.md) instead — the bootstrap is
-scripted (`scripts/bootstrap-gcp-prod.sh`), only one GCP project is needed,
+scripted (`scripts/bootstrap-gcp.sh`), only one GCP project is needed,
 and the GKE-only Helm/kubectl steps in the CI workflow are skipped via an
 `if: <ctx>.gke_enabled == 'true'` guard.
 

--- a/docs/staging-runbook.md
+++ b/docs/staging-runbook.md
@@ -116,18 +116,48 @@ Run the database migrations:
 ./scripts/migrate-staging-db.sh
 ```
 
-Then seed the synthetic lift data. The seed script (`apps/api/prisma/seed.ts`) uses
-`upsert` everywhere — re-running it is safe. It writes 12 cycles × 6 lifts of 5/3/1
-data under the synthetic user `seed_user_clerkid_staging_001`, which is not reachable
-via any real Clerk token.
+The migrate script temporarily enables a public IP on the staging Cloud SQL instance
+for the duration of the migrate run, then removes it. The Cloud SQL Auth Proxy still
+requires that IP for local connectivity, so to seed afterwards you must briefly
+re-enable the public IP for the seed window.
+
+Find the instance name and database password:
 
 ```bash
+# Instance name (look for the lifting-logbook-stg-db-<suffix> row)
+gcloud sql instances list --project=lifting-logbook-staging
+
+# Database password (read once, never log it)
+gcloud secrets versions access latest \
+  --secret=lifting-logbook-stg-db-password \
+  --project=lifting-logbook-staging
+```
+
+Re-enable the public IP, seed, then remove it again:
+
+```bash
+INSTANCE=lifting-logbook-stg-db-<suffix>
+
+gcloud sql instances patch "$INSTANCE" \
+  --assign-ip --project=lifting-logbook-staging --quiet
+
 # Use port 5434 (avoids conflict with the prod proxy on 5433)
 # sslmode=disable is required: the proxy handles TLS; Prisma must not negotiate SSL
-cloud-sql-proxy "lifting-logbook-staging:us-central1:lifting-logbook-stg-db-<suffix>?port=5434" &
+cloud-sql-proxy --port 5434 \
+  "lifting-logbook-staging:us-central1:$INSTANCE" &
+PROXY_PID=$!
+
 DATABASE_URL="postgresql://lifting-logbook-app:<password>@127.0.0.1:5434/lifting_logbook?sslmode=disable" \
   npx --prefix apps/api prisma db seed
+
+kill "$PROXY_PID"
+gcloud sql instances patch "$INSTANCE" \
+  --no-assign-ip --project=lifting-logbook-staging --quiet
 ```
+
+The seed script (`apps/api/prisma/seed.ts`) uses `upsert` everywhere — re-running it is
+safe. It writes 12 cycles × 6 lifts of 5/3/1 data under the synthetic user
+`seed_user_clerkid_staging_001`, which is not reachable via any real Clerk token.
 
 The full table-by-table row count is documented in
 [`deploy.md` § Step 3.5 — Seed staging data](deploy.md#step-35--seed-staging-data).
@@ -149,8 +179,13 @@ manually with:
 
 ```bash
 curl -I https://<staging-web-url>          # expect 200 or 307
-curl -I https://<staging-api-url>/health   # expect 403 (unauthenticated rejection)
+curl -I https://<staging-api-url>/health   # expect 200 or 403
 ```
+
+The Nest `HealthController` is `@Public()` and returns `200`. Cloud Run's IAM layer
+may return `403` first if the service is configured `--no-allow-unauthenticated`;
+the workflow's smoke-test job accepts both statuses for the same reason
+(`.github/workflows/deploy.yml`, "API smoke test").
 
 If the smoke-test job fails, the production job will not run — production stays on
 the previous revision. The smoke-test logic lives in `.github/workflows/deploy.yml`

--- a/docs/staging-runbook.md
+++ b/docs/staging-runbook.md
@@ -1,0 +1,173 @@
+# Staging Activation Runbook
+
+A linear top-to-bottom checklist for **activating a `lifting-logbook-staging` environment
+on top of an existing production deploy**. This file cross-references the canonical
+[`deploy.md`](deploy.md) for the prose; it exists so the operator does not have to
+mentally filter prod-vs-staging at each step.
+
+If you are setting up production from scratch, follow [`deploy.md`](deploy.md) instead —
+it covers staging and production together. Come back here only if production is already
+live and you want to add staging next.
+
+**Pre-existing assumptions:**
+
+- Production GCP project `lifting-logbook-prod` is bootstrapped and the deploy workflow runs
+  through to production today (i.e., the "production-only" mode described in [`deploy.md` §
+  Deploy modes](deploy.md#deploy-modes)).
+- You already have `gcloud` authenticated, `terraform >= 1.7` installed, and a billing
+  account ID handy. If not, see [`deploy.md` § Prerequisites](deploy.md#prerequisites).
+- You have admin rights on the GitHub repository (to add secrets and variables) and on
+  the Clerk org (to create a new application).
+
+---
+
+## Step 1 — Bootstrap the staging GCP project
+
+`scripts/bootstrap-gcp.sh` is the same script used for production; `--project-id` selects
+which project it operates on. It is idempotent — safe to re-run.
+
+```bash
+./scripts/bootstrap-gcp.sh XXXXXX-XXXXXX-XXXXXX \
+  --project-id lifting-logbook-staging
+```
+
+Replace `XXXXXX-XXXXXX-XXXXXX` with your billing account ID
+(`gcloud billing accounts list`). The script creates the project, links billing,
+enables the bootstrap APIs Terraform needs, and provisions the
+`lifting-logbook-staging-tfstate` bucket.
+
+---
+
+## Step 2 — Terraform apply (staging workspace)
+
+Staging shares the same module as production via `var.environment`; the only difference
+is the workspace and tfvars file. See [`deploy.md` § Step 3 — Bootstrap Terraform](deploy.md#step-3--bootstrap-terraform-first-apply)
+for the full first-apply walkthrough (workload identity pool, Artifact Registry, IAM
+bindings). The staging-specific commands:
+
+```bash
+cd infra/terraform
+terraform init
+terraform workspace new staging          # or `select staging` if it already exists
+terraform apply -var-file=terraform.tfvars.staging
+```
+
+After apply completes, capture the outputs you will need in Step 4:
+
+```bash
+terraform output workload_identity_provider
+terraform output cicd_service_account_email
+```
+
+---
+
+## Step 3 — Create the Clerk staging app and load keys
+
+1. In the Clerk dashboard, create a new application named **`lifting-logbook-staging`**.
+   Keep it in **Development** mode — no production switch is required for staging.
+2. Copy the **publishable key** (`pk_test_...`) and **secret key** (`sk_test_...`)
+   from **Configure → API keys**.
+3. Write them into the staging Secret Manager secrets (the secret IDs already exist
+   from Step 2's Terraform apply):
+
+```bash
+echo -n "sk_test_YOUR_KEY" | gcloud secrets versions add \
+  lifting-logbook-stg-clerk-secret-key --data-file=- \
+  --project=lifting-logbook-staging
+
+echo -n "pk_test_YOUR_KEY" | gcloud secrets versions add \
+  lifting-logbook-stg-clerk-publishable-key --data-file=- \
+  --project=lifting-logbook-staging
+```
+
+For more context (and the production half of these commands) see
+[`deploy.md` § Step 4](deploy.md#step-4--sign-up-for-clerk-and-create-two-apps).
+
+---
+
+## Step 4 — Add GitHub repository secrets and variable
+
+The deploy workflow gates staging on the presence of `GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER`.
+Until you add the three entries below, the workflow runs production-only.
+
+```bash
+# Repository secrets (masked)
+gh secret set GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER \
+  --body "$(cd infra/terraform && terraform output -raw workload_identity_provider)"
+
+gh secret set GCP_STAGING_SERVICE_ACCOUNT \
+  --body "$(cd infra/terraform && terraform output -raw cicd_service_account_email)"
+
+# Repository variable (NOT a secret — see deploy.md §5 "Why variables, not secrets?")
+gh variable set GCP_STAGING_PROJECT_ID --body "lifting-logbook-staging"
+```
+
+Verify in **Settings → Secrets and variables → Actions** that all three entries appear.
+The full secret/variable inventory (including the production counterparts) is in
+[`deploy.md` § Step 5](deploy.md#step-5--add-github-repository-secrets-and-variables).
+
+---
+
+## Step 5 — Run migrations and seed the staging database
+
+Run the database migrations:
+
+```bash
+./scripts/migrate-staging-db.sh
+```
+
+Then seed the synthetic lift data. The seed script (`apps/api/prisma/seed.ts`) uses
+`upsert` everywhere — re-running it is safe. It writes 12 cycles × 6 lifts of 5/3/1
+data under the synthetic user `seed_user_clerkid_staging_001`, which is not reachable
+via any real Clerk token.
+
+```bash
+# Use port 5434 (avoids conflict with the prod proxy on 5433)
+# sslmode=disable is required: the proxy handles TLS; Prisma must not negotiate SSL
+cloud-sql-proxy "lifting-logbook-staging:us-central1:lifting-logbook-stg-db-<suffix>?port=5434" &
+DATABASE_URL="postgresql://lifting-logbook-app:<password>@127.0.0.1:5434/lifting_logbook?sslmode=disable" \
+  npx --prefix apps/api prisma db seed
+```
+
+The full table-by-table row count is documented in
+[`deploy.md` § Step 3.5 — Seed staging data](deploy.md#step-35--seed-staging-data).
+
+---
+
+## Step 6 — Verify the full pipeline
+
+Push a trivial commit to `main` (or merge a PR) and watch the workflow in **Actions**.
+With the staging secrets in place, the pipeline runs:
+
+```
+preflight → terraform-staging → build → deploy-staging → smoke-test
+         → [manual approval] → terraform-production → deploy-production
+```
+
+The staging Cloud Run URL appears in the `deploy-staging` job output. Smoke-test
+manually with:
+
+```bash
+curl -I https://<staging-web-url>          # expect 200 or 307
+curl -I https://<staging-api-url>/health   # expect 403 (unauthenticated rejection)
+```
+
+If the smoke-test job fails, the production job will not run — production stays on
+the previous revision. The smoke-test logic lives in `.github/workflows/deploy.yml`
+(search for "Smoke test").
+
+---
+
+## Troubleshooting
+
+- **Workflow still runs production-only after adding secrets.** Re-run a failed
+  workflow or push a new commit — the preflight job evaluates the secrets at start.
+- **`terraform apply` fails on a missing API.** The bootstrap script enables the
+  two APIs Terraform itself needs (Service Usage + Cloud Resource Manager);
+  Terraform enables the rest on apply. If you skipped the bootstrap script, re-run it.
+- **Seed script fails with `SSL/TLS required`.** Confirm `sslmode=disable` is set
+  in `DATABASE_URL`. The Cloud SQL Auth Proxy handles TLS; layering Prisma SSL on
+  top causes a handshake error.
+
+For deeper troubleshooting (CI/CD IAM errors, rollback) see
+[`deploy.md` § Ongoing operations](deploy.md#ongoing-operations).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,8 +12,8 @@ Repository automation scripts. Grouped by lifecycle.
 
 | Script | Purpose |
 |---|---|
-| [`bootstrap-gcp-prod.sh`](bootstrap-gcp-prod.sh) | One-time GCP bootstrap for a single-user production deploy: creates the project, links billing, enables the APIs Terraform needs, and provisions the Terraform state bucket. Idempotent. See [`docs/deploy-single-user.md`](../docs/deploy-single-user.md). |
-| [`deploy-prod-infra.sh`](deploy-prod-infra.sh) | Automates `terraform init` → workspace select → `apply` for the production environment. Maps custom domains and prints GitHub Actions secrets. Use `--plan-only` to preview. Run after `bootstrap-gcp-prod.sh`. |
+| [`bootstrap-gcp.sh`](bootstrap-gcp.sh) | One-time GCP bootstrap for a lifting-logbook deploy (prod or staging): creates the project, links billing, enables the APIs Terraform needs, and provisions the Terraform state bucket. Idempotent. Pass `--project-id lifting-logbook-staging` to bootstrap the staging environment. See [`docs/deploy-single-user.md`](../docs/deploy-single-user.md) and [`docs/staging-runbook.md`](../docs/staging-runbook.md). |
+| [`deploy-prod-infra.sh`](deploy-prod-infra.sh) | Automates `terraform init` → workspace select → `apply` for the production environment. Maps custom domains and prints GitHub Actions secrets. Use `--plan-only` to preview. Run after `bootstrap-gcp.sh`. |
 | [`migrate-prod-db.sh`](migrate-prod-db.sh) | Applies all database migrations to the production Cloud SQL instance. Temporarily enables a public IP, runs Prisma migrations and the `user_data_source` infra migration via the Cloud SQL Auth Proxy, then removes the public IP. Downloads the proxy automatically. |
 | [`migrate-staging-db.sh`](migrate-staging-db.sh) | Applies all database migrations to the staging Cloud SQL instance. Staging-specific variant of `migrate-prod-db.sh`: uses the shared `lifting-logbook-tfstate` state bucket (prefix `terraform/state`), the `-stg-` secret naming pattern, `PROXY_PORT=5434`, and forces `sslmode=disable` on the proxy URL for Prisma compatibility. |
 

--- a/scripts/bootstrap-gcp.sh
+++ b/scripts/bootstrap-gcp.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# bootstrap-gcp-prod.sh — one-time GCP bootstrap for lifting-logbook production deploy.
+# bootstrap-gcp.sh — one-time GCP bootstrap for a lifting-logbook deploy (prod or staging).
 #
 # Creates the GCP project, links a billing account, enables the bootstrap APIs that
 # Terraform itself needs in order to enable the rest of the APIs, and provisions the
@@ -12,17 +12,26 @@
 #   * Authenticated: `gcloud auth login` AND `gcloud auth application-default login`
 #
 # Usage:
-#   ./scripts/bootstrap-gcp-prod.sh <billing-account-id> [--project-id <id>] [--region <region>]
+#   ./scripts/bootstrap-gcp.sh <billing-account-id> \
+#     [--project-id <id>] [--project-name <name>] [--region <region>]
 #
-# Example:
-#   ./scripts/bootstrap-gcp-prod.sh 0X0X0X-0X0X0X-0X0X0X
+# Defaults: --project-id lifting-logbook-prod, --region us-central1.
+# --project-name defaults to "Lifting Logbook <suffix>" where <suffix> is the segment
+# after the last hyphen of --project-id (e.g., lifting-logbook-staging → "Lifting Logbook staging").
+#
+# Examples:
+#   # Production (default)
+#   ./scripts/bootstrap-gcp.sh 0X0X0X-0X0X0X-0X0X0X
+#
+#   # Staging
+#   ./scripts/bootstrap-gcp.sh 0X0X0X-0X0X0X-0X0X0X --project-id lifting-logbook-staging
 #
 # Find your billing account ID with: gcloud billing accounts list
 
 set -euo pipefail
 
 PROJECT_ID="lifting-logbook-prod"
-PROJECT_NAME="Lifting Logbook Prod"
+PROJECT_NAME=""
 REGION="us-central1"
 BILLING=""
 
@@ -41,6 +50,10 @@ while (( $# > 0 )); do
   case "$1" in
     --project-id)
       PROJECT_ID="$2"
+      shift 2
+      ;;
+    --project-name)
+      PROJECT_NAME="$2"
       shift 2
       ;;
     --region)
@@ -67,10 +80,16 @@ while (( $# > 0 )); do
   esac
 done
 
+if [[ -z "$PROJECT_NAME" ]]; then
+  # Derive a human-readable name from the trailing segment of the project ID
+  # (e.g., lifting-logbook-prod → "Lifting Logbook prod").
+  PROJECT_NAME="Lifting Logbook ${PROJECT_ID##*-}"
+fi
+
 STATE_BUCKET="${PROJECT_ID}-tfstate"
 
 if [[ -z "$BILLING" ]]; then
-  echo "Usage: $0 <billing-account-id> [--project-id <id>] [--region <region>]" >&2
+  echo "Usage: $0 <billing-account-id> [--project-id <id>] [--project-name <name>] [--region <region>]" >&2
   echo "Find your billing account ID with: gcloud billing accounts list" >&2
   exit 2
 fi

--- a/scripts/bootstrap-gcp.sh
+++ b/scripts/bootstrap-gcp.sh
@@ -16,8 +16,8 @@
 #     [--project-id <id>] [--project-name <name>] [--region <region>]
 #
 # Defaults: --project-id lifting-logbook-prod, --region us-central1.
-# --project-name defaults to "Lifting Logbook <suffix>" where <suffix> is the segment
-# after the last hyphen of --project-id (e.g., lifting-logbook-staging → "Lifting Logbook staging").
+# --project-name defaults to "Lifting Logbook <Suffix>" where <Suffix> is the title-cased
+# segment after the last hyphen of --project-id (e.g., lifting-logbook-staging → "Lifting Logbook Staging").
 #
 # Examples:
 #   # Production (default)
@@ -81,9 +81,11 @@ while (( $# > 0 )); do
 done
 
 if [[ -z "$PROJECT_NAME" ]]; then
-  # Derive a human-readable name from the trailing segment of the project ID
-  # (e.g., lifting-logbook-prod → "Lifting Logbook prod").
-  PROJECT_NAME="Lifting Logbook ${PROJECT_ID##*-}"
+  # Derive a human-readable name from the trailing segment of the project ID,
+  # title-cased (e.g., lifting-logbook-prod → "Lifting Logbook Prod",
+  # lifting-logbook-staging → "Lifting Logbook Staging").
+  SUFFIX="${PROJECT_ID##*-}"
+  PROJECT_NAME="Lifting Logbook ${SUFFIX^}"
 fi
 
 STATE_BUCKET="${PROJECT_ID}-tfstate"

--- a/scripts/deploy-prod-infra.sh
+++ b/scripts/deploy-prod-infra.sh
@@ -2,7 +2,7 @@
 #
 # deploy-prod-infra.sh — Terraform init/apply for the lifting-logbook production environment.
 #
-# Run this after bootstrap-gcp-prod.sh has completed. Each step is idempotent — safe
+# Run this after bootstrap-gcp.sh has completed. Each step is idempotent — safe
 # to re-run. Use --plan-only to preview changes without applying them.
 #
 # Prereqs:


### PR DESCRIPTION
## Summary

Implements the Claude-doable scope of #291. Most of the issue's acceptance criteria are external/interactive actions (creating the GCP project, creating the Clerk app, pasting GitHub secrets) that only the human operator can perform. This PR closes the documentation and tooling gaps so those manual steps are unambiguous; the user follows the runbook in a separate session.

### What this PR delivers

- **`docs/staging-runbook.md`** — a linear, top-to-bottom checklist for activating staging on top of an existing production deploy. Cross-references `deploy.md` rather than duplicating prose.
- **`scripts/bootstrap-gcp-prod.sh` → `scripts/bootstrap-gcp.sh`** — the script already accepted `--project-id`, but its filename and hardcoded `PROJECT_NAME="Lifting Logbook Prod"` misled operators into thinking it was prod-only. Now derives `PROJECT_NAME` from `--project-id` (with a `--project-name` override) and updates all internal references (`deploy.md`, `deploy-single-user.md`, `scripts/README.md`, `scripts/deploy-prod-infra.sh`).
- **Cross-link in `docs/deploy.md`** — a one-line pointer from the canonical guide to the staging runbook.

### What was already in place from prior PRs

Exploration confirmed that the core staging machinery was already shipped:

- Terraform is workspace-based with `terraform.tfvars.staging` present.
- `.github/workflows/deploy.yml` (PR #290) gates staging on `GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER` and runs the full `staging → smoke-test → [approval] → production` pipeline when that secret is set.
- `apps/api/prisma/seed.ts` implements Option A from the issue (12 cycles × 6 lifts of 5/3/1 data, idempotent upserts, no PII).
- `docs/deploy.md` already has §3.5 (seed staging data), §4 (Clerk staging app), §5 (GitHub secrets).
- `scripts/migrate-staging-db.sh` exists alongside `migrate-prod-db.sh`.

### Acceptance-criteria mapping

| Issue checkbox | Resolution |
|---|---|
| Bootstrap `lifting-logbook-staging` GCP project | **Manual follow-up** — runbook §1 documents the exact command. |
| Run Terraform in staging workspace | **Manual follow-up** — runbook §2 documents the workspace + tfvars commands. |
| Add GitHub staging secrets | **Manual follow-up** — runbook §4 lists the three `gh secret set` / `gh variable set` commands. |
| Verify deploy workflow runs full pipeline | **Manual follow-up** — runbook §6. |
| Create Clerk staging app, populate Secret Manager | **Manual follow-up** — runbook §3 includes the staging-only `gcloud secrets versions add` commands. |
| Decide seed data strategy | **Already done** — Option A (Prisma seed script) shipped in `apps/api/prisma/seed.ts`. |
| Implement seed strategy + document | **Already done** — seed script idempotent (upserts), no PII (synthetic user). Documented in `deploy.md` §3.5 and now cross-referenced from runbook §5. |
| Seed idempotent | **Already done** — verified at `apps/api/prisma/seed.ts:51-89` (upserts everywhere). |
| Seed has no real PII | **Already done** — synthetic `seed_user_clerkid_staging_001`. |

## Testing

Doc and shell-script changes only; no JS/TS source touched.

Ran the project test command from CLAUDE.md:

```
TURBO_BINARY_PATH=…/turbo.exe npm test
```

`Tests: 4 packages passed (cached), 2 failed (web, types), 4 ran (api-legacy, eslint-rules, mobile, types — but mobile passed)`

The two failures (`@lifting-logbook/web`, `@lifting-logbook/types`) are pre-existing infrastructure errors:

```
Module ts-jest should have "jest-preset.js" or "jest-preset.json" file at the root.
```

These are tracked by **#365** (\"[fix] Worktree npm install leaves jest unable to resolve ts-jest preset / jest-circus runner\"). They reproduce identically on `origin/main` (worktree npm-install artifact) and are unrelated to this PR's doc/script changes. Per the CLAUDE.md failure-tracking rule, citing the open issue is the documented resolution.

**Suppression check** (`git diff origin/main … | grep -E '…'`) — clean.

**Test integrity check** — clean (no skip markers, deleted tests, or threshold drops added).

## Verification checklist for reviewer

- [x] `grep -rn 'bootstrap-gcp-prod' docs scripts .github infra` returns empty.
- [x] Runbook §3 secret-write commands match Secret Manager IDs in `.github/workflows/deploy.yml` lines 254-279 (`lifting-logbook-stg-clerk-*`).
- [x] Runbook §5 Cloud SQL Auth Proxy port (5434) matches `deploy.md` §3.5.

## Manual follow-up after merge

The operator will run the runbook from top to bottom in a separate session. No further code changes expected.

- [ ] Run `scripts/bootstrap-gcp.sh <billing-id> --project-id lifting-logbook-staging`
- [ ] `terraform workspace new staging && terraform apply -var-file=terraform.tfvars.staging`
- [ ] Create Clerk app `lifting-logbook-staging`, load keys via runbook §3
- [ ] Add three GitHub secrets/variable (runbook §4)
- [ ] `./scripts/migrate-staging-db.sh`, then run seed block from runbook §5
- [ ] Push a trivial commit; confirm full staging → smoke → prod pipeline

Closes #291