### PR TITLE
[infra] Build web image per-env to stop baking staging values into prod

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,40 +163,31 @@ jobs:
           PREFLIGHT_REPO="${{ needs.preflight.outputs.ar_repo }}"
           echo "repo=${STAGING_REPO:-$PREFLIGHT_REPO}" >> "$GITHUB_OUTPUT"
 
-      - name: Resolve API URL for web image build
-        id: api-url
-        run: |
-          if [[ "${{ needs.preflight.outputs.staging_enabled }}" == "true" ]]; then
-            echo "url=${{ needs.terraform-staging.outputs.cloud_run_api_url }}" >> "$GITHUB_OUTPUT"
-          else
-            # Production-only mode: gcloud auth is already done above.
-            URL=$(gcloud run services describe lifting-logbook-prod-api \
-              --region="${{ env.REGION }}" \
-              --project="${{ vars.GCP_PROD_PROJECT_ID }}" \
-              --format="value(status.url)")
-            echo "url=${URL}" >> "$GITHUB_OUTPUT"
-          fi
+      # ── Per-env value resolution for web image build (ADR-025) ────────────
+      # NEXT_PUBLIC_* values are inlined into the Next.js JS bundle at build
+      # time, so the web image is built once per target env with that env's
+      # values. Both image variants are pushed to the same AR repo (steps.ar)
+      # — the same pattern the API image uses today; per-env AR routing is
+      # out of scope for this change.
 
-      - name: Resolve Clerk publishable key for web image build
-        id: clerk-pub
+      - name: Resolve staging API URL (web image build)
+        id: api-url-staging
+        if: needs.preflight.outputs.staging_enabled == 'true'
+        run: |
+          echo "url=${{ needs.terraform-staging.outputs.cloud_run_api_url }}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve staging Clerk publishable key (web image build)
+        id: clerk-pub-staging
+        if: needs.preflight.outputs.staging_enabled == 'true'
         run: |
           # NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY is build-time embedded in the
           # Next.js bundle (see apps/web/Dockerfile ARG). Without it, `next
           # build` aborts on /_not-found prerender because <ClerkProvider>
-          # in the root layout throws "Missing publishableKey". The image
-          # is shared between staging and production deploys (cache reuse
-          # by tag=github.sha), so we follow the same staging-vs-prod
-          # convention as `Resolve API URL` above.
-          if [[ "${{ needs.preflight.outputs.staging_enabled }}" == "true" ]]; then
-            KEY=$(gcloud secrets versions access latest \
-              --secret="lifting-logbook-stg-clerk-publishable-key" \
-              --project="${{ vars.GCP_STAGING_PROJECT_ID }}")
-          else
-            KEY=$(gcloud secrets versions access latest \
-              --secret="lifting-logbook-prod-clerk-publishable-key" \
-              --project="${{ vars.GCP_PROD_PROJECT_ID }}")
-          fi
-          [ -n "$KEY" ] || { echo "ERROR: clerk-publishable-key fetch returned empty"; exit 1; }
+          # in the root layout throws "Missing publishableKey".
+          KEY=$(gcloud secrets versions access latest \
+            --secret="lifting-logbook-stg-clerk-publishable-key" \
+            --project="${{ vars.GCP_STAGING_PROJECT_ID }}")
+          [ -n "$KEY" ] || { echo "ERROR: staging clerk-publishable-key fetch returned empty"; exit 1; }
           # Use ::add-mask:: so the key never appears in logs even though
           # it is a publishable (non-secret) Clerk key. Defense in depth.
           echo "::add-mask::$KEY"
@@ -204,6 +195,48 @@ jobs:
           # but the Clerk publishable key is a single line so a direct echo
           # is safe.
           echo "key=${KEY}" >> "$GITHUB_OUTPUT"
