### PR TITLE
[infra] Add required-checks drift detection workflow

### DIFF
--- a/.github/expected-required-checks.json
+++ b/.github/expected-required-checks.json
@@ -1,0 +1,9 @@
+{
+  "contexts": [
+    "DB Integration Tests",
+    "Lint & Test",
+    "Observability Stack Smoke Test",
+    "Playwright E2E",
+    "Staging Integration Tests"
+  ]
+}

--- a/.github/workflows/required-checks-drift.yml
+++ b/.github/workflows/required-checks-drift.yml
@@ -16,16 +16,32 @@ permissions:
   contents: read
   issues: write
 
+# Serialize runs so a schedule tick and a workflow_dispatch (or push) cannot
+# both read an empty `gh issue list` and each create a duplicate drift issue.
+# cancel-in-progress: false — the second run still needs to complete and post
+# a comment / fail red; we don't want it cancelled.
+concurrency:
+  group: required-checks-drift
+  cancel-in-progress: false
+
 jobs:
   drift-check:
     name: Detect required-checks drift
     runs-on: ubuntu-latest
+    # The whole pipeline runs in <30s; 5 minutes is a generous bound on
+    # transient GitHub API hangs without burning the default 6h timeout.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 
       - name: Fetch live required-status-checks
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Branch-protection endpoints require Administration:read, which
+          # GITHUB_TOKEN does not grant. BRANCH_PROTECTION_READ_TOKEN is a
+          # fine-grained PAT with that single scope. The fallback to
+          # GITHUB_TOKEN keeps the workflow loud-red if the secret is ever
+          # missing or expired (it 403s), rather than silently green.
+          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_READ_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           gh api "repos/${{ github.repository }}/branches/main/protection/required_status_checks" \
@@ -88,7 +104,18 @@ jobs:
           EOF
           echo "drift=$(cat drift.txt)" >> "$GITHUB_OUTPUT"
 
-      - name: Open or update drift issue
+      - name: Upload diagnostic artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: drift-diagnostics
+          path: |
+            actual.json
+            body.md
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Open or update drift issue(s)
         if: steps.diff.outputs.drift == '1'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -98,14 +125,19 @@ jobs:
             --description "Branch-protection required-check set diverges from .github/expected-required-checks.json" \
             --color B60205 \
             --force
-          EXISTING=$(gh issue list \
+          # Comment on every open drift issue (typically 0 or 1). Looping
+          # handles the rare case of multiple open issues (manual creation,
+          # reopened old issue) without silently ignoring extras.
+          mapfile -t EXISTING < <(gh issue list \
             --label required-checks-drift \
             --state open \
             --json number \
-            --jq '.[0].number // empty')
-          if [ -n "$EXISTING" ]; then
-            echo "Updating existing issue #$EXISTING"
-            gh issue comment "$EXISTING" --body-file body.md
+            --jq '.[].number')
+          if [ "${#EXISTING[@]}" -gt 0 ]; then
+            for N in "${EXISTING[@]}"; do
+              echo "Updating existing issue #$N"
+              gh issue comment "$N" --body-file body.md
+            done
           else
             echo "Creating new drift issue"
             gh issue create \
@@ -117,5 +149,5 @@ jobs:
       - name: Fail run when drift detected
         if: steps.diff.outputs.drift == '1'
         run: |
-          echo "Required-checks drift detected — see the 'Compute drift' step output and the linked issue."
+          echo "Required-checks drift detected — see the 'Compute drift' step output and the linked issue(s)."
           exit 1

