### PR TITLE
[fix] Add public /healthz route + two-probe staging smoke

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -440,20 +440,43 @@ jobs:
     if: needs.preflight.outputs.staging_enabled == 'true' && needs.deploy-staging.result == 'success'
 
     steps:
-      - name: Smoke test Cloud Run staging (web)
+      # Two-probe staging smoke (#402). One probe owned by app code (/healthz),
+      # one by the user-facing auth flow (/sign-in). They distinguish three
+      # failure modes that a single `/` probe collapsed into "404":
+      #   /healthz 200, /sign-in 200 → safe to promote
+      #   /healthz 200, /sign-in non-200 → Clerk middleware misconfigured
+      #   /healthz non-200 → Next.js runtime not booting
+      # /healthz is excluded from clerkMiddleware's matcher; /sign-in is
+      # auth-public via createRouteMatcher.
+      - name: Smoke test Cloud Run staging — /healthz (web runtime)
         run: |
+          BASE_URL="${{ needs.terraform-staging.outputs.cloud_run_web_url }}"
           # Allow up to 3 minutes for Cloud Run to become healthy
           for i in $(seq 1 18); do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-              "${{ needs.terraform-staging.outputs.cloud_run_web_url }}/" || true)
-            if [ "$STATUS" = "200" ] || [ "$STATUS" = "307" ]; then
-              echo "Staging web returned $STATUS — OK"
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/healthz" || true)
+            if [ "$STATUS" = "200" ]; then
+              echo "Staging /healthz returned 200 — OK"
               exit 0
             fi
-            echo "Attempt $i: got $STATUS, retrying in 10s..."
+            echo "/healthz attempt $i: got $STATUS, retrying in 10s..."
             sleep 10
           done
-          echo "Staging smoke test timed out" && exit 1
+          echo "Staging /healthz smoke FAILED — Next.js runtime not serving 200 (probe owned by app code, distinct from Clerk auth flow)" && exit 1
+
+      - name: Smoke test Cloud Run staging — /sign-in (Clerk auth flow)
+        run: |
+          BASE_URL="${{ needs.terraform-staging.outputs.cloud_run_web_url }}"
+          # Allow up to 3 minutes for Clerk middleware + sign-in route to settle
+          for i in $(seq 1 18); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/sign-in" || true)
+            if [ "$STATUS" = "200" ]; then
+              echo "Staging /sign-in returned 200 — OK"
+              exit 0
+            fi
+            echo "/sign-in attempt $i: got $STATUS, retrying in 10s..."
+            sleep 10
+          done
+          echo "Staging /sign-in smoke FAILED — runtime healthy but Clerk auth flow not serving 200 (check middleware matcher and Clerk env vars)" && exit 1
 
       - name: Smoke test Cloud Run staging (API auth check)
         run: |

--- a/apps/web/app/healthz/route.test.ts
+++ b/apps/web/app/healthz/route.test.ts
@@ -1,0 +1,14 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from './route';
+
+describe('GET /healthz', () => {
+  it('returns 200 with text body "ok"', async () => {
+    const res = GET();
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('text/plain');
+    expect(await res.text()).toBe('ok');
+  });
+});

