### PR TITLE
[docs] Document local Playwright E2E run for apps/web UI string changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,6 +339,24 @@ npm test -w @lifting-logbook/api
 npm test -w @lifting-logbook/web
 ```
 
+### apps/web Playwright E2E (local)
+
+`apps/web` has two test layers. `npm test -w @lifting-logbook/web` runs Jest unit/component tests only. A separate Playwright suite lives in `apps/web/e2e/` and runs in CI's "Playwright E2E" job — it does **not** run as part of `npm test`.
+
+**Run it locally before pushing whenever a change touches `apps/web` and any of the following:**
+
+- UI display strings (headings, button labels, link text)
+- `aria-label` values on inputs or regions
+- Role names, tab labels, dialog titles
+- Any string a Playwright `getByLabel` / `getByRole` / `locator('text=...')` call might match
+
+```bash
+# From the repo root — playwright.config.ts auto-starts mock-api (port 3004) and next dev (port 3000)
+npm run test:e2e -w @lifting-logbook/web
+```
+
+Playwright must be installed (`npx playwright install --with-deps chromium` once). The config handles all env vars (dummy Clerk keys, `DEV_AUTH_TOKEN`, `API_URL`) so no manual setup is needed. The motivating incident is [#444](https://github.com/brownm09/lifting-logbook/issues/444) / PR #438, where an aria-label rename (`Back Squat` → `Squat`) passed Jest but broke the smoke spec and was only caught by CI.
+
 ### Coverage Requirements
 
 <!-- When #259 ships: remove the "until then" clause from the frontend row below. Tracked as a checklist item on issue #259. -->
@@ -347,6 +365,7 @@ npm test -w @lifting-logbook/web
 |---|---|
 | New API endpoint | In-memory E2E test in the same PR |
 | New frontend page or interactive feature | Playwright test once #259 is implemented; until then, a written test plan in the PR body |
+| `apps/web` UI string / aria-label / role-name change | Run `npm run test:e2e -w @lifting-logbook/web` locally before pushing (see above) |
 | Bug fix | Regression test that fails before the fix and passes after |
 | Refactor / docs only | None required — existing tests must pass |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,7 +355,7 @@ npm test -w @lifting-logbook/web
 npm run test:e2e -w @lifting-logbook/web
 ```
 
-Playwright must be installed (`npx playwright install --with-deps chromium` once). The config handles all env vars (dummy Clerk keys, `DEV_AUTH_TOKEN`, `API_URL`) so no manual setup is needed. The motivating incident is [#444](https://github.com/brownm09/lifting-logbook/issues/444) / PR #438, where an aria-label rename (`Back Squat` → `Squat`) passed Jest but broke the smoke spec and was only caught by CI.
+Playwright browsers must be installed once (`npx playwright install chromium`; CI uses the `--with-deps` form for its Linux runner — that flag is a no-op on Windows). The config handles all env vars (dummy Clerk keys, `DEV_AUTH_TOKEN`, `API_URL`) so no manual setup is needed. The motivating incident is [#444](https://github.com/brownm09/lifting-logbook/issues/444) / PR #438, where an aria-label rename (`Back Squat` → `Squat`) passed Jest but broke the smoke spec and was only caught by CI.
 
 ### Coverage Requirements
 


### PR DESCRIPTION
## Summary

Closes #444

The `test:e2e` script already existed in `apps/web/package.json` and `playwright.config.ts` already auto-manages the mock API (port 3004) and `next dev` (port 3000) servers — no infrastructure work was needed. The gap was purely documentation: the `## Testing` section in CLAUDE.md didn't mention the Playwright suite or when to run it locally.

**Changes:**

- Added an **apps/web Playwright E2E (local)** subsection under `## Testing` that:
  - Lists the trigger conditions (UI display strings, aria-labels, role names, locator-matched text)
  - Provides the one-command local run (`npm run test:e2e -w @lifting-logbook/web`)
  - Notes that `playwright.config.ts` handles all env setup (no manual config needed)
  - Cites the motivating incident (#444 / PR #438 `Back Squat` → `Squat` rename)

- Added a new row to the Coverage Requirements table: `apps/web` UI string / aria-label / role-name changes must run the Playwright suite locally before pushing.

## Testing

`Tests: 326 passed, 0 skipped, 0 failed (33.882s)` — full suite across all workspaces. This PR is docs-only (no code changes), so no new test coverage is required per the Coverage Requirements table (Refactor / docs only — existing tests must pass).

Suppression check: `git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|![.[]|!\s*[;,)]|\?\? null)'` — no output.

Test integrity check: no skip markers, deleted test files, or threshold changes.

## Review findings disposition

- **[documentation] Non-blocking — `--with-deps` install nit** — fixed in `88d6bc2`. The local one-time-install instruction dropped `--with-deps` (Linux/Debian-only, no-op-with-warning on the documented Windows 11 dev platform); CI's `--with-deps` form (`ci.yml:136`) left unchanged.

_Reviewed by `claude-opus-4-8` via `/review` — 0 blocking, 1 non-blocking._
