### PR TITLE
[fix] Probe readiness via /api/healthz so Clerk-init failures fail-closed

### DIFF
--- a/apps/web/app/api/healthz/route.test.ts
+++ b/apps/web/app/api/healthz/route.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from './route';
+
+jest.mock('@clerk/nextjs/server', () => ({
+  auth: jest.fn(),
+}));
+
+import { auth } from '@clerk/nextjs/server';
+
+const mockedAuth = auth as unknown as jest.Mock;
+
+describe('GET /api/healthz', () => {
+  const originalEnv = process.env.DEV_AUTH_TOKEN;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.DEV_AUTH_TOKEN;
+    } else {
+      process.env.DEV_AUTH_TOKEN = originalEnv;
+    }
+    mockedAuth.mockReset();
+  });
+
+  it('returns 200 with ok:true when Clerk auth() resolves', async () => {
+    delete process.env.DEV_AUTH_TOKEN;
+    mockedAuth.mockResolvedValueOnce({ userId: null });
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockedAuth).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression test for #382 / #385: a Clerk-init failure must fail readiness,
+  // not be hidden behind a 200 from a statically-rendered page.
+  it('returns 503 with the error message when Clerk auth() throws', async () => {
+    delete process.env.DEV_AUTH_TOKEN;
+    mockedAuth.mockRejectedValueOnce(new Error('Missing CLERK_SECRET_KEY'));
+
+    const res = await GET();
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({
+      ok: false,
+      error: 'Missing CLERK_SECRET_KEY',
+    });
+  });
+
+  it('skips Clerk and returns ok:true in DEV_AUTH_TOKEN mode', async () => {
+    process.env.DEV_AUTH_TOKEN = 'dev-token';
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, mode: 'dev-auth' });
+    expect(mockedAuth).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/healthz/route.test.ts
+++ b/apps/web/app/api/healthz/route.test.ts
@@ -34,19 +34,27 @@ describe('GET /api/healthz', () => {
     expect(mockedAuth).toHaveBeenCalledTimes(1);
   });
 
-  // Regression test for #382 / #385: a Clerk-init failure must fail readiness,
-  // not be hidden behind a 200 from a statically-rendered page.
-  it('returns 503 with the error message when Clerk auth() throws', async () => {
+  // Regression test for #385: when auth() throws (e.g., the route fell outside
+  // clerkMiddleware's matcher and the auth-status header is absent), the probe
+  // must return 503 so readiness fails. The error message is logged server-side
+  // but deliberately not included in the response body — see route.ts.
+  it('returns 503 with no error body when auth() throws', async () => {
     delete process.env.DEV_AUTH_TOKEN;
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
     mockedAuth.mockRejectedValueOnce(new Error('Missing CLERK_SECRET_KEY'));
 
     const res = await GET();
 
     expect(res.status).toBe(503);
-    expect(await res.json()).toEqual({
-      ok: false,
-      error: 'Missing CLERK_SECRET_KEY',
-    });
+    expect(await res.json()).toEqual({ ok: false });
+    // The original error is logged server-side for operators.
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[healthz]'),
+      expect.objectContaining({ message: 'Missing CLERK_SECRET_KEY' }),
+    );
+    consoleErrorSpy.mockRestore();
   });
 
   it('skips Clerk and returns ok:true in DEV_AUTH_TOKEN mode', async () => {

--- a/apps/web/app/api/healthz/route.ts
+++ b/apps/web/app/api/healthz/route.ts
@@ -1,0 +1,22 @@
+import { auth } from '@clerk/nextjs/server';
+import { NextResponse } from 'next/server';
+
+// Readiness probe target. Must not be statically rendered or edge-cached —
+// otherwise the same Clerk-init failure mode (#382) that broke production
+// would again be hidden from Kubernetes during rollout.
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  if (process.env.DEV_AUTH_TOKEN) {
+    return NextResponse.json({ ok: true, mode: 'dev-auth' });
+  }
+  try {
+    await auth();
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: err instanceof Error ? err.message : 'unknown' },
+      { status: 503 },
+    );
+  }
+}

--- a/apps/web/app/api/healthz/route.ts
+++ b/apps/web/app/api/healthz/route.ts
@@ -1,11 +1,26 @@
 import { auth } from '@clerk/nextjs/server';
 import { NextResponse } from 'next/server';
 
-// Readiness probe target. Must not be statically rendered or edge-cached —
-// otherwise the same Clerk-init failure mode (#382) that broke production
-// would again be hidden from Kubernetes during rollout.
+// Readiness probe target. Must stay force-dynamic so Next never prerenders
+// or edge-caches it — otherwise the failure mode this route exists to detect
+// (#382: clerkMiddleware throws on missing CLERK_SECRET_KEY) would be hidden
+// from Kubernetes during rollout the same way it was when the probe hit `/`.
 export const dynamic = 'force-dynamic';
 
+// Two guards in one handler:
+//   1. The route matches Clerk's `/(api|trpc)(.*)` middleware matcher, so a
+//      missing CLERK_SECRET_KEY (as in #382) throws inside clerkMiddleware
+//      → 500 → fails readiness, before this handler ever runs. That is the
+//      primary #382 regression detector.
+//   2. The auth() call below additionally verifies clerkMiddleware actually
+//      ran on this request — it inspects the `x-clerk-auth-status` header
+//      that middleware stamps. If a future matcher edit silently excludes
+//      `/api/healthz`, auth() throws "auth header missing" and we 503.
+// auth() does NOT re-validate the secret key or make a network call; that
+// work already happened in middleware. We deliberately keep the response
+// body minimal — no error.message — so a publicly-reachable probe endpoint
+// does not leak Clerk misconfiguration details. The original error is still
+// logged server-side for operators.
 export async function GET() {
   if (process.env.DEV_AUTH_TOKEN) {
     return NextResponse.json({ ok: true, mode: 'dev-auth' });
@@ -14,9 +29,8 @@ export async function GET() {
     await auth();
     return NextResponse.json({ ok: true });
   } catch (err) {
-    return NextResponse.json(
-      { ok: false, error: err instanceof Error ? err.message : 'unknown' },
-      { status: 503 },
-    );
+    // eslint-disable-next-line no-console -- server-side log only; not exposed
+    console.error('[healthz] auth() threw — middleware likely did not run:', err);
+    return NextResponse.json({ ok: false }, { status: 503 });
   }
 }

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -6,8 +6,10 @@ const isPublicRoute = createRouteMatcher([
   '/sign-in(.*)',
   '/sign-up(.*)',
   // Kubernetes readiness probe — must run through clerkMiddleware (to exercise
-  // Clerk init) but must not be redirected to /sign-in. See #385.
-  '/api/healthz',
+  // Clerk init) but must not be redirected to /sign-in. See #385. The `(.*)`
+  // suffix matches the sibling sign-in/sign-up patterns and tolerates trailing
+  // slashes or future sub-paths without re-opening the original issue.
+  '/api/healthz(.*)',
 ]);
 
 const clerkHandler = clerkMiddleware(async (auth, request) => {

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -2,7 +2,13 @@ import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
 import type { NextFetchEvent, NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
-const isPublicRoute = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)']);
+const isPublicRoute = createRouteMatcher([
+  '/sign-in(.*)',
+  '/sign-up(.*)',
+  // Kubernetes readiness probe — must run through clerkMiddleware (to exercise
+  // Clerk init) but must not be redirected to /sign-in. See #385.
+  '/api/healthz',
+]);
 
 const clerkHandler = clerkMiddleware(async (auth, request) => {
   if (!isPublicRoute(request)) {

--- a/infra/kubernetes/charts/web/values.yaml
+++ b/infra/kubernetes/charts/web/values.yaml
@@ -43,19 +43,30 @@ ingress:
   host: ""   # generated URL — empty means use the LB IP
 
 livenessProbe:
+  # Liveness intentionally targets `/`, which since #384 calls `auth()`
+  # server-side and is no longer statically prerendered. That means liveness
+  # now exercises clerkMiddleware too — a transient Clerk outage could fail
+  # the probe. failureThreshold is set higher than the K8s default of 3 so
+  # the pod is only killed after a sustained ~3-minute window of failure,
+  # giving Clerk room to recover without crash-looping the deployment.
   httpGet:
     path: /
     port: 3001
   initialDelaySeconds: 15
   periodSeconds: 20
+  timeoutSeconds: 3
+  failureThreshold: 9
 
 readinessProbe:
   # Hits a route that exercises clerkMiddleware so a Clerk-init failure
   # (e.g. missing CLERK_SECRET_KEY, as in #382) fails readiness during
-  # rollout instead of being masked by a statically-prerendered `/`.
-  # Liveness stays on `/` so transient middleware blips don't crash-loop.
+  # rollout instead of being masked. Readiness is more aggressive than
+  # liveness — we want a bad rollout to fail fast and stay un-Ready, while
+  # an already-Ready pod gets the longer liveness grace window above.
   httpGet:
     path: /api/healthz
     port: 3001
   initialDelaySeconds: 5
   periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3

--- a/infra/kubernetes/charts/web/values.yaml
+++ b/infra/kubernetes/charts/web/values.yaml
@@ -46,9 +46,13 @@ livenessProbe:
   # Liveness intentionally targets `/`, which since #384 calls `auth()`
   # server-side and is no longer statically prerendered. That means liveness
   # now exercises clerkMiddleware too — a transient Clerk outage could fail
-  # the probe. failureThreshold is set higher than the K8s default of 3 so
-  # the pod is only killed after a sustained ~3-minute window of failure,
-  # giving Clerk room to recover without crash-looping the deployment.
+  # the probe. Behavior for an anonymous probe request: clerkMiddleware's
+  # auth.protect() returns a 307 redirect to /sign-in before the page handler
+  # renders; the kubelet treats 307 as success, so only a middleware *throw*
+  # (e.g., #382 missing CLERK_SECRET_KEY) produces a 500 and fails the probe.
+  # failureThreshold is set higher than the K8s default of 3 so the pod is
+  # only killed after a sustained ~3-minute window of failure, giving Clerk
+  # room to recover without crash-looping the deployment.
   httpGet:
     path: /
     port: 3001

--- a/infra/kubernetes/charts/web/values.yaml
+++ b/infra/kubernetes/charts/web/values.yaml
@@ -50,8 +50,12 @@ livenessProbe:
   periodSeconds: 20
 
 readinessProbe:
+  # Hits a route that exercises clerkMiddleware so a Clerk-init failure
+  # (e.g. missing CLERK_SECRET_KEY, as in #382) fails readiness during
+  # rollout instead of being masked by a statically-prerendered `/`.
+  # Liveness stays on `/` so transient middleware blips don't crash-loop.
   httpGet:
-    path: /
+    path: /api/healthz
     port: 3001
   initialDelaySeconds: 5
   periodSeconds: 10


### PR DESCRIPTION
## Summary

The current readiness probe targets `/`, which until #384 was the static marketing page (`app/page.tsx`) and was served from the prerender cache, bypassing middleware. During the #382 outage, every protected route 500'd because Clerk middleware was throwing — but `/` stayed 200 and the bad rollout was promoted to Ready.

This PR moves readiness to a new `/api/healthz` route that runs through `clerkMiddleware` and returns an explicit 200/503 contract. The route is matched by Clerk's `/(api|trpc)(.*)` middleware matcher, so a missing `CLERK_SECRET_KEY` (as in #382) now throws inside middleware → 500 → fails readiness, before the route handler ever executes. The route handler's `auth()` call is an additional, distinct guard that detects "clerkMiddleware did not run on this request" (e.g., a future matcher misconfig) by inspecting the `x-clerk-auth-status` header middleware stamps; `auth()` does not re-validate the secret key.

Liveness stays on `/`. Since #384 merged, `/` is dynamic and exercises `clerkMiddleware` too — so liveness `failureThreshold` is bumped to 9 (~3 minutes of sustained failure before pod restart) so transient Clerk blips don't crash-loop pods. Readiness keeps `failureThreshold: 3` — bad rollouts must fail fast and stay un-Ready.

### Changes

- **`apps/web/app/api/healthz/route.ts`** (new) — `force-dynamic` route. Calls `auth()` and returns `200 {ok:true}` on success, `503 {ok:false}` on `auth()` throw (with the error logged server-side, not in the body — the route is reachable via the public Ingress), and `200 {mode:'dev-auth'}` when `DEV_AUTH_TOKEN` bypasses Clerk.
- **`apps/web/middleware.ts`** — add `/api/healthz(.*)` to `isPublicRoute` so `clerkMiddleware` still runs (exercising Clerk init) but `auth.protect()` doesn't redirect probe traffic. `(.*)` suffix matches the sibling sign-in/sign-up patterns.
- **`infra/kubernetes/charts/web/values.yaml`** — `readinessProbe.httpGet.path` → `/api/healthz`. Both probes get explicit `timeoutSeconds: 3` (K8s default of 1s is too tight for routes that do any work). Liveness `failureThreshold: 9`; readiness `failureThreshold: 3`.

No template changes — `deployment.yaml` renders `.Values.{liveness,readiness}Probe` via `toYaml`. Per-env values files don't override probes, so the chart-level change applies to staging and production.

## Acceptance criteria

- [x] Readiness probe path exercises middleware (`/api/healthz` runs through `clerkMiddleware`).
- [x] Reproducing the #382 failure mode (Clerk init throws) causes the new pod to fail readiness — `clerkMiddleware` throws inside `assertKey` before the route handler runs; the route handler's `try/catch` is a second guard for matcher misconfig regressions, covered by a test that mocks `auth()` to throw.
- [x] Liveness probe semantics reconsidered: with #384 making `/` dynamic, liveness `failureThreshold` raised to 9 so transient Clerk blips don't crash-loop running pods.

## Testing

Ran from repo root:

```bash
npx turbo run test --filter='!@lifting-logbook/api'
```

```
Tasks: 9 successful, 9 total
```

Web suite (new healthz tests included):
```
PASS app/api/healthz/route.test.ts
  GET /api/healthz
    √ returns 200 with ok:true when Clerk auth() resolves
    √ returns 503 with no error body when auth() throws
    √ skips Clerk and returns ok:true in DEV_AUTH_TOKEN mode
Tests: 39 passed, 0 skipped, 0 failed (19.4 s)
```

Cross-workspace totals: web 39 / core 160 / api-legacy 1 / eslint-rules 11 — all passing, 0 skipped, 0 failed.

### Pre-existing failure note

The `@lifting-logbook/api` workspace was excluded from this run because its Jest globalSetup requires Docker (Testcontainers Postgres), and Docker Desktop's WSL distro is missing on this machine. Tracked in #394. CI is unaffected — GitHub Actions provides a Postgres service container that bypasses Testcontainers. This PR does not touch any code in `apps/api`.


### Code-quality notes

Adds one ESLint suppression at `apps/web/app/api/healthz/route.ts:33` — `eslint-disable-next-line no-console -- server-side log only; not exposed`. The probe handler logs the swallowed `auth()` error via `console.error` for operators (the error is intentionally not in the 503 response body — the route is publicly reachable via the GCE Ingress). Rationale is inline at the call site; flagged here per the Suppression policy Rule 1 (PR-body justification).

## Test plan

- [ ] Watch CI for green api E2E suite (proves no cross-workspace regression).
- [ ] After merge, in next staging deploy: `kubectl describe pod <web>` shows readiness probe hitting `/api/healthz` with the new threshold values.
- [ ] Manual regression: deploy a web pod with `CLERK_SECRET_KEY` unset; readiness should stay failing and the rollout should not promote (was the #382 failure mode).

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)

