### PR TITLE
[fix] Disambiguate staging verify-prereqs guard (skipped vs misconfigured)

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -599,11 +599,24 @@ jobs:
     steps:
       - name: Verify deploy prerequisites
         run: |
-          if [[ "${{ needs.deploy-api.outputs.clerk_configured }}" != "true" ]]; then
+          # deploy-api.result is the source of truth for "did the job run at all".
+          # When build-images fails, deploy-api is skipped (per its `if:` guard) and
+          # its outputs come through as empty strings, not 'false' — so a plain
+          # `clerk_configured != 'true'` check would mis-report the skip as a Clerk
+          # misconfiguration. See #398 / PR #395 for the motivating incident.
+          DEPLOY_RESULT='${{ needs.deploy-api.result }}'
+          CLERK_OUT='${{ needs.deploy-api.outputs.clerk_configured }}'
+          API_DEPLOYED='${{ needs.deploy-api.outputs.cloud_run_api_deployed }}'
+
+          if [[ "$DEPLOY_RESULT" == "skipped" || "$DEPLOY_RESULT" == "cancelled" ]]; then
+            echo "::error::deploy-api did not run (result: $DEPLOY_RESULT) — likely because build-images failed. Check the 'Build & Push Images' job; re-run failed jobs if the failure was transient (e.g., Artifact Registry 504 on layer-blob push)."
+            exit 1
+          fi
+          if [[ "$CLERK_OUT" != "true" ]]; then
             echo "::error::Staging Clerk secret key is not configured. Follow docs/deploy.md Step 4 to set lifting-logbook-stg-clerk-secret-key in GCP Secret Manager, then re-run CI."
             exit 1
           fi
-          if [[ "${{ needs.deploy-api.outputs.cloud_run_api_deployed }}" != "true" ]]; then
+          if [[ "$API_DEPLOYED" != "true" ]]; then
             echo "::error::Cloud Run API deploy failed — integration tests cannot run. Check the 'Fetch Cloud Run API logs on failure' step in the Deploy API (staging) job. Tracked in #344."
             exit 1
           fi
@@ -714,13 +727,19 @@ jobs:
           script: |
             const shouldRun = '${{ needs.preflight.outputs.should_run }}' === 'true';
             const testResult = '${{ needs.staging-integration-tests.result }}';
+            const deployApiResult = '${{ needs.deploy-api.result }}';
             const webUrl = '${{ needs.deploy-web.outputs.web_url }}';
 
             let body;
             const clerkConfigured = '${{ needs.deploy-api.outputs.clerk_configured }}' === 'true';
             const cloudRunApiDeployed = '${{ needs.deploy-api.outputs.cloud_run_api_deployed }}' === 'true';
