### PR TITLE
[fix] Serialize deploy.yml runs to prevent Terraform state-lock races

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,14 @@ on:
     branches:
       - main
 
+# Serialize Deploy runs on main so back-to-back pushes do not race the staging
+# Terraform state lock (HTTP 412 conditionNotMet on the GCS-backed backend).
+# cancel-in-progress: false queues subsequent runs rather than cancelling — a
+# production deploy in flight must never be aborted by a later push. See #401.
+concurrency:
+  group: deploy-main
+  cancel-in-progress: false
+
 env:
   REGISTRY: us-central1-docker.pkg.dev
   ARTIFACT_REPO: lifting-logbook


### PR DESCRIPTION
## Summary

Adds a top-level `concurrency:` block to `.github/workflows/deploy.yml` so back-to-back pushes to `main` no longer race the staging Terraform state lock.

```yaml
concurrency:
  group: deploy-main
  cancel-in-progress: false
```

`cancel-in-progress: false` queues subsequent runs rather than cancelling — a production deploy in flight must not be aborted by a later push (Cloud Run revision rollout, `terraform apply` mid-flight, secret sync).

## Origin

Deploy run [26763984260](https://github.com/brownm09/lifting-logbook/actions/runs/26763984260) failed with HTTP 412 conditionNotMet on the GCS-backed TF state when two pushes to `main` arrived 11 seconds apart on 2026-05-31 (`fc4117c` then `c72af26`). Independent of #399/#400 — the smoke-URL fix does not address this.

## Acceptance Criteria

- [x] Top-level `concurrency` block added to `deploy.yml`
- [x] Group key is `deploy-main`
- [x] `cancel-in-progress: false`
- [x] PR body explains why cancellation must be disabled (above)

## Testing

Workflow-only YAML change; no test impact. Verified:
- `js-yaml` parse of `.github/workflows/deploy.yml` succeeds (OK)
- `npm test` from repo root with `--filter='!@lifting-logbook/api'`: **Tests: 211 passed, 0 skipped, 0 failed (21s)** across core, types, web, api-legacy, mobile, eslint-rules workspaces

Pre-existing failure: `@lifting-logbook/api` tests fail locally because Docker Desktop is not running in this environment (Testcontainers requires it for the Postgres DB E2E suite — see `apps/api/jest.global-setup.js`). CI runs Docker via service containers and is unaffected. The change in this PR is workflow-only YAML and does not touch any code path the API tests cover.

Functional concurrency behavior cannot be reproduced in isolation — it asserts on the next concurrent push to `main`.

## Coverage / suppression / test-integrity grep

All grep checks clean (no matches).

Closes #401