### PR TITLE
[infra] Add runtime 5xx paging backstop (per-route alert + Alertmanager routing)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,7 @@ services:
       - "--web.console.templates=/usr/share/prometheus/consoles"
     volumes:
       - ./infra/observability/prometheus-local.yml:/etc/prometheus/prometheus.yml:ro
+      - ./infra/observability/alerts:/etc/prometheus/alerts:ro
       - prometheus_data:/prometheus
     ports:
       - "9090:9090"
@@ -89,6 +90,26 @@ services:
     depends_on:
       otel-collector:
         condition: service_started
+      alertmanager:
+        condition: service_started
+
+  # Routes firing alert rules to notification channels (#462). Locally, delivery
+  # will fail without a reachable SMTP server / valid Slack webhook — that is
+  # expected; the value here is exercising the rule→route→receiver path. The
+  # production target is the Grafana Cloud Alertmanager (see docs/operations/slo.md).
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+    volumes:
+      - ./infra/observability/alertmanager.yaml:/etc/alertmanager/alertmanager.yml:ro
+    ports:
+      - "127.0.0.1:9093:9093"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9093/-/ready"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
 
   # DEV ONLY — anonymous Admin access, never copy this auth config to staging/prod
   grafana:

--- a/docs/README.md
+++ b/docs/README.md
@@ -166,8 +166,8 @@ monorepo/
 
 | Runbook | Covers |
 |---------|--------|
-| [Observability](runbooks/observability.md) | Local stack startup, Grafana dashboards, trace queries, log↔trace correlation, alert silencing, Grafana Cloud credential wiring |
-| [API 5xx surge](runbooks/api-5xx-surge.md) | `APIHighErrorRate` alert response — SEV2 |
+| [Observability](runbooks/observability.md) | Local stack startup, Grafana dashboards, trace queries, log↔trace correlation, alert rules + notification routing + silencing, Grafana Cloud credential wiring |
+| [API 5xx surge](runbooks/api-5xx-surge.md) | `APIRouteHighErrorRate` / `APIHighErrorRate` alert response — SEV2 |
 | [Database unreachable](runbooks/database-unreachable.md) | DB connection error triage — SEV1 |
 | [Auth provider outage](runbooks/auth-provider-outage.md) | 401/403 surge + Clerk status incident — SEV2 |
 | [Deploy regression rollback](runbooks/deploy-regression-rollback.md) | Error rate spike correlated with a recent deploy — SEV2 |

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -319,7 +319,8 @@ In the GitHub repository → **Settings → Secrets and variables → Actions**:
 
 This is the manual approval gate that prevents automatic production deploys.
 The `deploy-production` job in `.github/workflows/deploy.yml` will pause and
