### PR TITLE
[fix] Surface actionable error when Docker is unreachable for api E2E

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,7 +327,8 @@ npm test
 
 **Prerequisites:**
 - Run `npm run build` first if you have touched compiled output (e.g., API controllers, shared types in `packages/types`).
-- The API DB E2E suite (`apps/api/src/programs/programs.db.e2e.spec.ts`) auto-provisions Postgres via Testcontainers in `apps/api/jest.global-setup.js`. Docker Desktop must be running; no `DATABASE_URL` configuration is required locally. In CI, the existing service container provides `DATABASE_URL` and globalSetup uses it directly. See [`docs/testing/e2e-coverage.md`](docs/testing/e2e-coverage.md) for details.
+- The API DB E2E suite (`apps/api/src/programs/programs.db.e2e.spec.ts`) auto-provisions Postgres via Testcontainers in `apps/api/jest.global-setup.js`. Docker Desktop must be running; no `DATABASE_URL` configuration is required locally. In CI, the existing service container provides `DATABASE_URL` and globalSetup uses it directly.
+- **When Docker is down:** globalSetup hard-fails with a multi-line actionable message naming three recovery options (fix Docker, use `docker-compose.test.yml`, or set `LIFTING_SKIP_DB_E2E=1`). The escape hatch is only valid when the diff under test touches no DB code (no changes under `apps/api/prisma/`, no repository changes); cite [issue #394](https://github.com/brownm09/lifting-logbook/issues/394) in the PR body when it is used. See [`docs/testing/e2e-coverage.md`](docs/testing/e2e-coverage.md) for the full recovery procedure.
 
 Individual workspaces can be verified independently:
 

--- a/apps/api/jest.global-setup.js
+++ b/apps/api/jest.global-setup.js
@@ -1,18 +1,25 @@
 // Jest globalSetup — provisions a Postgres instance for the DB E2E suite.
 //
-// Two paths:
+// Three paths:
 //   1. CI (or any env that already exports DATABASE_URL): passthrough — re-expose
 //      the existing URL via LIFTING_TC_DATABASE_URL so the spec can pick it up
 //      without bypassing the env-isolation Proxy in jest.env.setup.js.
-//   2. Local: start an ephemeral postgres:16-alpine container via Testcontainers
+//   2. Explicit local opt-out (LIFTING_SKIP_DB_E2E=1): skip provisioning entirely;
+//      the DB E2E spec's describeOrSkip will leave its blocks pending. Contract:
+//      this escape hatch is only valid when the diff under test touches no DB
+//      code (prisma schema, migrations, repositories). See issue #394.
+//   3. Local: start an ephemeral postgres:16-alpine container via Testcontainers
 //      (matches CI image), run `prisma migrate deploy` against it, and stash the
-//      container handle on globalThis for teardown.
+//      container handle on globalThis for teardown. On any failure (Docker
+//      unreachable, image pull error, migration error) we throw an actionable
+//      multi-line error so the api workspace test run aborts with a clear cause
+//      — never a raw Testcontainers stack trace.
 //
-// In both cases the spec reads LIFTING_TC_DATABASE_URL (not DATABASE_URL) because
-// jest.env.setup.js force-blanks DATABASE_URL in every worker to keep the
-// in-memory e2e suite wiring InMemoryRepositoryFactory. The DB E2E spec restores
-// DATABASE_URL from the sentinel inside its own beforeAll; jest.env.setup.js
-// allows that one specific write through its Proxy.
+// In paths 1 and 3 the spec reads LIFTING_TC_DATABASE_URL (not DATABASE_URL)
+// because jest.env.setup.js force-blanks DATABASE_URL in every worker to keep
+// the in-memory e2e suite wiring InMemoryRepositoryFactory. The DB E2E spec
+// restores DATABASE_URL from the sentinel inside its own beforeAll;
+// jest.env.setup.js allows that one specific write through its Proxy.
 
 const path = require('path');
 const { execSync } = require('child_process');
@@ -22,6 +29,21 @@ const { execSync } = require('child_process');
 // latest postgres:16-alpine, capture its digest, and update both call sites.
 const POSTGRES_IMAGE = 'postgres:16-alpine@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229';
 const MIGRATION_TIMEOUT_MS = 120_000;
+
+function buildDockerUnavailableMessage(underlying) {
+  return [
+    '[jest.global-setup] Cannot start Postgres via Testcontainers — Docker appears unreachable.',
+    '',
+    'Recovery options:',
+    '  1. Fix Docker Desktop (see issue #394 for the WSL distro reset procedure).',
+    '  2. Set DATABASE_URL=postgresql://lifting:lifting@localhost:5433/lifting_test',
+    '     after `docker-compose -f docker-compose.test.yml up -d`.',
+    '  3. If your change does NOT touch apps/api/prisma or any DB repository,',
+    '     set LIFTING_SKIP_DB_E2E=1 to skip the DB suite for this run.',
+    '',
+    `Underlying error: ${underlying && underlying.message ? underlying.message : String(underlying)}`,
+  ].join('\n');
+}
 
 module.exports = async function globalSetup() {
   if (process.env.DATABASE_URL) {
@@ -33,13 +55,32 @@ module.exports = async function globalSetup() {
     return;
   }
 
+  if (process.env.LIFTING_SKIP_DB_E2E === '1') {
+    console.warn(
+      '[jest.global-setup] LIFTING_SKIP_DB_E2E=1 — skipping DB E2E provisioning. ' +
+        'DB-touching changes will not be locally verified. See issue #394.',
+    );
+    // Intentionally do not set LIFTING_TC_DATABASE_URL — the spec's
+    // describeOrSkip will leave its blocks pending.
+    return;
+  }
+
   const { PostgreSqlContainer } = require('@testcontainers/postgresql');
   console.log(`[jest.global-setup] Starting ${POSTGRES_IMAGE} via Testcontainers...`);
-  const container = await new PostgreSqlContainer(POSTGRES_IMAGE)
-    .withDatabase('lifting_test')
-    .withUsername('lifting')
-    .withPassword('lifting')
-    .start();
+
+  let container;
+  try {
+    container = await new PostgreSqlContainer(POSTGRES_IMAGE)
+      .withDatabase('lifting_test')
+      .withUsername('lifting')
+      .withPassword('lifting')
+      .start();
+  } catch (err) {
+    // Container.start() failed before we could stash a handle — most commonly
+    // because the Docker daemon is unreachable. Surface the actionable message
+    // so the failure is self-explanatory.
+    throw new Error(buildDockerUnavailableMessage(err));
+  }
 
   // Stash the handle before running migrations so globalTeardown can stop the
   // container even if migration fails (otherwise the started container would
@@ -59,7 +100,7 @@ module.exports = async function globalSetup() {
   } catch (err) {
     await container.stop().catch(() => {});
     globalThis.__LL_PG_CONTAINER__ = undefined;
-    throw err;
+    throw new Error(buildDockerUnavailableMessage(err));
   }
 
   process.env.LIFTING_TC_DATABASE_URL = url;

--- a/apps/api/jest.global-setup.js
+++ b/apps/api/jest.global-setup.js
@@ -10,10 +10,12 @@
 //      code (prisma schema, migrations, repositories). See issue #394.
 //   3. Local: start an ephemeral postgres:16-alpine container via Testcontainers
 //      (matches CI image), run `prisma migrate deploy` against it, and stash the
-//      container handle on globalThis for teardown. On any failure (Docker
-//      unreachable, image pull error, migration error) we throw an actionable
-//      multi-line error so the api workspace test run aborts with a clear cause
-//      — never a raw Testcontainers stack trace.
+//      container handle on globalThis for teardown. Two distinct failure
+//      messages so the headline matches reality (see Error Message Diligence
+//      in global CLAUDE.md): `container.start()` failures throw
+//      buildDockerUnavailableMessage (daemon unreachable, image pull, etc.);
+//      `prisma migrate deploy` failures throw buildMigrationFailedMessage
+//      (schema drift, SQL error, timeout — Docker is fine).
 //
 // In paths 1 and 3 the spec reads LIFTING_TC_DATABASE_URL (not DATABASE_URL)
 // because jest.env.setup.js force-blanks DATABASE_URL in every worker to keep
@@ -30,6 +32,9 @@ const { execSync } = require('child_process');
 const POSTGRES_IMAGE = 'postgres:16-alpine@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229';
 const MIGRATION_TIMEOUT_MS = 120_000;
 
+// Keep recovery copy in sync with docs/testing/e2e-coverage.md ("Running locally
+// when Docker is unavailable") and the CLAUDE.md Testing prerequisites bullet.
+// If you edit option text here, update both docs in the same PR.
 function buildDockerUnavailableMessage(underlying) {
   return [
     '[jest.global-setup] Cannot start Postgres via Testcontainers — Docker appears unreachable.',
@@ -45,6 +50,33 @@ function buildDockerUnavailableMessage(underlying) {
   ].join('\n');
 }
 
+// Distinct from buildDockerUnavailableMessage: by the time we hit this path,
+// the container has already started successfully, so the failure is in
+// `prisma migrate deploy` itself — schema drift, SQL error, Prisma version
+// mismatch, or migration timeout — NOT Docker reachability. Reporting "Docker
+// appears unreachable" here would misdirect the contributor (see global
+// CLAUDE.md → Error Message Diligence; lifting-logbook PR #423 review).
+function buildMigrationFailedMessage(underlying) {
+  return [
+    '[jest.global-setup] `prisma migrate deploy` failed against the started Testcontainers Postgres.',
+    '',
+    'Docker IS reachable — the container started cleanly. The failure is in the migration step itself.',
+    '',
+    'Likely causes:',
+    '  1. Schema drift between apps/api/prisma/schema.prisma and the migrations/ history.',
+    '  2. A SQL error in a new migration (run with DEBUG=prisma:* for the full trace).',
+    '  3. Prisma CLI / engine version mismatch (rare; rerun `npm install` and retry).',
+    '  4. Migration timeout (current limit: ' + (MIGRATION_TIMEOUT_MS / 1000) + 's — increase MIGRATION_TIMEOUT_MS if migrations have grown).',
+    '',
+    `Underlying error: ${underlying && underlying.message ? underlying.message : String(underlying)}`,
+  ].join('\n');
+}
+
+// Truthy variants the opt-out accepts. Anything else that is set-but-not-listed
+// triggers a near-miss warning so a typoed value doesn't silently fall through
+// to the hard-fail path.
+const SKIP_DB_E2E_TRUTHY = new Set(['1', 'true', 'yes']);
+
 module.exports = async function globalSetup() {
   if (process.env.DATABASE_URL) {
     process.env.LIFTING_TC_DATABASE_URL = process.env.DATABASE_URL;
@@ -55,14 +87,25 @@ module.exports = async function globalSetup() {
     return;
   }
 
-  if (process.env.LIFTING_SKIP_DB_E2E === '1') {
+  const skipRaw = process.env.LIFTING_SKIP_DB_E2E;
+  if (skipRaw !== undefined && skipRaw !== '') {
+    if (SKIP_DB_E2E_TRUTHY.has(skipRaw.toLowerCase())) {
+      console.warn(
+        `[jest.global-setup] LIFTING_SKIP_DB_E2E=${skipRaw} — skipping DB E2E provisioning. ` +
+          'DB-touching changes will not be locally verified. See issue #394.',
+      );
+      // Intentionally do not set LIFTING_TC_DATABASE_URL — the spec's
+      // describeOrSkip will leave its blocks pending.
+      return;
+    }
+    // Set but unrecognized — almost always a typo (e.g. "on", "skip", "Y").
+    // Warn loudly so the contributor sees their value was ignored before we
+    // proceed into the hard-fail path.
     console.warn(
-      '[jest.global-setup] LIFTING_SKIP_DB_E2E=1 — skipping DB E2E provisioning. ' +
-        'DB-touching changes will not be locally verified. See issue #394.',
+      `[jest.global-setup] LIFTING_SKIP_DB_E2E="${skipRaw}" is not a recognized truthy value ` +
+        `(accepted: ${[...SKIP_DB_E2E_TRUTHY].join(', ')}). Treating as unset — falling through ` +
+        'to Testcontainers provisioning.',
     );
-    // Intentionally do not set LIFTING_TC_DATABASE_URL — the spec's
-    // describeOrSkip will leave its blocks pending.
-    return;
   }
 
   const { PostgreSqlContainer } = require('@testcontainers/postgresql');
@@ -100,7 +143,7 @@ module.exports = async function globalSetup() {
   } catch (err) {
     await container.stop().catch(() => {});
     globalThis.__LL_PG_CONTAINER__ = undefined;
-    throw new Error(buildDockerUnavailableMessage(err));
+    throw new Error(buildMigrationFailedMessage(err));
   }
 
   process.env.LIFTING_TC_DATABASE_URL = url;

--- a/apps/api/scripts/check-globalsetup-failure-paths.js
+++ b/apps/api/scripts/check-globalsetup-failure-paths.js
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+// Verifies the three failure paths in jest.global-setup.js without needing
+// real Docker:
+//
+//   A. container.start() throws        → buildDockerUnavailableMessage headline,
+//                                         no container stashed, teardown is no-op.
+//   B. prisma migrate deploy throws    → buildMigrationFailedMessage headline,
+//                                         container.stop() called once, handle
+//                                         cleared, teardown is no-op (no second
+//                                         stop).
+//   C. LIFTING_SKIP_DB_E2E=foo (typo)  → near-miss warning, falls through; with
+//                                         our stub of start() also throwing, we
+//                                         then hit path A — confirms typoed
+//                                         values do not silently skip.
+//
+// Repeatable: `node apps/api/scripts/check-globalsetup-failure-paths.js`.
+// Exit 0 on all-pass, exit 1 with a diff-style report otherwise.
+//
+// This script monkey-patches require() for two modules and clears the require
+// cache for jest.global-setup.js between scenarios. It does not touch the
+// filesystem, network, or Docker. Linked from PR #423 review thread.
+
+'use strict';
+
+const Module = require('module');
+const path = require('path');
+
+const SETUP_PATH = path.resolve(__dirname, '..', 'jest.global-setup.js');
+const TEARDOWN_PATH = path.resolve(__dirname, '..', 'jest.global-teardown.js');
+
+const results = [];
+function record(name, ok, detail) {
+  results.push({ name, ok, detail });
+  const tag = ok ? 'PASS' : 'FAIL';
+  console.log(`[${tag}] ${name}${detail ? ' — ' + detail : ''}`);
+}
+
+// --- Test harness ----------------------------------------------------------
+
+let stopCallCount = 0;
+let lastWarn = [];
+let lastLog = [];
+
+function freshLoad(modulePath) {
+  delete require.cache[modulePath];
+  return require(modulePath);
+}
+
+function makeFakeContainer({ startThrows = false } = {}) {
+  stopCallCount = 0;
+  return {
+    start: async () => {
+      if (startThrows) {
+        const err = new Error('connect ECONNREFUSED /var/run/docker.sock (simulated)');
+        err.code = 'ECONNREFUSED';
+        throw err;
+      }
+      return {
+        getConnectionUri: () => 'postgresql://lifting:lifting@127.0.0.1:0/lifting_test',
+        stop: async () => {
+          stopCallCount += 1;
+        },
+      };
+    },
+  };
+}
+
+function installModuleMocks({ startThrows, migrateThrows }) {
+  const originalResolve = Module._resolveFilename;
+  const originalLoad = Module._load;
+
+  Module._load = function patchedLoad(request, parent, ...rest) {
+    if (request === '@testcontainers/postgresql') {
+      return {
+        PostgreSqlContainer: class {
+          constructor() {}
+          withDatabase() { return this; }
+          withUsername() { return this; }
+          withPassword() { return this; }
+          start() { return makeFakeContainer({ startThrows }).start(); }
+        },
+      };
+    }
+    if (request === 'child_process') {
+      const real = originalLoad.call(this, request, parent, ...rest);
+      return {
+        ...real,
+        execSync: (cmd, opts) => {
+          if (migrateThrows && /prisma migrate deploy/.test(cmd)) {
+            const err = new Error(
+              'P3018: A migration failed to apply. New migrations cannot be applied (simulated).',
+            );
+            throw err;
+          }
+          return real.execSync(cmd, opts);
+        },
+      };
+    }
+    return originalLoad.call(this, request, parent, ...rest);
+  };
+
+  return () => {
+    Module._resolveFilename = originalResolve;
+    Module._load = originalLoad;
+  };
+}
+
+function captureConsole() {
+  const origWarn = console.warn;
+  const origLog = console.log;
+  lastWarn = [];
+  lastLog = [];
+  console.warn = (...args) => lastWarn.push(args.join(' '));
+  console.log = (...args) => lastLog.push(args.join(' '));
+  return () => {
+    console.warn = origWarn;
+    console.log = origLog;
+  };
+}
+
+function clearEnv() {
+  delete process.env.DATABASE_URL;
+  delete process.env.LIFTING_SKIP_DB_E2E;
+  delete process.env.LIFTING_TC_DATABASE_URL;
+  delete globalThis.__LL_PG_CONTAINER__;
+}
+
+// --- Scenarios -------------------------------------------------------------
+
+async function scenarioA_startThrows() {
+  clearEnv();
+  const restoreLoader = installModuleMocks({ startThrows: true, migrateThrows: false });
+  const restoreConsole = captureConsole();
+  let caught;
+  try {
+    const globalSetup = freshLoad(SETUP_PATH);
+    await globalSetup();
+  } catch (err) {
+    caught = err;
+  } finally {
+    restoreConsole();
+    restoreLoader();
+  }
+
+  record(
+    'A.1 globalSetup throws when container.start() fails',
+    caught instanceof Error,
+    caught ? '' : 'no error thrown',
+  );
+  record(
+    'A.2 headline is buildDockerUnavailableMessage',
+    caught && caught.message.startsWith('[jest.global-setup] Cannot start Postgres via Testcontainers'),
+    caught ? '' : 'no error to inspect',
+  );
+  record(
+    'A.3 underlying error included in message',
+    caught && caught.message.includes('ECONNREFUSED'),
+  );
+  record(
+    'A.4 no container handle stashed on globalThis',
+    globalThis.__LL_PG_CONTAINER__ === undefined,
+    `handle = ${typeof globalThis.__LL_PG_CONTAINER__}`,
+  );
+
+  // Now confirm globalTeardown is a no-op (no throw, no second stop attempt).
+  let teardownErr;
+  try {
+    const globalTeardown = freshLoad(TEARDOWN_PATH);
+    await globalTeardown();
+  } catch (err) {
+    teardownErr = err;
+  }
+  record(
+    'A.5 globalTeardown is a no-op after start-throw',
+    teardownErr === undefined,
+    teardownErr ? `threw: ${teardownErr.message}` : '',
+  );
+}
+
+async function scenarioB_migrateThrows() {
+  clearEnv();
+  const restoreLoader = installModuleMocks({ startThrows: false, migrateThrows: true });
+  const restoreConsole = captureConsole();
+  let caught;
+  try {
+    const globalSetup = freshLoad(SETUP_PATH);
+    await globalSetup();
+  } catch (err) {
+    caught = err;
+  } finally {
+    restoreConsole();
+    restoreLoader();
+  }
+
+  record(
+    'B.1 globalSetup throws when migrate deploy fails',
+    caught instanceof Error,
+    caught ? '' : 'no error thrown',
+  );
+  record(
+    'B.2 headline is buildMigrationFailedMessage (NOT Docker-unreachable)',
+    caught && caught.message.startsWith('[jest.global-setup] `prisma migrate deploy` failed'),
+    caught ? `actual headline: ${caught.message.split('\n')[0]}` : '',
+  );
+  record(
+    'B.3 message explicitly states Docker IS reachable',
+    caught && caught.message.includes('Docker IS reachable'),
+  );
+  record(
+    'B.4 container.stop() was called exactly once',
+    stopCallCount === 1,
+    `stop call count = ${stopCallCount}`,
+  );
+  record(
+    'B.5 globalThis handle cleared to undefined',
+    globalThis.__LL_PG_CONTAINER__ === undefined,
+    `handle = ${typeof globalThis.__LL_PG_CONTAINER__}`,
+  );
+
+  const stopBeforeTeardown = stopCallCount;
+  let teardownErr;
+  try {
+    const globalTeardown = freshLoad(TEARDOWN_PATH);
+    await globalTeardown();
+  } catch (err) {
+    teardownErr = err;
+  }
+  record(
+    'B.6 globalTeardown is a no-op after migrate-throw (no double-stop, no throw)',
+    teardownErr === undefined && stopCallCount === stopBeforeTeardown,
+    teardownErr
+      ? `threw: ${teardownErr.message}`
+      : stopCallCount !== stopBeforeTeardown
+        ? `stop called again (count went ${stopBeforeTeardown} → ${stopCallCount})`
+        : '',
+  );
+}
+
+async function scenarioC_typoedSkipVar() {
+  clearEnv();
+  process.env.LIFTING_SKIP_DB_E2E = 'on'; // not in {1, true, yes}
+  // Have start() throw too — so if typo silently skipped, we'd return cleanly;
+  // if it falls through, we throw the Docker-unavailable error.
+  const restoreLoader = installModuleMocks({ startThrows: true, migrateThrows: false });
+  const restoreConsole = captureConsole();
+  let caught;
+  try {
+    const globalSetup = freshLoad(SETUP_PATH);
+    await globalSetup();
+  } catch (err) {
+    caught = err;
+  } finally {
+    restoreConsole();
+    restoreLoader();
+  }
+
+  record(
+    'C.1 typoed skip value does NOT silently skip — falls through to hard-fail',
+    caught instanceof Error && caught.message.includes('Cannot start Postgres'),
+    caught ? '' : 'no throw — silent skip regression',
+  );
+  record(
+    'C.2 near-miss warning was emitted before falling through',
+    lastWarn.some((line) => line.includes('not a recognized truthy value')),
+    `warnings: ${JSON.stringify(lastWarn)}`,
+  );
+
+  // And the accepted variants should actually skip:
+  for (const value of ['1', 'true', 'TRUE', 'yes']) {
+    clearEnv();
+    process.env.LIFTING_SKIP_DB_E2E = value;
+    const restoreLoader2 = installModuleMocks({ startThrows: true, migrateThrows: false });
+    const restoreConsole2 = captureConsole();
+    let err;
+    try {
+      const globalSetup = freshLoad(SETUP_PATH);
+      await globalSetup();
+    } catch (e) {
+      err = e;
+    } finally {
+      restoreConsole2();
+      restoreLoader2();
+    }
+    record(
+      `C.3 LIFTING_SKIP_DB_E2E=${value} skips cleanly (no throw)`,
+      err === undefined,
+      err ? `threw: ${err.message.split('\n')[0]}` : '',
+    );
+  }
+}
+
+// --- Run -------------------------------------------------------------------
+
+(async () => {
+  console.log('Exercising jest.global-setup.js failure paths (mocked Docker + execSync)...\n');
+  await scenarioA_startThrows();
+  console.log('');
+  await scenarioB_migrateThrows();
+  console.log('');
+  await scenarioC_typoedSkipVar();
+
+  const failed = results.filter((r) => !r.ok);
+  console.log(`\nSummary: ${results.length - failed.length}/${results.length} passed.`);
+  if (failed.length) {
+    console.log('\nFAILED checks:');
+    for (const f of failed) console.log(`  - ${f.name}${f.detail ? ' — ' + f.detail : ''}`);
+    process.exit(1);
+  }
+})();

--- a/docs/testing/e2e-coverage.md
+++ b/docs/testing/e2e-coverage.md
@@ -90,7 +90,34 @@ npm run test:db -w @lifting-logbook/api
 # container startup. Run migrations yourself in this case before invoking jest.
 ```
 
-> **Docker prerequisite.** Without Docker, globalSetup fails fast with a
-> clear Testcontainers error. The DB E2E describe block then skips
-> (`LIFTING_TC_DATABASE_URL` is unset), letting the rest of the suite still
-> run if you need to iterate on non-DB code.
+## Running locally when Docker is unavailable
+
+The default behavior is **hard-fail with an actionable message** when Docker is
+unreachable. globalSetup catches the underlying Testcontainers/daemon error and
+re-throws a multi-line message that names the root cause and lists three recovery
+options. This is intentional: a silent skip would let DB-touching changes ship
+without local verification, with CI as the only gate.
+
+The three recovery options the error names:
+
+1. **Fix Docker Desktop.** On Windows, the most common cause is an unregistered
+   `docker-desktop` WSL distro — see [issue #394](https://github.com/brownm09/lifting-logbook/issues/394)
+   for the factory-reset procedure.
+2. **Use `docker-compose.test.yml`.** Spin up the compose Postgres on 5433 and
+   set `DATABASE_URL` so globalSetup takes the CI passthrough branch:
+   ```bash
+   docker-compose -f docker-compose.test.yml up -d
+   DATABASE_URL=postgresql://lifting:lifting@localhost:5433/lifting_test \
+     npx prisma migrate deploy --schema=apps/api/prisma/schema.prisma
+   DATABASE_URL=postgresql://lifting:lifting@localhost:5433/lifting_test \
+     npm test -w @lifting-logbook/api
+   ```
+3. **Explicit skip via `LIFTING_SKIP_DB_E2E=1`.** Only valid when the diff
+   under test touches no DB code (no changes under `apps/api/prisma/`, no
+   repository changes, no schema changes). When set, globalSetup logs a warning
+   and returns; the DB E2E spec's `describeOrSkip` then leaves its blocks
+   pending so non-DB tests still run:
+   ```bash
+   LIFTING_SKIP_DB_E2E=1 npm test -w @lifting-logbook/api
+   ```
+   Cite issue #394 in the PR body when this escape hatch is used.


### PR DESCRIPTION
## Summary

When `apps/api` Jest `globalSetup` cannot reach Docker, the Testcontainers stack trace was the only signal — opaque unless you'd read the file. This PR wraps `container.start()` and `prisma migrate deploy` in try/catch and re-throws a multi-line message that names the root cause, links #394, and lists three recovery options.

- **Default behavior remains hard-fail** so DB-touching changes cannot ship without local verification.
- **`LIFTING_SKIP_DB_E2E=1` escape hatch** is documented as opt-in only: it skips DB provisioning entirely and lets the spec's existing `describeOrSkip` leave its blocks pending. Valid only when the diff under test touches no DB code.
- **CI passthrough branch** (`DATABASE_URL` pre-set) is untouched.
- Updated `CLAUDE.md` and `docs/testing/e2e-coverage.md` to document the new error contract and escape-hatch contributor rule.

Closes #394

## Testing

`npm test -w @lifting-logbook/api` (full api workspace, Docker up):

```
Test Suites: 22 passed, 22 total
Tests:       301 passed, 301 total
Snapshots:   0 total
Time:        11.506 s
```

`LIFTING_SKIP_DB_E2E=1 npx jest --testPathPatterns=programs.db.e2e` (escape-hatch path):

```
[jest.global-setup] LIFTING_SKIP_DB_E2E=1 — skipping DB E2E provisioning. DB-touching changes will not be locally verified. See issue #394.
Test Suites: 1 skipped, 0 of 1 total
Tests:       51 skipped, 51 total
```

The hard-fail message path was exercised by inspection — the original `Testcontainers/.start()` failure is now caught and re-thrown via `buildDockerUnavailableMessage(err)`. Cannot be exercised live in this PR because Docker came back up on this machine between the issue being filed and now (which is the third state covered by the test summary above).

### Coverage gate

No new product behavior — this is test-infrastructure ergonomics. Verified manually across all three paths (Docker up, opt-out, and by-inspection for hard-fail). No new automated tests required.

### Suppression / test-integrity

No new suppression markers added. No new `.skip`/`xit`/`describe.skip` markers introduced — the existing `describeOrSkip` in `programs.db.e2e.spec.ts` is untouched. The skipped count in the opt-out path is environment-gated by a documented contributor rule (escape hatch only valid for non-DB diffs).

## Test plan

- [x] `npm test -w @lifting-logbook/api` — 301 passed / 0 failed / 0 skipped with Docker up
- [x] `LIFTING_SKIP_DB_E2E=1 npx jest --testPathPatterns=programs.db.e2e` — 51 skipped, warning printed
- [ ] CI: api workspace passes against the GitHub Actions Postgres service container

🤖 Generated with [Claude Code](https://claude.com/claude-code)