### PR TITLE
[fix] Remove stale lint exclusions from pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -13,17 +13,13 @@ unset _COMMON
 
 _TURBO_INLINE="process.env.TURBO_BINARY_PATH=process.argv[1]; require('./node_modules/turbo/bin/turbo')"
 
-# Excluded until scaffolded/clean:
-#   @lifting-logbook/web  — no src/ yet (issue #9)
-#   @lifting-logbook/core — 51 pre-existing GAS-migration lint errors (issue #51)
+# Lints all workspaces, matching the CI "Lint & Test" job.
+#   @lifting-logbook/web was un-excluded once apps/web scaffolding completed (issue #9, closed).
+#   @lifting-logbook/core was un-excluded once its GAS-migration lint errors were resolved (issue #51, closed).
 if [ -n "$_MAIN_ROOT" ] && [ -f "$_WIN_TURBO" ]; then
-  node -e "$_TURBO_INLINE" "$_WIN_TURBO" run lint \
-    --filter=!@lifting-logbook/web \
-    --filter=!@lifting-logbook/core
+  node -e "$_TURBO_INLINE" "$_WIN_TURBO" run lint
 else
-  npx turbo run lint \
-    --filter=!@lifting-logbook/web \
-    --filter=!@lifting-logbook/core
+  npx turbo run lint
 fi
 RESULT=$?
 unset _MAIN_ROOT _WIN_TURBO _TURBO_INLINE


### PR DESCRIPTION
## Summary

Removes two stale workspace exclusions from `.husky/pre-commit`, so the local commit gate lints **all** workspaces — matching CI's "Lint & Test" job.

Both exclusions were scaffolding-era temporary measures whose tracking issues are now closed:

| Workspace | Why excluded | Status now |
|---|---|---|
| `@lifting-logbook/web` | No `src/` during early scaffolding ([#9](https://github.com/brownm09/lifting-logbook/issues/9)) | Fully built (Next.js App Router under `apps/web/app/`), defines `"lint": "eslint app"`, lints clean. #9 **closed**. |
| `@lifting-logbook/core` | 51 pre-existing GAS-migration lint errors ([#51](https://github.com/brownm09/lifting-logbook/issues/51)) | Lints clean today. #51 **closed**. |

The web exclusion let lint errors bypass `git commit` locally and surface only in CI — e.g. an unused import committed in [#438](https://github.com/brownm09/lifting-logbook/pull/438), caught only on a manual lint run. Since core now lints clean and its issue is closed, both filters were removed rather than just web; the hook now runs unfiltered `turbo run lint`.

The Windows `TURBO_BINARY_PATH` / `node -e` logic and the `else` fallback branch are preserved exactly — only the two `--filter=!…` lines were removed from each branch, and the comment block updated.

## Type

Hook/config change (no source or test behavior changed).

## Testing

**1. The exact command the hook now runs — full `turbo run lint`, no filters (forced, no cache):**
```
Tasks:    7 successful, 7 total
TURBO LINT EXIT: 0
```
All 7 workspaces lint clean. (`apps/web` emits one pre-existing non-blocking warning — unused eslint-disable directive in `apps/web/app/api/healthz/route.ts:32` — warnings don't fail `eslint app`, so the gate stays green. Left as a separate nicety.)

**2. Hook gating proof (negative + positive):** injected a temp unused-var lint error into `apps/web/app/`, ran `sh .husky/pre-commit`:
- With the web error → `Lint failed. Commit aborted.`, **exit 1** (web is now gated — was silently skipped before).
- Probe removed → **exit 0**.

**3. Full suite — `npm test` from repo root (Docker up; DB E2E via Testcontainers):**
- `@lifting-logbook/core`: 168 passed
- `@lifting-logbook/api`: 326 passed
- `@lifting-logbook/web`: 56 passed
- `@lifting-logbook/api-legacy`: 1 passed

**Tests: 551 passed, 0 skipped, 0 failed.** Turbo: 12 successful, 12 total.

## Pre-PR checks

- **Suppression grep** (`git diff origin/main`): clean.
- **Test-integrity grep**: clean.
- **Lockfile-sync**: N/A — no `package.json` touched.
- **ADR-warrant**: Not warranted. This un-does a scaffolding-era temporary exclusion; the rationale is fully recoverable from this PR, the linked issues, and `git log`. It establishes no new workflow rule and changes no documented architecture.

Closes #441