-wait for your approval before proceeding.
+wait for your approval before proceeding. To approve a paused run (UI or `gh` CLI),
+see [Approving a production deploy](#approving-a-production-deploy) under Ongoing operations.
 
 ---
 
@@ -336,6 +337,34 @@ the production URL will appear in the `deploy-production` job summary after appr
 ### Deploying a change
 
 Push or merge to `main`. The pipeline runs automatically.
+
+### Approving a production deploy
+
+After `build-images`, `deploy-staging`, and `smoke-test` succeed, the run pauses at the
+`production` environment gate (the Required-reviewer rule from [Step 6](#step-6--configure-github-environment-protection-rules))
+and waits for approval before the `deploy-production` job starts. This gate is what applies
+pending Prisma migrations to prod — it sits in front of the in-VPC migrate job and the
+DB-backed `/readyz` smoke ([ADR-027](adr/ADR-027-deploy-pipeline-migrations.md)) — so approve
+it deliberately, after sanity-checking staging.
+
+**From the GitHub UI:** open the Deploy workflow run, click **Review deployments**, select
+`production`, and approve.
+
+**From the CLI (no browser):**
+
+```bash
+# Find the latest Deploy run on main
+RUNID=$(gh run list --workflow Deploy --branch main --limit 1 --json databaseId -q '.[0].databaseId')
+
+# Inspect what is pending approval (optional)
+gh api repos/brownm09/lifting-logbook/actions/runs/$RUNID/pending_deployments
+
+# Approve the production environment (id 15694632193)
+gh api repos/brownm09/lifting-logbook/actions/runs/$RUNID/pending_deployments \
+  -X POST -f state=approved -F 'environment_ids[]=15694632193' -f comment="approved via gh"
+```
+
+The `production` environment id is `15694632193`. To **reject** instead, use `-f state=rejected`.
 
 ### Web image: per-env build (ADR-025)
 

--- a/docs/operations/slo.md
+++ b/docs/operations/slo.md
@@ -126,12 +126,38 @@ monthly review.
 SLO compliance is derived from the Prometheus metrics emitted by the OpenTelemetry SDK in
 `apps/api` and collected by the OTel Collector:
 
-- **Local dev:** Prometheus runs at `http://localhost:9090`; Grafana at `http://localhost:3030`
+- **Local dev:** Prometheus runs at `http://localhost:9090`; Grafana at `http://localhost:3030`;
+  Alertmanager at `http://localhost:9093`
 - **Production:** Grafana Cloud Metrics (Mimir); alert rules in
-  `infra/observability/alerts/api.yaml` are applied to the Grafana Cloud stack
+  `infra/observability/alerts/api.yaml` and the Alertmanager routing/notification config in
+  `infra/observability/alertmanager.yaml` are applied to the Grafana Cloud stack
 
 Ensure Mimir retention is set to **≥ 30 days** so 28-day window expressions have complete
 data. Contact the Grafana Cloud portal (Stack → Settings → Data retention) to verify.
+
+### Applying alert config to Grafana Cloud
+
+The rule and routing config are kept as code in `infra/observability/`. They are applied to the
+Grafana Cloud Mimir ruler + Alertmanager with [`mimirtool`](https://grafana.com/docs/mimir/latest/manage/tools/mimirtool/)
+(set `MIMIR_ADDRESS` / `MIMIR_API_USER` / `MIMIR_API_KEY` from the Grafana Cloud portal):
+
+```bash
+# Alert rules (Mimir ruler)
+mimirtool rules load infra/observability/alerts/api.yaml
+
+# Routing + notification config (Mimir Alertmanager)
+mimirtool alertmanager load infra/observability/alertmanager.yaml
+```
+
+> **Secrets, not committed.** `alertmanager.yaml` carries `.invalid` / `PLACEHOLDER` values for
+> the SMTP identity, on-call email recipient, and Slack webhook URL. Before loading, substitute
+> the real values from Secret Manager / the Grafana Cloud portal (or configure the contact
+> points directly in the Cloud Alertmanager UI) — never commit the real destinations. This is
+> what makes an alert actually **page** rather than sit on a dashboard; the gap it closes is the
+> #458/#460 outage that ran four days with no notification ([#462](https://github.com/brownm09/lifting-logbook/issues/462)).
+
+After loading, send a test notification from the Grafana Cloud Alertmanager UI to confirm both
+the email and Slack contact points reach the operator.
 
 ---
 

--- a/docs/runbooks/api-5xx-surge.md
+++ b/docs/runbooks/api-5xx-surge.md
@@ -1,7 +1,24 @@
 # Runbook: API 5xx Surge
 
-**Triggers:** `APIHighErrorRate` alert (5xx rate > 1% for 5 minutes); also the starting
-point for `APIHighP95Latency` — check the Latency panel alongside the Error Rate panel
+**Triggers:**
+- `APIRouteHighErrorRate` (severity **critical**) — a single route's 5xx rate > 5% for 5
+  minutes. This is the primary signal for a *one-endpoint* failure: it fires even when the
+  broken route carries only a small share of total traffic, so the API-wide ratio stays low.
+  It is the alert that would have caught the #458/#460 outage (`GET /programs/:program/lifts`
+  returned 500 on every call for four days while overall traffic was modest and the aggregate
+  rate never crossed 1%). The firing alert's `http_route` label names the failing endpoint —
+  start diagnosis there.
+- `APIHighErrorRate` (severity **warning**) — API-wide 5xx rate > 1% for 5 minutes; the signal
+  for a broad degradation hitting many routes at once.
+- Also the starting point for `APIHighP95Latency` — check the Latency panel alongside the
+  Error Rate panel.
+
+**Notification:** these alerts route through the Alertmanager config in
+[`infra/observability/alertmanager.yaml`](../../infra/observability/alertmanager.yaml) to the
+on-call **email + Slack** channels (warning/critical only; `APINoRequests`/info is held back
+from paging). If an alert fired but no page arrived, verify the Grafana Cloud Alertmanager
+contact points per [`docs/operations/slo.md`](../operations/slo.md#applying-alert-config-to-grafana-cloud).
+
 **Default severity:** SEV2 — escalate to SEV1 if error rate exceeds 10% for > 5 minutes
 **Dashboard:** Grafana → Lifting Logbook → API RED → Error Rate panel and Latency panel
 
@@ -9,8 +26,10 @@ point for `APIHighP95Latency` — check the Latency panel alongside the Error Ra
 
 ## Symptom
 
-- `APIHighErrorRate` alert fires in Grafana Alerting
-- The Error Rate panel in the API RED dashboard shows a spike above the 1% threshold
+- `APIRouteHighErrorRate` or `APIHighErrorRate` alert fires in Grafana Alerting and pages via
+  email + Slack
+- The Error Rate panel in the API RED dashboard shows a spike above the threshold (filter by
+  the `http_route` from the alert label for a single-endpoint failure)
 - Users report errors or the application appears broken
 
 ---

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -127,22 +127,53 @@ Both directions are wired via Grafana datasource provisioning in
 
 ---
 
-## Alert silencing
+## Alerting
 
 ### Alert rules
 
-Three Prometheus alert rules are defined in
+Four Prometheus alert rules are defined in
 [`infra/observability/alerts/api.yaml`](../../infra/observability/alerts/api.yaml):
 
 | Rule | Condition | Severity |
 |---|---|---|
-| `APIHighErrorRate` | 5xx rate > 1% over 5 minutes | warning |
+| `APIRouteHighErrorRate` | any single route's 5xx rate > 5% over 5 minutes (grouped `by (http_route)`) | critical |
+| `APIHighErrorRate` | API-wide 5xx rate > 1% over 5 minutes | warning |
 | `APIHighP95Latency` | p95 latency > 1 s over 5 minutes | warning |
 | `APINoRequests` | Zero requests for 10 minutes | info |
 
+`APIRouteHighErrorRate` exists because the API-wide `APIHighErrorRate` can stay below 1% when a
+single endpoint fails at 100% but carries little traffic — the exact shape of the #458/#460
+outage, which ran undetected for four days. The per-route rule trips on any one route's
+sustained 5xx regardless of overall volume. See
+[api-5xx-surge.md](api-5xx-surge.md) for first response.
+
 > **Known issue:** `APINoRequests` fires spuriously outside business hours because it
-> has no `for:` grace period. This is a documented open item in ADR-018. Silence it
-> during off-hours or add a time-based inhibition rule until the fix lands.
+> has no `for:` grace period. This is a documented open item in ADR-018. The Alertmanager
+> route (below) holds `severity=info` back from paging; you can also silence it during
+> off-hours.
+
+### Notification routing
+
+Firing rules are routed to notification channels by the Alertmanager config in
+[`infra/observability/alertmanager.yaml`](../../infra/observability/alertmanager.yaml). Without
+this, the rules above would evaluate but page no one — the gap that let the #458 outage run
+silently (#462).
+
+| Aspect | Behaviour |
+|---|---|
+| Channels | **email + Slack** (`oncall` receiver), both with `send_resolved` |
+| What pages | `severity =~ "warning|critical"` |
+| What is held back | `severity = "info"` (e.g. `APINoRequests`) → `null` receiver, visible in the Alertmanager UI but no page |
+| De-duplication | a route-level `APIRouteHighErrorRate` critical inhibits the redundant aggregate `APIHighErrorRate` warning for the same incident |
+| Grouping | `by (alertname, http_route)` so distinct failing routes page separately |
+
+The email address, SMTP credentials, and Slack webhook URL are **secrets** — they are never
+committed. The file carries clearly-marked `.invalid` / `PLACEHOLDER` values; the real
+destinations live in the Grafana Cloud Alertmanager (apply/update procedure:
+[`docs/operations/slo.md`](../operations/slo.md#applying-alert-config-to-grafana-cloud)).
+Locally, `docker compose up` starts an Alertmanager at <http://localhost:9093> so the
+rule → route → receiver path is exercisable (delivery fails without real creds, which is
+expected).
 
 ### Creating a silence
 
@@ -218,3 +249,5 @@ documented in:
 - [Grafana Tempo — search and query](https://grafana.com/docs/tempo/latest/tracing/tempo-search/) — TraceQL reference and search UI guide
 - [Grafana Loki — log exploration](https://grafana.com/docs/loki/latest/visualize/grafana/) — LogQL syntax and Explore panel usage
 - [OpenTelemetry Collector — environment variable substitution](https://opentelemetry.io/docs/collector/configuration/#environment-variables) — how `${env:VAR}` syntax works in collector config
+- [Prometheus — Alertmanager configuration](https://prometheus.io/docs/alerting/latest/configuration/) — the routing tree, receivers, and inhibit-rule syntax used in `infra/observability/alertmanager.yaml`
+- [Prometheus — Alerting rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) — the `groups`/`rules` syntax used in `infra/observability/alerts/api.yaml`

--- a/infra/observability/alertmanager.yaml
+++ b/infra/observability/alertmanager.yaml
@@ -65,9 +65,12 @@ receivers:
 
 inhibit_rules:
   # When a route-level critical is firing, suppress the redundant aggregate
-  # warning for the same incident to cut duplicate pages.
+  # warning to cut duplicate pages. No `equal:` scoping label — both alerts are
+  # produced by aggregating expressions (`sum(...)` / `sum by (http_route)(...)`)
+  # that drop per-target labels like `job`, so there is no shared label to key
+  # on; the intent is simply "if the route critical is firing, hold the aggregate
+  # warning."
   - source_matchers:
       - alertname = "APIRouteHighErrorRate"
     target_matchers:
       - alertname = "APIHighErrorRate"
-    equal: ["job"]

--- a/infra/observability/alertmanager.yaml
+++ b/infra/observability/alertmanager.yaml
@@ -1,0 +1,73 @@
+# Alertmanager routing + notification config for the API alert rules in
+# `infra/observability/alerts/api.yaml`.
+#
+# Why this file exists (#462): the alert *rules* have existed since the
+# observability stack landed, but nothing routed them to a channel that reaches
+# an operator — they were dashboard/rule-only. The #458/#460 outage ran for four
+# days undetected because no alert paged. This config is the missing backstop:
+# it routes a sustained 5xx alert to email + Slack so a regression that appears
+# *between* deploys surfaces within minutes.
+#
+# SECRETS: the values marked PLACEHOLDER below are NOT real and are never the
+# source of truth in production. The production target is the Grafana Cloud
+# Alertmanager (Mimir), where the SMTP credentials and Slack webhook URL are
+# configured as secrets and never committed to git. Locally, this config lets
+# the routing path be exercised end-to-end (delivery will simply fail without a
+# reachable SMTP server / valid webhook, which is fine for verifying routing).
+# Apply / update procedure: docs/operations/slo.md → "Applying alert config to
+# Grafana Cloud". First-response meaning: docs/runbooks/api-5xx-surge.md.
+
+global:
+  resolve_timeout: 5m
+  # PLACEHOLDER — real SMTP host/identity live in Grafana Cloud Alertmanager.
+  smtp_from: "alerts@lifting-logbook.invalid"
+  smtp_smarthost: "smtp.example.invalid:587"
+  smtp_require_tls: true
+
+route:
+  # Group by route so a single failing endpoint pages on its own, distinct from
+  # an aggregate-wide error spike.
+  group_by: ["alertname", "http_route"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  receiver: oncall
+  routes:
+    # APINoRequests (severity=info) is known to fire spuriously outside business
+    # hours (see ADR-018 / observability runbook). Keep it out of the paging
+    # channel until the `for:`-grace fix lands; it remains visible in the
+    # Alertmanager UI.
+    - matchers:
+        - severity = "info"
+      receiver: "null"
+    # Sustained 5xx (per-route critical or aggregate warning) pages on-call.
+    - matchers:
+        - severity =~ "warning|critical"
+      receiver: oncall
+      continue: false
+
+receivers:
+  - name: "null"
+
+  - name: oncall
+    email_configs:
+      # PLACEHOLDER — replace with the on-call address in Grafana Cloud Alertmanager.
+      - to: "oncall@lifting-logbook.invalid"
+        send_resolved: true
+    slack_configs:
+      # PLACEHOLDER — the real webhook URL is a secret set in Grafana Cloud
+      # Alertmanager, never committed here.
+      - api_url: "https://hooks.slack.com/services/PLACEHOLDER/PLACEHOLDER/PLACEHOLDER"
+        channel: "#alerts"
+        send_resolved: true
+        title: '{{ if eq .Status "firing" }}🔥{{ else }}✅{{ end }} {{ .CommonAnnotations.summary }}'
+        text: "{{ range .Alerts }}{{ .Annotations.description }}\nRunbook: {{ .Annotations.runbook_url }}\n{{ end }}"
+
+inhibit_rules:
+  # When a route-level critical is firing, suppress the redundant aggregate
+  # warning for the same incident to cut duplicate pages.
+  - source_matchers:
+      - alertname = "APIRouteHighErrorRate"
+    target_matchers:
+      - alertname = "APIHighErrorRate"
+    equal: ["job"]

--- a/infra/observability/alerts/api.test.yaml
+++ b/infra/observability/alerts/api.test.yaml
@@ -1,0 +1,64 @@
+# promtool unit tests for infra/observability/alerts/api.yaml.
+# Run: promtool test rules infra/observability/alerts/api.test.yaml
+#
+# Locks the #462 outage-detection property: a single route failing at 100% while
+# the API-wide 5xx ratio stays well under 1% must trip APIRouteHighErrorRate
+# (critical) but NOT the aggregate APIHighErrorRate (warning). This is exactly
+# the #458/#460 shape — without the per-route rule it went undetected for days.
+
+rule_files:
+  - api.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # Scenario: GET /programs/:program/lifts returns 500 on every call (low volume),
+  # while a busy /dashboard route serves 200s at high volume. Aggregate 5xx ratio
+  # is ~0.1% (1 of ~1001/min); the broken route's ratio is 100%.
+  - interval: 1m
+    input_series:
+      # Broken endpoint — only 5xx, ~1 req/min.
+      - series: 'http_server_request_duration_seconds_count{http_route="/programs/:program/lifts", http_response_status_code="500"}'
+        values: "0+1x10"
+      # Healthy high-traffic endpoint — only 2xx, ~1000 req/min.
+      - series: 'http_server_request_duration_seconds_count{http_route="/dashboard", http_response_status_code="200"}'
+        values: "0+1000x10"
+    alert_rule_test:
+      # After 5m active, the per-route critical fires for the broken route.
+      - eval_time: 6m
+        alertname: APIRouteHighErrorRate
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              http_route: "/programs/:program/lifts"
+            exp_annotations:
+              summary: "Route /programs/:program/lifts 5xx rate > 5%"
+              description: "100% of requests to /programs/:program/lifts are returning 5xx over the last 5m"
+              runbook_url: "https://github.com/brownm09/lifting-logbook/blob/main/docs/runbooks/api-5xx-surge.md"
+      # The aggregate warning must NOT fire — overall 5xx ratio is ~0.1%, under 1%.
+      - eval_time: 6m
+        alertname: APIHighErrorRate
+        exp_alerts: []
+      # Traffic is flowing, so the no-requests alert must stay inactive.
+      - eval_time: 6m
+        alertname: APINoRequests
+        exp_alerts: []
+
+  # Scenario: broad degradation — many routes returning 5xx pushes the API-wide
+  # ratio over 1%, so the aggregate warning fires too.
+  - interval: 1m
+    input_series:
+      - series: 'http_server_request_duration_seconds_count{http_route="/dashboard", http_response_status_code="500"}'
+        values: "0+30x10"
+      - series: 'http_server_request_duration_seconds_count{http_route="/dashboard", http_response_status_code="200"}'
+        values: "0+1000x10"
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: APIHighErrorRate
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "API error rate > 1%"
+              description: "2.913% of requests are returning 5xx"
+              runbook_url: "https://github.com/brownm09/lifting-logbook/blob/main/docs/runbooks/api-5xx-surge.md"

--- a/infra/observability/alerts/api.yaml
+++ b/infra/observability/alerts/api.yaml
@@ -14,6 +14,25 @@ groups:
           description: "{{ $value | humanizePercentage }} of requests are returning 5xx"
           runbook_url: "https://github.com/brownm09/lifting-logbook/blob/main/docs/runbooks/api-5xx-surge.md"
 
+      # Per-route 5xx rate. The aggregate APIHighErrorRate above can stay under 1%
+      # when a single endpoint fails at 100% but carries only a small share of total
+      # traffic — precisely the #458/#460 outage shape (GET /programs/:program/lifts
+      # returned 500 on every call for four days, undetected). Grouping by route trips
+      # this alert as soon as any one route's 5xx ratio is sustained, regardless of how
+      # much traffic the rest of the API is taking.
+      - alert: APIRouteHighErrorRate
+        expr: |
+          sum by (http_route) (rate(http_server_request_duration_seconds_count{http_response_status_code=~"5.."}[5m]))
+          / sum by (http_route) (rate(http_server_request_duration_seconds_count[5m]))
+          > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Route {{ $labels.http_route }} 5xx rate > 5%"
+          description: "{{ $value | humanizePercentage }} of requests to {{ $labels.http_route }} are returning 5xx over the last 5m"
+          runbook_url: "https://github.com/brownm09/lifting-logbook/blob/main/docs/runbooks/api-5xx-surge.md"
+
       - alert: APIHighP95Latency
         expr: |
           histogram_quantile(

--- a/infra/observability/prometheus-local.yml
+++ b/infra/observability/prometheus-local.yml
@@ -1,6 +1,19 @@
 global:
   scrape_interval: 15s
 
+# Load the API alert rules locally so the alerting path can be exercised in the
+# local stack, not just in Grafana Cloud Mimir (#462). Previously these rules
+# existed but were never loaded here, so a developer could not see them evaluate.
+rule_files:
+  - /etc/prometheus/alerts/api.yaml
+
+# Route firing alerts to the local Alertmanager, which applies the routing tree
+# and notification config in infra/observability/alertmanager.yaml.
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
 scrape_configs:
   - job_name: otel-collector
     static_configs:


### PR DESCRIPTION
## Summary

Closes the prevention story of the #458/#460 production outage. That incident (`GET /programs/:program/lifts` returned HTTP 500 on every call for four days because the `custom_lift` table was missing) ran undetected because **no alert paged**. [PR #461](https://github.com/brownm09/lifting-logbook/pull/461) added the deploy-time guards (migrate-status pre-check + DB-backed `/readyz` post-deploy smoke), which prevent and surface this class *at deploy time* — but neither covers a regression that appears *between* deploys. This PR adds the runtime backstop.

Pairs the substantive #462 work with the cheap docs-only #463.

### #462 — runtime alerting that actually pages
- **`APIRouteHighErrorRate`** (severity `critical`) — per-route 5xx ratio grouped `by (http_route)`, `> 5%` for 5m. The existing aggregate `APIHighErrorRate` (`> 1%` API-wide) can stay below threshold when a single endpoint fails at 100% while carrying little traffic — **exactly the outage shape**, so it would not have fired. The per-route rule trips on any one route's sustained 5xx regardless of overall volume. (`infra/observability/alerts/api.yaml`)
- **`infra/observability/alertmanager.yaml`** (new) — the missing routing/notification layer. Routes `severity=~"warning|critical"` to **email + Slack**; holds `severity=info` (`APINoRequests`, known noisy) back from paging via a `null` receiver; inhibits the redundant aggregate warning when the per-route critical fires; groups `by (alertname, http_route)`.
- **Local path made real & verifiable** — `prometheus-local.yml` now loads the rules (`rule_files`, which it *never did before*) and points at a new `alertmanager` service in `docker-compose.yml`. `docker compose up` exercises rule → route → receiver end-to-end at `localhost:9093`.
- **Docs** — `api-5xx-surge.md` (new alert meaning + first response), `observability.md` (rule table + Notification routing section), `slo.md` (mimirtool apply procedure), README runbook descriptions, Alertmanager/alerting-rules primary-source citations.

### #463 — document prod deploy approval via gh
- `docs/deploy.md` → new **"Approving a production deploy"** subsection: the run-page "Review deployments" location + the `gh api .../pending_deployments` CLI command (production env id `15694632193`), cross-referenced from Step 6 and ADR-027.

## Secrets
No real destinations are committed. `alertmanager.yaml` carries clearly-marked `.invalid` / `PLACEHOLDER` values for the SMTP identity, on-call email, and Slack webhook; the real values live in the Grafana Cloud Alertmanager / Secret Manager. Documented in `slo.md` → "Applying alert config to Grafana Cloud".

## Acceptance criteria

**#462**
- [x] An alert exists that would have fired within minutes of #458 onset (sustained 5xx on a route) — `APIRouteHighErrorRate`, `for: 5m`.
- [x] The alert routes to a channel that reaches the operator (not dashboard-only) — Alertmanager `oncall` receiver → email + Slack.
- [x] Runbook updated with the alert's meaning + first response — `api-5xx-surge.md`.

**#463**
- [x] `docs/deploy.md` has an "Approving a production deploy" subsection with run-page location + `gh api pending_deployments`.
- [x] Cross-referenced from the deploy overview / ADR-027.

## Testing

Ran `npm test` (full monorepo suite) via the documented `TURBO_BINARY_PATH` worktree workaround.

`Tests: 591 passed, 0 skipped, 0 failed` — api-legacy 1, core 174, web 76, api 340 (incl. the Testcontainers Postgres DB E2E suite). Turbo: 12/12 test tasks successful.

**Config validation (the substance of this change):**
- `promtool check rules infra/observability/alerts/api.yaml` → SUCCESS, 4 rules.
- `amtool check-config infra/observability/alertmanager.yaml` → SUCCESS, 2 receivers, 1 inhibit rule.
- `promtool check config` on the full Prometheus config → SUCCESS, `rule_files` resolves.
- **Live run** (`docker compose up prometheus alertmanager`): Prometheus loaded all 4 rules (`APIRouteHighErrorRate` severity=critical), all evaluated `health=ok` with no `lastError`, and discovered the Alertmanager (`active: http://alertmanager:9093/...`, 0 dropped); Alertmanager `/-/ready` → 200.

This is a config + docs change touching **no application source** — "refactor/docs-only" tier; the suite is unaffected and confirms no regression.

## Risk-dimension audit
- **Testing** — config validated statically (promtool/amtool) + live (rules load/evaluate/route); app suite green.
- **Observability** — this *is* the observability improvement; closes the no-page gap.
- **Security** — no secrets committed; SMTP/email/Slack destinations are placeholders, real values via Secret Manager / Cloud Alertmanager.
- **Resilience** — `for:` windows tuned to fire within minutes; `info` held back + inhibit rule to cut duplicate/noisy pages; rollback = revert YAML.
- **Performance** — N/A (alerting config, no runtime hot path).
- **Data integrity & migrations** — N/A (no schema/data change).
- **Accessibility** — N/A (no UI).

## Pre-PR gates
- Suppression grep: clean. Test-integrity grep: clean. Deleted tests: none. `package.json` unchanged → lockfile gate N/A.

## ADR-warrant
Considered: this implements the already-decided ADR-019 alerting methodology and ADR-018 stack; no new ADR. Rationale captured in the config comments + runbook + `slo.md`; Alertmanager primary-source citation added to the observability runbook References. (Choice of email/Slack over PagerDuty follows the on-call-readiness proposal's explicit deferral.)

## Related
- #393 closed as superseded (the manual prod approval gate it asked for already exists at `deploy.yml:646` via the #417/#452 consolidation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review findings disposition

`/review` (claude-opus-4-8) surfaced 0 blocking, 3 non-blocking findings ([review comment](https://github.com/brownm09/lifting-logbook/pull/467#issuecomment-4661781400)):

1. **[maintainability]** No committed regression test for `APIRouteHighErrorRate` — **fixed in `b420dfd`** (commit `[infra] Address PR #467 review`): added `infra/observability/alerts/api.test.yaml`, a `promtool test rules` fixture asserting the outage shape (single route at 100% 5xx + low aggregate → per-route critical fires, aggregate warning does not) plus a broad-degradation case. `promtool test rules` → SUCCESS.
2. **[maintainability]** Alertmanager inhibit `equal: ["job"]` keyed on a label neither aggregated alert carries — **fixed in `b420dfd`**: dropped the `equal` key (it worked only by both-absent; misleading). `amtool check-config` → SUCCESS.
3. **[reliability]** Per-route rule sensitivity on idle/low-traffic routes + `http_route` label-shape verification need real production metrics to calibrate — **filed [#468](https://github.com/brownm09/lifting-logbook/issues/468)** (Observability epic, v0.3), consistent with ADR-019 deferring threshold tuning until sustained prod traffic.

No findings left as-is.