--- a/apps/web/app/healthz/route.ts
+++ b/apps/web/app/healthz/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+
+// Pure runtime liveness probe for the staging deploy smoke (#402). Returns 200
+// iff the Next.js runtime is serving requests. Deliberately does NOT touch
+// Clerk, the API, the DB, or any downstream dep — the existing /api/healthz
+// route (#395) is the Clerk-init regression detector and runs *through*
+// clerkMiddleware; this route is the opposite contract and is excluded from
+// the middleware matcher in apps/web/middleware.ts so it never enters Clerk.
+//
+// force-dynamic prevents Next from prerendering or edge-caching the response,
+// so the probe always exercises the running runtime rather than a frozen build
+// artifact.
+export const dynamic = 'force-dynamic';
+
+export function GET() {
+  return new NextResponse('ok', {
+    status: 200,
+    headers: { 'content-type': 'text/plain' },
+  });
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -36,8 +36,12 @@ export const config = {
   // liveness probe that must NOT enter clerkMiddleware. It is distinct from
   // /api/healthz (#395), which deliberately runs through Clerk to detect
   // init failures — the (api|trpc) line below still captures that one.
+  //
+  // The healthz(?:[/?]|$) anchor pins the exclusion to an exact path segment,
+  // so a future route like /healthz-admin or /healthzfoo would still enter
+  // clerkMiddleware and not silently bypass auth.
   matcher: [
-    '/((?!_next|healthz|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+    '/((?!_next|healthz(?:[/?]|$)|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     '/(api|trpc)(.*)',
   ],
 };

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -31,8 +31,13 @@ export default function middleware(request: NextRequest, event: NextFetchEvent) 
 export const config = {
   // Standard Clerk matcher — excludes static assets (_next, images, fonts, etc.)
   // so the middleware only runs on page and API routes.
+  //
+  // `healthz` is also negated: the /healthz route (#402) is a pure runtime
+  // liveness probe that must NOT enter clerkMiddleware. It is distinct from
+  // /api/healthz (#395), which deliberately runs through Clerk to detect
+  // init failures — the (api|trpc) line below still captures that one.
   matcher: [
-    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+    '/((?!_next|healthz|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     '/(api|trpc)(.*)',
   ],
 };


### PR DESCRIPTION
## Summary

- Adds `GET /healthz` in `apps/web` returning `200 ok` (text/plain).
- Excludes `/healthz` from `clerkMiddleware()`'s matcher so the probe never enters Clerk.
- Splits the staging `smoke-test` step into two probes (`/healthz` and `/sign-in`), each with its own retry budget and a distinct failure message identifying which probe failed.

## Origin

Deploy run [26770343171](https://github.com/brownm09/lifting-logbook/actions/runs/26770343171) (post-merge of #400) failed at the staging web smoke step. The smoke targeted `/`, but `/` is gated by `clerkMiddleware()` and Clerk rewrites anonymous requests to a sentinel `/clerk_*` path that doesn't exist → 404. The app itself was healthy (`/sign-in` returned 200) but the one-probe smoke conflated "Next runtime dead" with "Clerk auth gate firing." Five deploys in a row could not surface this.

## Failure-mode matrix

| `/healthz` | `/sign-in` | Diagnosis |
|---|---|---|
| 200 | 200 | App + auth healthy — safe to promote |
| 200 | non-200 | Clerk middleware misconfigured (matcher / env vars / route map) |
| non-200 | * | Next.js runtime not booting |

`/healthz` is distinct from the existing `/api/healthz` route (added in #395): `/api/healthz` deliberately runs *through* `clerkMiddleware` as the Clerk init-failure regression detector for K8s readiness; `/healthz` is the opposite contract — pure runtime liveness, never enters Clerk.

## Acceptance Criteria

- [x] `apps/web` exposes `GET /healthz` returning `200 OK` with body `ok`
- [x] `apps/web/middleware.ts` matcher excludes `/healthz` (`healthz` added to the matcher's negative lookahead group; comment points at #402)
- [x] `.github/workflows/deploy.yml` staging smoke probes both `/healthz` and `/sign-in`, each expecting 200 within the existing per-step retry budget (18 attempts × 10s each)
- [x] Each probe's failure message identifies which probe failed
- [ ] Next Deploy run on `main` reaches the production approval gate (verified at merge time)

## Out of scope

Per issue: API `/healthz` (covered by existing `/health` probe), DB/Redis-depth checks, and the deploy-workflow concurrency block (separate PR #403 for #401).

## Testing

`npx turbo run test --filter='!@lifting-logbook/api'` from repo root: **Tests: 212 passed, 0 skipped, 0 failed (~18s)** across core, types, web, api-legacy, mobile, eslint-rules workspaces (web suite went from 39 → 40 with the new `app/healthz/route.test.ts`).

Pre-existing failure: `@lifting-logbook/api` tests fail locally because Docker Desktop is not running in this environment (Testcontainers needs it for the Postgres DB E2E suite — see `apps/api/jest.global-setup.js`). CI runs Docker via service containers and is unaffected. This PR does not touch any code path the API tests cover.

YAML parse of `.github/workflows/deploy.yml` succeeds (js-yaml load OK).

Smoke-step behavior is verified end-to-end by the next Deploy run on `main` after merge — that is the issue's acceptance gate.

## Suppression / test-integrity grep

All checks clean (no matches).

Closes #402