### PR TITLE
[fix] Add explicit approve-production gate in deploy.yml (closes #417)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -594,11 +594,42 @@ jobs:
             echo "API smoke test failed: expected 200 or 403, got $STATUS" && exit 1
           fi
 
-  # ── 5. Deploy to production (requires manual approval) ───────────────────
+  # ── 5. Manual approval gate ──────────────────────────────────────────────
+  # Surfaces the production approval gate in the workflow itself, in addition
+  # to (not instead of) the `environment: production` reference on
+  # deploy-production below. Required reviewers are configured on the
+  # production environment in repo Settings (see #417); this job has no
+  # `run:` of substance — it exists to:
+  #   1. Make the gate visible in code review of this file rather than only
+  #      in repo Settings → Environments → production.
+  #   2. Act as a tripwire — if a future refactor strips `environment:
+  #      production` from deploy-production, this job still pauses the
+  #      pipeline at the same point.
+  # The reviewer clicks Approve once; both this job and deploy-production
+  # share the same environment, so a single approval releases both.
+  approve-production:
+    name: Approve production deploy
+    runs-on: ubuntu-latest
+    needs: [preflight, build-images, deploy-staging, smoke-test]
+    # Same gating logic as deploy-production below — only request approval
+    # when the pipeline would actually be ready to deploy.
+    if: |
+      always() &&
+      needs.build-images.result == 'success' &&
+      (
+        needs.preflight.outputs.staging_enabled != 'true' ||
+        needs.smoke-test.result == 'success'
+      )
+    environment: production
+    steps:
+      - name: Approved
+        run: echo "Production deploy approved."
+
+  # ── 6. Deploy to production (requires manual approval) ───────────────────
   deploy-production:
     name: Deploy (production)
     runs-on: ubuntu-latest
-    needs: [preflight, build-images, deploy-staging, smoke-test]
+    needs: [preflight, build-images, deploy-staging, smoke-test, approve-production]
     # Run when:
     #   - build-images succeeded, AND
     #   - either staging is not configured (skipped), or smoke-test passed.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -630,16 +630,12 @@ jobs:
     name: Deploy (production)
     runs-on: ubuntu-latest
     needs: [preflight, build-images, deploy-staging, smoke-test, approve-production]
-    # Run when:
-    #   - build-images succeeded, AND
-    #   - either staging is not configured (skipped), or smoke-test passed.
-    if: |
-      always() &&
-      needs.build-images.result == 'success' &&
-      (
-        needs.preflight.outputs.staging_enabled != 'true' ||
-        needs.smoke-test.result == 'success'
-      )
+    # Gate is fully expressed by approve-production: if the reviewer rejects
+    # (or approve-production is skipped because its own if-clause was false),
+    # this job skips cleanly rather than triggering a second required-reviewer
+    # prompt from its own `environment: production` reference. The build/smoke
+    # conditions are already enforced by approve-production.if upstream.
+    if: always() && needs.approve-production.result == 'success'
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

Production deploys were running without the manual-approval gate the workflow header comment described, because the `production` environment in repo Settings had only a branch-policy protection rule — no required reviewers. Issue #417 covers the root cause and the masking history.

This PR ships the gate in two parts:

1. **Repo-settings change (applied via `gh api` before this PR was opened):** the `production` environment now has a `required_reviewers` protection rule (`brownm09`, `prevent_self_review=false`). `can_admins_bypass=true` was preserved so an admin can override per-run when needed.

2. **YAML change in this PR:** a dedicated `approve-production` job is inserted between `smoke-test` and `deploy-production`. It has `environment: production` and no substantive `run:` steps. `deploy-production` now `needs:` approve-production. Single Approve click releases both jobs because they share the env.

Why two layers: the env reference on `deploy-production` alone would gate correctly, but the rule then lives only in repo Settings. The new job (1) makes the gate visible in code review of `deploy.yml`, and (2) acts as a tripwire if a future refactor strips `environment: production` from `deploy-production`.

## Acceptance criteria (from #417)

- [x] `production` environment has Required reviewers configured (verified via `gh api repos/brownm09/lifting-logbook/environments/production`)
- [ ] Next main Deploy run pauses at `Approve production deploy` with an approval prompt — verifies post-merge
- [x] (Optional) Decided against a wait timer — single-user repo, admin can self-approve immediately
- [x] (Optional) Decided to encode the gate in YAML (this PR)

## Testing

Workflow-YAML-only change; no application code paths affected.

```
Tests: 6 suites failed, 20 passed, 105 individual tests passed (160s) — packages/core
Tests: 3 suites failed, several passed (passes vary) — apps/web
Tests: 1 passed, 1 total — apps/api-legacy
```

**All failures are pre-existing on `origin/main` (commit `73f89a1`) and unrelated to this change.** Tracked by [#419](https://github.com/brownm09/lifting-logbook/issues/419):
- `packages/core` — 6 Jest worker OOM crashes (Node 24 local environment; CI uses Node 20)
- `apps/web` — TS2576 errors against `NextResponse.json()` instance access in `app/api/healthz/route.test.ts`, `app/livez/route.test.ts`, and `lib/__tests__/programPlan.test.ts`

CI is green on Node 20 for both packages; #419 captures the Node-24-local symptoms for follow-up.

### Suppression / integrity checks

Both `git diff origin/main` greps returned clean — no `ts-ignore`, `eslint-disable`, `.skip`, deleted test files, or lowered coverage thresholds in this diff.

## Test plan (post-merge)

- [ ] Confirm the next Deploy run on `main` pauses at `Approve production deploy` with status `waiting`
- [ ] Approve the prompt and confirm `deploy-production` runs and succeeds (proves `prevent_self_review=false` works)
- [ ] If desired, test the `can_admins_bypass` escape hatch on a subsequent run

Closes #417