### PR TITLE
[fix] Register jest-dom matchers for web tests (#363)

### DIFF
--- a/apps/web/app/onboarding/steps/StepProgram.test.tsx
+++ b/apps/web/app/onboarding/steps/StepProgram.test.tsx
@@ -1,4 +1,3 @@
-import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';

--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -4,6 +4,7 @@ const base = require('../../jest.config.base.js');
 module.exports = {
   ...base,
   testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testMatch: ['**/*.test.ts', '**/*.test.tsx'],
   transform: {
     '^.+\\.tsx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],

--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -4,7 +4,7 @@ const base = require('../../jest.config.base.js');
 module.exports = {
   ...base,
   testEnvironment: 'jsdom',
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  setupFilesAfterEnv: [...(base.setupFilesAfterEnv ?? []), '<rootDir>/jest.setup.ts'],
   testMatch: ['**/*.test.ts', '**/*.test.tsx'],
   transform: {
     '^.+\\.tsx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],

--- a/apps/web/jest.setup.ts
+++ b/apps/web/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/apps/web/tsconfig.spec.json
+++ b/apps/web/tsconfig.spec.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "noEmit": true,
+    "types": ["jest", "node", "@testing-library/jest-dom"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"],


### PR DESCRIPTION
## Summary

`apps/web/app/onboarding/steps/StepProgram.test.tsx` failed to compile under ts-jest with `Property 'toBeInTheDocument' does not exist on type 'JestMatchers<HTMLElement>'` (and equivalents for `toBeDisabled` / `toHaveTextContent`). The matchers come from `@testing-library/jest-dom`, but the package's `jest.Matchers` type augmentation only takes effect if those types are reachable via the test's TypeScript program. `apps/web/tsconfig.spec.json` didn't declare them, so importing the package at the top of the test file had no effect on type-checking.

## Changes

- Add `apps/web/jest.setup.ts` that imports `@testing-library/jest-dom` once globally.
- Register it via `setupFilesAfterEnv` in `apps/web/jest.config.js` so every web test gets the matchers.
- Declare `"types": ["jest", "node", "@testing-library/jest-dom"]` in `apps/web/tsconfig.spec.json` so the type augmentation is picked up.
- Remove the now-redundant `import '@testing-library/jest-dom';` line from `StepProgram.test.tsx`.

## Testing

Ran `npm test -w @lifting-logbook/web` from the repo root.

```
Test Suites: 3 passed, 3 total
Tests:       28 passed, 0 skipped, 0 failed (9.503 s)
```

All 5 StepProgram tests pass (goal filter, coming-soon overlay both branches, confirm wiring, isPending state), and the previously-passing `programPlan` / `workoutPlan` suites still pass.

Verification was performed against the main repo's `node_modules` because the worktree's `npm install` produced corrupted installs for several packages (`unrs-resolver` native binding, `bs-logger/dist`, `node-int64/Int64.js` — same `.claude/worktrees/` install-quality issue noted in CLAUDE.md). The four file changes are identical between worktree and main.

Pre-PR suppression / test-integrity grep: clean (0 matches).

Closes #363