### PR TITLE
[fix] Drop duplicate https:// from staging web smoke test URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -445,7 +445,7 @@ jobs:
           # Allow up to 3 minutes for Cloud Run to become healthy
           for i in $(seq 1 18); do
             STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-              "https://${{ needs.terraform-staging.outputs.cloud_run_web_url }}/" || true)
+              "${{ needs.terraform-staging.outputs.cloud_run_web_url }}/" || true)
             if [ "$STATUS" = "200" ] || [ "$STATUS" = "307" ]; then
               echo "Staging web returned $STATUS — OK"
               exit 0


### PR DESCRIPTION
## Summary

One-line fix to `.github/workflows/deploy.yml:448`. The terraform output `cloud_run_web_url` already includes the scheme, so prepending `https://` produced `https://https://lifting-logbook-stg-web-...run.app/`. Curl returned `000` on all 18 retries, the smoke job failed, and the production deploy job was skipped — blocking every production deploy in the last 5 main pushes.

The staging API smoke test (line 464) uses the output value directly without prepending a scheme and passes; this aligns the web smoke with that pattern.

## Acceptance Criteria

- [x] Smoke test curl URL contains exactly one `https://` prefix
- [ ] Next Deploy run on `main` reaches the production approval gate (verified post-merge)

## Testing

**Not exercised by `npm test`** — this is a GitHub Actions workflow YAML change with no corresponding unit-test surface in the monorepo. The change is validated by the next Deploy workflow run on `main` after merge.

Tests: not run (workflow-only change; no unit-test coverage applies).

No suppressions added. No test-integrity violations (no skip markers, no deleted tests, no coverage threshold changes).

## Verification (post-merge)

1. Watch the Deploy workflow run triggered by the squash-merge commit.
2. Confirm `Smoke Test (staging) → Smoke test Cloud Run staging (web)` reports `Staging web returned 200` (or `307`) on attempt 1.
3. Confirm `Deploy (production)` reaches `waiting` status for environment approval.

Closes #399

## Review findings

Reviewed by Claude. One non-blocking finding: deploy.yml has no top-level `concurrency` block, allowing rapid back-to-back pushes to race for the Terraform state lock (precedent: runs `26763973774`/`26763984260` on 2026-05-31). Out of scope for this one-line URL fix; filed as #401 against the **CI/CD Foundation** epic in milestone **v0.1 — Foundation**. No blocking findings; no questions for the author (symmetric working pattern at line 464 confirms the fix).
