### PR TITLE
[fix] Push API + web images to prod Artifact Registry (#411)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -335,6 +335,54 @@ jobs:
           cache-from: type=gha,scope=web-prod-v2
           cache-to: type=gha,scope=web-prod-v2,mode=max
 
+      # ── Copy images to production AR (#411) ────────────────────────────────
+      # `steps.ar.outputs.repo` resolves to the *staging* AR in staging-enabled
+      # mode, so the api:<sha> and web:<sha>-prod tags pushed above only live
+      # in the staging registry. `deploy-production` pulls from the prod AR
+      # (steps.tf-prod.outputs.ar_repo) and would 404. Copy both images to the
+      # prod AR with `docker buildx imagetools create` — a registry-to-registry
+      # copy that does not require a rebuild or local Docker image state.
+      #
+      # Guarded by staging_enabled because production-only mode already pushed
+      # directly to the prod AR (steps.ar.outputs.repo resolves to prod there).
+
+      - name: Resolve production AR repo
+        id: ar-prod
+        if: needs.preflight.outputs.staging_enabled == 'true'
+        run: |
+          echo "repo=${{ env.REGISTRY }}/${{ vars.GCP_PROD_PROJECT_ID }}/${{ env.ARTIFACT_REPO }}" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to GCP (production, for prod-AR push)
+        if: needs.preflight.outputs.staging_enabled == 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_PROD_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_PROD_SERVICE_ACCOUNT }}
+
+      - name: Configure Docker for prod AR
+        if: needs.preflight.outputs.staging_enabled == 'true'
+        run: gcloud auth configure-docker ${{ env.REGISTRY }} --quiet
+
+      # `imagetools create` reads the source manifest from the staging AR and
+      # writes new tags in the prod AR. The prod CI/CD SA must have
+      # `roles/artifactregistry.reader` on the staging AR for the read; if
+      # this errors with permission denied, grant that role and rerun.
+      - name: Copy API image to prod AR
+        if: needs.preflight.outputs.staging_enabled == 'true'
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ steps.ar-prod.outputs.repo }}/api:${{ github.sha }} \
+            --tag ${{ steps.ar-prod.outputs.repo }}/api:latest \
+            ${{ steps.ar.outputs.repo }}/api:${{ github.sha }}
+
+      - name: Copy web image to prod AR
+        if: needs.preflight.outputs.staging_enabled == 'true'
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ steps.ar-prod.outputs.repo }}/web:${{ github.sha }}-prod \
+            --tag ${{ steps.ar-prod.outputs.repo }}/web:latest \
+            ${{ steps.ar.outputs.repo }}/web:${{ github.sha }}-prod
+
   # ── 3. Deploy to staging ─────────────────────────────────────────────────
   deploy-staging:
     name: Deploy (staging)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -383,6 +383,16 @@ jobs:
             --tag ${{ steps.ar-prod.outputs.repo }}/web:latest \
             ${{ steps.ar.outputs.repo }}/web:${{ github.sha }}-prod
 
+      # Auth context invariant: build-images now ends with the prod CI/CD SA
+      # active (the auth swap above for the imagetools copy is not restored).
+      # Any step appended after this point that needs staging-AR or staging-
+      # project credentials must re-auth to staging first (see the existing
+      # restore pattern at the start of the API/web push block above). The
+      # `staging_enabled == 'true'` guard does not save you — production-only
+      # mode skips the entire copy block and leaves the staging auth from the
+      # job header active, so a forgotten re-auth will silently flip behavior
+      # between the two modes.
+
   # ── 3. Deploy to staging ─────────────────────────────────────────────────
   deploy-staging:
     name: Deploy (staging)


### PR DESCRIPTION
## Summary

`Deploy (production)` failed on the post-#410 main run with `Image '…/lifting-logbook-prod/lifting-logbook/api:<sha>' not found`. Root cause: `build-images` only ever pushes to `steps.ar.outputs.repo`, which resolves to the **staging** AR in staging-enabled mode (`deploy.yml:180-182`). The `Build and push web image (production)` step is named misleadingly — it builds with prod NEXT_PUBLIC_* values but still pushes to the *staging* AR. `deploy-production` pulls from the prod AR (`steps.tf-prod.outputs.ar_repo`) and 404s for both images.

This was masked for weeks by the `/healthz` staging gate failure (#404, #408, #410). With the gate fixed in #410, production deploy is now reachable and the missing prod-AR push is exposed — API first, web would be next.

## Fix

After the existing build/push steps, add a five-step block in `build-images` that copies both images to the prod AR with `docker buildx imagetools create` — a registry-to-registry copy that requires no rebuild and no local Docker engine state:

1. Resolve prod AR repo (`${REGISTRY}/${vars.GCP_PROD_PROJECT_ID}/${ARTIFACT_REPO}`).
2. Re-auth to GCP-prod (`google-github-actions/auth@v2` with prod WIF/SA).
3. `gcloud auth configure-docker` for the same Artifact Registry hostname.
4. Copy `api:<sha>` and `api:latest`.
5. Copy `web:<sha>-prod` and `web:latest`.

All five steps are guarded by `if: needs.preflight.outputs.staging_enabled == 'true'` — production-only mode already pushes directly to the prod AR.

## Scope note

Issue #411 called out the API image only, but the web image has the same structural bug (named "production" build, pushed to staging AR). Both are fixed here so the next production deploy doesn't 404 on the web image.

## Acceptance criteria

- [x] Production-AR push for the API image
- [x] Production-AR push for the web image
- [ ] Next main Deploy run reaches the production approval gate
- [ ] Once approved, Deploy (production) actually deploys both revisions

## Testing

`npm test` from repo root:

```
Tasks:    8 successful, 12 total
Cached:    5 cached, 12 total
Failed:    @lifting-logbook/api#test
```

The `@lifting-logbook/api` workspace requires Testcontainers + Docker for `apps/api/jest.global-setup.js`. Docker Desktop is not running locally — same pre-existing environment limitation documented in PR #408. CI's API service container will exercise the full suite. **No `@lifting-logbook/api` or `@lifting-logbook/api-legacy` files are touched by this PR** — the change is `.github/workflows/deploy.yml` only. All 8 non-API workspace tasks passed.

### Coverage gate

No new testable runtime behavior — this is CI workflow YAML only. Verification is the post-merge deploy run reaching prod approval and `gcloud artifacts docker images list us-central1-docker.pkg.dev/lifting-logbook-prod/lifting-logbook --filter="tags:<sha>"` returning both images.

### Suppression / test-integrity greps

```
git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|it\.skip|...)' → no matches
```

No suppressions, no test changes, no deleted tests, no coverage thresholds touched.

## Known follow-up

The prod CI/CD service account must have `roles/artifactregistry.reader` on the staging AR for `imagetools create`'s manifest read. If the next deploy run errors with `permission denied` reading the staging AR, grant that role via Terraform and rerun.

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)