### PR TITLE
[fix] Resolve Node 24 local test failures (OOM + NextResponse type drift)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Include in your opening brief only: the issue you are working on, current branch
     - Malformed native binaries: `node_modules/@turbo/windows-64/bin/turbo.exe` failing with `EFTYPE`
 
     Downstream failures: `nest build` CJS resolution errors (`iconv-lite/lib/streams`, `minimatch/dist/commonjs/index.js`), `TS1110 Type expected` from `light-my-request`, or `spawnSync ... EFTYPE` from turbo. Fix: `rm -rf node_modules/<package> && npm install <package> --no-save` to re-extract a single package, or `rm -rf node_modules && npm ci` for a full reset. CI runs Node 20 and is unaffected. Original investigation: [#373](https://github.com/brownm09/lifting-logbook/issues/373).
+  - **Node 24 Jest worker OOM (Windows only):** Several `packages/core` CSV-fixture-heavy suites exhaust per-worker heap when run in parallel on Node 24. Codified workaround: `jest.config.base.js` applies `workerIdleMemoryLimit: '512MB'` + `maxWorkers: '50%'` when `process.platform === 'win32'`. Linux Node 20 CI is unaffected by both the failure and the setting. Investigation: [#419](https://github.com/brownm09/lifting-logbook/issues/419).
 - **Package manager:** npm (workspaces)
 - **`jq` is NOT available.** Use `node -e` with a temp file in the working directory for JSON parsing:
   ```bash

--- a/apps/web/app/api/healthz/route.test.ts
+++ b/apps/web/app/api/healthz/route.test.ts
@@ -30,7 +30,7 @@ describe('GET /api/healthz', () => {
     const res = await GET();
 
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true });
+    expect(await (res as Response).json()).toEqual({ ok: true });
     expect(mockedAuth).toHaveBeenCalledTimes(1);
   });
 
@@ -48,7 +48,7 @@ describe('GET /api/healthz', () => {
     const res = await GET();
 
     expect(res.status).toBe(503);
-    expect(await res.json()).toEqual({ ok: false });
+    expect(await (res as Response).json()).toEqual({ ok: false });
     // The original error is logged server-side for operators.
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining('[healthz]'),
@@ -63,7 +63,7 @@ describe('GET /api/healthz', () => {
     const res = await GET();
 
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true, mode: 'dev-auth' });
+    expect(await (res as Response).json()).toEqual({ ok: true, mode: 'dev-auth' });
     expect(mockedAuth).not.toHaveBeenCalled();
   });
 });

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -7,10 +7,13 @@ module.exports = {
     '^.+\\.tsx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.json' }],
   },
   transformIgnorePatterns: ['/node_modules/'],
-  // Local Node 24 (Windows) workers exhaust heap when several CSV-fixture-heavy
+  // Node 24 (Windows) workers exhaust heap when several CSV-fixture-heavy
   // packages/core suites run in parallel. Restarting idle workers above 512MB
-  // RSS and capping parallelism at 50% of CPU keeps Node 20 CI behaviour
-  // effectively unchanged while clearing the OOMs locally. See #419.
-  workerIdleMemoryLimit: '512MB',
-  maxWorkers: '50%',
+  // RSS and capping parallelism at 50% of CPU clears the OOMs locally. Scoped
+  // to win32 so Node 20 Linux CI keeps Jest's default parallelism (cpus - 1)
+  // and never pays the worker-restart cost. See #419 and CLAUDE.md's Node 24
+  // caveat for the codified workaround.
+  ...(process.platform === 'win32'
+    ? { workerIdleMemoryLimit: '512MB', maxWorkers: '50%' }
+    : {}),
 };

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -7,4 +7,10 @@ module.exports = {
     '^.+\\.tsx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.json' }],
   },
   transformIgnorePatterns: ['/node_modules/'],
+  // Local Node 24 (Windows) workers exhaust heap when several CSV-fixture-heavy
+  // packages/core suites run in parallel. Restarting idle workers above 512MB
+  // RSS and capping parallelism at 50% of CPU keeps Node 20 CI behaviour
+  // effectively unchanged while clearing the OOMs locally. See #419.
+  workerIdleMemoryLimit: '512MB',
+  maxWorkers: '50%',
 };


### PR DESCRIPTION
## Summary

Two changes that clear the pre-existing local failures documented in #419 without touching CI behaviour.

- **`jest.config.base.js`** — adds `workerIdleMemoryLimit: '512MB'` and `maxWorkers: '50%'`. Idle workers above 512MB RSS are restarted (reclaims heap between fixture-heavy suites); cap at 50% of CPU drops concurrent CSV-fixture loading on multi-core dev boxes enough to clear the 6 OOMs. Node 20 CI runners are already constrained, so the effective behaviour there doesn't change.
- **`apps/web/app/api/healthz/route.test.ts`** — three `await res.json()` sites now go through `(res as Response).json()`. `NextResponse` extends `Response`, so the cast is type-safe and runtime-equivalent; the Next 16.2.4 type declares `json` as a static factory which shadows the inherited instance method in `NextResponse<T>`, producing TS2576. Three lines, no production code, no `next` version pinning, no eslint suppression.

The issue body also lists `apps/web/app/livez/route.test.ts` and `apps/web/lib/__tests__/programPlan.test.ts` as affected, but neither uses `res.json()` on a `NextResponse` (`livez` uses `res.text()`; `programPlan` has no `NextResponse` usage at all). Only the three `healthz` call sites actually emit TS2576.

## Testing

Run on Node 24.13.0 locally after a clean `npm ci`:

- `npm test -w @lifting-logbook/web -- app/api/healthz/route.test.ts`
  - `Tests: 3 passed, 0 skipped, 0 failed (5.268s)`
- `npm test -w @lifting-logbook/core`
  - `Tests: 160 passed, 0 skipped, 0 failed (8.014s)` — all 26 suites green, including the 6 previously OOMing ones (`parseCycleDashboard`, `jsUtil`, `createGridV2`, `updateLiftDates`, `bodyWeight`, `validateLiftImport`)
- `npm test` (full monorepo via turbo)
  - 12/12 tasks successful (49.7s)
  - api: `Tests: 301 passed, 0 skipped, 0 failed (11.063s)`
  - web: `Tests: 56 passed, 0 skipped, 0 failed (8.495s)`
  - core: `Tests: 160 passed, 0 skipped, 0 failed (8.014s)`
- **Combined: `Tests: 517 passed, 0 skipped, 0 failed`** across the three workspaces with test suites.

Coverage-gate check: no new behaviour added — this is a Jest-config and test-cast change. Existing tests fully exercise the affected paths (healthz had three cases before and still does).

Suppression check (`git diff origin/main | grep -E '(ts-ignore|ts-expect-error|eslint-disable|!\.|!\[|!\s*[;,)]|\?\? null)'`): empty.

Test-integrity check (skip/xdescribe/passWithNoTests/etc. grep): empty. The `--passWithNoTests` flag in npm output is a pre-existing workspace `test` script setting, unchanged here.

## Side observation — install corruption recurrence

Reaching the green state above required two rounds of `rm -rf node_modules && npm ci` because the initial install on Node 24 left several packages with truncated extractions (`std-env/dist/index.mjs` missing; `jest-config/build/` containing only `index.js`, which made Jest's preset loader fail with `Preset ts-jest not found relative to rootDir`). This is the same failure class already documented in `CLAUDE.md`'s "Node 24 caveat" section. Worth tracking separately if it recurs — not in scope for #419.

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)