+
+      # Production-value resolution requires auth to the prod project. The
+      # staging auth above is replaced for the duration of these steps; the
+      # API image build and any subsequent staging push re-authenticate to
+      # staging below. In production-only mode this is a no-op re-auth.
+      - name: Authenticate to GCP (production, for prod web build-args)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_PROD_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_PROD_SERVICE_ACCOUNT }}
+
+      - name: Resolve production API URL (web image build)
+        id: api-url-prod
+        run: |
+          # The prod Cloud Run API service is created by terraform-production,
+          # which runs *after* this job. On first-time prod bootstrap the
+          # `describe` call fails; rerun this workflow after the prod Cloud
+          # Run service exists. Tracked as a known limitation in ADR-025.
+          URL=$(gcloud run services describe lifting-logbook-prod-api \
+            --region="${{ env.REGION }}" \
+            --project="${{ vars.GCP_PROD_PROJECT_ID }}" \
+            --format="value(status.url)")
+          [ -n "$URL" ] || { echo "ERROR: prod API URL fetch returned empty (is lifting-logbook-prod-api deployed?)"; exit 1; }
+          echo "url=${URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve production Clerk publishable key (web image build)
+        id: clerk-pub-prod
+        run: |
+          KEY=$(gcloud secrets versions access latest \
+            --secret="lifting-logbook-prod-clerk-publishable-key" \
+            --project="${{ vars.GCP_PROD_PROJECT_ID }}")
+          [ -n "$KEY" ] || { echo "ERROR: prod clerk-publishable-key fetch returned empty"; exit 1; }
+          echo "::add-mask::$KEY"
+          echo "key=${KEY}" >> "$GITHUB_OUTPUT"
+
+      # Restore staging auth for the image pushes that target the staging AR.
+      - name: Re-authenticate to GCP (staging, restore for pushes)
+        if: needs.preflight.outputs.staging_enabled == 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_STAGING_SERVICE_ACCOUNT }}
 
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker ${{ env.REGISTRY }} --quiet
@@ -223,18 +256,38 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Build and push web image
+      # ── Web image: per-env builds (ADR-025) ────────────────────────────────
+      # Two builds with per-env NEXT_PUBLIC_* values. The staging tag is built
+      # and pushed only when staging is enabled; the prod tag is always built.
+      # Both push to the same AR repo as the API image (steps.ar.outputs.repo).
+
+      - name: Build and push web image (staging)
+        if: needs.preflight.outputs.staging_enabled == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
           file: apps/web/Dockerfile
           push: true
           tags: |
-            ${{ steps.ar.outputs.repo }}/web:${{ github.sha }}
+            ${{ steps.ar.outputs.repo }}/web:${{ github.sha }}-staging
+          build-args: |
+            NEXT_PUBLIC_API_URL=${{ steps.api-url-staging.outputs.url }}
+            NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ steps.clerk-pub-staging.outputs.key }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push web image (production)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/web/Dockerfile
+          push: true
+          tags: |
+            ${{ steps.ar.outputs.repo }}/web:${{ github.sha }}-prod
             ${{ steps.ar.outputs.repo }}/web:latest
           build-args: |
-            NEXT_PUBLIC_API_URL=${{ steps.api-url.outputs.url }}
-            NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ steps.clerk-pub.outputs.key }}
+            NEXT_PUBLIC_API_URL=${{ steps.api-url-prod.outputs.url }}
+            NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ steps.clerk-pub-prod.outputs.key }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -335,7 +388,7 @@ jobs:
             --namespace=staging \
             --values=infra/kubernetes/values/staging-web.yaml \
             --set image.repository="${{ needs.build-images.outputs.ar_repo }}/web" \
-            --set image.tag="${{ github.sha }}" \
+            --set image.tag="${{ github.sha }}-staging" \
             --set gcp.projectId="${{ vars.GCP_STAGING_PROJECT_ID }}" \
             --set env.NODE_ENV=staging \
             --set env.API_URL="$API_CLUSTER_URL" \
@@ -355,7 +408,7 @@ jobs:
       - name: Deploy web to Cloud Run (staging)
         run: |
           gcloud run deploy lifting-logbook-stg-web \
-            --image="${{ needs.build-images.outputs.ar_repo }}/web:${{ github.sha }}" \
+            --image="${{ needs.build-images.outputs.ar_repo }}/web:${{ github.sha }}-staging" \
             --region="${{ env.REGION }}" \
             --project="${{ vars.GCP_STAGING_PROJECT_ID }}" \
             --platform=managed \
@@ -536,7 +589,7 @@ jobs:
             --namespace=production \
             --values=infra/kubernetes/values/production-web.yaml \
             --set image.repository="${{ steps.tf-prod.outputs.ar_repo }}/web" \
-            --set image.tag="${{ github.sha }}" \
+            --set image.tag="${{ github.sha }}-prod" \
             --set gcp.projectId="${{ vars.GCP_PROD_PROJECT_ID }}" \
             --set env.NODE_ENV=production \
             --set env.API_URL="$API_CLUSTER_URL" \
@@ -555,7 +608,7 @@ jobs:
       - name: Deploy web to Cloud Run (production)
         run: |
           gcloud run deploy lifting-logbook-prod-web \
