### PR TITLE
feat: custom user-created lifts (persistence, ownership, resolution)

### DIFF
--- a/apps/api/prisma/migrations/20260603000000_add_custom_lift/migration.sql
+++ b/apps/api/prisma/migrations/20260603000000_add_custom_lift/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "custom_lift" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "classification" TEXT NOT NULL,
+    "movementTags" TEXT[],
+    "isBodyweightComponent" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "custom_lift_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "custom_lift_userId_idx" ON "custom_lift"("userId");
+
+-- CreateUniqueIndex
+CREATE UNIQUE INDEX "custom_lift_userId_name_key" ON "custom_lift"("userId", "name");

--- a/apps/api/prisma/migrations/20260603000000_add_custom_lift/migration.sql
+++ b/apps/api/prisma/migrations/20260603000000_add_custom_lift/migration.sql
@@ -14,5 +14,5 @@ CREATE TABLE "custom_lift" (
 -- CreateIndex
 CREATE INDEX "custom_lift_userId_idx" ON "custom_lift"("userId");
 
--- CreateUniqueIndex
+-- CreateIndex
 CREATE UNIQUE INDEX "custom_lift_userId_name_key" ON "custom_lift"("userId", "name");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -147,6 +147,20 @@ model LiftMetadata {
   @@map("lift_metadata")
 }
 
+model CustomLift {
+  id                    String   @id @default(uuid())
+  userId                String
+  name                  String
+  classification        String
+  movementTags          String[]
+  isBodyweightComponent Boolean  @default(false)
+  createdAt             DateTime @default(now())
+
+  @@unique([userId, name])
+  @@index([userId])
+  @@map("custom_lift")
+}
+
 model UserSettings {
   userId          String  @id
   activeProgram   String?

--- a/apps/api/src/adapters/factory/in-memory-repository-factory.ts
+++ b/apps/api/src/adapters/factory/in-memory-repository-factory.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { LiftRecord } from '@lifting-logbook/core';
 import { AuthUser } from '../../ports/auth';
 import { IRepositoryFactory, RepositoryBundle } from '../../ports/factory';
+import { InMemoryCustomLiftRepository } from '../in-memory/custom-lift.adapter';
 import { InMemoryCycleDashboardRepository } from '../in-memory/cycle-dashboard.adapter';
 import { InMemoryCycleScheduledWorkoutRepository } from '../in-memory/cycle-scheduled-workout.adapter';
 import { InMemoryLiftMetadataRepository } from '../in-memory/lift-metadata.adapter';
@@ -35,6 +36,7 @@ export class InMemoryRepositoryFactory implements IRepositoryFactory {
         ? new Map([[SEED_PROGRAM, seedLiftRecords()]])
         : new Map();
       this.bundles.set(user.id, {
+        customLift: new InMemoryCustomLiftRepository(user.id),
         cycleDashboard: new InMemoryCycleDashboardRepository(preSeed),
         cycleScheduledWorkout: new InMemoryCycleScheduledWorkoutRepository(),
         liftMetadata: new InMemoryLiftMetadataRepository(),

--- a/apps/api/src/adapters/factory/system-db-repository-factory.ts
+++ b/apps/api/src/adapters/factory/system-db-repository-factory.ts
@@ -4,6 +4,7 @@ import { Pool } from 'pg';
 import { LiftRecord } from '@lifting-logbook/core';
 import { AuthUser } from '../../ports/auth';
 import { IRepositoryFactory, RepositoryBundle } from '../../ports/factory';
+import { PrismaCustomLiftRepository } from '../prisma/custom-lift.repository';
 import { PrismaLiftRecordRepository } from '../prisma/lift-record.repository';
 import { PrismaStrengthGoalRepository } from '../prisma/strength-goal.repository';
 import { PrismaTrainingMaxRepository } from '../prisma/training-max.repository';
@@ -13,6 +14,7 @@ import { PrismaLiftMetadataRepository } from '../prisma/lift-metadata.repository
 import { PrismaWorkoutDateOverrideRepository } from '../prisma/workout-date-override.repository';
 import { PrismaWorkoutLiftOverrideRepository } from '../prisma/workout-lift-override.repository';
 import { PrismaWorkoutRepository } from '../prisma/workout.repository';
+import { InMemoryCustomLiftRepository } from '../in-memory/custom-lift.adapter';
 import { InMemoryCycleDashboardRepository } from '../in-memory/cycle-dashboard.adapter';
 import { InMemoryLiftMetadataRepository } from '../in-memory/lift-metadata.adapter';
 import { InMemoryLiftingProgramSpecRepository } from '../in-memory/lifting-program-spec.adapter';
@@ -85,6 +87,7 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
     if (adapterType === 'postgres') {
       const prisma = this.getOrCreatePrisma();
       return {
+        customLift: new PrismaCustomLiftRepository(prisma, userId),
         cycleDashboard: new PrismaCycleDashboardRepository(prisma, userId),
         cycleScheduledWorkout: new PrismaCycleScheduledWorkoutRepository(prisma, userId),
         liftMetadata: new PrismaLiftMetadataRepository(prisma, userId),
@@ -107,6 +110,7 @@ export class SystemDbRepositoryFactory implements IRepositoryFactory, OnModuleDe
     // and matches InMemoryRepositoryFactory).
     const sharedRecords: Map<string, LiftRecord[]> = new Map();
     return {
+      customLift: new InMemoryCustomLiftRepository(userId),
       cycleDashboard: new InMemoryCycleDashboardRepository(),
       cycleScheduledWorkout: new InMemoryCycleScheduledWorkoutRepository(),
       liftMetadata: new InMemoryLiftMetadataRepository(),

--- a/apps/api/src/adapters/in-memory/custom-lift.adapter.ts
+++ b/apps/api/src/adapters/in-memory/custom-lift.adapter.ts
@@ -1,0 +1,72 @@
+import { randomUUID } from 'crypto';
+import { CustomLift } from '@lifting-logbook/types';
+import {
+  CreateCustomLiftInput,
+  ICustomLiftRepository,
+  UpdateCustomLiftPatch,
+} from '../../ports/ICustomLiftRepository';
+import { CustomLiftConflictError, CustomLiftNotFoundError } from '../../ports/errors';
+
+export class InMemoryCustomLiftRepository implements ICustomLiftRepository {
+  // Keyed by uuid id (the REST key), not name — names are mutable.
+  private readonly store = new Map<string, CustomLift>();
+
+  constructor(private readonly userId: string) {}
+
+  async list(): Promise<CustomLift[]> {
+    return Array.from(this.store.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  async create(input: CreateCustomLiftInput): Promise<CustomLift> {
+    if (this.nameTaken(input.name)) {
+      throw new CustomLiftConflictError(input.name);
+    }
+    const lift: CustomLift = {
+      id: randomUUID(),
+      userId: this.userId,
+      name: input.name,
+      classification: input.classification,
+      movementTags: input.movementTags ?? [],
+      isBodyweightComponent: input.isBodyweightComponent ?? false,
+      isCustom: true,
+      createdAt: new Date(),
+    };
+    this.store.set(lift.id, lift);
+    return lift;
+  }
+
+  async update(id: string, patch: UpdateCustomLiftPatch): Promise<CustomLift> {
+    const existing = this.store.get(id);
+    if (!existing) {
+      throw new CustomLiftNotFoundError(id);
+    }
+    if (patch.name !== undefined && this.nameTaken(patch.name, id)) {
+      throw new CustomLiftConflictError(patch.name);
+    }
+    const updated: CustomLift = {
+      ...existing,
+      ...(patch.name !== undefined ? { name: patch.name } : {}),
+      ...(patch.classification !== undefined ? { classification: patch.classification } : {}),
+      ...(patch.movementTags !== undefined ? { movementTags: patch.movementTags } : {}),
+      ...(patch.isBodyweightComponent !== undefined
+        ? { isBodyweightComponent: patch.isBodyweightComponent }
+        : {}),
+    };
+    this.store.set(id, updated);
+    return updated;
+  }
+
+  async delete(id: string): Promise<void> {
+    if (!this.store.has(id)) {
+      throw new CustomLiftNotFoundError(id);
+    }
+    this.store.delete(id);
+  }
+
+  private nameTaken(name: string, exceptId?: string): boolean {
+    for (const lift of this.store.values()) {
+      if (lift.name === name && lift.id !== exceptId) return true;
+    }
+    return false;
+  }
+}

--- a/apps/api/src/adapters/prisma/custom-lift.repository.ts
+++ b/apps/api/src/adapters/prisma/custom-lift.repository.ts
@@ -1,0 +1,102 @@
+import { PrismaClient } from '@prisma/client';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
+import { CustomLift, LiftClassification, MovementTag } from '@lifting-logbook/types';
+import {
+  CreateCustomLiftInput,
+  ICustomLiftRepository,
+  UpdateCustomLiftPatch,
+} from '../../ports/ICustomLiftRepository';
+import { CustomLiftConflictError, CustomLiftNotFoundError } from '../../ports/errors';
+
+interface CustomLiftRow {
+  id: string;
+  userId: string;
+  name: string;
+  classification: string;
+  movementTags: string[];
+  isBodyweightComponent: boolean;
+  createdAt: Date;
+}
+
+export class PrismaCustomLiftRepository implements ICustomLiftRepository {
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly userId: string,
+  ) {}
+
+  async list(): Promise<CustomLift[]> {
+    const rows = await this.prisma.customLift.findMany({
+      where: { userId: this.userId },
+      orderBy: { name: 'asc' },
+    });
+    return rows.map((r: CustomLiftRow) => this.toCustomLift(r));
+  }
+
+  async create(input: CreateCustomLiftInput): Promise<CustomLift> {
+    try {
+      const row = await this.prisma.customLift.create({
+        data: {
+          userId: this.userId,
+          name: input.name,
+          classification: input.classification,
+          movementTags: input.movementTags ?? [],
+          isBodyweightComponent: input.isBodyweightComponent ?? false,
+        },
+      });
+      return this.toCustomLift(row);
+    } catch (e) {
+      if (e instanceof PrismaClientKnownRequestError && e.code === 'P2002') {
+        throw new CustomLiftConflictError(input.name);
+      }
+      throw e;
+    }
+  }
+
+  async update(id: string, patch: UpdateCustomLiftPatch): Promise<CustomLift> {
+    // The PK is `id` alone, so guard on userId to preserve ownership isolation —
+    // a bare where:{id} would let one user mutate another user's lift.
+    const owned = await this.prisma.customLift.findFirst({ where: { id, userId: this.userId } });
+    if (!owned) {
+      throw new CustomLiftNotFoundError(id);
+    }
+    const data = {
+      ...(patch.name !== undefined ? { name: patch.name } : {}),
+      ...(patch.classification !== undefined ? { classification: patch.classification } : {}),
+      ...(patch.movementTags !== undefined ? { movementTags: patch.movementTags } : {}),
+      ...(patch.isBodyweightComponent !== undefined
+        ? { isBodyweightComponent: patch.isBodyweightComponent }
+        : {}),
+    };
+    try {
+      const row = await this.prisma.customLift.update({ where: { id }, data });
+      return this.toCustomLift(row);
+    } catch (e) {
+      if (e instanceof PrismaClientKnownRequestError && e.code === 'P2002') {
+        throw new CustomLiftConflictError(patch.name ?? owned.name);
+      }
+      throw e;
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    // Guard on userId for the same isolation reason as update().
+    const owned = await this.prisma.customLift.findFirst({ where: { id, userId: this.userId } });
+    if (!owned) {
+      throw new CustomLiftNotFoundError(id);
+    }
+    await this.prisma.customLift.delete({ where: { id } });
+  }
+
+  private toCustomLift(row: CustomLiftRow): CustomLift {
+    return {
+      id: row.id,
+      userId: row.userId,
+      name: row.name,
+      classification: row.classification as LiftClassification,
+      movementTags: row.movementTags as MovementTag[],
+      isBodyweightComponent: row.isBodyweightComponent,
+      isCustom: true,
+      createdAt: row.createdAt,
+    };
+  }
+}

--- a/apps/api/src/adapters/prisma/prisma-repository-factory.ts
+++ b/apps/api/src/adapters/prisma/prisma-repository-factory.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { AuthUser } from '../../ports/auth';
 import { IRepositoryFactory, RepositoryBundle } from '../../ports/factory';
 import { PrismaService } from './prisma.service';
+import { PrismaCustomLiftRepository } from './custom-lift.repository';
 import { PrismaCycleDashboardRepository } from './cycle-dashboard.repository';
 import { PrismaCycleScheduledWorkoutRepository } from './cycle-scheduled-workout.repository';
 import { PrismaLiftMetadataRepository } from './lift-metadata.repository';
@@ -29,6 +30,7 @@ export class PrismaRepositoryFactory implements IRepositoryFactory {
 
   async forUser(user: AuthUser): Promise<RepositoryBundle> {
     return {
+      customLift: new PrismaCustomLiftRepository(this.prisma, user.id),
       cycleDashboard: new PrismaCycleDashboardRepository(this.prisma, user.id),
       cycleScheduledWorkout: new PrismaCycleScheduledWorkoutRepository(this.prisma, user.id),
       liftMetadata: new PrismaLiftMetadataRepository(this.prisma, user.id),

--- a/apps/api/src/lifts/create-custom-lift.dto.ts
+++ b/apps/api/src/lifts/create-custom-lift.dto.ts
@@ -1,0 +1,26 @@
+import { ArrayMaxSize, IsArray, IsBoolean, IsIn, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import { LiftClassification, MovementTag } from '@lifting-logbook/types';
+
+const CLASSIFICATIONS: LiftClassification[] = ['compound', 'accessory'];
+const MOVEMENT_TAGS: MovementTag[] = ['push', 'pull', 'vertical', 'horizontal', 'hinge', 'carry', 'squat'];
+
+export class CreateCustomLiftDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  name!: string;
+
+  @IsString()
+  @IsIn(CLASSIFICATIONS)
+  classification!: LiftClassification;
+
+  @IsArray()
+  @ArrayMaxSize(7)
+  @IsIn(MOVEMENT_TAGS, { each: true })
+  @IsOptional()
+  movementTags?: MovementTag[];
+
+  @IsBoolean()
+  @IsOptional()
+  isBodyweightComponent?: boolean;
+}

--- a/apps/api/src/lifts/custom-lift.controller.ts
+++ b/apps/api/src/lifts/custom-lift.controller.ts
@@ -1,0 +1,90 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { CustomLift, CustomLiftResponse } from '@lifting-logbook/types';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { AuthUser } from '../ports/auth';
+import { IRepositoryFactory } from '../ports/factory';
+import { UpdateCustomLiftPatch } from '../ports/ICustomLiftRepository';
+import { REPOSITORY_FACTORY } from '../ports/tokens';
+import { CreateCustomLiftDto } from './create-custom-lift.dto';
+import { UpdateCustomLiftDto } from './update-custom-lift.dto';
+
+function toCustomLiftResponse(lift: CustomLift): CustomLiftResponse {
+  return {
+    id: lift.id,
+    name: lift.name,
+    classification: lift.classification,
+    movementTags: lift.movementTags,
+    isBodyweightComponent: lift.isBodyweightComponent ?? false,
+    isCustom: true,
+    createdAt: lift.createdAt.toISOString(),
+  };
+}
+
+@Controller('lifts')
+export class CustomLiftController {
+  constructor(
+    @Inject(REPOSITORY_FACTORY) private readonly factory: IRepositoryFactory,
+  ) {}
+
+  @Get('custom')
+  async list(@CurrentUser() user: AuthUser): Promise<CustomLiftResponse[]> {
+    const { customLift } = await this.factory.forUser(user);
+    const lifts = await customLift.list();
+    return lifts.map(toCustomLiftResponse);
+  }
+
+  @Post('custom')
+  @HttpCode(HttpStatus.CREATED)
+  async create(
+    @Body() dto: CreateCustomLiftDto,
+    @CurrentUser() user: AuthUser,
+  ): Promise<CustomLiftResponse> {
+    const { customLift } = await this.factory.forUser(user);
+    const created = await customLift.create({
+      name: dto.name,
+      classification: dto.classification,
+      ...(dto.movementTags !== undefined ? { movementTags: dto.movementTags } : {}),
+      ...(dto.isBodyweightComponent !== undefined
+        ? { isBodyweightComponent: dto.isBodyweightComponent }
+        : {}),
+    });
+    return toCustomLiftResponse(created);
+  }
+
+  @Patch('custom/:id')
+  @HttpCode(HttpStatus.OK)
+  async update(
+    @Param('id') id: string,
+    @Body() dto: UpdateCustomLiftDto,
+    @CurrentUser() user: AuthUser,
+  ): Promise<CustomLiftResponse> {
+    const { customLift } = await this.factory.forUser(user);
+    const patch: UpdateCustomLiftPatch = {};
+    if (dto.name !== undefined) patch.name = dto.name;
+    if (dto.classification !== undefined) patch.classification = dto.classification;
+    if (dto.movementTags !== undefined) patch.movementTags = dto.movementTags;
+    if (dto.isBodyweightComponent !== undefined) {
+      patch.isBodyweightComponent = dto.isBodyweightComponent;
+    }
+    const updated = await customLift.update(id, patch);
+    return toCustomLiftResponse(updated);
+  }
+
+  @Delete('custom/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(@Param('id') id: string, @CurrentUser() user: AuthUser): Promise<void> {
+    const { customLift } = await this.factory.forUser(user);
+    await customLift.delete(id);
+  }
+}

--- a/apps/api/src/lifts/custom-lift.e2e.spec.ts
+++ b/apps/api/src/lifts/custom-lift.e2e.spec.ts
@@ -1,0 +1,185 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import { CustomLiftResponse } from '@lifting-logbook/types';
+import { AppModule } from '../app.module';
+import { SEED_PROGRAM } from '../adapters/in-memory/fixtures';
+import { DomainConflictFilter } from '../programs/conflict.filter';
+import { DomainNotFoundFilter } from '../programs/not-found.filter';
+
+describe('Custom Lifts HTTP (e2e, in-memory adapters)', () => {
+  let app: NestFastifyApplication;
+
+  beforeAll(async () => {
+    app = await NestFactory.create<NestFastifyApplication>(
+      AppModule,
+      new FastifyAdapter(),
+      { logger: false },
+    );
+    app.useGlobalFilters(new DomainNotFoundFilter(), new DomainConflictFilter());
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }));
+    await app.init();
+    await app.getHttpAdapter().getInstance().ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const AUTH = { authorization: 'Bearer dev-token' };
+
+  const inject = (
+    method: string,
+    url: string,
+    opts: { headers?: Record<string, string>; body?: unknown } = {},
+  ) => {
+    const headers = opts.headers ?? AUTH;
+    if (opts.body !== undefined) {
+      return app.getHttpAdapter().getInstance().inject({
+        method: method as 'GET',
+        url,
+        headers: { 'content-type': 'application/json', ...headers },
+        payload: JSON.stringify(opts.body),
+      });
+    }
+    return app.getHttpAdapter().getInstance().inject({ method: method as 'GET', url, headers });
+  };
+
+  const create = (body: unknown, headers?: Record<string, string>) =>
+    inject('POST', '/lifts/custom', { body, headers });
+
+  it('creates a custom lift, returning a uuid id and isCustom:true', async () => {
+    const res = await create({
+      name: 'Safety Bar Squat',
+      classification: 'compound',
+      movementTags: ['squat'],
+    });
+    expect(res.statusCode).toBe(201);
+    const lift = res.json() as CustomLiftResponse;
+    expect(lift.id).toMatch(/[0-9a-f-]{36}/);
+    expect(lift.name).toBe('Safety Bar Squat');
+    expect(lift.classification).toBe('compound');
+    expect(lift.movementTags).toEqual(['squat']);
+    expect(lift.isBodyweightComponent).toBe(false);
+    expect(lift.isCustom).toBe(true);
+    expect(typeof lift.createdAt).toBe('string');
+  });
+
+  it('lists the created custom lift', async () => {
+    await create({ name: 'Pin Press', classification: 'compound' });
+    const res = await inject('GET', '/lifts/custom');
+    expect(res.statusCode).toBe(200);
+    const lifts = res.json() as CustomLiftResponse[];
+    expect(lifts.some((l) => l.name === 'Pin Press')).toBe(true);
+  });
+
+  it('rejects a duplicate name with 409', async () => {
+    await create({ name: 'Zercher Squat', classification: 'compound' });
+    const dup = await create({ name: 'Zercher Squat', classification: 'accessory' });
+    expect(dup.statusCode).toBe(409);
+  });
+
+  it('updates classification, tags and name via PATCH', async () => {
+    const created = await create({ name: 'Belt Squat', classification: 'accessory' });
+    const id = (created.json() as CustomLiftResponse).id;
+    const res = await inject('PATCH', `/lifts/custom/${id}`, {
+      body: { classification: 'compound', movementTags: ['squat'], name: 'Belt Squat v2' },
+    });
+    expect(res.statusCode).toBe(200);
+    const lift = res.json() as CustomLiftResponse;
+    expect(lift.id).toBe(id);
+    expect(lift.classification).toBe('compound');
+    expect(lift.movementTags).toEqual(['squat']);
+    expect(lift.name).toBe('Belt Squat v2');
+  });
+
+  it('returns 404 when PATCHing an unknown id', async () => {
+    const res = await inject('PATCH', '/lifts/custom/does-not-exist', {
+      body: { classification: 'compound' },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('deletes a custom lift and returns 204', async () => {
+    const created = await create({ name: 'Hack Squat', classification: 'accessory' });
+    const id = (created.json() as CustomLiftResponse).id;
+    const del = await inject('DELETE', `/lifts/custom/${id}`);
+    expect(del.statusCode).toBe(204);
+    const list = await inject('GET', '/lifts/custom');
+    expect((list.json() as CustomLiftResponse[]).some((l) => l.id === id)).toBe(false);
+  });
+
+  it('returns 404 when DELETEing an unknown id', async () => {
+    const res = await inject('DELETE', '/lifts/custom/does-not-exist');
+    expect(res.statusCode).toBe(404);
+  });
+
+  describe('validation', () => {
+    it('rejects a missing name with 400', async () => {
+      const res = await create({ classification: 'compound' });
+      expect(res.statusCode).toBe(400);
+    });
+    it('rejects an invalid classification with 400', async () => {
+      const res = await create({ name: 'Bad Class', classification: 'isolation' });
+      expect(res.statusCode).toBe(400);
+    });
+    it('rejects an invalid movement tag with 400', async () => {
+      const res = await create({ name: 'Bad Tag', classification: 'compound', movementTags: ['twist'] });
+      expect(res.statusCode).toBe(400);
+    });
+    it('rejects an unknown extra field with 400', async () => {
+      const res = await create({ name: 'Extra Field', classification: 'compound', userId: 'hacker' });
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe('ownership isolation', () => {
+    const AS_CLARKE = { authorization: 'Bearer user-clarke-lifts' };
+    const AS_DANA = { authorization: 'Bearer user-dana-lifts' };
+
+    it("user B cannot see, update, or delete user A's custom lift", async () => {
+      const created = await create(
+        { name: 'Clarke Special', classification: 'compound' },
+        AS_CLARKE,
+      );
+      expect(created.statusCode).toBe(201);
+      const id = (created.json() as CustomLiftResponse).id;
+
+      // Dana's list does not include Clarke's lift
+      const danaList = await inject('GET', '/lifts/custom', { headers: AS_DANA });
+      expect((danaList.json() as CustomLiftResponse[]).some((l) => l.id === id)).toBe(false);
+
+      // Dana cannot update Clarke's lift
+      const danaUpdate = await inject('PATCH', `/lifts/custom/${id}`, {
+        headers: AS_DANA,
+        body: { classification: 'accessory' },
+      });
+      expect(danaUpdate.statusCode).toBe(404);
+
+      // Dana cannot delete Clarke's lift
+      const danaDelete = await inject('DELETE', `/lifts/custom/${id}`, { headers: AS_DANA });
+      expect(danaDelete.statusCode).toBe(404);
+
+      // Clarke still has it
+      const clarkeList = await inject('GET', '/lifts/custom', { headers: AS_CLARKE });
+      expect((clarkeList.json() as CustomLiftResponse[]).some((l) => l.id === id)).toBe(true);
+    });
+  });
+
+  describe('consumption: GET /programs/:program/lifts', () => {
+    const AS_PICKER = { authorization: 'Bearer user-picker-lifts' };
+
+    it('includes the user custom lift names in the selectable lifts list', async () => {
+      await create({ name: 'Trap Bar Deadlift', classification: 'compound' }, AS_PICKER);
+      const res = await inject('GET', `/programs/${SEED_PROGRAM}/lifts`, { headers: AS_PICKER });
+      expect(res.statusCode).toBe(200);
+      const lifts = res.json() as string[];
+      expect(lifts).toContain('Trap Bar Deadlift');
+      expect(lifts).toContain('Squat'); // built-ins still present
+    });
+  });
+});

--- a/apps/api/src/lifts/lifts.module.ts
+++ b/apps/api/src/lifts/lifts.module.ts
@@ -1,7 +1,8 @@
 import { Module } from '@nestjs/common';
+import { CustomLiftController } from './custom-lift.controller';
 import { LiftMetadataController } from './lift-metadata.controller';
 
 @Module({
-  controllers: [LiftMetadataController],
+  controllers: [LiftMetadataController, CustomLiftController],
 })
 export class LiftsModule {}

--- a/apps/api/src/lifts/update-custom-lift.dto.ts
+++ b/apps/api/src/lifts/update-custom-lift.dto.ts
@@ -1,0 +1,28 @@
+import { ArrayMaxSize, IsArray, IsBoolean, IsIn, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import { LiftClassification, MovementTag } from '@lifting-logbook/types';
+
+const CLASSIFICATIONS: LiftClassification[] = ['compound', 'accessory'];
+const MOVEMENT_TAGS: MovementTag[] = ['push', 'pull', 'vertical', 'horizontal', 'hinge', 'carry', 'squat'];
+
+export class UpdateCustomLiftDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(100)
+  @IsOptional()
+  name?: string;
+
+  @IsString()
+  @IsIn(CLASSIFICATIONS)
+  @IsOptional()
+  classification?: LiftClassification;
+
+  @IsArray()
+  @ArrayMaxSize(7)
+  @IsIn(MOVEMENT_TAGS, { each: true })
+  @IsOptional()
+  movementTags?: MovementTag[];
+
+  @IsBoolean()
+  @IsOptional()
+  isBodyweightComponent?: boolean;
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -10,6 +10,7 @@ import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify
 import multipart from '@fastify/multipart';
 import { Logger } from 'nestjs-pino';
 import { AppModule } from './app.module';
+import { DomainConflictFilter } from './programs/conflict.filter';
 import { DomainNotFoundFilter } from './programs/not-found.filter';
 
 async function bootstrap() {
@@ -21,7 +22,7 @@ async function bootstrap() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   await app.register(multipart as any, { limits: { fileSize: 5 * 1024 * 1024, files: 1 } });
   app.useLogger(app.get(Logger));
-  app.useGlobalFilters(new DomainNotFoundFilter());
+  app.useGlobalFilters(new DomainNotFoundFilter(), new DomainConflictFilter());
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }));
   const port = parseInt(process.env.PORT ?? '3004', 10);
   await app.listen(port, '0.0.0.0');

--- a/apps/api/src/ports/ICustomLiftRepository.ts
+++ b/apps/api/src/ports/ICustomLiftRepository.ts
@@ -1,0 +1,27 @@
+import { CustomLift, LiftClassification, MovementTag } from '@lifting-logbook/types';
+
+export interface CreateCustomLiftInput {
+  name: string;
+  classification: LiftClassification;
+  movementTags?: MovementTag[];
+  isBodyweightComponent?: boolean;
+}
+
+export interface UpdateCustomLiftPatch {
+  name?: string;
+  classification?: LiftClassification;
+  movementTags?: MovementTag[];
+  isBodyweightComponent?: boolean;
+}
+
+/**
+ * Per-user store of user-created lifts. The owning userId is bound to the
+ * adapter at construction time (via the repository factory), never passed
+ * per call — mirroring the other per-user repositories.
+ */
+export interface ICustomLiftRepository {
+  list(): Promise<CustomLift[]>;
+  create(input: CreateCustomLiftInput): Promise<CustomLift>;
+  update(id: string, patch: UpdateCustomLiftPatch): Promise<CustomLift>;
+  delete(id: string): Promise<void>;
+}

--- a/apps/api/src/ports/errors.ts
+++ b/apps/api/src/ports/errors.ts
@@ -38,3 +38,17 @@ export class StrengthGoalNotFoundError extends Error {
     this.name = 'StrengthGoalNotFoundError';
   }
 }
+
+export class CustomLiftNotFoundError extends Error {
+  constructor(public readonly id: string) {
+    super(`Custom lift '${id}' not found`);
+    this.name = 'CustomLiftNotFoundError';
+  }
+}
+
+export class CustomLiftConflictError extends Error {
+  constructor(public readonly liftName: string) {
+    super(`A custom lift named '${liftName}' already exists`);
+    this.name = 'CustomLiftConflictError';
+  }
+}

--- a/apps/api/src/ports/factory.ts
+++ b/apps/api/src/ports/factory.ts
@@ -1,4 +1,5 @@
 import { AuthUser } from './auth';
+import { ICustomLiftRepository } from './ICustomLiftRepository';
 import { ICycleDashboardRepository } from './ICycleDashboardRepository';
 import { ICycleScheduledWorkoutRepository } from './ICycleScheduledWorkoutRepository';
 import { ILiftMetadataRepository } from './ILiftMetadataRepository';
@@ -15,6 +16,7 @@ import { IWorkoutRepository } from './IWorkoutRepository';
 import { IWorkoutSkipOverrideRepository } from './IWorkoutSkipOverrideRepository';
 
 export interface RepositoryBundle {
+  customLift: ICustomLiftRepository;
   cycleDashboard: ICycleDashboardRepository;
   cycleScheduledWorkout: ICycleScheduledWorkoutRepository;
   liftMetadata: ILiftMetadataRepository;

--- a/apps/api/src/ports/ports.compile-test.ts
+++ b/apps/api/src/ports/ports.compile-test.ts
@@ -10,6 +10,7 @@ import { BodyWeightEntry } from '@lifting-logbook/types';
 import { AuthUser, IAuthProvider } from './auth';
 import { IBodyWeightRepository } from './IBodyWeightRepository';
 import { IRepositoryFactory, RepositoryBundle } from './factory';
+import { ICustomLiftRepository } from './ICustomLiftRepository';
 import { ICycleDashboardRepository } from './ICycleDashboardRepository';
 import { ICycleScheduledWorkoutRepository } from './ICycleScheduledWorkoutRepository';
 import { ILiftingProgramSpecRepository } from './ILiftingProgramSpecRepository';
@@ -160,7 +161,35 @@ const _userSettingsRepo: IUserSettingsRepository = {
   getSettings: () => Promise.resolve({ activeProgram: null, workoutSchedule: null }),
 };
 
+const _customLiftRepo: ICustomLiftRepository = {
+  list: () => Promise.resolve([]),
+  create: (input) =>
+    Promise.resolve({
+      id: '',
+      userId: '',
+      name: input.name,
+      classification: input.classification,
+      movementTags: input.movementTags ?? [],
+      isBodyweightComponent: input.isBodyweightComponent ?? false,
+      isCustom: true,
+      createdAt: new Date(),
+    }),
+  update: (id, _patch) =>
+    Promise.resolve({
+      id,
+      userId: '',
+      name: '',
+      classification: 'compound',
+      movementTags: [],
+      isBodyweightComponent: false,
+      isCustom: true,
+      createdAt: new Date(),
+    }),
+  delete: () => Promise.resolve(),
+};
+
 const _repositoryBundle: RepositoryBundle = {
+  customLift: _customLiftRepo,
   cycleDashboard: _cycleDashboardRepo,
   cycleScheduledWorkout: _cycleScheduledWorkoutRepo,
   liftMetadata: _liftMetadataRepo,

--- a/apps/api/src/programs/conflict.filter.ts
+++ b/apps/api/src/programs/conflict.filter.ts
@@ -1,0 +1,27 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpStatus,
+} from '@nestjs/common';
+import { FastifyReply } from 'fastify';
+import { CustomLiftConflictError } from '../ports/errors';
+
+type DomainConflict = CustomLiftConflictError;
+
+/**
+ * Translates framework-agnostic domain "conflict" errors raised by port
+ * adapters into HTTP 409 responses. Mirrors DomainNotFoundFilter so adapters
+ * stay free of `@nestjs/common` HTTP dependencies.
+ */
+@Catch(CustomLiftConflictError)
+export class DomainConflictFilter implements ExceptionFilter {
+  catch(err: DomainConflict, host: ArgumentsHost): void {
+    const res = host.switchToHttp().getResponse<FastifyReply>();
+    res.status(HttpStatus.CONFLICT).send({
+      statusCode: HttpStatus.CONFLICT,
+      message: err.message,
+      error: 'Conflict',
+    });
+  }
+}

--- a/apps/api/src/programs/manage-lifts.controller.spec.ts
+++ b/apps/api/src/programs/manage-lifts.controller.spec.ts
@@ -40,11 +40,12 @@ describe('ManageLiftsController', () => {
     specRepoB = { getProgramSpec: jest.fn().mockResolvedValue(STUB_SPEC) } as jest.Mocked<ILiftingProgramSpecRepository>;
     dashboardRepoA = { getCycleDashboard: jest.fn().mockResolvedValue({}), saveCycleDashboard: jest.fn() } as unknown as jest.Mocked<ICycleDashboardRepository>;
     dashboardRepoB = { getCycleDashboard: jest.fn().mockResolvedValue({}), saveCycleDashboard: jest.fn() } as unknown as jest.Mocked<ICycleDashboardRepository>;
+    const customLiftRepo = { list: jest.fn().mockResolvedValue([]) };
     factory = {
       forUser: jest.fn().mockImplementation(async (user) =>
         user.id === MOCK_USER_A.id
-          ? { cycleDashboard: dashboardRepoA, workoutLiftOverride: liftOverrideRepoA, liftingProgramSpec: specRepoA }
-          : { cycleDashboard: dashboardRepoB, workoutLiftOverride: liftOverrideRepoB, liftingProgramSpec: specRepoB },
+          ? { cycleDashboard: dashboardRepoA, workoutLiftOverride: liftOverrideRepoA, liftingProgramSpec: specRepoA, customLift: customLiftRepo }
+          : { cycleDashboard: dashboardRepoB, workoutLiftOverride: liftOverrideRepoB, liftingProgramSpec: specRepoB, customLift: customLiftRepo },
       ),
     };
     const module: TestingModule = await Test.createTestingModule({
@@ -55,8 +56,8 @@ describe('ManageLiftsController', () => {
   });
 
   describe('getLifts', () => {
-    it('returns the full LIFT_NAMES catalog', () => {
-      const result = controller.getLifts();
+    it('returns the full LIFT_NAMES catalog when the user has no custom lifts', async () => {
+      const result = await controller.getLifts(MOCK_USER_A);
       expect(result).toEqual([...LIFT_NAMES]);
       expect(result.length).toBeGreaterThan(0);
     });

--- a/apps/api/src/programs/manage-lifts.controller.ts
+++ b/apps/api/src/programs/manage-lifts.controller.ts
@@ -26,8 +26,15 @@ export class ManageLiftsController {
   ) {}
 
   @Get('lifts')
-  getLifts(): string[] {
-    return [...LIFT_NAMES];
+  async getLifts(@CurrentUser() user: AuthUser): Promise<string[]> {
+    // Merge the user's custom lift names with the built-in catalog so they are
+    // selectable everywhere lifts are picked. Downstream consumers (training
+    // maxes, lift records, workout generation) already accept arbitrary lift
+    // strings, so no further wiring is needed. Deduped so a custom lift named
+    // after a built-in does not appear twice.
+    const { customLift } = await this.factory.forUser(user);
+    const customNames = (await customLift.list()).map((c) => c.name);
+    return Array.from(new Set([...LIFT_NAMES, ...customNames]));
   }
 
   @Post('cycles/:cycleNum/workouts/:workoutNum/lift-overrides')

--- a/apps/api/src/programs/not-found.filter.ts
+++ b/apps/api/src/programs/not-found.filter.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { FastifyReply } from 'fastify';
 import {
+  CustomLiftNotFoundError,
   HistoryEntryNotFoundError,
   ProgramNotFoundError,
   StrengthGoalNotFoundError,
@@ -16,14 +17,21 @@ type DomainNotFound =
   | ProgramNotFoundError
   | WorkoutNotFoundError
   | HistoryEntryNotFoundError
-  | StrengthGoalNotFoundError;
+  | StrengthGoalNotFoundError
+  | CustomLiftNotFoundError;
 
 /**
  * Translates framework-agnostic domain "not found" errors raised by port
  * adapters into HTTP 404 responses. Keeps adapters free of `@nestjs/common`
  * HTTP dependencies so they can be reused by non-HTTP callers.
  */
-@Catch(ProgramNotFoundError, WorkoutNotFoundError, HistoryEntryNotFoundError, StrengthGoalNotFoundError)
+@Catch(
+  ProgramNotFoundError,
+  WorkoutNotFoundError,
+  HistoryEntryNotFoundError,
+  StrengthGoalNotFoundError,
+  CustomLiftNotFoundError,
+)
 export class DomainNotFoundFilter implements ExceptionFilter {
   catch(err: DomainNotFound, host: ArgumentsHost): void {
     const res = host.switchToHttp().getResponse<FastifyReply>();

--- a/apps/api/src/programs/programs.db.e2e.spec.ts
+++ b/apps/api/src/programs/programs.db.e2e.spec.ts
@@ -26,6 +26,7 @@ import {
   seedTrainingMaxes,
 } from '../adapters/in-memory/fixtures';
 import { DomainNotFoundFilter } from './not-found.filter';
+import { DomainConflictFilter } from './conflict.filter';
 
 const TEST_USER = 'db-e2e-primary';
 const USER_ALICE = 'db-e2e-alice';
@@ -37,11 +38,13 @@ const USER_SETT = 'db-e2e-settings';
 const USER_SETT_OTHER = 'db-e2e-settings-other';
 const USER_CUST = 'db-e2e-custom';
 const USER_CUST_OTHER = 'db-e2e-custom-other';
+const USER_CLIFT = 'db-e2e-custom-lift';
+const USER_CLIFT_OTHER = 'db-e2e-custom-lift-other';
 const USER_BW   = 'db-e2e-body-weight';
 const USER_SW   = 'db-e2e-switch';
 
 async function cleanTestUsers(prisma: PrismaClient): Promise<void> {
-  const users = [TEST_USER, USER_ALICE, USER_BOB, USER_INIT, USER_HIST, USER_SETT, USER_SETT_OTHER, USER_CUST, USER_CUST_OTHER, USER_BW, USER_SW];
+  const users = [TEST_USER, USER_ALICE, USER_BOB, USER_INIT, USER_HIST, USER_SETT, USER_SETT_OTHER, USER_CUST, USER_CUST_OTHER, USER_CLIFT, USER_CLIFT_OTHER, USER_BW, USER_SW];
   await prisma.liftRecord.deleteMany({ where: { userId: { in: users } } });
   await prisma.trainingMax.deleteMany({ where: { userId: { in: users } } });
   await prisma.trainingMaxHistory.deleteMany({ where: { userId: { in: users } } });
@@ -52,6 +55,7 @@ async function cleanTestUsers(prisma: PrismaClient): Promise<void> {
   await prisma.liftMetadata.deleteMany({ where: { userId: { in: users } } });
   await prisma.userSettings.deleteMany({ where: { userId: { in: users } } });
   await prisma.customProgram.deleteMany({ where: { userId: { in: users } } });
+  await prisma.customLift.deleteMany({ where: { userId: { in: users } } });
 }
 
 const TC_DATABASE_URL = process.env.LIFTING_TC_DATABASE_URL;
@@ -195,7 +199,7 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
     );
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await app.register(multipart as any, { limits: { fileSize: 5 * 1024 * 1024, files: 1 } });
-    app.useGlobalFilters(new DomainNotFoundFilter());
+    app.useGlobalFilters(new DomainNotFoundFilter(), new DomainConflictFilter());
     app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
     await app.init();
     await app.getHttpAdapter().getInstance().ready();
@@ -1109,6 +1113,130 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
       const res = await injectRaw({ method: 'GET', url: '/programs/custom', headers: AS_OTHER });
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual([]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Custom lifts — Prisma-backed (PrismaCustomLiftRepository). The in-memory
+  // e2e (custom-lift.e2e.spec.ts) covers the HTTP contract against the in-memory
+  // adapter; this block exercises the Prisma adapter against real Postgres,
+  // including the P2002 -> 409 conflict path and — critically — the userId guard
+  // on update/delete (the PK is `id` alone, so a bare where:{id} would let one
+  // user mutate another's lift). Order-sensitive within the block.
+  // ---------------------------------------------------------------------------
+
+  describe('custom lifts (DB)', () => {
+    const AS_OWNER = { authorization: `Bearer ${USER_CLIFT}` };
+    const AS_OTHER = { authorization: `Bearer ${USER_CLIFT_OTHER}` };
+    const injectRaw = () =>
+      app.getHttpAdapter().getInstance().inject.bind(app.getHttpAdapter().getInstance());
+
+    let liftId = '';
+
+    it('POST /lifts/custom creates a row (uuid id, isCustom) and persists to DB', async () => {
+      const res = await injectRaw()({
+        method: 'POST',
+        url: '/lifts/custom',
+        headers: { 'content-type': 'application/json', ...AS_OWNER },
+        payload: JSON.stringify({ name: 'Zercher Squat', classification: 'compound', movementTags: ['squat'] }),
+      });
+      expect(res.statusCode).toBe(201);
+      const body = res.json() as {
+        id: string; name: string; isCustom: boolean; createdAt: string; userId?: string;
+      };
+      expect(body.id).toMatch(/^[0-9a-f-]{36}$/);
+      expect(body.name).toBe('Zercher Squat');
+      expect(body.isCustom).toBe(true);
+      expect(body.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(body).not.toHaveProperty('userId');
+      liftId = body.id;
+
+      const row = await prisma.customLift.findFirst({ where: { id: liftId } });
+      expect(row).not.toBeNull();
+      expect(row?.userId).toBe(USER_CLIFT);
+      expect(row?.classification).toBe('compound');
+      expect(row?.movementTags).toEqual(['squat']);
+    });
+
+    it('GET /lifts/custom lists the created lift for the owner', async () => {
+      const res = await injectRaw()({ method: 'GET', url: '/lifts/custom', headers: AS_OWNER });
+      expect(res.statusCode).toBe(200);
+      const list = res.json() as { id: string; name: string }[];
+      expect(list.some((l) => l.id === liftId && l.name === 'Zercher Squat')).toBe(true);
+    });
+
+    it('POST duplicate name for same user returns 409 (Prisma P2002 -> conflict)', async () => {
+      const res = await injectRaw()({
+        method: 'POST',
+        url: '/lifts/custom',
+        headers: { 'content-type': 'application/json', ...AS_OWNER },
+        payload: JSON.stringify({ name: 'Zercher Squat', classification: 'accessory' }),
+      });
+      expect(res.statusCode).toBe(409);
+    });
+
+    it('PATCH /lifts/custom/:id updates the owner\'s lift and persists', async () => {
+      const res = await injectRaw()({
+        method: 'PATCH',
+        url: `/lifts/custom/${liftId}`,
+        headers: { 'content-type': 'application/json', ...AS_OWNER },
+        payload: JSON.stringify({ name: 'Zercher Squat (SSB)', classification: 'accessory' }),
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({ id: liftId, name: 'Zercher Squat (SSB)', classification: 'accessory' });
+
+      const row = await prisma.customLift.findFirst({ where: { id: liftId } });
+      expect(row?.name).toBe('Zercher Squat (SSB)');
+      expect(row?.classification).toBe('accessory');
+    });
+
+    it('user isolation — another user cannot see, modify, or delete the lift', async () => {
+      // OTHER's list must not include OWNER's lift.
+      const listRes = await injectRaw()({ method: 'GET', url: '/lifts/custom', headers: AS_OTHER });
+      expect(listRes.statusCode).toBe(200);
+      expect((listRes.json() as { id: string }[]).some((l) => l.id === liftId)).toBe(false);
+
+      // OTHER's PATCH on OWNER's id -> 404 (userId guard, not a bare where:{id}).
+      const patchRes = await injectRaw()({
+        method: 'PATCH',
+        url: `/lifts/custom/${liftId}`,
+        headers: { 'content-type': 'application/json', ...AS_OTHER },
+        payload: JSON.stringify({ name: 'HACKED' }),
+      });
+      expect(patchRes.statusCode).toBe(404);
+
+      // OTHER's DELETE on OWNER's id -> 404.
+      const delRes = await injectRaw()({ method: 'DELETE', url: `/lifts/custom/${liftId}`, headers: AS_OTHER });
+      expect(delRes.statusCode).toBe(404);
+
+      // DB layer — the row is untouched: still owned by OWNER with the pre-attack name.
+      const row = await prisma.customLift.findFirst({ where: { id: liftId } });
+      expect(row).not.toBeNull();
+      expect(row?.userId).toBe(USER_CLIFT);
+      expect(row?.name).toBe('Zercher Squat (SSB)');
+    });
+
+    it('PATCH unknown id returns 404', async () => {
+      const res = await injectRaw()({
+        method: 'PATCH',
+        url: '/lifts/custom/00000000-0000-0000-0000-000000000000',
+        headers: { 'content-type': 'application/json', ...AS_OWNER },
+        payload: JSON.stringify({ name: 'nope' }),
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('DELETE /lifts/custom/:id removes the owner\'s row', async () => {
+      const res = await injectRaw()({ method: 'DELETE', url: `/lifts/custom/${liftId}`, headers: AS_OWNER });
+      expect(res.statusCode).toBe(204);
+
+      const row = await prisma.customLift.findFirst({ where: { id: liftId } });
+      expect(row).toBeNull();
+    });
+
+    it('DELETE unknown id returns 404', async () => {
+      const res = await injectRaw()({ method: 'DELETE', url: `/lifts/custom/${liftId}`, headers: AS_OWNER });
+      expect(res.statusCode).toBe(404);
     });
   });
 

--- a/packages/core/src/catalog/resolve.ts
+++ b/packages/core/src/catalog/resolve.ts
@@ -3,22 +3,26 @@ import { Lift } from '@lifting-logbook/types';
 /**
  * Resolves a slot name to a Lift from the catalog.
  *
- * @param slotName  - The exercise slot name (e.g., the `lift` field from LiftingProgramSpec).
- * @param slotMap   - A mapping from slot name → catalog Lift id.
- * @param catalog   - The Lift catalog to search.
+ * @param slotName    - The exercise slot name (e.g., the `lift` field from LiftingProgramSpec).
+ * @param slotMap     - A mapping from slot name → catalog Lift id.
+ * @param catalog     - The Lift catalog to search.
+ * @param customLifts - A user's custom lifts, consulted before the catalog so they take
+ *                      precedence over a built-in entry with the same id (user intent wins).
+ *                      Passed as plain data — this function performs no I/O.
  * @returns The matching Lift.
- * @throws  If the slot name is not in slotMap or the resolved id is not in the catalog.
+ * @throws  If the slot name is not in slotMap or the resolved id is in neither list.
  */
 export function resolveLift(
   slotName: string,
   slotMap: Readonly<Record<string, string>>,
   catalog: readonly Lift[],
+  customLifts: readonly Lift[] = [],
 ): Lift {
   const liftId = slotMap[slotName];
   if (liftId === undefined) {
     throw new Error(`Unknown exercise slot: "${slotName}". Add it to the slot map.`);
   }
-  const lift = catalog.find((l) => l.id === liftId);
+  const lift = customLifts.find((l) => l.id === liftId) ?? catalog.find((l) => l.id === liftId);
   if (!lift) {
     throw new Error(`Lift id "${liftId}" not found in catalog.`);
   }

--- a/packages/core/tests/core/catalog/liftCatalog.test.ts
+++ b/packages/core/tests/core/catalog/liftCatalog.test.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_SLOT_MAP, LIFT_CATALOG, resolveLift } from "@src/core";
+import type { Lift } from "@lifting-logbook/types";
 
 describe("LIFT_CATALOG", () => {
   it("contains at least 20 lifts", () => {
@@ -173,6 +174,49 @@ describe("resolveLift", () => {
   it("throws when resolved lift id is not in the catalog", () => {
     const badMap: Record<string, string> = { 'Squat': 'nonexistent-id' };
     expect(() => resolveLift('Squat', badMap, LIFT_CATALOG)).toThrow(
+      /not found in catalog/,
+    );
+  });
+});
+
+describe("resolveLift with custom lifts", () => {
+  const customSafetyBar: Lift = {
+    id: 'custom-safety-bar-squat',
+    name: 'Safety Bar Squat',
+    classification: 'compound',
+    movementTags: ['squat'],
+    isCustom: true,
+  };
+
+  it("resolves a slot-mapped id to a custom lift not present in the catalog", () => {
+    const slotMap: Record<string, string> = { 'SSB': 'custom-safety-bar-squat' };
+    const lift = resolveLift('SSB', slotMap, LIFT_CATALOG, [customSafetyBar]);
+    expect(lift).toBe(customSafetyBar);
+    expect(lift.isCustom).toBe(true);
+  });
+
+  it("prefers a custom lift over a catalog entry with the same id (user intent wins)", () => {
+    const shadow: Lift = {
+      id: 'deadlift',
+      name: 'My Deadlift',
+      classification: 'compound',
+      movementTags: ['hinge'],
+      isCustom: true,
+    };
+    const lift = resolveLift('Deadlift', DEFAULT_SLOT_MAP, LIFT_CATALOG, [shadow]);
+    expect(lift).toBe(shadow);
+    expect(lift.name).toBe('My Deadlift');
+  });
+
+  it("falls back to the catalog when no custom lift matches the resolved id", () => {
+    const lift = resolveLift('Deadlift', DEFAULT_SLOT_MAP, LIFT_CATALOG, [customSafetyBar]);
+    expect(lift.id).toBe('deadlift');
+    expect(lift.isCustom).toBeUndefined();
+  });
+
+  it("still throws when the resolved id is in neither the custom list nor the catalog", () => {
+    const badMap: Record<string, string> = { 'Squat': 'nonexistent-id' };
+    expect(() => resolveLift('Squat', badMap, LIFT_CATALOG, [customSafetyBar])).toThrow(
       /not found in catalog/,
     );
   });

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1,4 +1,4 @@
-import { BodyWeightEntry, LiftName, WeightUnit, WeekNumber, CycleNumber, WeekType } from './domain';
+import { BodyWeightEntry, LiftClassification, LiftName, MovementTag, WeightUnit, WeekNumber, CycleNumber, WeekType } from './domain';
 
 // ---------------------------------------------------------------------------
 // Training Maxes
@@ -473,4 +473,35 @@ export interface ImportLiftRecordsResponse {
    * become custom programs when edited; custom programs have no lift restrictions.
    */
   skipped: SkippedRecord[];
+}
+
+// ---------------------------------------------------------------------------
+// Custom Lifts
+// ---------------------------------------------------------------------------
+
+/** Serialized custom lift as returned by the API. `userId` is intentionally omitted. */
+export interface CustomLiftResponse {
+  id: string; // uuid — the REST key
+  name: string;
+  classification: LiftClassification;
+  movementTags: MovementTag[];
+  isBodyweightComponent: boolean;
+  isCustom: true;
+  createdAt: string; // ISO 8601 date string
+}
+
+/** Request body for POST /lifts/custom. */
+export interface CreateCustomLiftRequest {
+  name: string;
+  classification: LiftClassification;
+  movementTags?: MovementTag[];
+  isBodyweightComponent?: boolean;
+}
+
+/** Request body for PATCH /lifts/custom/:id. All fields optional. */
+export interface UpdateCustomLiftRequest {
+  name?: string;
+  classification?: LiftClassification;
+  movementTags?: MovementTag[];
+  isBodyweightComponent?: boolean;
 }

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -15,6 +15,19 @@ export interface Lift {
   movementTags: MovementTag[];
   /** True when body weight contributes to the total load (e.g. chin-ups, dips). */
   isBodyweightComponent?: boolean;
+  /** True for user-created lifts; absent/false for built-in catalog entries. */
+  isCustom?: boolean;
+}
+
+/**
+ * A user-created lift. Persisted per user and resolved alongside the built-in
+ * catalog (custom entries take precedence). `id` is a stable uuid (the REST key),
+ * independent of `name` so a lift can be renamed without breaking references.
+ */
+export interface CustomLift extends Lift {
+  userId: string;
+  isCustom: true;
+  createdAt: Date;
 }
 
 /**


### PR DESCRIPTION
Closes #425

## Summary

Adds a per-user `CustomLift` entity that persists, resolves alongside the built-in catalog (custom takes precedence), and is selectable everywhere lifts are picked. Follows the hexagonal boundary (ADR-002): catalog data stays pure in `packages/core`; persistence lives in the API adapter layer.

### Design decisions
- **`Lift.id` is a stable uuid** (the DB row PK, surfaced directly as the REST key) — *not* derived from the name. A lift can be renamed via PATCH without breaking references. DB keeps `@@unique([userId, name])` to block duplicate names per user.
- **`resolveLift` gains an optional `customLifts` arg** searched before the catalog — pure, source-compatible with existing 3-arg call sites, unknown id still throws.
- **Consumption wiring:** since the production system keys lifts by free `LiftName` string (catalog `id`/`resolveLift` are not on the production path), the single touch-point is `GET /programs/:program/lifts`, which now merges the user's custom-lift names. All downstream consumers (training maxes, lift records, workout generation, lift-metadata) already accept arbitrary lift strings.

### Changes
- **types:** `CustomLift extends Lift`, `Lift.isCustom?`; `CustomLiftResponse`/`CreateCustomLiftRequest`/`UpdateCustomLiftRequest`
- **core:** `resolveLift` custom-first lookup + unit tests
- **prisma:** `CustomLift` model + migration `20260603000000_add_custom_lift`, `@@unique([userId, name])`, `@@index([userId])`
- **ports/adapters:** `ICustomLiftRepository` (full CRUD) with in-memory + Prisma adapters, threaded through all three repository factories. Prisma `update`/`delete` are **userId-guarded** (PK is `id` alone) to preserve ownership isolation.
- **api:** `GET/POST/PATCH/DELETE /lifts/custom` (`CustomLiftController` in `LiftsModule`); 404 `CustomLiftNotFoundError` (added to `DomainNotFoundFilter`), new 409 `DomainConflictFilter` for `CustomLiftConflictError`, registered in `main.ts`.

## Acceptance criteria
- [x] `CustomLift` type exported; `Lift.isCustom?` added
- [x] `CustomLift` Prisma model + migration, unique per `(userId, name)`
- [x] `ICustomLiftRepository` with in-memory + Prisma adapters via the per-user factory
- [x] `resolveLift` prefers custom over catalog; unknown id still errors
- [x] `GET/POST/PATCH/DELETE /lifts/custom` with in-memory E2E coverage
- [x] Ownership isolation E2E (user A cannot read/mutate user B's lifts)
- [x] Strict TS compilation passes across `packages/types`, `packages/core`, `apps/api`

## Testing
Run from repo root.

- `npm run build -w @lifting-logbook/api` — **passes** (strict TS; exercises `RepositoryBundle` exhaustiveness across all three factories + the compile-test).
- `npm test -w @lifting-logbook/api` — `Tests: 263 passed, 51 skipped, 0 failed (~30s)` across 22 passed suites (new `custom-lift.e2e.spec.ts` passes: CRUD, 409 duplicate, 404 unknown, validation 400s incl. `forbidNonWhitelisted`, ownership isolation, and the `GET /programs/:program/lifts` merge).
- `npm test -w @lifting-logbook/core` — `Tests: 164 passed, 0 failed` (incl. new `resolveLift with custom lifts` block).
- `npm test -w @lifting-logbook/types` — no tests (`--passWithNoTests`).

**Skipped-count justification (test-integrity policy):** the 51 skipped tests are the DB-container E2E suite (`*.db.e2e`), skipped via the project's documented `LIFTING_SKIP_DB_E2E=1` escape hatch because Docker is unavailable in this environment (Postgres unreachable, `@testcontainers/postgresql` not installed locally). **This diff touches DB code (schema, migration, Prisma adapter), so CI must run the DB E2E suite against a real container** — the Prisma `CustomLift` adapter and migration are not exercised by the local in-memory run. The in-memory E2E suite fully covers the controller/port contract and ownership isolation.

**Coverage gate:** new API endpoints ship with in-memory E2E coverage in this PR ✔.

## Notes
- Naming a custom lift after a built-in (e.g. "Squat") is allowed; the lifts list dedupes by name ("user intent wins" per the proposal's open question).
- Type casts in the Prisma adapter (`as LiftClassification`, `as MovementTag[]`) narrow DB `String`/`String[]` columns to domain unions — the same legitimate-narrowing pattern used by the existing `PrismaStrengthGoalRepository`, not error-silencing.

## Review follow-up (subagent review, 2026-06-03)

A subagent review surfaced one real gap: the Prisma adapter's userId ownership-guard (the riskiest code in the PR) was only exercised via the in-memory adapter, not against real Postgres. Addressed in this PR:

- **Added a `custom lifts (DB)` block to `apps/api/src/programs/programs.db.e2e.spec.ts`** exercising `PrismaCustomLiftRepository` against a real `postgres:16-alpine` container: create (uuid id, `isCustom`, `userId` omitted from the response) + DB row assertion; list; **P2002 → 409** duplicate-name conflict; owner PATCH update + DB assertion; **ownership isolation** — another user cannot list/PATCH/DELETE the lift (both → 404, with a DB-level assertion that the row is untouched after the attack), proving the `findFirst({where:{id,userId}})` guard; PATCH/DELETE unknown → 404; owner DELETE → 204 + DB row removed. Registered `DomainConflictFilter` in the DB e2e bootstrap so the 409 maps.
- **Normalized the hand-written migration's `-- CreateUniqueIndex` comment to Prisma's canonical `-- CreateIndex`** so a future `prisma migrate diff` sees no drift (cosmetic; SQL is unchanged).
- **Rebased onto `main`** after #432/#433 (lockfile resync) merged, so the earlier `npm ci` CI failures (pre-existing lockfile desync, unrelated to this PR) are now cleared.

**Re-verified locally (Docker + Testcontainers):**
- DB E2E suite: `Tests: 59 passed, 0 failed (~27s)` (51 prior + 8 new custom-lift DB tests; migration applied via `migrate deploy`).
- Full API suite (container provisioned): `Tests: 322 passed, 0 skipped, 0 failed (23 suites)`.

The earlier "51 skipped (Docker unavailable)" note in the Testing section above is superseded — the DB suite now runs locally and the Prisma adapter guard is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

