### PR TITLE
[docs] Proposals: custom lifts, onboarding any-lift maxes, movement profiles

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -110,6 +110,9 @@ Web and mobile clients functional end-to-end. Key user-facing features implement
 | [On-Call Readiness](docs/proposals/2026-05-08-on-call-readiness.md) | Runbooks, SLOs, incident response guide, and severity/escalation framework; sequences after #199 | [#201](https://github.com/brownm09/lifting-logbook/issues/201) | shipped |
 | [Historical Lift Data Backfill](docs/proposals/2026-05-11-historical-lift-data-backfill.md) | CSV upload endpoint and web UI to ingest historical `LiftRecord` rows with all-or-nothing validation | [#225](https://github.com/brownm09/lifting-logbook/issues/225) | draft |
 | [Workout Scheduling Override](docs/proposals/2026-05-17-workout-scheduling-override.md) | User-defined preferred workout days (fixed or rotating A/B) + per-program `workoutsPerWeek` override with automatic cycle date distribution | [#267](https://github.com/brownm09/lifting-logbook/issues/267) | shipped |
+| [Custom User-Created Lifts](docs/proposals/2026-06-03-custom-lifts.md) | Per-user persisted `CustomLift` entity (Prisma model + `ICustomLiftRepository` port + ownership isolation); `resolveLift` prefers custom over catalog; `GET/POST/PATCH/DELETE /lifts/custom`. Foundational for #426 and #427 | [#425](https://github.com/brownm09/lifting-logbook/issues/425) | draft |
+| [Onboarding — Any-Lift Max Estimation](docs/proposals/2026-06-03-onboarding-any-lift-max-estimation.md) | Dynamic add/remove lift list in onboarding for any catalog or custom lift; persists confirmed maxes (closes the discard gap in `createFirstCycle`) | [#426](https://github.com/brownm09/lifting-logbook/issues/426) | draft |
+| [Lift Movement Profiles](docs/proposals/2026-06-03-lift-movement-profiles.md) | Combined `MovementProfile` (patterns + joint actions + complexity) on `Lift`; preconfigured for the 25 catalog entries, editable for custom lifts | [#427](https://github.com/brownm09/lifting-logbook/issues/427) | draft |
 
 ---
 

--- a/docs/proposals/2026-06-03-custom-lifts.md
+++ b/docs/proposals/2026-06-03-custom-lifts.md
@@ -1,0 +1,120 @@
+# Proposal: Custom User-Created Lifts
+
+**Status:** `draft`
+**Date:** 2026-06-03
+**Issue:** [#425](https://github.com/brownm09/lifting-logbook/issues/425)
+
+---
+
+## Problem
+
+Lifts are referenced throughout the domain as plain strings (`LiftRecord.lift`, `TrainingMax.lift`,
+and `LiftMetadata.lift` are all unconstrained `String` columns), and the exercise catalog is a fixed,
+in-code array of 25 movements in `packages/core/src/catalog/lifts.ts` with zero persistence. A user who
+trains a movement the catalog does not contain — a machine variation, a specialty bar lift, a sport-specific
+accessory — has no first-class way to add it. They can type an arbitrary string into a lift-record field,
+but that lift carries no classification, no movement metadata, and no identity the rest of the system
+recognizes.
+
+This gap blocks two planned features that both need a user-owned lift entity to attach to:
+
+- **Onboarding for any lift** ([onboarding any-lift max estimation](2026-06-03-onboarding-any-lift-max-estimation.md))
+  needs to offer custom lifts alongside catalog lifts when seeding initial maxes.
+- **Movement profiles** ([lift movement profiles](2026-06-03-lift-movement-profiles.md)) needs custom lifts
+  to carry editable joint-action and complexity metadata, since catalog values are read-only.
+
+The [original lift-library proposal](2026-04-13-lift-library-exercise-tagging.md) explicitly left
+user-created exercises out of scope and flagged the persistence/ownership boundary as a spike to resolve
+before client work. This proposal is that resolution.
+
+## Proposed Solution
+
+Introduce custom lifts as a per-user persisted entity that resolves transparently alongside the built-in
+catalog, preserving the hexagonal boundary (ADR-002): catalog data stays pure in `packages/core`, and
+custom-lift persistence lives entirely in the API adapter layer.
+
+**1. Types** (`packages/types/src/domain.ts`)
+
+Add a `CustomLift` shape that extends the existing `Lift` fields with ownership, and add an `isCustom?`
+discriminator to the base `Lift` (catalog entries are implicitly `false`):
+
+```ts
+export interface CustomLift extends Lift {
+  userId: string;
+  isCustom: true;
+  createdAt: Date;
+}
+```
+
+**2. Persistence** (`apps/api/prisma/schema.prisma`)
+
+Add a `CustomLift` model following the per-user isolation pattern already established by `LiftMetadata`,
+`TrainingMax`, and `StrengthGoal`:
+
+```prisma
+model CustomLift {
+  id             String   @id @default(uuid())
+  userId         String
+  name           String
+  classification String
+  // movement metadata persisted per the movement-profile proposal
+  createdAt      DateTime @default(now())
+
+  @@unique([userId, name])
+  @@index([userId])
+  @@map("custom_lift")
+}
+```
+
+**3. Port + adapters**
+
+Add an `ICustomLiftRepository` port (`apps/api/src/ports/`) with in-memory and Prisma adapters, wired
+through the existing `IRepositoryFactory.forUser(...)` per-user factory (the pattern introduced in
+[#144](https://github.com/brownm09/lifting-logbook/issues/144)).
+
+**4. Resolution**
+
+Extend `resolveLift` (`packages/core/src/catalog/resolve.ts`) so that a user's custom catalog is consulted
+**before** the built-in `LIFT_CATALOG`. Core stays pure: custom lifts are passed in as a data argument by
+the API layer — no database access leaks into `packages/core`.
+
+**5. API**
+
+Add `GET/POST/PATCH/DELETE /lifts/custom`, returning the same `Lift`-shaped contract the catalog already
+uses, so existing lift-consuming UI (the manage-lifts type-ahead, the lift-metadata editor) works against
+custom lifts without modification.
+
+## Acceptance Criteria
+
+- [ ] `CustomLift` type exported from `packages/types`; `Lift.isCustom?: boolean` added
+- [ ] `CustomLift` Prisma model + migration, unique per `(userId, name)`
+- [ ] `ICustomLiftRepository` port with in-memory and Prisma adapters, threaded through the per-user factory
+- [ ] `resolveLift` prefers a user's custom lifts over the built-in catalog; an unknown id still errors
+- [ ] `GET/POST/PATCH/DELETE /lifts/custom` with in-memory E2E coverage (per Testing → Coverage Requirements)
+- [ ] Ownership isolation: user A cannot read or mutate user B's custom lifts (auth-guard E2E)
+- [ ] Strict TypeScript compilation passes across `packages/types`, `packages/core`, and `apps/api`
+
+## Out of Scope
+
+- Sharing or copying custom lifts between users
+- Admin curation, moderation, or promoting a custom lift into the global catalog
+- Movement-profile metadata shape itself (defined in the [movement-profiles proposal](2026-06-03-lift-movement-profiles.md);
+  this proposal persists whatever shape that one lands)
+- Deduplication / fuzzy-matching a custom lift against an existing catalog lift
+
+## Open Questions
+
+- Should a custom lift whose name later collides with a newly added catalog entry be reconciled, or continue
+  to shadow the catalog entry for that user? Initial answer: continue to shadow (user intent wins); revisit
+  if it causes confusion.
+
+## References
+
+- [ADR-002 — Ports and Adapters (Hexagonal Architecture)](../adr/ADR-002-ports-and-adapters.md) —
+  governs why catalog data must stay pure in `packages/core` and persistence lives in the adapter layer
+- [Cockburn, Alistair — "Hexagonal Architecture"](https://alistair.cockburn.us/hexagonal-architecture/) —
+  authoritative source for the ports-and-adapters boundary
+- [Prisma — Data model / relations](https://www.prisma.io/docs/orm/prisma-schema/data-model/models) —
+  per-user model and unique-constraint patterns used by `LiftMetadata`, `TrainingMax`, `StrengthGoal`
+- [Lift Library and Exercise Tagging proposal](2026-04-13-lift-library-exercise-tagging.md) — the open
+  question this proposal resolves

--- a/docs/proposals/2026-06-03-lift-movement-profiles.md
+++ b/docs/proposals/2026-06-03-lift-movement-profiles.md
@@ -1,0 +1,97 @@
+# Proposal: Lift Movement Profiles — Joint Action and Complexity Metadata
+
+**Status:** `draft`
+**Date:** 2026-06-03
+**Issue:** [#427](https://github.com/brownm09/lifting-logbook/issues/427)
+
+---
+
+## Problem
+
+The `Lift` model (`packages/types/src/domain.ts`) describes a lift along two axes today:
+
+- `classification` (`compound | accessory`) — a training **role** (is this a primary progressive lift or a
+  supplemental accessory?)
+- `movementTags` (`push | pull | vertical | horizontal | hinge | carry | squat`) — a movement **pattern**
+
+Neither captures the anatomical joint actions a lift trains — internal rotation, external rotation, flexion,
+extension, abduction, adduction — nor its movement **complexity** (simple vs compound). Without these, the
+app cannot reason about balance across joint actions, surface them in lift detail, or let users describe a
+custom lift accurately. These descriptors should be **preconfigured for in-catalog lifts** and **editable
+for custom lifts**.
+
+Note the deliberate distinction this proposal must preserve: movement *complexity* (`simple | compound`,
+i.e. single-joint vs multi-joint) is **not** the same as the existing `classification` (`compound |
+accessory`, a training role). A Goblet Squat is movement-`compound` but role-`accessory`. Both axes are
+kept.
+
+## Proposed Solution
+
+Per the chosen modeling approach, fold pattern, joint action, and complexity into a **single combined
+movement-profile structure** rather than scattering independent fields across the model.
+
+**1. New combined structure** (`packages/types/src/domain.ts`)
+
+```ts
+export type JointAction =
+  | 'flexion' | 'extension'
+  | 'internal-rotation' | 'external-rotation'
+  | 'abduction' | 'adduction';
+
+export type MovementComplexity = 'simple' | 'compound';
+
+export interface MovementProfile {
+  patterns: MovementTag[];        // existing push/pull/vertical/... preserved here
+  jointActions: JointAction[];    // new anatomical axis
+  complexity: MovementComplexity; // new simple/compound axis
+}
+```
+
+Extend `Lift` with `movementProfile: MovementProfile`. The existing `movementTags` data migrates into
+`movementProfile.patterns`. To avoid a churny break, `movementTags` may be retained as a deprecated alias of
+`movementProfile.patterns` for one release, or every call site migrated in the same PR — implementer's call.
+`classification` (`compound | accessory`) is retained unchanged as the training-role axis; the proposal text
+states the role-vs-complexity distinction explicitly.
+
+**2. Preconfigure the catalog** (`packages/core/src/catalog/lifts.ts`)
+
+Give all 25 catalog entries a sensible `movementProfile`. Examples:
+
+- **Back Squat** → patterns `['squat']`, jointActions `['flexion', 'extension']`, complexity `compound`
+- **Face Pull** → patterns `['pull', 'horizontal']`, jointActions `['external-rotation']`, complexity `simple`
+- **Cable Curl** → patterns `['pull']`, jointActions `['flexion']`, complexity `simple`
+
+**3. Editable for custom lifts**
+
+The custom-lift create/edit form and `POST/PATCH /lifts/custom` (per the
+[custom-lifts proposal](2026-06-03-custom-lifts.md)) accept a `movementProfile`. For catalog lifts the
+profile is a read-only default the user can view.
+
+## Acceptance Criteria
+
+- [ ] `JointAction`, `MovementComplexity`, and `MovementProfile` exported from `packages/types`
+- [ ] `Lift.movementProfile` added; existing `movementTags` data preserved under `.patterns`
+- [ ] All 25 catalog entries carry a preconfigured `movementProfile`; `packages/core` unit tests assert each
+- [ ] Custom-lift create/edit accepts and persists a `movementProfile` (depends on the custom-lifts work)
+- [ ] The role-vs-complexity distinction (`classification` vs `complexity`) is documented in the type's doc comment
+- [ ] Strict TypeScript compilation passes across `packages/types`, `packages/core`, and updated call sites
+
+## Out of Scope
+
+- Volume or analytics aggregation by joint action
+- A movement-pattern browse / filter UI
+- Auto-inferring a movement profile from a lift's name
+
+## Open Questions
+
+- Should `jointActions` be required (non-empty) for every lift, or allowed empty for lifts where it is not
+  meaningful (e.g. a loaded carry)? Initial answer: allow empty, mirroring how Calf Raise carries no
+  movement tags today.
+
+## References
+
+- [Cardinal planes & anatomical movement terms — joint actions (flexion/extension, rotation, abduction/adduction)](https://www.ncbi.nlm.nih.gov/books/NBK557555/) —
+  primary anatomical reference for the `JointAction` taxonomy
+- [Lift Library and Exercise Tagging proposal](2026-04-13-lift-library-exercise-tagging.md) — the
+  `classification` + `movementTags` model this proposal extends
+- [Custom User-Created Lifts proposal](2026-06-03-custom-lifts.md) — dependency for the editable-for-custom half

--- a/docs/proposals/2026-06-03-onboarding-any-lift-max-estimation.md
+++ b/docs/proposals/2026-06-03-onboarding-any-lift-max-estimation.md
@@ -1,0 +1,78 @@
+# Proposal: Onboarding — Estimate Maxes for Any Catalog or Custom Lift
+
+**Status:** `draft`
+**Date:** 2026-06-03
+**Issue:** [#426](https://github.com/brownm09/lifting-logbook/issues/426)
+
+---
+
+## Problem
+
+The onboarding wizard's "Enter Lifts" step is hardcoded to exactly three lifts — Bench Press, Back Squat,
+and Deadlift — via `LiftKey = 'bench' | 'squat' | 'deadlift'` and the `LIFT_LABELS` record in
+`apps/web/app/(authed)/onboarding/lib.ts`. A lifter whose program centers on other movements (Overhead
+Press, Barbell Row, weighted Chin-up) cannot seed those maxes during setup, and there is no path at all for
+a lift outside the catalog. The product goal — let a user submit a recent heavy set for **any** lift,
+catalog or custom, and have its max estimated — is unmet.
+
+There is a second, latent defect in the same flow: **the maxes the wizard computes are never persisted.**
+`OnboardingFlow.tsx` computes `computedMaxes` and displays them on the Confirm step, but `handleConfirm`
+calls `createFirstCycle(selectedProgramId)` (`onboarding/actions.ts`) with only the program id — the
+entered maxes are discarded, and the user lands on `/cycle/1` with no training maxes set from onboarding.
+
+## Proposed Solution
+
+Make the "Enter Lifts" step a dynamic, user-managed list and persist the confirmed maxes on completion.
+
+**1. Dynamic lift list**
+
+Replace the fixed `LiftKey` union and `LIFT_LABELS` record with a list of lift rows the user can add to and
+remove from. Seed the list with the three big lifts so a zero-config user sees no change, but allow **add a
+row** by selecting any lift from the built-in catalog **or any custom lift** (per the
+[custom-lifts proposal](2026-06-03-custom-lifts.md)). Reuse the existing lift-picker / type-ahead component
+built for the manage-lifts screen rather than introducing a new selector.
+
+**2. Estimation unchanged**
+
+Continue using the client-side `brzycki1RM` helper (`onboarding/lib.ts`) for the live on-screen estimate,
+which mirrors the canonical core utility `estimateTrainingMax`
+(`packages/core/src/services/maxes/estimateTrainingMax.ts`). Rep-range guidance ("stay under 10 reps for
+accuracy") is preserved.
+
+**3. Persist confirmed maxes**
+
+Extend `createFirstCycle` (`onboarding/actions.ts`) to accept the confirmed `{ lift, oneRm }[]` and write
+them via the existing `PATCH /programs/:program/training-maxes` endpoint before redirecting to `/cycle/1`.
+This closes the discard gap so onboarding actually seeds the training maxes it collects.
+
+## Acceptance Criteria
+
+- [ ] "Enter Lifts" supports adding and removing lift rows; any catalog or custom lift is selectable
+- [ ] The three big lifts remain the default rows for a zero-config user
+- [ ] Confirmed maxes are persisted to training maxes on completion (the discard gap is closed)
+- [ ] Estimation continues to use the Brzycki path; rep-range guidance is unchanged
+- [ ] Web test coverage per the "new frontend feature" rule (Playwright once
+      [#259](https://github.com/brownm09/lifting-logbook/issues/259) lands; until then a written test plan
+      in the PR body)
+
+## Out of Scope
+
+- Mobile onboarding — `apps/mobile` is a "coming soon" placeholder
+- Test-week max discovery — shipped in [#129](https://github.com/brownm09/lifting-logbook/issues/129)
+- Automatic re-estimation of maxes from logged workout sets after onboarding
+
+## Open Questions
+
+- Should custom-lift selection hard-block onboarding until the [custom-lifts](2026-06-03-custom-lifts.md)
+  work lands, or should onboarding ship catalog-only first and gain custom lifts when that dependency
+  merges? Recommended: ship catalog-only selection first if the dependency slips.
+
+## References
+
+- [Brzycki, M. (1993). "Strength Testing—Predicting a One-Rep Max from Reps-to-Fatigue." *JOPERD* 64(1):88–90.](https://www.tandfonline.com/doi/abs/10.1080/07303084.1993.10606684) —
+  the estimation formula used on the Enter Lifts / Confirm steps
+- [Initial Training Max Discovery proposal](2026-04-30-initial-training-max-discovery.md) — the
+  `estimateTrainingMax` core utility this flow mirrors
+- [Custom User-Created Lifts proposal](2026-06-03-custom-lifts.md) — dependency for custom-lift selection
+- [Next.js — Server Actions and Mutations](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations) —
+  the `createFirstCycle` Server Action extended to persist maxes


### PR DESCRIPTION
Files high-priority feature work as three `/propose` triads — a proposal doc + a GitHub issue + a ROADMAP Proposals-table row each. Docs-only; no feature code in this PR.

## Issues filed

| # | Feature | Depends on |
|---|---|---|
| [#425](https://github.com/brownm09/lifting-logbook/issues/425) | **Custom user-created lifts** — persistence, ownership, resolution | — (foundational) |
| [#426](https://github.com/brownm09/lifting-logbook/issues/426) | **Onboarding** — estimate maxes for any catalog or custom lift | #425 |
| [#427](https://github.com/brownm09/lifting-logbook/issues/427) | **Lift movement profiles** — joint action + complexity metadata | #425 |

## Why these three

The two requested features — onboarding for any/custom lift, and configurable movement type + complexity — both depend on a **custom-lift entity that doesn't exist yet** (lifts are stored as plain strings; the catalog is fixed in-code data in `packages/core`). #425 is split out as the foundational piece both build on.

Key design decisions captured from the requester:
- **Movement modeling:** one combined `MovementProfile` structure (patterns + joint actions + complexity), not separate scattered fields. The role-vs-complexity distinction (`classification` `compound|accessory` vs `complexity` `simple|compound`) is preserved and documented.
- **Custom lifts:** a separate foundational issue rather than folded into the other two.

This PR also documents a latent defect found while scoping #426: onboarding computes maxes but `createFirstCycle` discards them (only `programId` is passed). #426 closes that gap by persisting via `PATCH /training-maxes`.

## Contents

- `docs/proposals/2026-06-03-custom-lifts.md`
- `docs/proposals/2026-06-03-onboarding-any-lift-max-estimation.md`
- `docs/proposals/2026-06-03-lift-movement-profiles.md`
- `ROADMAP.md` — three rows appended to the v0.3 Proposals table

## Notes / follow-ups

- **Priority:** the repo has no `priority:*` label taxonomy, so each issue notes **Priority: High** in its body rather than via a label.
- **Milestone:** all three set to **v0.3 — Client Applications (#3)**, the `[Current]` milestone. v0.4 is already `[Shipped]`, so placement is slightly ambiguous — happy to move to a new milestone if preferred.
- **Project board / Epic:** the CLAUDE.md GitHub Project workflow uses `gh project` / GraphQL with the `project` scope, which isn't reachable via the GitHub MCP tools here. Suggested Epic: **Client Applications** (`31d3931e`) — left as a manual follow-up.

https://claude.ai/code/session_01Uw7sfxaoqNDWisgzbFyNko

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uw7sfxaoqNDWisgzbFyNko)_