### PR TITLE
[infra] Bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -67,7 +67,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -97,7 +97,7 @@ jobs:
     needs: lint-and-test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -140,7 +140,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,16 +97,16 @@ jobs:
       web_workload_sa: ${{ steps.tf-outputs.outputs.web_workload_sa }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Authenticate to GCP (staging)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_STAGING_SERVICE_ACCOUNT }}
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "~> 1.7"
           terraform_wrapper: false
@@ -156,12 +156,12 @@ jobs:
       ar_repo: ${{ steps.ar.outputs.repo }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # In staging mode, Artifact Registry lives in the staging project.
       - name: Authenticate to GCP (staging)
         if: needs.preflight.outputs.staging_enabled == 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_STAGING_SERVICE_ACCOUNT }}
@@ -169,7 +169,7 @@ jobs:
       # In production-only mode, use production credentials for the prod AR repo.
       - name: Authenticate to GCP (production-only mode)
         if: needs.preflight.outputs.staging_enabled != 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_PROD_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_PROD_SERVICE_ACCOUNT }}
@@ -219,7 +219,7 @@ jobs:
       # API image build and any subsequent staging push re-authenticate to
       # staging below. In production-only mode this is a no-op re-auth.
       - name: Authenticate to GCP (production, for prod web build-args)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_PROD_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_PROD_SERVICE_ACCOUNT }}
@@ -251,7 +251,7 @@ jobs:
       # Restore staging auth for the image pushes that target the staging AR.
       - name: Re-authenticate to GCP (staging, restore for pushes)
         if: needs.preflight.outputs.staging_enabled == 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_STAGING_SERVICE_ACCOUNT }}
@@ -261,7 +261,7 @@ jobs:
       # staging-AR-capable (restored by the Re-authenticate step above); in
       # production-only mode the prod auth step above is sufficient. Any step
       # inserted between the auth-restore and here must preserve this invariant
-      # (do not call `auth@v2` with a different identity between them).
+      # (do not call `auth` with a different identity between them).
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker ${{ env.REGISTRY }} --quiet
 
@@ -354,7 +354,7 @@ jobs:
 
       - name: Authenticate to GCP (production, for prod-AR push)
         if: needs.preflight.outputs.staging_enabled == 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_PROD_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_PROD_SERVICE_ACCOUNT }}
@@ -405,10 +405,10 @@ jobs:
     environment: staging
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Authenticate to GCP (staging)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_STAGING_SERVICE_ACCOUNT }}
@@ -615,16 +615,16 @@ jobs:
     environment: production   # triggers GitHub required-reviewer gate
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Authenticate to GCP (production)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_PROD_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_PROD_SERVICE_ACCOUNT }}
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "~> 1.7"
           terraform_wrapper: false

--- a/.github/workflows/required-checks-drift.yml
+++ b/.github/workflows/required-checks-drift.yml
@@ -32,7 +32,7 @@ jobs:
     # transient GitHub API hangs without burning the default 6h timeout.
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Fetch live required-status-checks
         env:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -107,16 +107,16 @@ jobs:
       web_workload_sa: ${{ steps.tf-outputs.outputs.web_workload_sa }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Authenticate to GCP (staging)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_STAGING_SERVICE_ACCOUNT }}
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "~> 1.7"
           terraform_wrapper: false
@@ -166,7 +166,7 @@ jobs:
       image_tag: ${{ steps.image-tag.outputs.image_tag }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Decide whether to rebuild or reuse a prior image.
       #
@@ -225,7 +225,7 @@ jobs:
       # neighboring step.
       - name: Authenticate to GCP (staging)
         if: steps.image-tag.outputs.skip_build != 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_STAGING_SERVICE_ACCOUNT }}
@@ -314,10 +314,10 @@ jobs:
       cloud_run_api_deployed: ${{ steps.deploy-api.outcome == 'success' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Authenticate to GCP (staging)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_STAGING_SERVICE_ACCOUNT }}
@@ -479,10 +479,10 @@ jobs:
       web_url: ${{ steps.deploy-web.outputs.url }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Authenticate to GCP (staging)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_STAGING_SERVICE_ACCOUNT }}
@@ -608,7 +608,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -624,7 +624,7 @@ jobs:
         working-directory: apps/web
 
       - name: Authenticate to GCP (staging) for Secret Manager access
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_STAGING_SERVICE_ACCOUNT }}


### PR DESCRIPTION
## Summary

GitHub will force all Node 20-based JavaScript actions to run on Node 24 starting **2026-06-16**, and remove Node 20 from runners on **2026-09-16** ([blog post](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The staging workflow currently emits a deprecation warning naming three actions. This PR bumps each to the next major that ships Node 24 binaries.

| Action | Before | After | Source |
|---|---|---|---|
| `actions/checkout` | v4 | v5 | [v5.0.0 release](https://github.com/actions/checkout/releases/tag/v5.0.0) |
| `google-github-actions/auth` | v2 | v3 | [v3.0.0 release](https://github.com/google-github-actions/auth/releases/tag/v3.0.0) |
| `hashicorp/setup-terraform` | v3 | v4 | [v4.0.0 release](https://github.com/hashicorp/setup-terraform/releases/tag/v4.0.0) |

I deliberately stop at the next major (not the latest tip, e.g. checkout v6) to minimize unrelated behavior drift.

## Input-compatibility check

Verified against [`auth/v3.0.0/action.yml`](https://github.com/google-github-actions/auth/blob/v3.0.0/action.yml) that every input we pass remains supported:
- `workload_identity_provider` ✓
- `service_account` ✓
- `terraform_version`, `terraform_wrapper` (setup-terraform v4) — unchanged

The "old parameters" removed in `auth` v3.0.0 are auth-method shims (`credentials_file_path`, etc.) that this repo does not use.

## Files modified

- `.github/workflows/staging.yml`
- `.github/workflows/deploy.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/required-checks-drift.yml`

Also tidied a stale `auth@v2` reference in a `deploy.yml` comment.

## Testing

Non-Docker workspaces:
```
@lifting-logbook/core       Tests: 160 passed, 160 total
@lifting-logbook/api-legacy Tests:   1 passed,   1 total
@lifting-logbook/eslint-rules tests 11, pass 11, fail 0
@lifting-logbook/web/types/mobile  No tests found, --passWithNoTests
```

**`@lifting-logbook/api` workspace skipped locally** — its Testcontainers-based globalSetup cannot start a Postgres container because Docker Desktop on this Windows host is currently broken (separate environmental issue tracked in #394). The change here is YAML-only and cannot affect Jest behavior. CI's `db-integration` job uses its own service container (not Testcontainers) and will exercise the API suite end-to-end on the PR run.

Tests: 172 passed, 0 skipped, 0 failed (~30s) — across the workspaces that ran locally.

## Test integrity / suppression checks

- `git diff origin/main` suppression grep: clean
- `git diff origin/main` test-integrity grep: clean
- Deleted tests: none
- Coverage thresholds: unchanged

## Acceptance criteria

- [x] All four workflow files updated
- [x] `grep -nE 'checkout@v4|auth@v2|setup-terraform@v3' .github/workflows/*.yml` returns zero hits
- [x] Local test suite passes (api skipped per #394; see Testing above)
- [ ] On this PR run, "Node.js 20 actions are deprecated" warning is gone from the Staging workflow log
- [ ] `terraform-staging` and other auth+terraform jobs complete green

Closes #415