### PR TITLE
[infra] Grant prod CI/CD SA artifactregistry.reader on staging AR (#413)

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -288,6 +288,19 @@ resource "google_artifact_registry_repository" "images" {
   depends_on    = [google_project_service.required_apis]
 }
 
+# Cross-project reader grants on this environment's Artifact Registry.
+# In staging, the production CI/CD SA is included so build-images can copy
+# images staging-AR → prod-AR via `docker buildx imagetools create` (see
+# .github/workflows/deploy.yml and #411). In production, the list is empty.
+resource "google_artifact_registry_repository_iam_member" "external_readers" {
+  for_each   = toset(var.external_ar_reader_service_accounts)
+  project    = var.project_id
+  location   = google_artifact_registry_repository.images.location
+  repository = google_artifact_registry_repository.images.name
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:${each.value}"
+}
+
 # ─── IAM — CI/CD service account ─────────────────────────────────────────────
 
 resource "google_service_account" "cicd" {

--- a/infra/terraform/terraform.tfvars.staging
+++ b/infra/terraform/terraform.tfvars.staging
@@ -21,3 +21,10 @@ enable_gke = true
 # Cold-start latency is acceptable here — the A/B harness measures steady-state
 # performance, not first-request response time. Prod sets this to 1 for warm starts.
 cloud_run_min_instances = 0
+
+# Cross-project AR reader: the production CI/CD SA reads the staging AR when
+# build-images copies images staging-AR → prod-AR via `docker buildx imagetools
+# create` (see .github/workflows/deploy.yml and #411).
+external_ar_reader_service_accounts = [
+  "lifting-logbook-prod-cicd@lifting-logbook-prod.iam.gserviceaccount.com",
+]

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -80,3 +80,18 @@ variable "cloud_run_min_instances" {
   type        = number
   default     = null
 }
+
+variable "external_ar_reader_service_accounts" {
+  description = <<-EOT
+    Service account emails (in other GCP projects) granted
+    `roles/artifactregistry.reader` on this environment's Artifact Registry.
+
+    Set in staging tfvars to include the production CI/CD SA: build-images
+    (.github/workflows/deploy.yml) re-auths to the prod SA at the tail of the
+    job and uses `docker buildx imagetools create` to copy api:<sha> and
+    web:<sha>-prod from the staging AR to the prod AR. The source-manifest
+    read uses prod credentials, so the prod SA needs reader access here.
+  EOT
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary

Pre-stages the IAM grant that PR #412 needs to actually run successfully on its first post-merge `main` deploy. PR #412 (issue #411) copies API + web images staging-AR → prod-AR via `docker buildx imagetools create`. The build-images step re-authenticates to the prod CI/CD SA for the prod-AR write — and the `imagetools create` source-manifest read uses that same active credential. Without `roles/artifactregistry.reader` on the staging AR, the next deploy run fails at `Copy API image to prod AR` with `permission denied`.

Reviewed in [#412 comment](https://github.com/brownm09/lifting-logbook/pull/412#issuecomment-4605174300) (path (a): pre-stage IAM, then merge #412).

## Change

- New variable `external_ar_reader_service_accounts` (list of strings) in `variables.tf`, default `[]`.
- New `google_artifact_registry_repository_iam_member.external_readers` in `main.tf`, `for_each` over the variable.
- `terraform.tfvars.staging` sets the list to `["lifting-logbook-prod-cicd@lifting-logbook-prod.iam.gserviceaccount.com"]`.
- `terraform.tfvars.production` unchanged (default empty).

Modeling it as a tfvars list (rather than hardcoding the SA email in module code) keeps the cross-project trust relationship visible at the per-env tfvars layer, which is where every other env-specific value already lives. Empty default means a fresh apply in any new environment is no-op.

## Acceptance criteria

- [x] Terraform variable + IAM resource added
- [x] Staging tfvars populated with prod CI/CD SA
- [ ] `terraform-staging` applies cleanly on this PR's merge-to-main run
- [ ] After PR #412 merges next, `Copy API image to prod AR` succeeds

## Testing

`npm test` from repo root:

```
Tasks:    8 successful, 12 total
Cached:    5 cached, 12 total
Failed:    @lifting-logbook/api#test
```

Same documented environment limitation as PR #408 / PR #412: `@lifting-logbook/api` requires Docker for Testcontainers (`apps/api/jest.global-setup.js`); Docker Desktop is not running locally. CI's API service container exercises the suite. No `apps/api` or `apps/api-legacy` files are touched by this PR — change is `infra/terraform/` only.

### Coverage gate

No new testable runtime behavior — Terraform IAM resource. Verification is the next `terraform-staging` apply on main showing the new `google_artifact_registry_repository_iam_member.external_readers["..."]` resource in the plan + apply, and the subsequent PR #412 deploy reaching the prod approval gate without `permission denied` on `imagetools create`.

### Suppression / test-integrity greps

```
git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|it\.skip|...)' → no matches
```

No suppressions, no test changes, no deleted tests, no coverage thresholds touched. Diff is `infra/terraform/*` only.

## Ordering

This PR must merge before #412 so `terraform-staging` on its main run applies the IAM grant before the next #412-flavored main run attempts the copy step.

Closes #413