-            --image="${{ steps.tf-prod.outputs.ar_repo }}/web:${{ github.sha }}" \
+            --image="${{ steps.tf-prod.outputs.ar_repo }}/web:${{ github.sha }}-prod" \
             --region="${{ env.REGION }}" \
             --project="${{ vars.GCP_PROD_PROJECT_ID }}" \
             --platform=managed \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -238,6 +238,12 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_STAGING_SERVICE_ACCOUNT }}
 
+      # Auth context invariant: at this point, credentials must be capable of
+      # pushing to steps.ar.outputs.repo. In staging-enabled mode that means
+      # staging-AR-capable (restored by the Re-authenticate step above); in
+      # production-only mode the prod auth step above is sufficient. Any step
+      # inserted between the auth-restore and here must preserve this invariant
+      # (do not call `auth@v2` with a different identity between them).
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker ${{ env.REGISTRY }} --quiet
 
@@ -276,6 +282,14 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # `:latest` is intentionally moved here from the (previously single) web
+      # build. In staging-enabled mode this means the `:latest` tag in the
+      # staging AR resolves to the *prod*-configured bundle, not the
+      # staging-configured one. Any downstream consumer that pulls `:latest`
+      # from the staging AR (manual ops, cache-warming jobs) must be aware of
+      # this asymmetry. The staging deploy never references `:latest` — it
+      # uses the explicit `-staging` SHA tag — so the asymmetry is invisible
+      # to the deploy pipeline itself.
       - name: Build and push web image (production)
         uses: docker/build-push-action@v6
         with:

--- a/docs/README.md
+++ b/docs/README.md
@@ -156,6 +156,7 @@ monorepo/
 | [ADR-022](adr/ADR-022-monorepo-docker-build-strategy.md)     | Monorepo Docker Build Strategy — Full Copy Over Turbo Prune         | Accepted |
 | [ADR-023](adr/ADR-023-staging-integration-test-design.md)   | Staging Integration Test Design                                     | Accepted |
 | [ADR-024](adr/ADR-024-prisma-otel-sdk-override.md)          | Prisma OTel SDK Version Conflict — postinstall Cleanup              | Accepted |
+| [ADR-025](adr/ADR-025-web-image-per-env-build.md)           | Per-Environment Web Image Build                                     | Accepted |
 
 ---
 

