### PR TITLE
[fix] Consolidate production approval gate onto deploy-production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -594,25 +594,28 @@ jobs:
             echo "API smoke test failed: expected 200 or 403, got $STATUS" && exit 1
           fi
 
-  # ── 5. Manual approval gate ──────────────────────────────────────────────
-  # Surfaces the production approval gate in the workflow itself, in addition
-  # to (not instead of) the `environment: production` reference on
-  # deploy-production below. Required reviewers are configured on the
-  # production environment in repo Settings (see #417); this job has no
-  # `run:` of substance — it exists to:
-  #   1. Make the gate visible in code review of this file rather than only
-  #      in repo Settings → Environments → production.
-  #   2. Act as a tripwire — if a future refactor strips `environment:
-  #      production` from deploy-production, this job still pauses the
-  #      pipeline at the same point.
-  # The reviewer clicks Approve once; both this job and deploy-production
-  # share the same environment, so a single approval releases both.
-  approve-production:
-    name: Approve production deploy
+  # ── 5. Deploy to production (requires manual approval) ───────────────────
+  # The `environment: production` reference below is the manual approval gate.
+  # GitHub raises one required-reviewer prompt per job that targets a protected
+  # environment, so the gate lives on this job alone — the job that actually
+  # deploys — giving a single approval, the GitHub-enforced backstop on the
+  # real deploy, and an accurate deployment record against the production
+  # environment.
+  #
+  # History: a separate `approve-production` job previously carried this
+  # environment "in addition to" deploy-production (#417), on the assumption
+  # that two jobs sharing one environment would prompt only once. They don't —
+  # GitHub prompts per-job — which produced a double approval (#451). The gate
+  # is now consolidated onto the deploy job, where the environment protection
+  # belongs.
+  deploy-production:
+    name: Deploy (production)
     runs-on: ubuntu-latest
     needs: [preflight, build-images, deploy-staging, smoke-test]
-    # Same gating logic as deploy-production below — only request approval
-    # when the pipeline would actually be ready to deploy.
+    # Only deploy when the pipeline is actually ready: build succeeded and,
+    # when staging is enabled, the staging smoke test passed. `always()` lets
+    # this run even though deploy-staging/smoke-test are skipped in
+    # production-only mode (their `skipped` result is not `success`).
     if: |
       always() &&
       needs.build-images.result == 'success' &&
@@ -620,25 +623,10 @@ jobs:
         needs.preflight.outputs.staging_enabled != 'true' ||
         needs.smoke-test.result == 'success'
       )
-    environment: production
-    steps:
-      - name: Approved
-        run: echo "Production deploy approved."
-
-  # ── 6. Deploy to production (requires manual approval) ───────────────────
-  deploy-production:
-    name: Deploy (production)
-    runs-on: ubuntu-latest
-    needs: [preflight, build-images, deploy-staging, smoke-test, approve-production]
-    # Gate is fully expressed by approve-production: if the reviewer rejects
-    # (or approve-production is skipped because its own if-clause was false),
-    # this job skips cleanly. No `environment: production` here — that would
-    # trigger a second required-reviewer prompt. The build/smoke conditions are
-    # already enforced by approve-production.if upstream.
-    if: always() && needs.approve-production.result == 'success'
     permissions:
       contents: read
       id-token: write
+    environment: production   # manual approval gate (required reviewer, #417)
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -632,14 +632,13 @@ jobs:
     needs: [preflight, build-images, deploy-staging, smoke-test, approve-production]
     # Gate is fully expressed by approve-production: if the reviewer rejects
     # (or approve-production is skipped because its own if-clause was false),
-    # this job skips cleanly rather than triggering a second required-reviewer
-    # prompt from its own `environment: production` reference. The build/smoke
-    # conditions are already enforced by approve-production.if upstream.
+    # this job skips cleanly. No `environment: production` here — that would
+    # trigger a second required-reviewer prompt. The build/smoke conditions are
+    # already enforced by approve-production.if upstream.
     if: always() && needs.approve-production.result == 'success'
     permissions:
       contents: read
       id-token: write
-    environment: production   # triggers GitHub required-reviewer gate
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

Fixes the double approval prompt on production deploys by **consolidating the `environment: production` gate onto the `deploy-production` job** and removing the redundant `approve-production` job.

**Root cause:** `approve-production` was added (#417) on the assumption — stated in its own comment — that "both this job and deploy-production share the same environment, so a single approval releases both." That assumption is wrong: GitHub raises one required-reviewer prompt **per job** that targets a protected environment, not one per environment. With both jobs referencing `environment: production`, reviewers were prompted twice.

**Fix:** Delete `approve-production` and put `environment: production` back on `deploy-production`, inheriting the build/smoke gating `if` that previously lived on `approve-production`. This yields:
- A single approval prompt.
- The GitHub-enforced approval backstop on the job that actually deploys (not just a workflow `if`).
- An accurate GitHub deployment record (attached to the real deploy, not a no-op job).
- `docs/deploy.md` Step 6 ("the `deploy-production` job will pause and wait for your approval") is correct again with no doc change.

## Testing

YAML-only change. Validated by parsing the workflow with `js-yaml` and asserting: `approve-production` is removed, `deploy-production.environment == 'production'`, and `deploy-production.needs` no longer references the deleted job. Pre-commit lint passed (7/7 packages). No application code touched.

Tests: N/A — no testable source changes (CI workflow definition only).

## Review findings disposition

Review by `claude-opus-4-8` on the initial approach (0 blocking, 2 non-blocking + 1 design question): https://github.com/brownm09/lifting-logbook/pull/452#issuecomment-4626024717

- **[documentation] `docs/deploy.md:318-320` stale** — Fixed in `d5d47d1`. Consolidating the gate back onto `deploy-production` makes the existing doc sentence accurate again; no edit required.
- **[reliability] deployment record on no-op job** — Fixed in `d5d47d1`. The deployment record now attaches to `deploy-production` (the job that actually deploys), so production environment status reflects real deploy outcome.
- **[question] gate placement design** — Resolved by adopting alternative (b) from the review: deleted `approve-production`, gate lives on `deploy-production`. Chosen because the separate approval job's entire rationale rested on the disproven "one prompt per environment" assumption.

Closes #451
