### PR TITLE
[fix] Fall back to full lift catalog when onboarding fetch fails

### DIFF
--- a/apps/web/app/(authed)/onboarding/page.test.tsx
+++ b/apps/web/app/(authed)/onboarding/page.test.tsx
@@ -1,0 +1,71 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { ReactElement } from 'react';
+import { LIFT_NAMES } from '@lifting-logbook/types';
+
+jest.mock('@/lib/api', () => ({
+  fetchLiftCatalog: jest.fn(),
+}));
+
+jest.mock('@/lib/active-program', () => ({
+  getActiveProgram: jest.fn().mockResolvedValue('5-3-1'),
+}));
+
+// Stub the client flow so the test isolates the page's catalog-fetch fallback.
+// It echoes the resolved catalog so we can assert what the page passed down.
+jest.mock('./OnboardingFlow', () => ({
+  OnboardingFlow: ({ catalog }: { catalog: string[] }) => (
+    <div data-catalog={JSON.stringify(catalog)}>onboarding-flow</div>
+  ),
+}));
+
+import { fetchLiftCatalog } from '@/lib/api';
+import OnboardingPage from './page';
+import { DEFAULT_LIFTS } from './lib';
+
+const mockedFetch = fetchLiftCatalog as unknown as jest.Mock;
+
+describe('OnboardingPage — catalog fetch fallback', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('passes the fetched catalog to the flow on success', async () => {
+    const fetched = ['Squat', 'Bench Press', 'My Custom Lift'];
+    mockedFetch.mockResolvedValue(fetched);
+
+    const element = (await OnboardingPage()) as ReactElement;
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain('onboarding-flow');
+    // Data-level assertion: the real fetched catalog — including the custom
+    // lift that no fallback would produce — reached the flow.
+    expect(html).toContain('My Custom Lift');
+  });
+
+  it('falls back to the full built-in LIFT_NAMES when the fetch fails', async () => {
+    mockedFetch.mockRejectedValue(new Error('API down'));
+    // Silence the intentional error log this path emits.
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const element = (await OnboardingPage()) as ReactElement;
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain('onboarding-flow');
+
+    // The fallback must be the full built-in catalog, NOT the three seeded
+    // DEFAULT_LIFTS. Overhead Press is in LIFT_NAMES but not DEFAULT_LIFTS, so
+    // its presence proves the picker stays searchable when the API is down (#458).
+    const overheadInDefaults = (DEFAULT_LIFTS as readonly string[]).includes('Overhead Press');
+    expect(overheadInDefaults).toBe(false);
+    expect(LIFT_NAMES).toContain('Overhead Press');
+    expect(html).toContain('Overhead Press');
+
+    // The catalog handed down is exactly the built-in list.
+    expect(html).toContain(`data-catalog="${JSON.stringify([...LIFT_NAMES]).replace(/"/g, '&quot;')}"`);
+
+    // The failure is surfaced, not silently swallowed.
+    expect(errSpy).toHaveBeenCalledWith(
+      'OnboardingPage: lift catalog fetch failed, falling back to built-in LIFT_NAMES',
+      expect.any(Error),
+    );
+    errSpy.mockRestore();
+  });
+});

