### PR TITLE
[fix] Guard /healthz in standalone build; isolate web image cache scopes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -277,8 +277,12 @@ jobs:
           tags: |
             ${{ steps.ar.outputs.repo }}/api:${{ github.sha }}
             ${{ steps.ar.outputs.repo }}/api:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Per-image cache scope (#407). Same rationale as the web builds
+          # below — isolates the API build cache from any other image flavor
+          # so a stale layer in one cannot poison another. `-v2` suffix forces
+          # a one-time miss on merge.
+          cache-from: type=gha,scope=api-deploy-v2
+          cache-to: type=gha,scope=api-deploy-v2,mode=max
 
       # ── Web image: per-env builds (ADR-025) ────────────────────────────────
       # Two builds with per-env NEXT_PUBLIC_* values. The staging tag is built

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -297,8 +297,15 @@ jobs:
           build-args: |
             NEXT_PUBLIC_API_URL=${{ steps.api-url-staging.outputs.url }}
             NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ steps.clerk-pub-staging.outputs.key }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Per-env cache scope (#407). Previously both staging and prod web
+          # builds shared an unscoped `type=gha`, which was suspected of
+          # poisoning the cache across builds — three consecutive main runs
+          # produced images missing /healthz from the standalone tree despite
+          # the route being on main. Scoping isolates per-image-flavor caches
+          # and the new name (`-v2`) forces a one-time miss on this PR's merge,
+          # rebuilding the next-build layer from scratch.
+          cache-from: type=gha,scope=web-staging-v2
+          cache-to: type=gha,scope=web-staging-v2,mode=max
 
       # `:latest` is intentionally moved here from the (previously single) web
       # build. In staging-enabled mode this means the `:latest` tag in the
@@ -320,8 +327,9 @@ jobs:
           build-args: |
             NEXT_PUBLIC_API_URL=${{ steps.api-url-prod.outputs.url }}
             NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ steps.clerk-pub-prod.outputs.key }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Per-env cache scope (#407) — see staging build above for context.
+          cache-from: type=gha,scope=web-prod-v2
+          cache-to: type=gha,scope=web-prod-v2,mode=max
 
   # ── 3. Deploy to staging ─────────────────────────────────────────────────
   deploy-staging:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -266,8 +266,10 @@ jobs:
           tags: |
             ${{ steps.ar.outputs.repo }}/api:${{ github.event.pull_request.head.sha }}
             ${{ steps.ar.outputs.repo }}/api:pr-${{ github.event.pull_request.number }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Per-image cache scope (#407). Isolates the PR-branch API build
+          # from the deploy.yml main-branch API cache, mirroring the web scoping.
+          cache-from: type=gha,scope=api-pr-v2
+          cache-to: type=gha,scope=api-pr-v2,mode=max
 
       - name: Build and push web image
         if: steps.image-tag.outputs.skip_build != 'true'

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -282,8 +282,11 @@ jobs:
           build-args: |
             NEXT_PUBLIC_API_URL=${{ steps.api-url.outputs.url }}
             NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ steps.clerk-pub-key.outputs.key }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Scoped cache (#407). Isolates PR-branch builds from the deploy.yml
+          # main-branch web caches so a stale layer in one workflow cannot
+          # silently poison the other.
+          cache-from: type=gha,scope=web-pr-v2
+          cache-to: type=gha,scope=web-pr-v2,mode=max
 
   # ── 3a. Deploy API (staging) ──────────────────────────────────────────────
   # Split into per-service jobs so they run in parallel within a single PR.

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -30,6 +30,17 @@ ARG NEXT_PUBLIC_API_URL
 ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 RUN npx turbo run build --filter=@lifting-logbook/web
 
+# Build-time guard for #407: the staging deploy smoke probes /healthz and
+# /api/healthz; both routes must reach the standalone output the runner stage
+# copies in. If they're missing here, the image will 404 in production and the
+# Deploy workflow stalls at the staging gate. Failing the build instead surfaces
+# the regression at image-build time on every workflow (staging.yml PR builds
+# and deploy.yml main builds), not after a 3-minute smoke timeout.
+RUN test -d /app/apps/web/.next/standalone/apps/web/.next/server/app/healthz \
+ && test -d /app/apps/web/.next/standalone/apps/web/.next/server/app/api/healthz \
+ || (echo "ERROR (#407): required healthz routes missing from .next/standalone build" && \
+     ls -la /app/apps/web/.next/standalone/apps/web/.next/server/app && exit 1)
+
 # ── Stage 3: runner ──────────────────────────────────────────────────────────
 # Minimal production image using Next.js standalone output.
 FROM node:20.11.1-alpine AS runner

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -36,6 +36,11 @@ RUN npx turbo run build --filter=@lifting-logbook/web
 # Deploy workflow stalls at the staging gate. Failing the build instead surfaces
 # the regression at image-build time on every workflow (staging.yml PR builds
 # and deploy.yml main builds), not after a 3-minute smoke timeout.
+#
+# Path layout is Next.js App Router with `output: standalone` (currently
+# Next 16.2.4). If a future Next.js upgrade flattens route handlers from
+# `app/<route>/route.js` directories to flat files, update this guard rather
+# than trusting a false-positive trip.
 RUN test -d /app/apps/web/.next/standalone/apps/web/.next/server/app/healthz \
  && test -d /app/apps/web/.next/standalone/apps/web/.next/server/app/api/healthz \
  || (echo "ERROR (#407): required healthz routes missing from .next/standalone build" && \


### PR DESCRIPTION
## Summary

Three consecutive `main` Deploy runs ([9937da1](https://github.com/brownm09/lifting-logbook/actions/runs/26797013015), [b9f76a2](https://github.com/brownm09/lifting-logbook/actions/runs/26780207624), [1881226](https://github.com/brownm09/lifting-logbook/actions/runs/26779634287)) have failed at the staging smoke gate with `/healthz` → 404, blocking production approval. The route file is committed on main and `/api/healthz` (a sibling route under `app/api/`) returns 200 — so the Next.js runtime is up, Clerk middleware is correctly configured, and the issue is specific to `/healthz`.

PR #404's PR-branch CI saw `/healthz` → 200, so the build is capable of producing the route. Something diverges between PR-branch builds (staging.yml) and main builds (deploy.yml), both of which use the same Dockerfile and previously shared an unscoped `type=gha` BuildKit cache.

This PR ships two complementary changes:

1. **Build-time assertion** in `apps/web/Dockerfile`: a `RUN test -d` step after `next build` that fails the image build if `.next/standalone/.../app/healthz` or `.../app/api/healthz` is missing. This is the regression guard required by AC #5 and serves as a deterministic diagnostic — if the assertion fails on the next deploy, the failure mode is build-time exclusion (confirmed); if it passes but the route still 404s, the failure mode is runtime routing (escalates to investigation, not a blind smoke retry).
2. **Per-flavor cache scopes** in `deploy.yml` and `staging.yml`: each web image flavor now has its own GHA cache scope (`web-staging-v2`, `web-prod-v2`, `web-pr-v2`) instead of all three sharing the unscoped namespace. The `-v2` suffix forces a one-time cache miss on merge, rebuilding the `next build` layer from clean inputs. This is the most likely root cause given the static evidence and is hypothesis #3 from the issue.

Closes #407

## Root cause (suspected, pending CI confirmation)

GHA BuildKit cache poisoning on the post-merge main runs. The three web image builds (staging.yml's `web-image`, deploy.yml's `web (staging)`, deploy.yml's `web (production)`) shared an unscoped `type=gha` cache. A stale `next build` layer cached from before `apps/web/app/healthz/route.ts` existed (#404 added it) appears to have been silently reused. The new scopes isolate per-flavor caches; the `-v2` suffix breaks lineage.

If the assertion trips on the next staging.yml run after merge, the build will fail loudly with a directory listing of `.next/standalone/.../app/`, telling us exactly what is and isn't being built. If it passes and the smoke step still 404s, this is hypothesis #2 or #4 from the issue (Next.js trace pruning or middleware interception) and gets a follow-up investigation.

## Testing

```
npm test -w @lifting-logbook/web
```

Result: `Tests: 56 passed, 56 total` (8 suites passed, 0 skipped, 0 failed, 17.952s) — confirms `apps/web/app/healthz/route.test.ts` and `middleware.matcher.test.ts` (the #405 lockdown test) still pass.

Full-repo `npm test` could not be run locally: the `@lifting-logbook/api` workspace requires Testcontainers + Docker, and my local Docker Desktop daemon is currently returning HTTP 500 on all image-API calls. Pre-existing environment failure unrelated to this PR; CI's API workspace will exercise the full suite. No `@lifting-logbook/api` or `@lifting-logbook/api-legacy` files are touched by this PR.

The other workspace tests run by turbo before the API one were successful (`@lifting-logbook/api-legacy:test` completed cleanly in the same turbo invocation).

### Coverage gate

No new testable runtime behavior is introduced — the Dockerfile assertion is build-tooling, not application code; the workflow cache-scope change is CI config. The existing tests for `/healthz` and middleware matcher cover the application contract. No new tests required.

### Suppression / test-integrity / pre-existing failure greps

```
git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|!\.|...)'   → no matches
git diff origin/main -- . | grep -E '(it\.skip|xit\(|...)'                                  → no matches
git diff --diff-filter=D --name-only origin/main -- '*.test.*' '*.spec.*'                   → no matches
```

No suppressions added. No tests deleted or skipped. No coverage thresholds changed.

## Verification plan after merge

1. Watch the post-merge `main` Deploy run for the web image builds. **Pass condition:** both `web (staging)` and `web (production)` build steps complete without the assertion firing.
2. `curl -sI https://lifting-logbook-stg-web-mn3pkptvma-uc.a.run.app/healthz` → expect `HTTP/2 200`.
3. Confirm the Deploy run reaches the production approval gate (the smoke-test job's `/healthz` probe should succeed within the 18-attempt loop, where previously it failed 18/18).
4. **If the assertion trips:** the build will fail loudly with `ls -la` of the `app/` directory — investigate from there (Phase 2B of the plan).