### PR TITLE
[fix] Correctness audit — cross-user spec isolation, domain guards, schedule fallback

### DIFF
--- a/apps/api/src/adapters/prisma/hybrid-program-spec.repository.spec.ts
+++ b/apps/api/src/adapters/prisma/hybrid-program-spec.repository.spec.ts
@@ -1,0 +1,53 @@
+import { PrismaClient } from '@prisma/client';
+import { HybridLiftingProgramSpecRepository } from './hybrid-program-spec.repository';
+
+const CUSTOM_PROGRAM_ID = '11111111-1111-4111-8111-111111111111';
+
+function makePrisma(): PrismaClient {
+  return {
+    customProgramSpec: {
+      findMany: jest.fn().mockResolvedValue([]),
+    },
+  } as unknown as PrismaClient;
+}
+
+describe('HybridLiftingProgramSpecRepository', () => {
+  it('routes built-in (non-UUID) program names to the in-memory adapter', async () => {
+    const prisma = makePrisma();
+    const repo = new HybridLiftingProgramSpecRepository(prisma, 'user-1');
+
+    const spec = await repo.getProgramSpec('5-3-1');
+
+    // In-memory built-in program resolves without touching the DB.
+    expect(spec.length).toBeGreaterThan(0);
+    expect(prisma.customProgramSpec.findMany).not.toHaveBeenCalled();
+  });
+
+  it('scopes custom-program lookups to the requesting user (isolation guard)', async () => {
+    const prisma = makePrisma();
+    const repo = new HybridLiftingProgramSpecRepository(prisma, 'user-1');
+
+    await repo.getProgramSpec(CUSTOM_PROGRAM_ID);
+
+    expect(prisma.customProgramSpec.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { programId: CUSTOM_PROGRAM_ID, program: { userId: 'user-1' } },
+      }),
+    );
+  });
+
+  it("returns [] when another user's id yields no owned rows", async () => {
+    const prisma = makePrisma();
+    // findMany already resolves to [] for a non-owner because of the userId guard.
+    const repo = new HybridLiftingProgramSpecRepository(prisma, 'attacker');
+
+    const spec = await repo.getProgramSpec(CUSTOM_PROGRAM_ID);
+
+    expect(spec).toEqual([]);
+    expect(prisma.customProgramSpec.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { programId: CUSTOM_PROGRAM_ID, program: { userId: 'attacker' } },
+      }),
+    );
+  });
+});

