### PR TITLE
[fix] Isolate no-uncovered-error-fallback test sandbox from ancestor .git

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -112,7 +112,7 @@ Web and mobile clients functional end-to-end. Key user-facing features implement
 | [Workout Scheduling Override](docs/proposals/2026-05-17-workout-scheduling-override.md) | User-defined preferred workout days (fixed or rotating A/B) + per-program `workoutsPerWeek` override with automatic cycle date distribution | [#267](https://github.com/brownm09/lifting-logbook/issues/267) | shipped |
 | [Custom User-Created Lifts](docs/proposals/2026-06-03-custom-lifts.md) | Per-user persisted `CustomLift` entity (Prisma model + `ICustomLiftRepository` port + ownership isolation); `resolveLift` prefers custom over catalog; `GET/POST/PATCH/DELETE /lifts/custom`. Foundational for #426 and #427 | [#425](https://github.com/brownm09/lifting-logbook/issues/425) | draft |
 | [Onboarding — Any-Lift Max Estimation](docs/proposals/2026-06-03-onboarding-any-lift-max-estimation.md) | Dynamic add/remove lift list in onboarding for any catalog or custom lift; persists confirmed maxes (closes the discard gap in `createFirstCycle`) | [#426](https://github.com/brownm09/lifting-logbook/issues/426) | draft |
-| [Lift Movement Profiles](docs/proposals/2026-06-03-lift-movement-profiles.md) | Combined `MovementProfile` (patterns + joint actions + complexity) on `Lift`; preconfigured for the 25 catalog entries, editable for custom lifts | [#427](https://github.com/brownm09/lifting-logbook/issues/427) | draft |
+| [Lift Movement Profiles](docs/proposals/2026-06-03-lift-movement-profiles.md) | Combined `MovementProfile` (patterns + joint actions + complexity) on `Lift`; preconfigured for the 23 catalog entries, editable for custom lifts | [#427](https://github.com/brownm09/lifting-logbook/issues/427) | shipped |
 
 ---
 

--- a/tools/eslint-rules/no-uncovered-error-fallback.test.js
+++ b/tools/eslint-rules/no-uncovered-error-fallback.test.js
@@ -18,6 +18,13 @@ const tsParser = require('@typescript-eslint/parser');
 // poison the module-level cache for subsequent cases).
 function makeSandbox(testFiles) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'eslint-rule-test-'));
+  // Write a `.git` marker at the sandbox root. `findRepoRoot` checks for `.git`
+  // first and walks all the way up, so without this marker it escapes the sandbox
+  // and resolves to the nearest ancestor `.git` instead — which happens whenever
+  // os.tmpdir() lives inside a git repo (e.g. a Windows home dir under version
+  // control: C:\Users\<name>\AppData\Local\Temp). The package.json + turbo.json
+  // fallback only applies when no `.git` is found anywhere above. See #439.
+  fs.writeFileSync(path.join(root, '.git'), 'gitdir: sandbox\n');
   fs.writeFileSync(path.join(root, 'package.json'), '{"name":"sandbox","private":true}');
   fs.writeFileSync(path.join(root, 'turbo.json'), '{}');
   for (const [rel, content] of Object.entries(testFiles)) {


### PR DESCRIPTION
## Summary

The `no-uncovered-error-fallback` ESLint rule's test suite fails 4 of 11 cases on any machine whose `os.tmpdir()` lives **inside a git repo** — notably Windows, where the temp dir is `C:\Users\<name>\AppData\Local\Temp` and the home directory is frequently itself under version control. This makes `npm test` red locally and forces per-workspace runs as a workaround.

**Root cause:** each test builds a sandbox fixture under `os.tmpdir()` and relies on the rule's `findRepoRoot` resolving to that sandbox. `findRepoRoot` checks for `.git` **first** and walks to the filesystem root before falling back to the sandbox's `package.json` + `turbo.json` pair. When an ancestor of the temp dir contains a `.git`, it returns that ancestor instead of the sandbox; the reference scan then finds no test files and the rule over-flags. Linux CI passes because `/tmp` has no ancestor `.git`, masking the bug.

**Fix:** write a `.git` marker at each sandbox root so `findRepoRoot` stops there (nearer than any ancestor). This is a **test-only** change — the rule itself is unaffected and is already correct for real linting (a real package's own `.git` is the nearest ancestor).

## Also included (post-merge reconciliation)

- `ROADMAP.md`: flip the **Lift Movement Profiles (#427)** proposal row from `draft` → `shipped` (merged via #437 earlier this session) and correct the catalog count 25 → 23. One editorial line, bundled here to avoid a near-empty standalone PR.

## Acceptance criteria

- [x] `node --test tools/eslint-rules/no-uncovered-error-fallback.test.js` passes 11/11 on Windows (temp dir under a git repo) and Linux CI
- [x] The fix isolates the sandbox from ancestor `.git` without weakening `findRepoRoot`'s real-world behavior

## Testing

Full `npm test` (turbo) across all workspaces, Docker up (DB e2e via Testcontainers):

- **eslint-rules:** 11 passed, 0 failed (the regression target — was 7 passed / 4 failed before)
- **core:** Tests: 164 passed, 0 skipped, 0 failed
- **api:** Tests: 322 passed, 0 skipped, 0 failed
- **api-legacy:** Tests: 1 passed, 0 skipped, 0 failed
- **web:** Tests: 56 passed, 0 skipped, 0 failed
- **turbo: Tasks 12 successful, 12 total**

No suppressions, skip markers, or coverage-threshold changes introduced (test-isolation fix only; pre-PR integrity grep clean). No `package.json` change, so no lockfile impact.

Closes #439