--- a/docs/adr-references.md
+++ b/docs/adr-references.md
@@ -228,6 +228,17 @@ References from [`docs/security-review-checklist.md`](security-review-checklist.
 
 ---
 
+## Deployment Pipeline
+
+| Source | Cited In | Relevance |
+|---|---|---|
+| [Next.js — Configuring Environment Variables](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables) | [ADR-025](adr/ADR-025-web-image-per-env-build.md) | Authoritative on `NEXT_PUBLIC_*` build-time inlining; values are inlined into JavaScript sent to the browser and fixed at build time, the root cause that forces per-env image builds. |
+| [Docker — `ARG` and build-time variables](https://docs.docker.com/engine/reference/builder/#arg) | [ADR-025](adr/ADR-025-web-image-per-env-build.md) | Build-arg semantics; a build-arg change invalidates downstream layer cache, which is why the staging and prod web builds re-execute `RUN npx turbo run build` despite sharing the install layers. |
+| [Clerk — Publishable Key](https://clerk.com/docs/deployments/clerk-environment-variables#clerk-publishable-key) | [ADR-025](adr/ADR-025-web-image-per-env-build.md) | Documents that the publishable key is environment-bound (one key per Clerk instance) and is required by `<ClerkProvider>` at client mount. |
+| [`docker/build-push-action`](https://github.com/docker/build-push-action) | [ADR-025](adr/ADR-025-web-image-per-env-build.md) | GitHub Action used to invoke `docker build`; `cache-from`/`cache-to: type=gha` semantics for GitHub Actions layer cache reuse between the staging and prod builds. |
+
+---
+
 ## Testing and CI
 
 | Source | Cited In | Relevance |

--- a/docs/adr/ADR-025-web-image-per-env-build.md
+++ b/docs/adr/ADR-025-web-image-per-env-build.md
@@ -1,0 +1,151 @@
+# ADR-025: Per-Environment Web Image Build
+
+**Status:** Accepted
+**Date:** 2026-05-31
+**Closes:** [#388](https://github.com/brownm09/lifting-logbook/issues/388)
+**Related:** [ADR-022](ADR-022-monorepo-docker-build-strategy.md) (web Dockerfile structure), [ADR-009](ADR-009-infrastructure-kubernetes-cloud-run.md) (deploy targets), [#383](https://github.com/brownm09/lifting-logbook/pull/383), [#387](https://github.com/brownm09/lifting-logbook/pull/387), [#382](https://github.com/brownm09/lifting-logbook/issues/382)
+
+---
+
+## Context
+
+`apps/web/Dockerfile` is a Next.js App Router build. Next.js inlines any `NEXT_PUBLIC_*`
+environment variable into the client JS bundle **at build time** — the value is literally
+substituted into the compiled JavaScript shipped to browsers and embedded in Cloud Run /
+GKE container images. Two such variables are currently consumed as Docker build-args:
+
+- `NEXT_PUBLIC_API_URL` — the Cloud Run API URL the web frontend calls.
+- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` — the Clerk frontend key required by `<ClerkProvider>`
+  in the root layout. Without it, `next build` aborts during `/_not-found` prerender.
+
+Prior to this ADR, `.github/workflows/deploy.yml`'s `build-images` job resolved both values
+from the **staging** project whenever `staging_enabled == true`, built a single
+`web:${{ github.sha }}` image, and let both `deploy-staging` and `deploy-production` pull
+that same tag. The production web pod therefore served a JS bundle with staging values
+inlined — invisible while staging and production share infrastructure, but a guaranteed
+silent production break the moment they don't (separate Clerk instances per env, separate
+API hosts, separate publishable keys).
+
+This is the same failure shape as [#382](https://github.com/brownm09/lifting-logbook/issues/382)
+at a different layer. Two recent fixes — [#383](https://github.com/brownm09/lifting-logbook/pull/383)
+(runtime `CLERK_SECRET_KEY`) and [#387](https://github.com/brownm09/lifting-logbook/pull/387)
+(build-time `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`) — addressed individual symptoms of the
+broader pattern "Clerk credential not wired through deploy pipeline" but preserved the
+inherited "use staging value, deploy to both" shortcut. This ADR fixes the root pattern.
+
+## Decision
+
+Build the web image **twice per pipeline run** when staging is enabled, with
+environment-specific build-args:
+
+- `web:${{ github.sha }}-staging` — built with staging `NEXT_PUBLIC_*` values; deployed
+  exclusively to staging.
+- `web:${{ github.sha }}-prod` — built with production `NEXT_PUBLIC_*` values; deployed
+  exclusively to production. Also tagged `:latest`.
+
+In production-only mode (no staging configured), only the `-prod` image is built.
+
+The `api` image is unchanged — it has no `NEXT_PUBLIC_*` build-args and continues to follow
+build-once / promote-everywhere.
+
+### Explicit trade
+
+This decision **breaks the byte-identical promotion contract for the web image**. The image
+exercised by the `smoke-test` job in staging is no longer the same artifact deployed to
+production; the two differ in the values of `NEXT_PUBLIC_API_URL` and
+`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` (and any future `NEXT_PUBLIC_*` value) embedded in the
+JS bundle. The staging gate validates the image's **structure and runtime behavior** — that
+`next build` succeeded, that the standalone server boots, that `/` returns 200 — not its
+embedded public config. Production-specific embedded values are not exercised by any
+automated check prior to production deploy; the "deliberate dry-run" in the
+[Verification](#verification) section is the only check that production-specific values are
+correctly baked.
+
+This trade is acceptable because the alternative (option discussed below) preserves the
+contract but ships wrong values to production. Phase 2 (see [Follow-up](#follow-up))
+restores the contract by eliminating the build-time embedding entirely.
+
+## Consequences
+
+**Positive:**
+- Production web pod serves a bundle with production `NEXT_PUBLIC_*` values. Staging serves
+  staging values. The two environments are decoupled at the artifact level.
+- Each image is a sealed, auditable artifact — "does this image have the right key baked
+  in?" is answered by the tag.
+- No application code changes; isolated to the deploy pipeline.
+
+**Negative:**
+- Web image build time roughly doubles on the staging-enabled path (two
+  `RUN npx turbo run build` invocations; the install layers cache across both). Empirically
+  ~2–3 minutes added per deploy on current build sizes.
+- Artifact Registry storage for the web image roughly doubles (two SHA-tagged images per
+  commit instead of one). Negligible at current scale.
+- Every new `NEXT_PUBLIC_*` value going forward must be wired into **both** build invocations
+  in `build-images` and resolved twice (staging + prod secret lookups). The cost of forgetting
+  is the original bug. Mitigation: a checklist in [`docs/deploy.md`](../deploy.md) under
+  "Adding a new `NEXT_PUBLIC_*` variable".
+- The smoke-test gate no longer guarantees that the production-tagged artifact will boot
+  successfully — only that the staging-tagged sibling does. A `next build` failure caused by
+  a malformed production-only value (e.g., a Clerk publishable key with a typo in the prod
+  secret) is caught at `build-images` time (the prod build step fails the pipeline), but a
+  runtime issue specific to the prod image's embedded values would only surface in production.
+
+## Alternatives Considered
+
+### Runtime public config (deferred to follow-up)
+
+Refactor `apps/web` to inject `NEXT_PUBLIC_*` values at runtime — either via a
+server-rendered `<script>` in the root layout that sets a `window.__PUBLIC_CONFIG__` global
+before the client React tree mounts, or via a Server Component that fetches the values and
+passes them through React context. Remove `ARG NEXT_PUBLIC_*` from the Dockerfile. Restore
+single-image build-once / promote-everywhere.
+
+**Why deferred:** the refactor touches the `<ClerkProvider>` bootstrap path — the same
+codepath that [#383](https://github.com/brownm09/lifting-logbook/pull/383) and
+[#387](https://github.com/brownm09/lifting-logbook/pull/387) just stabilized. It also has
+its own regression surface (any client component reading `process.env.NEXT_PUBLIC_*`
+directly), warrants its own ADR documenting the bootstrap pattern chosen, and should not
+block closing [#388](https://github.com/brownm09/lifting-logbook/issues/388). Tracked as a
+follow-up issue that, once shipped, will supersede this ADR.
+
+### Promote prod build to staging
+
+Build one image with **production** values and deploy it to both staging and production.
+Trivial pipeline change. Rejected: staging then exercises Clerk's production tenant and
+calls the production API URL, defeating the purpose of having a separate staging
+environment for those components and creating a real risk of staging-originated traffic
+mutating production-Clerk user state.
+
+## Verification
+
+- **CI:** `deploy.yml` runs on every push to `main`. A push of this branch validates that
+  the two-build path succeeds end-to-end (both `web:<sha>-staging` and `web:<sha>-prod`
+  built, pushed, and pulled by the corresponding deploy jobs).
+- **Smoke test:** existing `smoke-test` job continues to validate the staging-tagged image.
+- **Deliberate dry-run (AC #3 of [#388](https://github.com/brownm09/lifting-logbook/issues/388)):**
+  after the first deploy on this branch, follow the procedure in
+  [`docs/deploy.md`](../deploy.md) → "Verifying per-env web image build" to grep the served
+  JS bundle in each environment for the **other** environment's Clerk publishable key
+  prefix and API URL hostname. Both must be absent.
+
+## Follow-up
+
+Open a separate `[design]` issue titled "Refactor apps/web public config to runtime
+injection (supersedes ADR-025)" immediately after [#388](https://github.com/brownm09/lifting-logbook/issues/388)
+closes. That work will supersede this ADR.
+
+## References
+
+- [Next.js — Configuring Environment Variables](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables) —
+  Authoritative on `NEXT_PUBLIC_*` build-time inlining: "the value will be inlined into
+  JavaScript sent to the browser" and is fixed at build time, not runtime.
+- [Docker — `ARG` and build-time variables](https://docs.docker.com/engine/reference/builder/#arg) —
+  Build-arg semantics; a build-arg change invalidates downstream layer cache, which is why
+  the two build invocations re-execute `RUN npx turbo run build` despite sharing the
+  install layers.
+- [Clerk — Publishable Key](https://clerk.com/docs/deployments/clerk-environment-variables#clerk-publishable-key) —
+  Documents that the publishable key is environment-bound (one key per Clerk instance) and
+  is required by `<ClerkProvider>` at client mount.
+- [`docker/build-push-action`](https://github.com/docker/build-push-action) — The GitHub
+  Action used to invoke `docker build`; `cache-from`/`cache-to: type=gha` semantics for
+  GitHub Actions layer cache reuse between the staging and prod builds.

--- a/docs/adr/ADR-025-web-image-per-env-build.md
+++ b/docs/adr/ADR-025-web-image-per-env-build.md
@@ -128,11 +128,73 @@ mutating production-Clerk user state.
   JS bundle in each environment for the **other** environment's Clerk publishable key
   prefix and API URL hostname. Both must be absent.
 
+## Cross-project Artifact Registry note
+
+In staging-enabled mode, both web image variants (`web:<sha>-staging` and
+`web:<sha>-prod`) are pushed to the **staging** project's Artifact Registry
+(`steps.ar.outputs.repo` resolves from `terraform-staging.outputs.ar_repo`),
+while `deploy-production` pulls images from the **production** project's AR
+(`steps.tf-prod.outputs.ar_repo`). This asymmetry is **not new** to this ADR
+— the API image has the same shape today (built at `steps.ar.outputs.repo`,
+deployed from `steps.tf-prod.outputs.ar_repo`) — but it deserves explicit
+mention because per-env image tags make the cross-project pull path more
+load-bearing.
+
+This works in practice via one of two mechanisms (both currently in use):
+
+1. **Production-only mode** (`staging_enabled == false`): the preflight job
+   hardcodes `ar_repo` to the prod project (`deploy.yml` line ~58), and
+   `terraform-production.outputs.ar_repo` resolves to the same value. The
+   "asymmetry" collapses to a no-op.
+2. **Staging-enabled mode**: the production service accounts hold an
+   `artifactregistry.reader` IAM grant on the staging project's AR, so prod
+   GKE/Cloud Run can pull the prod-tagged image from the staging AR. This
+   grant must be in place before any production deploy succeeds.
+
+Per-env AR routing (each environment publishing to its own AR) is the
+cleaner long-term shape and is tracked as a follow-up to this ADR. Until
+then, do not remove the cross-project IAM grant without also moving the
+production push target.
+
 ## Follow-up
 
-Open a separate `[design]` issue titled "Refactor apps/web public config to runtime
-injection (supersedes ADR-025)" immediately after [#388](https://github.com/brownm09/lifting-logbook/issues/388)
-closes. That work will supersede this ADR.
+Two follow-ups are tracked:
+
+1. **Runtime public config (Phase 2):** open a separate `[design]` issue
+   titled "Refactor apps/web public config to runtime injection (supersedes
+   ADR-025)" immediately after [#388](https://github.com/brownm09/lifting-logbook/issues/388)
+   closes. That work will supersede this ADR by removing the build-time
+   embedding entirely.
+2. **Per-env AR routing:** track separately. Push each environment's image
+   variant to that environment's AR, eliminating the cross-project pull
+   dependency.
+
+## First-time prod bootstrap
+
+The `Resolve production API URL` step calls
+`gcloud run services describe lifting-logbook-prod-api` from `build-images`,
+which runs **before** `deploy-production` (where `terraform-production`
+creates the service). On the very first deploy to a new prod project (where
+the prod Cloud Run API service does not yet exist), this step fails and
+aborts the entire `build-images` job — including any in-flight staging
+deploy.
+
+This is a one-time bootstrap concern. Recovery procedure:
+
+1. Run the pipeline once in **production-only mode** (do not set
+   `GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER`). The prod-only path does not
+   depend on the prod Cloud Run service existing because the URL resolution
+   is the same `describe` call — so this still fails on bootstrap. Instead:
+2. Run `terraform apply` against the production workspace manually from a
+   workstation with prod credentials. This creates the prod Cloud Run API
+   service.
+3. Re-run the CI pipeline. `Resolve production API URL` now succeeds.
+
+A cleaner long-term shape (depending on `terraform-production` outputs from
+`build-images`) is blocked by the current job DAG: `terraform-production`
+runs as a *step* inside `deploy-production`, which depends on `build-images`.
+Restructuring requires hoisting `terraform-production` to its own job — out
+of scope for this ADR.
 
 ## References
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -395,6 +395,36 @@ Run the symmetric check against staging for the production values. Both must pro
 `OK:` to satisfy the verification gate from
 [#388](https://github.com/brownm09/lifting-logbook/issues/388).
 
+#### First-time prod bootstrap
+
+The `build-images` job's `Resolve production API URL` step calls
+`gcloud run services describe lifting-logbook-prod-api` before
+`terraform-production` has had a chance to create that service. On the very
+first deploy to a new prod project this aborts `build-images` and (in
+staging-enabled mode) also blocks the staging deploy. Recovery:
+
+1. From a workstation with prod credentials, run `terraform apply` against
+   the production workspace manually:
+   ```bash
+   cd infra/terraform
+   terraform init -backend-config="bucket=<TF_STATE_BUCKET>" \
+                  -backend-config="prefix=terraform/state"
+   terraform workspace select production || terraform workspace new production
+   terraform apply -var-file=terraform.tfvars.production \
+                   -var="billing_account=<billing-account-id>"
+   ```
+2. Confirm the prod Cloud Run API service now exists:
+   ```bash
+   gcloud run services describe lifting-logbook-prod-api \
+     --region=us-central1 --project=<prod-project>
+   ```
+3. Re-run the failed CI pipeline. `Resolve production API URL` now succeeds
+   and the rest of `build-images` and the downstream deploys proceed.
+
+This is a one-time bootstrap concern per prod project. The long-term fix
+(hoisting `terraform-production` to its own job so `build-images` can
+depend on its outputs) is documented in ADR-025 as a deferred follow-up.
+
 ### Recovering from CI/CD IAM errors
 
 If a CI run fails with `Error 403 ... setIamPolicy denied`, the CI/CD service account is

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -335,6 +335,66 @@ the production URL will appear in the `deploy-production` job summary after appr
 
 Push or merge to `main`. The pipeline runs automatically.
 
+### Web image: per-env build (ADR-025)
+
+The `apps/web` image is built **twice per pipeline run** when staging is enabled:
+
+- `web:<sha>-staging` — built with staging `NEXT_PUBLIC_API_URL` and
+  `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`. Deployed exclusively by `deploy-staging`.
+- `web:<sha>-prod` — built with production values. Deployed exclusively by `deploy-production`.
+  Also tagged `:latest`.
+
+In production-only mode (no staging configured), only the `-prod` image is built.
+
+See [ADR-025](adr/ADR-025-web-image-per-env-build.md) for the rationale and the explicit
+trade — the staging gate validates image structure and boot behavior, **not** the embedded
+production `NEXT_PUBLIC_*` values.
+
+#### Adding a new `NEXT_PUBLIC_*` variable
+
+Every new `NEXT_PUBLIC_*` value must be wired into **both** web-image build invocations in
+`.github/workflows/deploy.yml` → `build-images`. Checklist:
+
+1. Add `ARG <NAME>` to `apps/web/Dockerfile` builder stage.
+2. Add staging value resolution as a new step alongside `clerk-pub-staging` (gated on
+   `staging_enabled == true`). Use `gcloud secrets versions access` for secret-store values
+   or a Terraform output for infra-derived values.
+3. Add production value resolution as a new step alongside `clerk-pub-prod`.
+4. Wire both into the `build-args:` block of `Build and push web image (staging)` and
+   `Build and push web image (production)`.
+5. Mask secret-store values with `::add-mask::` before writing to `GITHUB_OUTPUT`.
+6. Update this section if the variable affects deploy behavior at runtime as well.
+
+Forgetting any of the above resurrects the bug ADR-025 was written to fix.
+
+#### Verifying per-env web image build (deliberate dry-run)
+
+After a deploy completes, confirm each environment's bundle contains only its own
+`NEXT_PUBLIC_*` values. From a workstation with both env's Clerk publishable-key prefixes
+known (e.g., `pk_test_...` for staging, `pk_live_...` for production):
+
+```bash
+# Production must NOT contain staging Clerk key prefix or staging API hostname.
+PROD_WEB="$(gcloud run services describe lifting-logbook-prod-web \
+  --region=us-central1 --project=lifting-logbook-prod --format='value(status.url)')"
+STG_API_HOST="$(gcloud run services describe lifting-logbook-stg-api \
+  --region=us-central1 --project=lifting-logbook-stg --format='value(status.url)' \
+  | sed -e 's#^https\?://##' -e 's#/.*##')"
+STG_PK_PREFIX="pk_test_"  # adjust to actual staging key's distinguishing prefix
+
+curl -sL "$PROD_WEB" -o /tmp/prod-index.html
+# Pull each referenced /_next/static/chunks/*.js and grep
+for chunk in $(grep -oE '/_next/static/chunks/[a-zA-Z0-9_./-]+\.js' /tmp/prod-index.html | sort -u); do
+  curl -sL "${PROD_WEB}${chunk}" | grep -E "($STG_API_HOST|$STG_PK_PREFIX)" \
+    && { echo "FAIL: staging value found in $chunk"; exit 1; }
+done
+echo "OK: production bundle is free of staging values"
+```
+
+Run the symmetric check against staging for the production values. Both must produce
+`OK:` to satisfy the verification gate from
+[#388](https://github.com/brownm09/lifting-logbook/issues/388).
+
 ### Recovering from CI/CD IAM errors
 
 If a CI run fails with `Error 403 ... setIamPolicy denied`, the CI/CD service account is


### PR DESCRIPTION
## Summary

- Build the `apps/web` image twice per pipeline run with per-env `NEXT_PUBLIC_*` build-args: `web:<sha>-staging` (staging-only) and `web:<sha>-prod` (production-only, also `:latest`).
- Update `deploy-staging` and `deploy-production` to reference the env-specific tag for both GKE (Helm) and Cloud Run deploys.
- New ADR-025 records the decision and the explicit trade (staging gate no longer validates prod-embedded public values); `docs/deploy.md` adds a checklist for new `NEXT_PUBLIC_*` variables, a bundle-grep verification procedure, and a first-time prod bootstrap recovery procedure.

Closes #388.

## Why

Root-pattern fix following the runtime (#383) and build-time (#387) Clerk credential fixes. Previously a single `web:<sha>` image was built with staging values when `staging_enabled == true` and promoted unchanged to production. The prod web pod ran a JS bundle with staging values inlined — silent today because staging/prod share infra, silently broken the moment they don't (same shape as #382).

Phase 2 (runtime public-config refactor, will supersede ADR-025) is tracked as a follow-up issue per the ADR — it touches `apps/web` source and the `<ClerkProvider>` bootstrap path, so it shouldn't block closing #388.

## Pipeline shape (build-images)

1. Resolve staging values (gated on `staging_enabled`).
2. Re-auth to prod, resolve prod values (always).
3. Re-auth to staging for the staging-AR pushes (gated on `staging_enabled`).
4. Push API image (unchanged).
5. Build+push `web:<sha>-staging` (gated on `staging_enabled`).
6. Build+push `web:<sha>-prod` + `:latest` (always).

Both web variants are pushed to the same AR repo as the API image (`steps.ar.outputs.repo`) — per-env AR routing is out of scope for this PR. The cross-project pull arrangement (prod GKE/Cloud Run pulling from staging AR when staging is enabled) is documented in ADR-025 § "Cross-project Artifact Registry note" and tracked as a follow-up.

## Review findings addressed (commit 03935c7)

`/review` posted https://github.com/brownm09/lifting-logbook/pull/392#issuecomment-4589404188 — 1 blocking + 5 non-blocking findings + 2 author questions. All resolved in commit `03935c7`:

- **(blocking documentation)** `docs/README.md` Architecture Decision Records table now includes ADR-025.
- **(reliability)** Bootstrap concern documented in ADR-025 § "First-time prod bootstrap" and `docs/deploy.md` § "First-time prod bootstrap" with the three-step manual `terraform apply` recovery procedure. Hard-fail behavior kept (loud surface > silent skip).
- **(reliability)** Auth-context invariant comment added immediately before `Configure Docker for Artifact Registry` in deploy.yml.
- **(maintainability)** `:latest` semantics comment added on the prod build step.
- **(maintainability)** Cross-project AR pull arrangement documented in ADR-025 with the explicit warning not to remove the prod-SA `artifactregistry.reader` grant on staging AR without also moving the push target.
- **(maintainability)** PR body Testing section now includes a contractual status line (below).

## Testing

`npm test` from the repo root.

Tests: not run on this branch — Jest module resolution blocked by [#373](https://github.com/brownm09/lifting-logbook/issues/373) (Node 24 / Windows `npm install` tarball corruption; `nvm` not on PATH in this shell). This PR touches only `.github/workflows/deploy.yml` and `docs/*.md` — no application or test source — so it cannot affect test outcomes.

End-to-end verification of the pipeline change happens when this branch is pushed to `main` and `deploy.yml` runs; the bundle-grep procedure documented in `docs/deploy.md` → "Verifying per-env web image build" satisfies acceptance criterion #3 of #388.

### Suppression / test-integrity / coverage

- Suppression grep: clean.
- Test-integrity grep: clean. No skip markers, deleted tests, lowered thresholds, or `passWithNoTests` introduced.
- Coverage gate: no testable behavior added (CI YAML + docs only). N/A.

## Test plan

- [ ] After merge: `deploy.yml` run on `main` shows both `Build and push web image (staging)` and `Build and push web image (production)` steps succeed and push to AR.
- [ ] `deploy-staging` pulls `web:<sha>-staging`; `deploy-production` pulls `web:<sha>-prod`.
- [ ] Run the bundle-grep procedure in `docs/deploy.md` against each env; both must report `OK:` (no cross-env values).