--- a/apps/web/app/(authed)/onboarding/page.test.tsx
+++ b/apps/web/app/(authed)/onboarding/page.test.tsx
@@ -58,8 +58,13 @@ describe('OnboardingPage — catalog fetch fallback', () => {
     expect(LIFT_NAMES).toContain('Overhead Press');
     expect(html).toContain('Overhead Press');
 
-    // The catalog handed down is exactly the built-in list.
-    expect(html).toContain(`data-catalog="${JSON.stringify([...LIFT_NAMES]).replace(/"/g, '&quot;')}"`);
+    // The catalog handed down is exactly the built-in list. Parse the echoed
+    // attribute rather than matching React's escaped serialization, so the
+    // assertion tracks the data contract instead of the renderer's escaping rules.
+    const encoded = html.match(/data-catalog="([^"]*)"/)?.[1];
+    if (encoded === undefined) throw new Error('data-catalog attribute not found in rendered output');
+    const passedCatalog = JSON.parse(encoded.replace(/&quot;/g, '"'));
+    expect(passedCatalog).toEqual([...LIFT_NAMES]);
 
     // The failure is surfaced, not silently swallowed.
     expect(errSpy).toHaveBeenCalledWith(

--- a/apps/web/app/(authed)/onboarding/page.tsx
+++ b/apps/web/app/(authed)/onboarding/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
+import { LIFT_NAMES } from "@lifting-logbook/types";
 import { fetchLiftCatalog } from "@/lib/api";
 import { getActiveProgram } from "@/lib/active-program";
 import { OnboardingFlow } from "./OnboardingFlow";
-import { DEFAULT_LIFTS } from "./lib";
 
 export const metadata: Metadata = {
   title: "Get Started — Lifting Logbook",
@@ -15,20 +15,26 @@ export default async function OnboardingPage() {
   // and ignores the :program param, so the active-program default is safe even
   // before a cycle exists.
   //
-  // Error-fallback coverage (docs/standards/error-fallback-test-coverage.md,
-  // option c — structure-only justification): the catch below swallows a
-  // catalog-fetch failure and falls back to the seeded DEFAULT_LIFTS. This is
-  // intentional and not asserted by a test because the only behavior that
-  // matters on failure is that onboarding still renders with at least the
-  // big-three lifts selectable — there is no data shape to assert beyond "the
-  // flow does not hard-fail," which OnboardingFlow's tests already exercise
-  // against an explicit catalog.
+  // On fetch failure we fall back to the full built-in LIFT_NAMES rather than
+  // the three seeded DEFAULT_LIFTS: OnboardingFlow pre-selects those same three
+  // as the starting rows, so a DEFAULT_LIFTS fallback leaves the picker with
+  // nothing selectable for any query — every search collapses to the
+  // "add as a custom lift" option and the catalog search appears broken (#458).
+  // LIFT_NAMES keeps search functional offline. The failure is logged rather
+  // than swallowed so the upstream catalog-fetch failure is observable.
+  // Fallback coverage (docs/standards/error-fallback-test-coverage.md, option b):
+  // page.test.tsx asserts the fallback catalog is the full built-in list,
+  // distinct from the pre-selected defaults.
   let catalog: string[];
   try {
     const program = await getActiveProgram();
     catalog = await fetchLiftCatalog(program);
-  } catch {
-    catalog = [...DEFAULT_LIFTS];
+  } catch (e) {
+    console.error(
+      "OnboardingPage: lift catalog fetch failed, falling back to built-in LIFT_NAMES",
+      e,
+    );
+    catalog = [...LIFT_NAMES];
   }
 
   return <OnboardingFlow catalog={catalog} />;


### PR DESCRIPTION
## Summary

The onboarding **Enter Lifts** search box only ever offered *"Add ⟨text⟩ as a custom lift"* and never surfaced built-in catalog matches (Overhead Press, Barbell Row, etc.), making the search appear broken.

**Root cause:** the picker's custom-lift option correctly only appears when `available.length === 0`. But on a catalog-fetch failure, [`onboarding/page.tsx`](apps/web/app/(authed)/onboarding/page.tsx) fell back to `DEFAULT_LIFTS` (`Bench Press`, `Squat`, `Deadlift`) — the exact three lifts `OnboardingFlow` pre-selects as the starting rows. Every fallback entry was therefore already selected, so `available` was empty for **every** query and the picker collapsed to the custom-lift option. The failure was also silently swallowed by a bare `catch {}`, hiding the upstream fetch failure (Clerk + GCP identity-token handshake on Cloud Run) in production.

## Changes

- Fall back to the full built-in `LIFT_NAMES` instead of `DEFAULT_LIFTS`, so catalog search stays functional even when the API is unreachable.
- Log the swallowed fetch error via `console.error` so the upstream failure is observable.
- Add `apps/web/app/(authed)/onboarding/page.test.tsx` covering the success path and asserting the fallback catalog is the full built-in list (distinct from the pre-selected defaults), plus that the error is logged.

## Acceptance Criteria

- [x] When the catalog fetch fails, the picker still offers built-in lifts not already selected (e.g. Overhead Press, Barbell Row).
- [x] The catalog-fetch failure is logged server-side rather than silently swallowed.
- [x] Test coverage asserts the fallback catalog is the full built-in list, distinct from the pre-selected defaults.

## Testing

Run from the repo root:

```
npm test -w @lifting-logbook/web
npx turbo run lint --filter=@lifting-logbook/web
```

- Full web suite: **Tests: 76 passed, 0 skipped, 0 failed (17.7s)** — includes the new `page.test.tsx` (success + fallback assertions). Re-run after the review-finding fix below.
- Lint: clean.
- Pre-PR suppression and test-integrity greps: clean (no suppressions, skips, or integrity violations added).
- No `package.json` changed → lockfile-sync check N/A.
- DB E2E suite not run (Docker): change is web-only, touches no `apps/api/prisma/` or repository code.

## Notes

This makes the fallback graceful and the failure observable. The separate question of *why* the catalog fetch fails in production (the onboarding-time auth-token handshake) is upstream of this fix and can now be diagnosed from the logged error.

## Review findings disposition

`/review` ([comment](https://github.com/brownm09/lifting-logbook/pull/459#issuecomment-4653206103)): 0 blocking, 1 non-blocking.

- **[maintainability]** `page.test.tsx` — fallback assertion matched React's hand-escaped serialized attribute, coupling the test to renderer escaping rules. **Fixed in `e35af06`** — now parses the echoed `data-catalog` attribute and compares arrays (`toEqual([...LIFT_NAMES])`).

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)
