### PR TITLE
[fix] Pass NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY to web image build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,6 +177,34 @@ jobs:
             echo "url=${URL}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Resolve Clerk publishable key for web image build
+        id: clerk-pub
+        run: |
+          # NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY is build-time embedded in the
+          # Next.js bundle (see apps/web/Dockerfile ARG). Without it, `next
+          # build` aborts on /_not-found prerender because <ClerkProvider>
+          # in the root layout throws "Missing publishableKey". The image
+          # is shared between staging and production deploys (cache reuse
+          # by tag=github.sha), so we follow the same staging-vs-prod
+          # convention as `Resolve API URL` above.
+          if [[ "${{ needs.preflight.outputs.staging_enabled }}" == "true" ]]; then
+            KEY=$(gcloud secrets versions access latest \
+              --secret="lifting-logbook-stg-clerk-publishable-key" \
+              --project="${{ vars.GCP_STAGING_PROJECT_ID }}")
+          else
+            KEY=$(gcloud secrets versions access latest \
+              --secret="lifting-logbook-prod-clerk-publishable-key" \
+              --project="${{ vars.GCP_PROD_PROJECT_ID }}")
+          fi
+          [ -n "$KEY" ] || { echo "ERROR: clerk-publishable-key fetch returned empty"; exit 1; }
+          # Use ::add-mask:: so the key never appears in logs even though
+          # it is a publishable (non-secret) Clerk key. Defense in depth.
+          echo "::add-mask::$KEY"
+          # GITHUB_OUTPUT does not accept multi-line values without delimiters
+          # but the Clerk publishable key is a single line so a direct echo
+          # is safe.
+          echo "key=${KEY}" >> "$GITHUB_OUTPUT"
+
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker ${{ env.REGISTRY }} --quiet
 
@@ -206,6 +234,7 @@ jobs:
             ${{ steps.ar.outputs.repo }}/web:latest
           build-args: |
             NEXT_PUBLIC_API_URL=${{ steps.api-url.outputs.url }}
+            NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ steps.clerk-pub.outputs.key }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Summary

Production deploys to `main` have been silently failing on the **Build & Push Images** job for at least three commits (`026f46f`, `c3c1093`, `0cbc16c`). The web Dockerfile declares `ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` because Next.js needs it during `/_not-found` prerender (the root layout's `<ClerkProvider>` throws "Missing publishableKey" otherwise), but `deploy.yml`'s `Build and push web image` step only passed `NEXT_PUBLIC_API_URL` as a build-arg. The result: no new web image has been pushed to Artifact Registry recently, and the Clerk runtime fix from #383 was sitting at the gate.

This is the build-time analogue of #382/#383 — same root cause class (Clerk publishable key missing from web deploy pipeline), different layer (image build vs. runtime env).

## Changes

- `.github/workflows/deploy.yml` — new `Resolve Clerk publishable key for web image build` step that fetches `lifting-logbook-{stg,prod}-clerk-publishable-key` from Secret Manager (staging vs. prod mode same as the existing `Resolve API URL` step). Passes the value through to `Build and push web image` as a second build-arg. Includes the same empty-value guard pattern as #383. Masks the key in logs via `::add-mask::` for defense in depth, even though Clerk publishable keys are non-secret by design.

Closes #386.

## Testing

Infra/workflow-only change; no application code or tests are modified. `npm test` was not run because the diff cannot affect any unit/integration suite. Pre-PR grep checks:

- Suppression policy grep against the diff: **0 matches**.
- Test-integrity grep against the diff: **0 matches**.

The actual verification surface is post-merge — the CI build itself is the test:

- [ ] Post-merge `Build & Push Images` job succeeds on commit landing in main (previously failing for 3+ consecutive commits).
- [ ] `deploy-staging` consumes the new image and passes smoke + integration tests.
- [ ] Production deploy completes and `curl -sI https://liftinglogbook.com/cycle` returns 307→`/sign-in`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
