### PR TITLE
[fix] Add ARIA combobox semantics to onboarding lift picker

### DIFF
--- a/apps/web/app/(authed)/onboarding/steps/StepLifts.test.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepLifts.test.tsx
@@ -53,20 +53,31 @@ describe('StepLifts — default rows', () => {
 });
 
 describe('StepLifts — add a lift', () => {
+  it('exposes combobox role and aria-expanded on the search input', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    const input = screen.getByRole('combobox', { name: 'Add a lift' });
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(input);
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+  });
+
   it('shows available catalog lifts when the input is focused with no query', async () => {
     const user = userEvent.setup();
     render(<Harness />);
 
     // Before focus: no picker items visible
-    expect(screen.queryByRole('button', { name: 'Overhead Press' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Overhead Press' })).not.toBeInTheDocument();
 
     await user.click(screen.getByLabelText('Add a lift'));
 
     // After focus with empty query: unselected catalog lifts appear immediately
-    expect(screen.getByRole('button', { name: 'Overhead Press' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Barbell Row' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Overhead Press' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Barbell Row' })).toBeInTheDocument();
     // Already-selected lifts are not offered
-    expect(screen.queryByRole('button', { name: 'Squat' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Squat' })).not.toBeInTheDocument();
   });
 
   it('appends a catalog lift selected from the picker', async () => {
@@ -77,7 +88,7 @@ describe('StepLifts — add a lift', () => {
     expect(screen.queryByText('Overhead Press')).not.toBeInTheDocument();
 
     await user.type(screen.getByLabelText('Add a lift'), 'overhead');
-    await user.click(screen.getByRole('button', { name: 'Overhead Press' }));
+    await user.click(screen.getByRole('option', { name: 'Overhead Press' }));
 
     expect(screen.getByText('Overhead Press')).toBeInTheDocument();
     expect(screen.getByLabelText('Overhead Press weight')).toBeInTheDocument();
@@ -88,8 +99,8 @@ describe('StepLifts — add a lift', () => {
     render(<Harness />);
 
     await user.type(screen.getByLabelText('Add a lift'), 'squat');
-    // 'Squat' is already a default row, so no picker option button for it
-    expect(screen.queryByRole('button', { name: 'Squat' })).not.toBeInTheDocument();
+    // 'Squat' is already a default row, so no picker option for it
+    expect(screen.queryByRole('option', { name: 'Squat' })).not.toBeInTheDocument();
   });
 
   it('adds a free-text custom lift that is not in the catalog', async () => {
@@ -99,7 +110,7 @@ describe('StepLifts — add a lift', () => {
     // 'Zercher Carry' is not in CATALOG — the picker should offer it as custom
     await user.type(screen.getByLabelText('Add a lift'), 'Zercher Carry');
     await user.click(
-      screen.getByRole('button', { name: /Add .*Zercher Carry.* as a custom lift/i }),
+      screen.getByRole('option', { name: /Add .*Zercher Carry.* as a custom lift/i }),
     );
 
     expect(screen.getByText('Zercher Carry')).toBeInTheDocument();
@@ -113,9 +124,9 @@ describe('StepLifts — add a lift', () => {
     // 'Overhead Press' is a catalog lift not yet added — it is offered as a
     // normal catalog option, never as a "custom lift".
     await user.type(screen.getByLabelText('Add a lift'), 'Overhead Press');
-    expect(screen.getByRole('button', { name: 'Overhead Press' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Overhead Press' })).toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: /as a custom lift/i }),
+      screen.queryByRole('option', { name: /as a custom lift/i }),
     ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/(authed)/onboarding/steps/StepLifts.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepLifts.tsx
@@ -106,32 +106,34 @@ export function StepLifts({ method, lifts, catalog, onChange, onAdd, onRemove }:
           aria-label="Add a lift"
         />
         {focused && (available.length > 0 || canAddCustom || query.length > 0) && (
-          <ul id={listboxId} role="listbox" aria-label="Available lifts" className={styles.liftPickerList}>
-            {available.map((lift) => (
-              <li
-                key={lift}
-                role="option"
-                aria-selected={false}
-                className={styles.liftPickerItem}
-                onMouseDown={(e) => { e.preventDefault(); handleAdd(lift); }}
-              >
-                {lift}
-              </li>
-            ))}
-            {canAddCustom && (
-              <li
-                role="option"
-                aria-selected={false}
-                className={styles.liftPickerItem}
-                onMouseDown={(e) => { e.preventDefault(); handleAdd(trimmed); }}
-              >
-                Add &ldquo;{trimmed}&rdquo; as a custom lift
-              </li>
-            )}
+          <>
+            <ul id={listboxId} role="listbox" aria-label="Available lifts" className={styles.liftPickerList}>
+              {available.map((lift) => (
+                <li
+                  key={lift}
+                  role="option"
+                  aria-selected={false}
+                  className={styles.liftPickerItem}
+                  onMouseDown={(e) => { e.preventDefault(); handleAdd(lift); }}
+                >
+                  {lift}
+                </li>
+              ))}
+              {canAddCustom && (
+                <li
+                  role="option"
+                  aria-selected={false}
+                  className={styles.liftPickerItem}
+                  onMouseDown={(e) => { e.preventDefault(); handleAdd(trimmed); }}
+                >
+                  Add &ldquo;{trimmed}&rdquo; as a custom lift
+                </li>
+              )}
+            </ul>
             {available.length === 0 && !canAddCustom && (
-              <li className={styles.liftPickerEmpty}>No lifts match &ldquo;{query}&rdquo;</li>
+              <p className={styles.liftPickerEmpty}>No lifts match &ldquo;{query}&rdquo;</p>
             )}
-          </ul>
+          </>
         )}
       </div>
 

--- a/apps/web/app/(authed)/onboarding/steps/StepLifts.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepLifts.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import styles from '../onboarding.module.css';
 import type { DiscoveryMethod, LiftRow } from '../lib';
 
@@ -16,6 +16,7 @@ type Props = {
 export function StepLifts({ method, lifts, catalog, onChange, onAdd, onRemove }: Props) {
   const [query, setQuery] = useState('');
   const [focused, setFocused] = useState(false);
+  const listboxId = useId();
 
   const selected = new Set(lifts.map((row) => row.lift));
   const available = catalog.filter(
@@ -90,6 +91,11 @@ export function StepLifts({ method, lifts, catalog, onChange, onAdd, onRemove }:
 
       <div className={styles.liftPicker}>
         <input
+          role="combobox"
+          aria-expanded={focused && (available.length > 0 || canAddCustom || query.length > 0)}
+          aria-haspopup="listbox"
+          aria-controls={listboxId}
+          aria-autocomplete="list"
           type="search"
           placeholder="Add a lift…"
           value={query}
@@ -100,27 +106,26 @@ export function StepLifts({ method, lifts, catalog, onChange, onAdd, onRemove }:
           aria-label="Add a lift"
         />
         {focused && (available.length > 0 || canAddCustom || query.length > 0) && (
-          <ul className={styles.liftPickerList}>
+          <ul id={listboxId} role="listbox" aria-label="Available lifts" className={styles.liftPickerList}>
             {available.map((lift) => (
-              <li key={lift}>
-                <button
-                  type="button"
-                  className={styles.liftPickerItem}
-                  onMouseDown={(e) => { e.preventDefault(); handleAdd(lift); }}
-                >
-                  {lift}
-                </button>
+              <li
+                key={lift}
+                role="option"
+                aria-selected={false}
+                className={styles.liftPickerItem}
+                onMouseDown={(e) => { e.preventDefault(); handleAdd(lift); }}
+              >
+                {lift}
               </li>
             ))}
             {canAddCustom && (
-              <li>
-                <button
-                  type="button"
-                  className={styles.liftPickerItem}
-                  onMouseDown={(e) => { e.preventDefault(); handleAdd(trimmed); }}
-                >
-                  Add &ldquo;{trimmed}&rdquo; as a custom lift
-                </button>
+              <li
+                role="option"
+                aria-selected={false}
+                className={styles.liftPickerItem}
+                onMouseDown={(e) => { e.preventDefault(); handleAdd(trimmed); }}
+              >
+                Add &ldquo;{trimmed}&rdquo; as a custom lift
               </li>
             )}
             {available.length === 0 && !canAddCustom && (


### PR DESCRIPTION
## Problem

The lift picker in the onboarding \"Enter Lifts\" step behaves like a combobox but lacked the corresponding ARIA attributes. Screen readers had no way to know the input controls a popup listbox, or to announce the available options.

Surfaced as a non-blocking finding in the PR #449 code review.

## Changes

**[`StepLifts.tsx`](apps/web/app/(authed)/onboarding/steps/StepLifts.tsx)**
- Add `useId()` to generate a stable, SSR-safe ID for the listbox
- Input: `role="combobox"`, `aria-expanded` (reflects open/closed state), `aria-haspopup="listbox"`, `aria-controls` (links to listbox), `aria-autocomplete="list"`
- `<ul>`: `role="listbox"`, `id` (matched by `aria-controls`), `aria-label="Available lifts"`
- Replace `<li><button>` with `<li role="option" aria-selected={false}>` — options are owned by the listbox and follow the ARIA combobox 1.2 pattern; `onMouseDown`+`e.preventDefault()` stays on the `<li>` to keep the existing blur-prevention behaviour
- "No lifts match" message moved outside the `<ul>` as a `<p>` sibling — a non-option `<li>` inside `role="listbox"` violates ARIA's `aria-required-children` rule (fixed in `e34db92` after review)

**[`StepLifts.test.tsx`](apps/web/app/(authed)/onboarding/steps/StepLifts.test.tsx)**
- New test: "exposes combobox role and aria-expanded on the search input" — verifies `aria-expanded` flips false→true on focus
- Updated all picker-option queries from `getByRole('button', ...)` to `getByRole('option', ...)` to match the new `role="option"` elements

## Testing

Tests: 73 passed, 73 total (Test Suites: 12 passed), 0 skipped, 0 failed (~19s)

Pre-PR checks clean:
- Suppression grep: no new suppressions
- Test integrity grep: no skip markers, no deleted tests, no threshold changes

## Suppressions / integrity notes

None.

## Review findings disposition

Review: [comment](https://github.com/brownm09/lifting-logbook/pull/453#issuecomment-4626072292) — 1 blocking, 0 non-blocking.

| Finding | Disposition |
|---|---|
| `listbox` ARIA ownership violation on "No lifts match" `<li>` | Fixed in `e34db92` |

Closes #450