### PR TITLE
[fix] Mount CLERK_SECRET_KEY in web deployments (prod auth broken)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -273,9 +273,11 @@ jobs:
           CLERK_PUB=$(gcloud secrets versions access latest \
             --secret="lifting-logbook-stg-clerk-publishable-key" \
             --project="${{ vars.GCP_STAGING_PROJECT_ID }}")
+          [ -n "$CLERK_PUB" ] || { echo "ERROR: clerk-publishable-key fetch returned empty (staging)"; exit 1; }
           CLERK_KEY=$(gcloud secrets versions access latest \
             --secret="lifting-logbook-stg-clerk-secret-key" \
             --project="${{ vars.GCP_STAGING_PROJECT_ID }}")
+          [ -n "$CLERK_KEY" ] || { echo "ERROR: clerk-secret-key fetch returned empty (staging)"; exit 1; }
           kubectl create secret generic web-secrets \
             --namespace=staging \
             --from-literal=clerk-publishable-key="$CLERK_PUB" \
@@ -471,9 +473,11 @@ jobs:
           CLERK_PUB=$(gcloud secrets versions access latest \
             --secret="lifting-logbook-prod-clerk-publishable-key" \
             --project="${{ vars.GCP_PROD_PROJECT_ID }}")
+          [ -n "$CLERK_PUB" ] || { echo "ERROR: clerk-publishable-key fetch returned empty (production)"; exit 1; }
           CLERK_KEY=$(gcloud secrets versions access latest \
             --secret="lifting-logbook-prod-clerk-secret-key" \
             --project="${{ vars.GCP_PROD_PROJECT_ID }}")
+          [ -n "$CLERK_KEY" ] || { echo "ERROR: clerk-secret-key fetch returned empty (production)"; exit 1; }
           kubectl create secret generic web-secrets \
             --namespace=production \
             --from-literal=clerk-publishable-key="$CLERK_PUB" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -273,9 +273,13 @@ jobs:
           CLERK_PUB=$(gcloud secrets versions access latest \
             --secret="lifting-logbook-stg-clerk-publishable-key" \
             --project="${{ vars.GCP_STAGING_PROJECT_ID }}")
+          CLERK_KEY=$(gcloud secrets versions access latest \
+            --secret="lifting-logbook-stg-clerk-secret-key" \
+            --project="${{ vars.GCP_STAGING_PROJECT_ID }}")
           kubectl create secret generic web-secrets \
             --namespace=staging \
             --from-literal=clerk-publishable-key="$CLERK_PUB" \
+            --from-literal=clerk-secret-key="$CLERK_KEY" \
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Helm deploy API (GKE staging)
@@ -467,9 +471,13 @@ jobs:
           CLERK_PUB=$(gcloud secrets versions access latest \
             --secret="lifting-logbook-prod-clerk-publishable-key" \
             --project="${{ vars.GCP_PROD_PROJECT_ID }}")
+          CLERK_KEY=$(gcloud secrets versions access latest \
+            --secret="lifting-logbook-prod-clerk-secret-key" \
+            --project="${{ vars.GCP_PROD_PROJECT_ID }}")
           kubectl create secret generic web-secrets \
             --namespace=production \
             --from-literal=clerk-publishable-key="$CLERK_PUB" \
+            --from-literal=clerk-secret-key="$CLERK_KEY" \
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Helm deploy API (GKE production)

--- a/infra/cloud-run/web-service.yaml
+++ b/infra/cloud-run/web-service.yaml
@@ -43,3 +43,8 @@ spec:
                 secretKeyRef:
                   name: lifting-logbook-prod-clerk-publishable-key
                   key: latest
+            - name: CLERK_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: lifting-logbook-prod-clerk-secret-key
+                  key: latest

--- a/infra/kubernetes/charts/web/templates/deployment.yaml
+++ b/infra/kubernetes/charts/web/templates/deployment.yaml
@@ -38,6 +38,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "lifting-logbook-web.fullname" . }}-secrets
                   key: clerk-publishable-key
+            - name: CLERK_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "lifting-logbook-web.fullname" . }}-secrets
+                  key: clerk-secret-key
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           livenessProbe:


### PR DESCRIPTION
## Summary

Production `liftinglogbook.com` does not prompt for login. Confirmed live:
- `GET /` → 200 (marketing page renders; no redirect to `/sign-in`)
- `GET /cycle` → **500**

Root cause: the web deployment never receives `CLERK_SECRET_KEY`. `apps/web/middleware.ts` calls `auth.protect()` on every non-public route, which requires the secret key server-side. Without it Clerk middleware throws — Next.js returns 500 instead of redirecting to `/sign-in`. The Clerk secret already exists in Secret Manager (the API workflow consumes it at deploy.yml:454); only the web side was missing.

## Changes

- `infra/kubernetes/charts/web/templates/deployment.yaml` — add `CLERK_SECRET_KEY` env entry sourced from the `web-secrets` Kubernetes Secret (key `clerk-secret-key`).
- `.github/workflows/deploy.yml` — staging and production "Sync web secrets to Kubernetes" steps now fetch `lifting-logbook-{stg,prod}-clerk-secret-key` and include `--from-literal=clerk-secret-key=…` in the `kubectl create secret` invocation.
- `infra/cloud-run/web-service.yaml` — add `CLERK_SECRET_KEY` env entry sourced from `lifting-logbook-prod-clerk-secret-key` Secret Manager secret (the 10% A/B Cloud Run target).

No app-code changes. Closes #382.

## Testing

Infra/YAML-only change; no application code or tests are modified. `npm test` was not run because the diff cannot affect any unit/integration suite. Pre-PR grep checks:

- Suppression policy grep against the diff: **0 matches**.
- Test-integrity grep against the diff: **0 matches**.

Verification will be live, post-deploy:

- [ ] After deploy: `curl -sI https://liftinglogbook.com/cycle` returns `307` redirecting to `/sign-in` (currently returns 500).
- [ ] After deploy: signing in via Clerk lands back on the requested page.
- [ ] `kubectl -n production get secret lifting-logbook-web-secrets -o jsonpath='{.data}'` shows both `clerk-publishable-key` and `clerk-secret-key`.
- [ ] `gcloud run services describe lifting-logbook-prod-web --region=us-central1 --format='value(spec.template.spec.containers[0].env[].name)'` includes `CLERK_SECRET_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)