### PR TITLE
fix(api): repair test:db script for Jest 30 flag rename

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,7 @@
     "start": "node dist/main.js",
     "lint": "eslint src",
     "test": "jest",
-    "test:db": "jest --testPathPattern=db\\.e2e",
+    "test:db": "jest --testPathPatterns=db\\.e2e",
     "db:generate": "prisma generate",
     "postinstall": "prisma generate"
   },


### PR DESCRIPTION
Closes #430

## Problem

Jest 30 (pinned `^30.2.0`) renamed the CLI flag `--testPathPattern` → `--testPathPatterns` (plural). The `test:db` script in `apps/api/package.json` still used the old singular form, so the DB-backed E2E suite was unrunnable via the documented command:

```
$ npm run test:db -w @lifting-logbook/api
Option "testPathPattern" was replaced by "--testPathPatterns". "--testPathPatterns" is only available as a command-line option.
```

## Fix

One-character change: `--testPathPattern` → `--testPathPatterns`. This was the only occurrence of the old flag in the repo (verified by grep across scripts, `.github/workflows`, and docs). `docs/testing/e2e-coverage.md` invokes the script by name (`npm run test:db`), so it needs no change and is now correct.

## Testing

```
$ npm run test:db -w @lifting-logbook/api
Tests: 51 passed, 0 skipped, 0 failed (51 total, ~17s)
```

The `test:db` script runs only the DB-backed E2E suite: it provisions a `postgres:16-alpine` testcontainer and runs all 51 DB E2E tests green. Requires Docker running and `@testcontainers/postgresql` installed (`npm install`). The default `npm test` script is untouched.

No new tests added — this repairs the ability to run an existing suite; the fix is self-verifying (the script now executes the 51-test suite instead of erroring out).

## CI note

Earlier CI runs on this branch were red at the `npm ci` step due to a pre-existing `package-lock.json` desync on `main` (clerk-backend/clerk-shared minor bumps + a missing `react` entry) — unrelated to this one-line script change. That desync was fixed in #432/#433 (lockfile resync), and this branch has been rebased onto the fixed `main`, so CI should now be green.

## Background

Discovered while implementing #425 (custom lifts). Pre-existing and unrelated to that feature; filed and fixed separately per the small-fix workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
