### PR TITLE
[fix] Bump ts-jest to ^29.4.11 for jest@30 + Node 24 compat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Include in your opening brief only: the issue you are working on, current branch
 ## Platform & Environment
 
 - **OS:** Windows 11, Git Bash terminal
-- **Node:** 20.11.1 (managed by nvm for Windows; `.nvmrc` is set — run `nvm use $(cat .nvmrc)` at session start if not already active)
+- **Node:** 20.11.1 (managed by nvm for Windows; `.nvmrc` is set — run `nvm use $(cat .nvmrc)` at session start if not already active). Node 24 runs the jest suites, but `apps/api` `nest build` currently fails on Node 24 with transitive CJS/ESM resolution errors in `iconv-lite` and `minimatch` — tracked in [#373](https://github.com/brownm09/lifting-logbook/issues/373). CI runs Node 20 and is unaffected.
 - **Package manager:** npm (workspaces)
 - **`jq` is NOT available.** Use `node -e` with a temp file in the working directory for JSON parsing:
   ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@typescript-eslint/parser": "^8.53.0",
         "eslint": "^9.39.2",
         "jest": "^30.2.0",
-        "ts-jest": "^29.4.6",
+        "ts-jest": "^29.4.11",
         "turbo": "latest",
         "typescript": "^5.9.3"
       },
@@ -13622,9 +13622,9 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19160,9 +19160,9 @@
       "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -20545,19 +20545,19 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "node_modules/ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.8.0",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -20574,7 +20574,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/parser": "^8.53.0",
     "eslint": "^9.39.2",
     "jest": "^30.2.0",
-    "ts-jest": "^29.4.6",
+    "ts-jest": "^29.4.11",
     "turbo": "latest",
     "typescript": "^5.9.3"
   },


### PR DESCRIPTION
## Summary

`npm test` failed on Node 24 with `Module ts-jest should have "jest-preset.js" or "jest-preset.json" file at the root.` ts-jest 29.4.6 predated jest@30's preset-loader changes; under Node 24's stricter CJS module resolution, the preset shim could not be located.

ts-jest 29.4.7+ declares peer `jest: ^29.0.0 || ^30.0.0` and ships the expected preset shape. Bumping the root `devDependency` to `^29.4.11` (current `latest`) clears the error without touching any workspace jest config — all workspaces inherit `preset: 'ts-jest'` from [`jest.config.base.js`](https://github.com/brownm09/lifting-logbook/blob/main/jest.config.base.js).

No `ts-jest@30` exists yet (`next` dist-tag points at `29.0.0-next.1`), so the forward-compatible fix stays inside the 29.x line.

## Acceptance criteria

- [x] `npm test` runs end-to-end on Node 24.13.0 without preset-resolution errors. *(ts-jest preset error is gone; jest now runs in every workspace — see Testing below)*
- [x] CI (Node 20) continues to pass. *(no behavioral change; minor-version bump within a peer-supported range)*
- [x] If Node 24 is not yet fully supportable, follow-up tracked. *(see #373 — `nest build` still hits unrelated CJS/ESM resolution issues in `iconv-lite` and `minimatch` transitive deps; out of scope for #370 which is preset-only)*

## Testing

Node 24.13.0 (Windows 11), worktree under `.claude/worktrees/…`:

- `npm test -w @lifting-logbook/core` → **Tests: 160 passed, 0 skipped, 0 failed (~27s)** — full ts-jest preset path exercised across 26 suites.
- `npm test -w @lifting-logbook/types` → **0 tests, exit 0** (`--passWithNoTests`).
- `npm test -w @lifting-logbook/mobile` → **0 tests, exit 0** (`--passWithNoTests`).
- `npm test -w @lifting-logbook/eslint-rules` → **11 passed, 0 skipped, 0 failed** (node `--test` runner, no ts-jest).
- `npm test -w @lifting-logbook/web` → **23 passed, 0 skipped + 1 suite fails on a TypeScript matcher type error (`toBeInTheDocument` not on `JestMatchers`)** — pre-existing on `main`, tracked by #363, unrelated to ts-jest.
- Full `npm test` via turbo: ts-jest preset error is gone for every jest workspace. `@lifting-logbook/api#build` (and its dependent `api:test` / `api-legacy:test`) fail on Node 24 with `nest build` transitive CJS resolution errors (`iconv-lite/./streams`, `minimatch/dist/commonjs/index.js`). Same `api:build` fails on `main` with a different downstream error (`Prisma.InputJsonValue`). Both are unrelated to the ts-jest preset issue and now tracked in #373.

CI runs on Node 20 and is unaffected by either #370 or #373.

### Pre-existing failures cited

- #363 — `apps/web` `StepProgram.test.tsx`: jest-dom matchers not registered (TS-level type errors). Pre-existing on `main`.
- #373 — Node 24 `nest build` CJS/ESM transitive resolution failures. Filed as part of this work after surfacing during Node 24 verification.

## Suppression / test-integrity grep

Both pre-PR greps against `origin/main` returned empty. No suppressions added, no skips added, no coverage thresholds touched.

Closes #370