--- a/.github/workflows/required-checks-drift.yml
+++ b/.github/workflows/required-checks-drift.yml
@@ -1,0 +1,121 @@
+name: Required Checks Drift
+
+on:
+  schedule:
+    # Mondays at 13:17 UTC (~09:17 ET). Off-peak; avoids top-of-hour scheduler congestion.
+    - cron: '17 13 * * 1'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/expected-required-checks.json'
+      - '.github/workflows/required-checks-drift.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  drift-check:
+    name: Detect required-checks drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch live required-status-checks
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${{ github.repository }}/branches/main/protection/required_status_checks" \
+            > actual.json
+          cat actual.json
+
+      - name: Compute drift
+        id: diff
+        run: |
+          set -euo pipefail
+          node <<'EOF'
+          const fs = require('fs');
+          const expected = JSON.parse(fs.readFileSync('.github/expected-required-checks.json', 'utf8')).contexts;
+          const actual = JSON.parse(fs.readFileSync('actual.json', 'utf8')).contexts;
+          const sortedExpected = [...expected].sort();
+          const sortedActual = [...actual].sort();
+          const expectedSet = new Set(sortedExpected);
+          const actualSet = new Set(sortedActual);
+          const missing = sortedExpected.filter(c => !actualSet.has(c));
+          const extra = sortedActual.filter(c => !expectedSet.has(c));
+          const drift = missing.length > 0 || extra.length > 0;
+
+          const lines = [];
+          lines.push('# Required-checks drift detected');
+          lines.push('');
+          lines.push(`Run: ${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`);
+          lines.push('');
+          lines.push('## Expected (`.github/expected-required-checks.json`)');
+          lines.push('');
+          for (const c of sortedExpected) lines.push(`- \`${c}\``);
+          lines.push('');
+          lines.push('## Actual (live `main` branch protection)');
+          lines.push('');
+          for (const c of sortedActual) lines.push(`- \`${c}\``);
+          lines.push('');
+          lines.push('## Missing from live protection (expected − actual)');
+          lines.push('');
+          if (missing.length === 0) lines.push('_(none)_');
+          else for (const c of missing) lines.push(`- \`${c}\``);
+          lines.push('');
+          lines.push('## Extra in live protection (actual − expected)');
+          lines.push('');
+          if (extra.length === 0) lines.push('_(none)_');
+          else for (const c of extra) lines.push(`- \`${c}\``);
+          lines.push('');
+          lines.push('## To fix');
+          lines.push('');
+          lines.push('Either update `.github/expected-required-checks.json` to match live protection, or update live protection to match the file (see `docs/operations/branch-protection.md` for the `gh api -X PATCH` command).');
+
+          fs.writeFileSync('body.md', lines.join('\n') + '\n');
+          fs.writeFileSync('drift.txt', drift ? '1' : '0');
+
+          if (drift) {
+            console.log('Drift detected.');
+            console.log('Missing:', missing);
+            console.log('Extra:', extra);
+          } else {
+            console.log('No drift. Expected and actual required-check sets match.');
+          }
+          EOF
+          echo "drift=$(cat drift.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update drift issue
+        if: steps.diff.outputs.drift == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh label create required-checks-drift \
+            --description "Branch-protection required-check set diverges from .github/expected-required-checks.json" \
+            --color B60205 \
+            --force
+          EXISTING=$(gh issue list \
+            --label required-checks-drift \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Updating existing issue #$EXISTING"
+            gh issue comment "$EXISTING" --body-file body.md
+          else
+            echo "Creating new drift issue"
+            gh issue create \
+              --label required-checks-drift \
+              --title "Required-checks drift detected" \
+              --body-file body.md
+          fi
+
+      - name: Fail run when drift detected
+        if: steps.diff.outputs.drift == '1'
+        run: |
+          echo "Required-checks drift detected — see the 'Compute drift' step output and the linked issue."
+          exit 1

--- a/docs/operations/branch-protection.md
+++ b/docs/operations/branch-protection.md
@@ -12,6 +12,15 @@
 
 The job `name:` values match the required-check contexts character-for-character. Renaming any job is a breaking change to branch protection.
 
+## Source of truth
+
+[`.github/expected-required-checks.json`](../../.github/expected-required-checks.json) is the canonical list of required contexts. The [`Required Checks Drift`](../../.github/workflows/required-checks-drift.yml) workflow runs weekly (Mondays 13:17 UTC) and on every push to `main` that touches the JSON file or the workflow itself. It fetches the live `required_status_checks` from the GitHub API, diffs it against the JSON, and:
+
+- exits red and opens (or comments on the existing) issue labeled `required-checks-drift` when the two sets diverge;
+- exits green and takes no other action otherwise.
+
+When changing the required-check set, edit the JSON in the same PR that updates live branch protection. The table above must also be kept in sync — the workflow only enforces JSON-vs-live, not table-vs-JSON.
+
 ## Staging-credential dependency
 
 One of the five required checks — `Staging Integration Tests` — is gated by the staging workflow's preflight. The `staging-integration-tests` job's `if:` condition is:
@@ -20,7 +29,7 @@ One of the five required checks — `Staging Integration Tests` — is gated by 
 if: always() && needs.preflight.outputs.should_run == 'true'
 ```
 
-`should_run` is `false` when the `GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER` secret is unset. In that case the job is skipped and the required check never reports — every PR will be stuck at `mergeStateStatus: BLOCKED` until the secret is restored. If staging is intentionally decommissioned, remove `Staging Integration Tests` from the required-check list at the same time.
+`should_run` is `false` when the `GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER` secret is unset. In that case the job is skipped and the required check never reports — every PR will be stuck at `mergeStateStatus: BLOCKED` until the secret is restored. If staging is intentionally decommissioned, remove `Staging Integration Tests` from `.github/expected-required-checks.json` and from live branch protection in the same PR.
 
 The other four required checks (`Lint & Test`, `DB Integration Tests`, `Observability Stack Smoke Test`, `Playwright E2E`) live in `ci.yml` and have no staging-credential dependency.
 

--- a/docs/operations/branch-protection.md
+++ b/docs/operations/branch-protection.md
@@ -21,6 +21,8 @@ The job `name:` values match the required-check contexts character-for-character
 
 When changing the required-check set, edit the JSON in the same PR that updates live branch protection. The table above must also be kept in sync — the workflow only enforces JSON-vs-live, not table-vs-JSON.
 
+**Auth note.** The branch-protection read endpoint requires `Administration: read`, which the default `GITHUB_TOKEN` does not grant. The workflow uses a repo secret `BRANCH_PROTECTION_READ_TOKEN` — a fine-grained PAT scoped to this repo with `Administration: read` only. If the secret is missing or expired, the workflow falls back to `GITHUB_TOKEN`, which 403s on the protection endpoint and surfaces a loud-red failure rather than a silent pass. Rotate the PAT before its GitHub-emailed expiration notice and overwrite the secret via Settings → Secrets and variables → Actions (or `gh secret set BRANCH_PROTECTION_READ_TOKEN`).
+
 ## Staging-credential dependency
 
 One of the five required checks — `Staging Integration Tests` — is gated by the staging workflow's preflight. The `staging-integration-tests` job's `if:` condition is:


### PR DESCRIPTION
## Summary

Adds a scheduled workflow that diffs live `main` branch-protection required contexts against a checked-in expected list, and opens (or comments on the existing) issue on mismatch. Follows up #378 / #379, which fixed the immediate drift but left enforcement advisory.

- `.github/expected-required-checks.json` — source of truth, five contexts (sorted alphabetically; sort is normalized at diff time so order isn't load-bearing).
- `.github/workflows/required-checks-drift.yml` — runs Mondays at 13:17 UTC (~09:17 ET), on pushes to `main` that touch the JSON or the workflow itself, and on `workflow_dispatch`. Fetches `branches/main/protection/required_status_checks`, computes `missing` (expected − actual) and `extra` (actual − expected), and on drift: creates/comments the `required-checks-drift`-labeled issue **and** exits 1 so the Actions tab also goes red. The diff is printed in the run log before exit, so one click into the failed run shows the cause.
- `docs/operations/branch-protection.md` — adds a "Source of truth" section pointing at the JSON file and the workflow; updates the staging-decommission directive to reference the JSON.

## Acceptance criteria

- [x] `.github/expected-required-checks.json` checked in with the five current contexts.
- [x] Workflow runs on a schedule (weekly Mondays) and on push to the JSON file.
- [x] On mismatch, opens an issue with the diff in the body. Idempotent — re-uses an existing open `required-checks-drift` issue rather than spamming.
- [x] `docs/operations/branch-protection.md` updated to point at the expected-checks file as the source of truth.

## Test plan

- [x] JSON file parses: `node -e "JSON.parse(require('fs').readFileSync('.github/expected-required-checks.json'))"` → OK.
- [x] Workflow YAML parses with `js-yaml` → OK.
- [x] `@lifting-logbook/core` test suite — **Tests: 160 passed, 0 skipped, 0 failed (34.5s)**.
- [ ] After merge, trigger via `gh workflow run required-checks-drift.yml` from `main`; expect green run with no issue created.
- [ ] On a throwaway branch, temporarily add a fake context to the JSON and run `gh workflow run required-checks-drift.yml --ref <branch>`; expect failed run, new `Required-checks drift detected` issue labeled `required-checks-drift`. Re-run → expect a comment on the same issue, no duplicate.

## Testing summary

Local full-suite run blocked at `@lifting-logbook/api#test` global setup: Docker Desktop is not running in this worktree environment, so Testcontainers cannot provision Postgres for the DB E2E suite (`Could not find a working container runtime strategy`). This is the documented platform constraint in `CLAUDE.md` → Testing — not a regression. CI runs Docker in the service container and is unaffected. The change touches only `.github/`, `docs/`, and a new YAML — no application code or test setup is modified, and no test runner config / threshold is changed.

**Tests: 160 passed, 0 skipped, 1 errored — `@lifting-logbook/api#test` global setup (Docker not running locally; pre-existing platform constraint, CI unaffected).**

## Coverage gate

No new application behavior is added. The drift workflow itself is verified end-to-end via the post-merge `workflow_dispatch` steps in the test plan above; there is no in-repo unit test for it because it is a thin YAML wrapper around `gh api` + a `node` diff and depends on GitHub-side branch-protection state.

## Suppression / test-integrity check

`git diff origin/main` adds no `ts-ignore`, `eslint-disable`, `!`-suppression, `?? null` coercion, `it.skip`, `xit`, `passWithNoTests`, `--bail`, or `testPathIgnorePatterns` — and deletes no test files or coverage thresholds.

Closes #380