--- a/apps/api/src/adapters/prisma/hybrid-program-spec.repository.ts
+++ b/apps/api/src/adapters/prisma/hybrid-program-spec.repository.ts
@@ -6,11 +6,13 @@ import { PrismaService } from './prisma.service';
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export class HybridLiftingProgramSpecRepository implements ILiftingProgramSpecRepository {
-  private readonly inMemory = new InMemoryLiftingProgramSpecRepository();
-
+  // The built-in spec data is user-independent. It defaults to a fresh in-memory
+  // repo for standalone construction (tests), but the factory injects a shared
+  // instance so the seed map is built once per process rather than per request.
   constructor(
     private readonly prisma: PrismaService,
     private readonly userId: string,
+    private readonly inMemory: ILiftingProgramSpecRepository = new InMemoryLiftingProgramSpecRepository(),
   ) {}
 
   async getProgramSpec(program: string): Promise<LiftingProgramSpec[]> {

--- a/apps/api/src/adapters/prisma/hybrid-program-spec.repository.ts
+++ b/apps/api/src/adapters/prisma/hybrid-program-spec.repository.ts
@@ -8,7 +8,10 @@ const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{
 export class HybridLiftingProgramSpecRepository implements ILiftingProgramSpecRepository {
   private readonly inMemory = new InMemoryLiftingProgramSpecRepository();
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly userId: string,
+  ) {}
 
   async getProgramSpec(program: string): Promise<LiftingProgramSpec[]> {
     if (UUID_PATTERN.test(program)) {
@@ -18,8 +21,10 @@ export class HybridLiftingProgramSpecRepository implements ILiftingProgramSpecRe
   }
 
   private async getCustomSpec(id: string): Promise<LiftingProgramSpec[]> {
+    // Guard on the owning program's userId — a bare where:{ programId } would let
+    // any authenticated user read another user's custom program spec by UUID.
     const rows = await this.prisma.customProgramSpec.findMany({
-      where: { programId: id },
+      where: { programId: id, program: { userId: this.userId } },
       orderBy: [{ week: 'asc' }, { order: 'asc' }],
     });
     return rows.map((s) => ({

--- a/apps/api/src/adapters/prisma/prisma-repository-factory.ts
+++ b/apps/api/src/adapters/prisma/prisma-repository-factory.ts
@@ -16,14 +16,18 @@ import { PrismaWorkoutSkipOverrideRepository } from './workout-skip-override.rep
 import { PrismaWorkoutRepository } from './workout.repository';
 import { HybridLiftingProgramSpecRepository } from './hybrid-program-spec.repository';
 import { InMemoryProgramPhilosophyRepository } from '../in-memory/program-philosophy.adapter';
+import { InMemoryLiftingProgramSpecRepository } from '../in-memory/lifting-program-spec.adapter';
 import { UserSettingsRepository } from '../../user-settings/user-settings.repository';
 
 @Injectable()
 export class PrismaRepositoryFactory implements IRepositoryFactory {
   // Built-in program philosophy is user-independent, so it can be a singleton. The
-  // spec repo is NOT — its custom-program branch must be scoped to the requesting
-  // user, so it is constructed per-request inside forUser() like every other repo.
+  // spec repo's custom-program branch must be scoped to the requesting user, so a
+  // thin per-user wrapper is built in forUser() — but its built-in spec data is
+  // global, so the in-memory delegate is shared here rather than rebuilt (and
+  // re-seeded) on every request.
   private readonly philosophyRepo = new InMemoryProgramPhilosophyRepository();
+  private readonly inMemorySpecRepo = new InMemoryLiftingProgramSpecRepository();
 
   constructor(private readonly prisma: PrismaService) {}
 
@@ -43,7 +47,11 @@ export class PrismaRepositoryFactory implements IRepositoryFactory {
       workoutDateOverride: new PrismaWorkoutDateOverrideRepository(this.prisma, user.id),
       workoutLiftOverride: new PrismaWorkoutLiftOverrideRepository(this.prisma, user.id),
       workoutSkipOverride: new PrismaWorkoutSkipOverrideRepository(this.prisma, user.id),
-      liftingProgramSpec: new HybridLiftingProgramSpecRepository(this.prisma, user.id),
+      liftingProgramSpec: new HybridLiftingProgramSpecRepository(
+        this.prisma,
+        user.id,
+        this.inMemorySpecRepo,
+      ),
     };
   }
 }

--- a/apps/api/src/adapters/prisma/prisma-repository-factory.ts
+++ b/apps/api/src/adapters/prisma/prisma-repository-factory.ts
@@ -20,13 +20,12 @@ import { UserSettingsRepository } from '../../user-settings/user-settings.reposi
 
 @Injectable()
 export class PrismaRepositoryFactory implements IRepositoryFactory {
-  // Spec repo handles both in-memory built-in programs and DB-backed custom programs.
-  private readonly programSpecRepo: HybridLiftingProgramSpecRepository;
+  // Built-in program philosophy is user-independent, so it can be a singleton. The
+  // spec repo is NOT — its custom-program branch must be scoped to the requesting
+  // user, so it is constructed per-request inside forUser() like every other repo.
   private readonly philosophyRepo = new InMemoryProgramPhilosophyRepository();
 
-  constructor(private readonly prisma: PrismaService) {
-    this.programSpecRepo = new HybridLiftingProgramSpecRepository(prisma);
-  }
+  constructor(private readonly prisma: PrismaService) {}
 
   async forUser(user: AuthUser): Promise<RepositoryBundle> {
     return {
@@ -44,7 +43,7 @@ export class PrismaRepositoryFactory implements IRepositoryFactory {
       workoutDateOverride: new PrismaWorkoutDateOverrideRepository(this.prisma, user.id),
       workoutLiftOverride: new PrismaWorkoutLiftOverrideRepository(this.prisma, user.id),
       workoutSkipOverride: new PrismaWorkoutSkipOverrideRepository(this.prisma, user.id),
-      liftingProgramSpec: this.programSpecRepo,
+      liftingProgramSpec: new HybridLiftingProgramSpecRepository(this.prisma, user.id),
     };
   }
 }

--- a/apps/api/src/custom-programs/create-custom-program.dto.spec.ts
+++ b/apps/api/src/custom-programs/create-custom-program.dto.spec.ts
@@ -1,0 +1,61 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreateCustomProgramDto } from './create-custom-program.dto';
+
+const VALID_SPEC_ROW = {
+  week: 1,
+  offset: 0,
+  lift: 'Bench Press',
+  increment: 5,
+  order: 1,
+  sets: 3,
+  reps: 5,
+  amrap: false,
+  warmUpPct: '0.4,0.5,0.6',
+  wtDecrementPct: 0.1,
+  activation: 'none',
+};
+
+function dtoWith(specOverride: Record<string, unknown>): CreateCustomProgramDto {
+  return plainToInstance(CreateCustomProgramDto, {
+    name: 'My Program',
+    specs: [{ ...VALID_SPEC_ROW, ...specOverride }],
+  });
+}
+
+async function flattenConstraintKeys(dto: CreateCustomProgramDto): Promise<string[]> {
+  const errors = await validate(dto, { whitelist: true });
+  const keys: string[] = [];
+  const walk = (errs: typeof errors): void => {
+    for (const e of errs) {
+      if (e.constraints) keys.push(...Object.keys(e.constraints));
+      if (e.children?.length) walk(e.children);
+    }
+  };
+  walk(errors);
+  return keys;
+}
+
+describe('CreateCustomProgramDto validation', () => {
+  it('accepts a well-formed program', async () => {
+    const errors = await validate(dtoWith({}), { whitelist: true });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects a zero increment (would make MROUND divide by zero)', async () => {
+    expect(await flattenConstraintKeys(dtoWith({ increment: 0 }))).toContain('isPositive');
+  });
+
+  it('rejects a negative increment', async () => {
+    expect(await flattenConstraintKeys(dtoWith({ increment: -5 }))).toContain('isPositive');
+  });
+
+  it('rejects a wtDecrementPct above 1', async () => {
+    expect(await flattenConstraintKeys(dtoWith({ wtDecrementPct: 1.5 }))).toContain('max');
+  });
+
+  it('rejects a negative wtDecrementPct', async () => {
+    expect(await flattenConstraintKeys(dtoWith({ wtDecrementPct: -0.1 }))).toContain('min');
+  });
+});

--- a/apps/api/src/custom-programs/create-custom-program.dto.spec.ts
+++ b/apps/api/src/custom-programs/create-custom-program.dto.spec.ts
@@ -58,4 +58,17 @@ describe('CreateCustomProgramDto validation', () => {
   it('rejects a negative wtDecrementPct', async () => {
     expect(await flattenConstraintKeys(dtoWith({ wtDecrementPct: -0.1 }))).toContain('min');
   });
+
+  it('rejects a wtDecrementPct that drives the final set negative (cross-field)', async () => {
+    // 0.6 passes @Max(1) but 1 - (3-1)*0.6 = -0.2 → final set negative.
+    expect(
+      await flattenConstraintKeys(dtoWith({ wtDecrementPct: 0.6, sets: 3 })),
+    ).toContain('wtDecrementWithinSetBound');
+  });
+
+  it('accepts the boundary where the final set is exactly 0', async () => {
+    // 1 - (3-1)*0.5 = 0 → allowed (mirrors the core guard).
+    const errors = await validate(dtoWith({ wtDecrementPct: 0.5, sets: 3 }), { whitelist: true });
+    expect(errors).toHaveLength(0);
+  });
 });

--- a/apps/api/src/custom-programs/create-custom-program.dto.ts
+++ b/apps/api/src/custom-programs/create-custom-program.dto.ts
@@ -10,9 +10,34 @@ import {
   IsString,
   Max,
   Min,
+  Validate,
   ValidateNested,
+  ValidationArguments,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+
+// Cross-field guard: the work percentage for set i is (1 - i * wtDecrementPct), so the
+// final set is (1 - (sets-1) * wtDecrementPct). When that goes below 0 the prescribed
+// weight is negative — PROG_SPEC_WORK_PCTS throws a RangeError at plan-generation time.
+// Enforcing the bound here turns that latent 500 into a 400 at creation. Mirrors the
+// core guard exactly (minPct >= 0 is allowed; a final set of 0 is valid).
+@ValidatorConstraint({ name: 'wtDecrementWithinSetBound', async: false })
+export class WtDecrementWithinSetBound implements ValidatorConstraintInterface {
+  validate(value: unknown, args: ValidationArguments): boolean {
+    const { sets } = args.object as { sets?: unknown };
+    // Defer to @IsInt/@Min/@IsNumber for type/range errors on the sibling fields;
+    // a single-set scheme has no later set to drive negative.
+    if (typeof sets !== 'number' || typeof value !== 'number' || sets <= 1) return true;
+    return 1 - (sets - 1) * value >= 0;
+  }
+  defaultMessage(args: ValidationArguments): string {
+    const { sets } = args.object as { sets?: number };
+    const bound = typeof sets === 'number' && sets > 1 ? 1 / (sets - 1) : 1;
+    return `wtDecrementPct must be at most ${bound} for ${sets ?? '?'} sets (a larger value drives the final set's weight negative)`;
+  }
+}
 
 export class CustomProgramSpecRowDto {
   @IsInt() @IsIn([1, 2, 3]) week!: number;
@@ -25,10 +50,9 @@ export class CustomProgramSpecRowDto {
   @IsInt() @Min(1) @Max(20) reps!: number;
   @IsBoolean() amrap!: boolean;
   @IsString() warmUpPct!: string;
-  // Per-set weight drop, as a fraction of TM. A large value drives later sets'
-  // work percentage negative; the exact cross-field bound (≤ 1/(sets-1)) is
-  // enforced downstream by PROG_SPEC_WORK_PCTS. Here we block the obvious cases.
-  @IsNumber() @Min(0) @Max(1) wtDecrementPct!: number;
+  // Per-set weight drop, as a fraction of TM. @Min/@Max block the gross cases;
+  // WtDecrementWithinSetBound enforces the exact cross-field bound (≤ 1/(sets-1)).
+  @IsNumber() @Min(0) @Max(1) @Validate(WtDecrementWithinSetBound) wtDecrementPct!: number;
   @IsString() activation!: string;
   @IsOptional() @IsString() weekType?: string;
 }

--- a/apps/api/src/custom-programs/create-custom-program.dto.ts
+++ b/apps/api/src/custom-programs/create-custom-program.dto.ts
@@ -6,6 +6,7 @@ import {
   IsInt,
   IsNumber,
   IsOptional,
+  IsPositive,
   IsString,
   Max,
   Min,
@@ -17,13 +18,17 @@ export class CustomProgramSpecRowDto {
   @IsInt() @IsIn([1, 2, 3]) week!: number;
   @IsInt() @Min(0) offset!: number;
   @IsString() lift!: string;
-  @IsNumber() increment!: number;
+  // Must be > 0 — a zero increment makes MROUND divide by zero (NaN weights).
+  @IsNumber() @IsPositive() increment!: number;
   @IsInt() @Min(1) order!: number;
   @IsInt() @Min(1) @Max(20) sets!: number;
   @IsInt() @Min(1) @Max(20) reps!: number;
   @IsBoolean() amrap!: boolean;
   @IsString() warmUpPct!: string;
-  @IsNumber() wtDecrementPct!: number;
+  // Per-set weight drop, as a fraction of TM. A large value drives later sets'
+  // work percentage negative; the exact cross-field bound (≤ 1/(sets-1)) is
+  // enforced downstream by PROG_SPEC_WORK_PCTS. Here we block the obvious cases.
+  @IsNumber() @Min(0) @Max(1) wtDecrementPct!: number;
   @IsString() activation!: string;
   @IsOptional() @IsString() weekType?: string;
 }

--- a/apps/api/src/programs/programs.db.e2e.spec.ts
+++ b/apps/api/src/programs/programs.db.e2e.spec.ts
@@ -1073,7 +1073,10 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
       reps: 5,
       amrap: false,
       warmUpPct: '40/50/60/70/75/80',
-      wtDecrementPct: 0.9,
+      // 0.1 per-set drop over 3 sets → work %s [1, 0.9, 0.8], all positive. (A prior
+      // value of 0.9 produced a negative final set; it survived only because this
+      // block never generates a plan. The cross-field DTO guard now rejects it.)
+      wtDecrementPct: 0.1,
       activation: 'standard',
     };
 
@@ -1113,6 +1116,43 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
       const res = await injectRaw({ method: 'GET', url: '/programs/custom', headers: AS_OTHER });
       expect(res.statusCode).toBe(200);
       expect(res.json()).toEqual([]);
+    });
+
+    it('user isolation — another user cannot read the owner\'s custom program SPEC', async () => {
+      // Regression guard for the cross-user spec leak (#434): GET /programs/:uuid/spec
+      // resolves through HybridLiftingProgramSpecRepository.getCustomSpec, which must
+      // scope by the owning program's userId. A bare where:{ programId } would return
+      // the owner's rows to any caller who knows the UUID. This asserts the fix at the
+      // real Postgres layer (the unit spec only checks the query shape).
+      const injectRaw = app.getHttpAdapter().getInstance().inject.bind(app.getHttpAdapter().getInstance());
+
+      // Owner creates a program with a spec row.
+      const createRes = await injectRaw({
+        method: 'POST',
+        url: '/programs/custom',
+        headers: { 'content-type': 'application/json', ...AS_CUST },
+        payload: JSON.stringify({ name: 'Spec Isolation Program', specs: [MINIMAL_SPEC] }),
+      });
+      expect(createRes.statusCode).toBe(201);
+      const programId = (createRes.json() as { id: string }).id;
+
+      // Owner sees the spec.
+      const ownerSpec = await injectRaw({
+        method: 'GET',
+        url: `/programs/${programId}/spec`,
+        headers: AS_CUST,
+      });
+      expect(ownerSpec.statusCode).toBe(200);
+      expect((ownerSpec.json() as unknown[]).length).toBeGreaterThan(0);
+
+      // A different user requesting the same UUID gets an empty spec, not the owner's rows.
+      const otherSpec = await injectRaw({
+        method: 'GET',
+        url: `/programs/${programId}/spec`,
+        headers: { authorization: `Bearer ${USER_CUST_OTHER}` },
+      });
+      expect(otherSpec.statusCode).toBe(200);
+      expect(otherSpec.json()).toEqual([]);
     });
   });
 

--- a/apps/web/app/(authed)/settings/schedule/page.test.tsx
+++ b/apps/web/app/(authed)/settings/schedule/page.test.tsx
@@ -1,0 +1,49 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { ReactElement } from 'react';
+
+jest.mock('@/lib/api', () => ({
+  fetchUserSettings: jest.fn(),
+}));
+
+// Stub the client form so the test isolates the page's data-fetch fallback.
+// It echoes the resolved schedule so we can assert what the page passed down.
+jest.mock('./ScheduleForm', () => ({
+  __esModule: true,
+  default: ({ initialSchedule }: { initialSchedule: unknown }) => (
+    <div data-schedule={JSON.stringify(initialSchedule)}>schedule-form</div>
+  ),
+}));
+
+import { fetchUserSettings } from '@/lib/api';
+import SchedulePage from './page';
+
+const mockedFetch = fetchUserSettings as unknown as jest.Mock;
+
+describe('SchedulePage — fetch fallback', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders the form with the fetched schedule on success', async () => {
+    mockedFetch.mockResolvedValue({
+      activeProgram: '5-3-1',
+      workoutSchedule: { type: 'fixed', days: [0, 2, 4] },
+    });
+
+    const element = (await SchedulePage()) as ReactElement;
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain('schedule-form');
+    // Data-level assertion: the real fetched schedule reached the form.
+    expect(html).toContain('&quot;type&quot;:&quot;fixed&quot;');
+  });
+
+  it('falls back to a null schedule (no throw) when the API is unreachable', async () => {
+    mockedFetch.mockRejectedValue(new Error('API down'));
+
+    const element = (await SchedulePage()) as ReactElement;
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain('schedule-form');
+    // The fallback passes workoutSchedule: null — distinct from any fetched value.
+    expect(html).toContain('data-schedule="null"');
+  });
+});

--- a/apps/web/app/(authed)/settings/schedule/page.tsx
+++ b/apps/web/app/(authed)/settings/schedule/page.tsx
@@ -1,7 +1,13 @@
 import { fetchUserSettings } from '@/lib/api';
+import type { UserSettingsResponse } from '@lifting-logbook/types';
 import ScheduleForm from './ScheduleForm';
 
+const DEFAULT_SETTINGS: UserSettingsResponse = { activeProgram: null, workoutSchedule: null };
+
 export default async function SchedulePage() {
-  const settings = await fetchUserSettings();
+  // Fall back to empty settings when the API is unreachable — matches /programs and
+  // /cycle, and keeps the build-time prerender from crashing when no API is running.
+  // fallback-covered-by: apps/web/app/(authed)/settings/schedule/page.test.tsx
+  const settings = await fetchUserSettings().catch(() => DEFAULT_SETTINGS);
   return <ScheduleForm initialSchedule={settings.workoutSchedule} />;
 }

--- a/apps/web/app/api/healthz/route.ts
+++ b/apps/web/app/api/healthz/route.ts
@@ -29,7 +29,7 @@ export async function GET() {
     await auth();
     return NextResponse.json({ ok: true });
   } catch (err) {
-    // eslint-disable-next-line no-console -- server-side log only; not exposed
+    // Server-side log only (not exposed in the response body, per the note above).
     console.error('[healthz] auth() threw — middleware likely did not run:', err);
     return NextResponse.json({ ok: false }, { status: 503 });
   }

--- a/packages/core/src/constants/config.ts
+++ b/packages/core/src/constants/config.ts
@@ -47,6 +47,9 @@ export const PROG_SPEC_WARMUP_PCTS = (
     .map((pct) => parseFloat(pct));
 
 export const MROUND = (number: number, multiple: number) => {
+  // A zero multiple (e.g. a custom program saved with increment 0) would divide
+  // by zero and yield NaN. Degrade safely to the unrounded value instead.
+  if (multiple === 0) return number;
   return Math.round(number / multiple) * multiple;
 };
 
@@ -54,6 +57,16 @@ export const PROG_SPEC_WORK_PCTS = (
   numSets: number,
   wtDecrementPct: number,
 ) => {
+  // Each set i gets work percentage (1 - i * wtDecrementPct). When wtDecrementPct
+  // is large relative to numSets the final set goes negative, which would produce
+  // a negative prescribed weight. Reject rather than silently emit bad sets.
+  const minPct = 1 - (numSets - 1) * wtDecrementPct;
+  if (minPct < 0) {
+    throw new RangeError(
+      `wtDecrementPct ${wtDecrementPct} produces a negative work percentage ` +
+        `(${minPct}) over ${numSets} sets; it must be at most ${1 / (numSets - 1)}.`,
+    );
+  }
   return Array(numSets)
     .fill(1)
     .reduce((acc, num) => {

--- a/packages/core/tests/core/constants/config.test.ts
+++ b/packages/core/tests/core/constants/config.test.ts
@@ -1,0 +1,34 @@
+import { MROUND, PROG_SPEC_WORK_PCTS } from "@src/core";
+
+describe("MROUND", () => {
+  it("rounds to the nearest multiple", () => {
+    expect(MROUND(183, 5)).toBe(185);
+    expect(MROUND(182, 5)).toBe(180);
+  });
+
+  it("returns the unrounded value when the multiple is 0 (no NaN)", () => {
+    // A custom program saved with increment 0 must not poison weight math.
+    expect(MROUND(187, 0)).toBe(187);
+    expect(Number.isNaN(MROUND(187, 0))).toBe(false);
+  });
+});
+
+describe("PROG_SPEC_WORK_PCTS", () => {
+  it("produces a descending percentage per set", () => {
+    expect(PROG_SPEC_WORK_PCTS(3, 0.1)).toEqual([1, 0.9, 0.8]);
+  });
+
+  it("returns a single full-percentage set when there is no decrement", () => {
+    expect(PROG_SPEC_WORK_PCTS(1, 0.1)).toEqual([1]);
+    expect(PROG_SPEC_WORK_PCTS(3, 0)).toEqual([1, 1, 1]);
+  });
+
+  it("throws a RangeError when the decrement drives a set negative", () => {
+    // 1 - (3 - 1) * 0.6 = -0.2 → final set would be a negative weight.
+    expect(() => PROG_SPEC_WORK_PCTS(3, 0.6)).toThrow(RangeError);
+  });
+
+  it("allows a decrement exactly at the boundary (final set = 0)", () => {
+    expect(PROG_SPEC_WORK_PCTS(3, 0.5)).toEqual([1, 0.5, 0]);
+  });
+});


### PR DESCRIPTION
## Summary

Acts on the `#434` deep correctness audit. Three findings, all fixed here; the housekeeping items (#441, #421, #418) ride in a separate PR so this security fix is reviewable on its own.

### CRITICAL — cross-user custom-program-spec leak
`HybridLiftingProgramSpecRepository.getCustomSpec()` queried `customProgramSpec` by `programId` alone. Any authenticated user could read another user's custom program spec by UUID. The repo was also a **startup singleton** in `PrismaRepositoryFactory` (constructed with no `userId`), so it could not be scoped per-request.

- Added a `userId` constructor param; the query now guards via the relation: `where: { programId, program: { userId } }`.
- Moved instantiation into `forUser(user)` alongside every other per-user repo.

### HIGH — domain-logic guards (boundary + defense-in-depth)
`CustomProgramSpecRowDto` had no bounds on `increment` or `wtDecrementPct`, so nonsensical specs persisted:
- `increment: 0` → `MROUND` divided by zero → `NaN` weights.
- large `wtDecrementPct` → later sets' work percentage went negative → negative prescribed weight.

Fixes:
- **Boundary (root cause):** `@IsPositive()` on `increment`; `@Min(0) @Max(1)` on `wtDecrementPct`.
- **Core (defense-in-depth):** `MROUND` returns the unrounded value when `multiple === 0`; `PROG_SPEC_WORK_PCTS` throws `RangeError` when the decrement drives the final set's percentage negative.

### HIGH — `/settings/schedule` missing fetch fallback
The page awaited `fetchUserSettings()` with no `.catch()`, unlike `/programs` and `/cycle`. It crashed the build-time prerender (and runtime) when the API was unreachable. Added `.catch(() => DEFAULT_SETTINGS)`, annotated `fallback-covered-by:` per the error-fallback-test-coverage standard.

## Testing

```
core: Test Suites: 27 passed, 27 total · Tests: 174 passed, 174 total
web:  Test Suites: 12 passed, 12 total · Tests: 71 passed, 71 total
api:  Test Suites: 25 passed, 25 total · Tests: 334 passed, 334 total
```
Combined: **Tests: 579 passed, 0 skipped, 0 failed**. API suite ran the full Testcontainers Postgres DB E2E (Docker up locally).

New tests:
- `hybrid-program-spec.repository.spec.ts` — built-in routing + cross-user isolation where-clause + non-owner returns `[]`.
- `create-custom-program.dto.spec.ts` — rejects `increment` ≤ 0 and `wtDecrementPct` outside [0,1].
- `config.test.ts` — `MROUND(N, 0)` no longer `NaN`; `PROG_SPEC_WORK_PCTS` boundary + negative-throw.
- `schedule/page.test.tsx` — success path passes fetched schedule; failure path falls back to `null` without throwing (data-level assertions, not structure-only).

Pre-PR checks: suppression grep clean, test-integrity grep clean, no deleted tests, lockfile unchanged. Lint clean for `api`/`core`/`web` (one pre-existing unused-`eslint-disable` warning in `apps/web/app/api/healthz/route.ts:32`, untouched here).

## Acceptance criteria (#434)
- [x] Domain/core edge cases around rounding audited and guarded.
- [x] Per-user isolation invariant restored on the custom-program-spec read path.
- [x] `apps/web` static-vs-dynamic fetch correctness — `/settings/schedule` no longer crashes without an API (matches the `getActiveProgram` fallback pattern called out in the issue).

Closes #434

---

## Review findings disposition

`/review` (claude-opus-4-8) reported 1 blocking + 2 non-blocking; all fixed in `b503f3a`:

- **[blocking · reliability]** DTO `@Max(1)` admitted a cross-field-invalid `wtDecrementPct` (e.g. `0.6`/3 sets) that passed validation, persisted, then threw an uncaught `RangeError` → 500 at plan generation. **Fixed** — added the `WtDecrementWithinSetBound` cross-field validator (400 at creation); the core `RangeError` is now a true backstop. Corrected the e2e fixture (`0.9` → `0.1`), which was itself out-of-range.
- **[non-blocking · performance]** `HybridLiftingProgramSpecRepository` rebuilt the global in-memory seed map per request. **Fixed** — the factory now shares one `InMemoryLiftingProgramSpecRepository` and injects it; the per-user wrapper binds only `prisma` + `userId`.
- **[non-blocking · maintainability]** Isolation unit test asserted query shape, not Prisma's actual filtering. **Fixed** — added a Testcontainers DB E2E: owner creates a custom program; a different user requesting the same UUID's `/spec` gets `[]`.
- **[question · existing data]** No production concern — custom programs shipped in #425 with no real user data yet; the only out-of-range instance was the e2e's own fixture, corrected here.

Updated test totals: api **25 suites, 337 passed** (+2 DTO cross-field, +1 DB isolation E2E). Full suite remains green (core 174, web 71).


---

### Additional change (not a review finding)

`8f2543b` removes an unused `eslint-disable-next-line no-console` in `apps/web/app/api/healthz/route.ts` (`no-console` is inactive for `apps/web`, so the directive only tripped ESLint's "unused directive" warning). This was the last warning blocking a fully clean `apps/web` lint (now 0/0). Folded in here at the author's request as part of the #434 quality pass; it is the only other `apps/web` change on this branch.
