### PR TITLE
[fix] Hide custom-lift option when partial catalog match exists

### DIFF
--- a/apps/web/app/(authed)/onboarding/steps/StepLifts.test.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepLifts.test.tsx
@@ -129,6 +129,19 @@ describe('StepLifts — add a lift', () => {
       screen.queryByRole('option', { name: /as a custom lift/i }),
     ).not.toBeInTheDocument();
   });
+
+  it('does not offer custom-add when the query partially matches a catalog lift', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    // 'overhead' partially matches 'Overhead Press' — the catalog option appears
+    // but the custom-add option must not, since there are catalog results.
+    await user.type(screen.getByLabelText('Add a lift'), 'overhead');
+    expect(screen.getByRole('option', { name: 'Overhead Press' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', { name: /as a custom lift/i }),
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe('StepLifts — remove a lift', () => {

--- a/apps/web/app/(authed)/onboarding/steps/StepLifts.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepLifts.tsx
@@ -30,7 +30,7 @@ export function StepLifts({ method, lifts, catalog, onChange, onAdd, onRemove }:
   const normalized = trimmed.toLowerCase();
   const alreadySelected = lifts.some((row) => row.lift.toLowerCase() === normalized);
   const matchesCatalog = catalog.some((lift) => lift.toLowerCase() === normalized);
-  const canAddCustom = trimmed.length > 0 && !alreadySelected && !matchesCatalog;
+  const canAddCustom = trimmed.length > 0 && !alreadySelected && !matchesCatalog && available.length === 0;
 
   function handleAdd(lift: string) {
     onAdd(lift);


### PR DESCRIPTION
## Summary

Fixes #454.

Typing a partial lift name (e.g. `overhead`) now shows only the matching catalog option (`Overhead Press`) without also displaying an "Add as a custom lift" offer. Previously, `canAddCustom` only excluded exact catalog matches — partial matches set `available.length > 0` and `canAddCustom = true` simultaneously, so both the catalog option and the custom-add option appeared.

**Root cause:** `canAddCustom` checked `!matchesCatalog` (exact match only) but not whether any catalog lifts already appeared in `available`. Fix: add `available.length === 0` to the guard.

## Changes

- `StepLifts.tsx`: `canAddCustom` gains `&& available.length === 0` — custom-add only offered when no catalog results are present
- `StepLifts.test.tsx`: regression test covering the partial-match case ("type 'overhead' → only catalog option appears, no custom-add")

## Testing

```
npm test -w @lifting-logbook/web
Tests: 74 passed, 74 total (12 suites) — 1.353s
```

Suppressions: none added.
Test integrity: no skip markers, no deleted tests, no lowered thresholds.

TS compile warnings in `StepLifts.test.tsx` are pre-existing (jest-dom augmentation gap tracked in #421, mitigated by `diagnostics: { warnOnly: true }` in `jest.config.js`).