+            // deploy-api skipped/cancelled means an upstream job (typically build-images)
+            // failed. Surface that explicitly so the bot doesn't mis-report the cascade
+            // as a Clerk-secret misconfiguration — see #398 / PR #395.
             if (!shouldRun) {
               body = '⚪ **Staging skipped** — `GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER` is not configured.';
+            } else if (deployApiResult === 'skipped' || deployApiResult === 'cancelled') {
+              body = `⚠️ **Staging integration tests did not run** — \`deploy-api\` was ${deployApiResult}, likely because \`build-images\` failed. Re-run failed jobs in the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) if the failure was transient (e.g., Artifact Registry 504 on layer-blob push).`;
             } else if (!clerkConfigured) {
               body = '⚠️ **Staging integration tests skipped** — `lifting-logbook-stg-clerk-secret-key` in GCP Secret Manager is still the placeholder value. Follow [docs/deploy.md Step 4](https://github.com/${{ github.repository }}/blob/${{ github.event.pull_request.head.sha }}/docs/deploy.md#step-4--sign-up-for-clerk-and-create-two-apps) to configure the staging Clerk secret key, then re-run CI.';
             } else if (!cloudRunApiDeployed) {

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -599,17 +599,20 @@ jobs:
     steps:
       - name: Verify deploy prerequisites
         run: |
-          # deploy-api.result is the source of truth for "did the job run at all".
-          # When build-images fails, deploy-api is skipped (per its `if:` guard) and
-          # its outputs come through as empty strings, not 'false' — so a plain
-          # `clerk_configured != 'true'` check would mis-report the skip as a Clerk
-          # misconfiguration. See #398 / PR #395 for the motivating incident.
+          # deploy-api.result is the source of truth for "did the job deliver its outputs".
+          # The integration-tests job runs under `if: always()` (see #345), so deploy-api
+          # can reach this step in any of three non-success states:
+          #   - skipped/cancelled: upstream build-images failed (per deploy-api's `if:` guard).
+          #   - failure: deploy-api ran but a step errored (e.g., GCP auth, Cloud Run deploy).
+          # In all three, `clerk_configured` and `cloud_run_api_deployed` may be empty rather
+          # than 'false', so a plain `clerk_configured != 'true'` check mis-reports any of
+          # them as a Clerk misconfiguration. See #398 / PR #395 for the motivating incident.
           DEPLOY_RESULT='${{ needs.deploy-api.result }}'
           CLERK_OUT='${{ needs.deploy-api.outputs.clerk_configured }}'
           API_DEPLOYED='${{ needs.deploy-api.outputs.cloud_run_api_deployed }}'
 
-          if [[ "$DEPLOY_RESULT" == "skipped" || "$DEPLOY_RESULT" == "cancelled" ]]; then
-            echo "::error::deploy-api did not run (result: $DEPLOY_RESULT) — likely because build-images failed. Check the 'Build & Push Images' job; re-run failed jobs if the failure was transient (e.g., Artifact Registry 504 on layer-blob push)."
+          if [[ "$DEPLOY_RESULT" != "success" ]]; then
+            echo "::error::deploy-api did not succeed (result: $DEPLOY_RESULT). If 'skipped' or 'cancelled', build-images likely failed — check the 'Build & Push Images' job (e.g., Artifact Registry 504 on layer-blob push) and re-run failed jobs if transient. If 'failure', open the Deploy API (staging) job log for the step that errored (commonly GCP auth or the Cloud Run deploy itself)."
             exit 1
           fi
           if [[ "$CLERK_OUT" != "true" ]]; then
@@ -733,13 +736,20 @@ jobs:
             let body;
             const clerkConfigured = '${{ needs.deploy-api.outputs.clerk_configured }}' === 'true';
             const cloudRunApiDeployed = '${{ needs.deploy-api.outputs.cloud_run_api_deployed }}' === 'true';
-            // deploy-api skipped/cancelled means an upstream job (typically build-images)
-            // failed. Surface that explicitly so the bot doesn't mis-report the cascade
-            // as a Clerk-secret misconfiguration — see #398 / PR #395.
+            // Any non-success deployApiResult means the deploy-api job didn't deliver
+            // its outputs cleanly — skipped/cancelled (upstream build-images failed) or
+            // failure (an internal step errored, e.g., GCP auth). In all of these,
+            // clerkConfigured and cloudRunApiDeployed default to false because the
+            // outputs are empty strings, so we surface the upstream state explicitly
+            // rather than mis-reporting it as a Clerk-secret misconfiguration —
+            // see #398 / PR #395.
             if (!shouldRun) {
               body = '⚪ **Staging skipped** — `GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER` is not configured.';
-            } else if (deployApiResult === 'skipped' || deployApiResult === 'cancelled') {
-              body = `⚠️ **Staging integration tests did not run** — \`deploy-api\` was ${deployApiResult}, likely because \`build-images\` failed. Re-run failed jobs in the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) if the failure was transient (e.g., Artifact Registry 504 on layer-blob push).`;
+            } else if (deployApiResult !== 'success') {
+              const upstreamHint = (deployApiResult === 'skipped' || deployApiResult === 'cancelled')
+                ? 'likely because `build-images` failed'
+                : 'a step in deploy-api errored (commonly GCP auth or the Cloud Run deploy itself)';
+              body = `⚠️ **Staging integration tests did not run** — \`deploy-api\` result was \`${deployApiResult}\`; ${upstreamHint}. Open the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) and re-run failed jobs if the failure was transient (e.g., Artifact Registry 504 on layer-blob push).`;
             } else if (!clerkConfigured) {
               body = '⚠️ **Staging integration tests skipped** — `lifting-logbook-stg-clerk-secret-key` in GCP Secret Manager is still the placeholder value. Follow [docs/deploy.md Step 4](https://github.com/${{ github.repository }}/blob/${{ github.event.pull_request.head.sha }}/docs/deploy.md#step-4--sign-up-for-clerk-and-create-two-apps) to configure the staging Clerk secret key, then re-run CI.';
             } else if (!cloudRunApiDeployed) {


### PR DESCRIPTION
## Summary

Closes #398.

The `Verify deploy prerequisites` step in `staging-integration-tests` and the bot comment template in `report-status` both used `needs.deploy-api.outputs.clerk_configured != 'true'` as a proxy for "Clerk misconfigured." When `deploy-api` is skipped (because `build-images` failed), the output comes through as the empty string, not `'false'`, so the check fired identically in both cases and mis-reported transient build failures (e.g., Artifact Registry 504) as a phantom Clerk-secret misconfiguration.

Both call sites now consult `needs.deploy-api.result` first:
- `result !== 'success'` (covers `failure`, `skipped`, `cancelled`) → distinct error naming the upstream cause. The bot template further refines the message with an `upstreamHint` ternary so `skipped`/`cancelled` points at `build-images` while `failure` points at a step error inside `deploy-api`.
- `success` with `clerk_configured == 'false'` → unchanged Clerk-config message.
- `success` with `cloud_run_api_deployed == 'false'` → unchanged Cloud Run failure message.

Because `staging-integration-tests` runs under `if: always() && needs.preflight.outputs.should_run == 'true'` (see [#345](https://github.com/brownm09/lifting-logbook/issues/345)), a hard-fail (`deploy-api.result === 'failure'`) is also reachable here, not just `skipped`/`cancelled`. The v1 patch only branched on `skipped`/`cancelled` — it was extended to `!= 'success'` after `/review` flagged the `failure` gap.

Motivating incident: [PR #395](https://github.com/brownm09/lifting-logbook/pull/395) (2026-06-01).

## Acceptance criteria

- [x] `Verify deploy prerequisites` step distinguishes any non-`success` `deploy-api.result` (empty outputs) from `'false'` outputs (real misconfig) and emits separate error messages with distinct, actionable guidance.
- [x] Same split applied to `cloud_run_api_deployed` (now gated behind the `deploy-api.result` check, so the empty-string conflation can no longer reach it).
- [x] Bot review-comment template (`report-status` job) updated so a transient-build cascade does not post a Clerk-config warning on the PR; the message names the right cause for `failure` vs `skipped`/`cancelled`.
- [ ] Behavior verification deferred to the next real transient `build-images` failure — there is no clean way to deliberately fail Artifact Registry in CI without invasive scaffolding. See Test plan below.

## Test plan

- [x] **Unit / integration suite** — `npm test` from the repo root.
  - Tests: 23 passed, 0 skipped, 0 failed (132 s) in the suites that compile. 6 of 8 `apps/web` test suites fail to *compile* with `TS2339` for `@testing-library/jest-dom` matchers and `process.env` — these are TypeScript compile errors, not test skips/failures. **Pre-existing on `origin/main`** (verified by stashing this diff and re-running). Tracked in [#421](https://github.com/brownm09/lifting-logbook/issues/421). Outside the scope of this YAML-only change.
  - Workspace summary: 10 of 12 turbo tasks succeeded; only `@lifting-logbook/web#test` failed, for the reason above. `@lifting-logbook/core`, `@lifting-logbook/api`, and remaining workspaces all green.
- [ ] **CI staging workflow** — exercised by this PR's own staging run; if `build-images` succeeds, the new branches are not hit but parsing/structure is validated. If `build-images` fails, the new "deploy-api did not succeed" message should appear.
- [ ] **Real behavior verification** — confirm against the next transient `build-images` failure (or deploy-api step failure) that the new guard message names the upstream state and that the bot posts the corresponding comment.

## Compliance checks

- **Suppression policy grep**: clean (YAML-only edit).
- **Test integrity grep**: clean.
- **Test integrity skipped count**: 0 skipped in the runs that completed; pre-existing failures are compile-time TS errors, not skip markers.
