### PR TITLE
[infra] Add CI lockfile-sync guard with clear drift message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
+      - name: Verify package-lock.json is in sync with package.json
+        run: |
+          # Layer 2 of the lockfile-drift defense (see issue #435). Regenerate the
+          # lockfile metadata from package.json without touching node_modules, then
+          # fail with a clear message if it differs from the committed lockfile.
+          # This surfaces drift before the cryptic `npm ci` EUSAGE error fires below.
+          npm install --package-lock-only --ignore-scripts
+          if ! git diff --exit-code package-lock.json; then
+            echo "::error::package-lock.json is out of sync with package.json."
+            echo "A dependency was changed without regenerating the lockfile (the diff above shows the delta)."
+            echo "Fix: run 'npm install' locally and commit the updated package-lock.json in the same change."
+            exit 1
+          fi
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary

Layer 2 of the 4-layer lockfile-drift defense. Adds an early step to the `Lint & Test` job in `ci.yml` that regenerates the lockfile metadata and fails with an actionable message if `package-lock.json` has drifted from `package.json` — surfacing the root cause before the cryptic `npm ci` EUSAGE error that turned `main` red (fixed reactively in #432/#433).

```yaml
npm install --package-lock-only --ignore-scripts
git diff --exit-code package-lock.json   # clear ::error:: + remediation on drift
```

## Acceptance Criteria

- [x] Early CI step regenerates lockfile metadata and `git diff --exit-code`s it
- [x] On drift, prints a clear remediation message (run `npm install`, commit the regenerated lockfile)
- [x] Verified: passes on the current in-sync lockfile
- [x] Verified: fails on a deliberately drifted lockfile (`@types/jest` range change)

## Testing

This is a **CI-workflow-only change** (single addition to `.github/workflows/ci.yml`); it touches no application, package, or test code, so the monorepo test suite cannot validate it. Verification was done by directly exercising the guard's exact commands:

- **Synced lockfile:** `npm install --package-lock-only --ignore-scripts` → `git diff --exit-code package-lock.json` exits 0 (PASS, no drift).
- **Deliberately drifted lockfile:** changed `@types/jest` range `^30.0.0` → `^29.5.0`, re-ran the guard → diff non-empty, would `exit 1` (guard correctly FAILS). Working tree restored clean afterward.
- Pre-commit lint hook: `Tasks: 5 successful, 5 total`.

Full `npm test` not run: the change is CI-config only and the suite (which requires Docker/Playwright) yields no signal on workflow YAML. No suppressions or test-integrity violations introduced (pre-PR greps clean).

Closes #435

_Test-integrity note: no suite run — this change is CI-workflow-only and the test suite cannot validate workflow YAML; verification is the synced/drifted simulation above (Tests: not applicable)._
