### PR TITLE
[refactor] Consolidate web HTTP clients into packages/api-client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ Turborepo monorepo with npm workspaces:
 ```
 packages/core        — pure domain logic (no infrastructure dependencies)
 packages/types       — shared TypeScript interfaces and API contracts
+packages/api-client  — typed REST client with pluggable auth (shared by web server + browser)
 apps/api             — NestJS + Fastify (primary): REST + GraphQL
 apps/web             — Next.js App Router frontend
 apps/mobile          — React Native (Expo) mobile client

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,13 +97,22 @@ this wrong and requests 403 behind Cloud Run IAM.
 | **Server → API** (`lib/api.ts`, Server Components, route handlers) | `X-Clerk-Authorization` | Cloud Run IAM consumes `Authorization` for the GCP identity token, so the Clerk JWT needs a separate header that `apps/api` `auth.guard.ts` reads. |
 | **Browser → API** (`lib/client-api.ts`, Client Components) | `Authorization` | No Cloud Run IAM hop on the client path, so the standard header is free. |
 
+Both paths share **one** typed client — `createApiClient({ baseUrl, getAuthHeaders })` in
+[`packages/api-client`](packages/api-client) ([#466](https://github.com/brownm09/lifting-logbook/issues/466)).
+The endpoints and DTOs live there once; `lib/api.ts` and `lib/client-api.ts` are thin wrappers
+that differ only in the `getAuthHeaders` strategy above. The client merges those headers with
+**auth-wins precedence**, so a call site cannot override them.
+
 Rules:
 
 - **Never construct `Authorization` / `X-Clerk-Authorization` headers inline at a call site.**
-  Route server-side requests through `apiFetch` / `apiFetchNullable` and client-side requests
-  through `clientFetch`; both inherit the correct header strategy automatically.
-- The dual-header split is the single most error-prone thing in the web↔API boundary. It will
-  be lint-enforced once the HTTP clients are consolidated into `packages/api-client` ([#466](https://github.com/brownm09/lifting-logbook/issues/466)).
+  Import the endpoint functions from `@/lib/api` (server) or `@/lib/client-api` (browser); they
+  bind the shared client to the correct strategy automatically. Add a new endpoint to
+  `packages/api-client` and re-export it from the relevant wrapper — never call `fetch()` to the
+  API directly.
+- The dual-header split is the single most error-prone thing in the web↔API boundary. The
+  consolidation above is its structural mitigation; lint-enforcing "no direct `fetch()` to the
+  API" is tracked as flag 6 of the architecture review ([#464](https://github.com/brownm09/lifting-logbook/issues/464)).
 
 ## Claude Code sessions
 

--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -19,6 +19,7 @@ module.exports = {
     '\\.module\\.css$': 'identity-obj-proxy',
     '^@src/core$': '<rootDir>/../../packages/core/src/index.ts',
     '^@src/core/(.*)$': '<rootDir>/../../packages/core/src/$1',
+    '^@lifting-logbook/api-client$': '<rootDir>/../../packages/api-client/src/index.ts',
     '^@lifting-logbook/core$': '<rootDir>/../../packages/core/src/index.ts',
     '^@lifting-logbook/types$': '<rootDir>/../../packages/types/src/index.ts',
     '^@/(.*)$': '<rootDir>/$1',

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,47 +1,25 @@
 import 'server-only';
 
 import { auth } from '@clerk/nextjs/server';
+import { createApiClient } from '@lifting-logbook/api-client';
 import { getGcpIdentityToken } from './gcp-identity-token';
-import type {
-  BodyWeightResponse,
-  CreateCustomProgramRequest,
-  CreateLiftRecordRequest,
-  CustomProgramResponse,
-  CustomProgramSummaryResponse,
-  CycleDashboardResponse,
-  LiftMetadataResponse,
-  LiftingProgramSpecResponse,
-  LiftRecordResponse,
-  RecordBodyWeightRequest,
-  StrengthGoalResponse,
-  SwitchProgramResponse,
-  UpsertStrengthGoalRequest,
-  TrainingMaxHistoryResponse,
-  TrainingMaxResponse,
-  UpdateCustomProgramRequest,
-  UpdateLiftRecordRequest,
-  UpdateTrainingMaxesRequest,
-  UpdateUserSettingsRequest,
-  UserSettingsResponse,
-  WorkoutResponse,
-} from '@lifting-logbook/types';
 
 const API_URL = process.env.API_URL ?? 'http://localhost:3004';
 const isCloudRun = API_URL.startsWith('https://');
 
 // ---------------------------------------------------------------------------
-// AUTH HEADER INVARIANT — read before adding any server-side API call.
+// AUTH HEADER INVARIANT (server path) — read before changing this strategy.
 //
 // Server -> API requests cross Cloud Run IAM, which consumes the `Authorization`
 // header for the GCP identity token. The Clerk JWT therefore travels in the custom
 // `X-Clerk-Authorization` header (read by apps/api auth.guard.ts). Hand-building an
 // `Authorization: Bearer <clerk-jwt>` header on this path will 403 behind Cloud Run IAM.
 //
-// DO NOT construct auth headers inline at call sites. Route every server-side request
-// through apiFetch / apiFetchNullable so it inherits getAuthHeaders() below. The
-// browser path uses a DIFFERENT scheme (plain Authorization) — see lib/client-api.ts.
-// This split will be lint-enforced once packages/api-client lands (#466).
-// See CONTRIBUTING.md -> API auth headers.
+// This is the ONLY thing the server wrapper does differently from the browser one:
+// every endpoint lives in @lifting-logbook/api-client; this module just supplies the
+// strategy below. The client merges these headers with auth-wins precedence, so call
+// sites cannot override them. The browser path uses a DIFFERENT scheme (plain
+// Authorization) — see lib/client-api.ts. See CONTRIBUTING.md -> API auth headers.
 // ---------------------------------------------------------------------------
 async function getAuthHeaders(): Promise<Record<string, string>> {
   if (!isCloudRun) {
@@ -87,329 +65,35 @@ async function getAuthHeaders(): Promise<Record<string, string>> {
   return {};
 }
 
-// NestJS ValidationPipe returns { statusCode, message: string | string[], error }.
-// Surface that detail so client-side error UIs can show actionable text instead of just
-// "Request failed: 400".
-async function extractErrorMessage(res: Response, path: string): Promise<string> {
-  try {
-    const body = (await res.json()) as { message?: string | string[] };
-    if (Array.isArray(body.message)) return body.message.join('; ');
-    if (typeof body.message === 'string') return body.message;
-  } catch {
-    // fall through to generic
-  }
-  return `API ${res.status} ${res.statusText} for ${path}`;
-}
-
-async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
-  const authHeaders = await getAuthHeaders();
-  const res = await fetch(`${API_URL}${path}`, {
-    ...init,
-    headers: { ...(init?.headers as Record<string, string> | undefined), ...authHeaders },
-  });
-  if (!res.ok) {
-    throw new Error(await extractErrorMessage(res, path));
-  }
-  return res.json() as Promise<T>;
-}
-
-/** Like apiFetch but returns null on 404 instead of throwing. */
-async function apiFetchNullable<T>(path: string, init?: RequestInit): Promise<T | null> {
-  const authHeaders = await getAuthHeaders();
-  const res = await fetch(`${API_URL}${path}`, {
-    ...init,
-    headers: { ...(init?.headers as Record<string, string> | undefined), ...authHeaders },
-  });
-  if (res.status === 404) return null;
-  if (!res.ok) throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
-  return res.json() as Promise<T>;
-}
-
-export function fetchCycleDashboard(
-  program: string,
-): Promise<CycleDashboardResponse | null> {
-  return apiFetchNullable(
-    `/programs/${encodeURIComponent(program)}/cycles/current`,
-    { cache: 'no-store' },
-  );
-}
-
-export function createCycle(programId: string): Promise<CycleDashboardResponse> {
-  return apiFetch(`/programs/${encodeURIComponent(programId)}/cycles`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({}),
-  });
-}
-
-export function initializeCycle(
-  programId: string,
-  options: { cycleDate?: string } = {},
-): Promise<CycleDashboardResponse> {
-  return apiFetch(`/programs/${encodeURIComponent(programId)}/cycles/initialize`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(options),
-  });
-}
-
-export function fetchProgramSpec(
-  program: string,
-): Promise<LiftingProgramSpecResponse[]> {
-  return apiFetch(`/programs/${encodeURIComponent(program)}/spec`, {
-    next: { revalidate: 3600 },
-  } as RequestInit);
-}
-
-export function fetchTrainingMaxes(
-  program: string,
-): Promise<TrainingMaxResponse[]> {
-  return apiFetch(
-    `/programs/${encodeURIComponent(program)}/training-maxes`,
-    { cache: 'no-store' },
-  );
-}
-
-export function fetchTrainingMaxHistory(
-  program: string,
-): Promise<TrainingMaxHistoryResponse> {
-  return apiFetch(
-    `/programs/${encodeURIComponent(program)}/training-maxes/history`,
-    { cache: 'no-store' },
-  );
-}
-
-export function updateTrainingMaxHistoryEntry(
-  program: string,
-  id: string,
-  body: { isPR?: boolean; goalMet?: boolean },
-): Promise<TrainingMaxHistoryResponse['entries'][number]> {
-  return apiFetch(
-    `/programs/${encodeURIComponent(program)}/training-maxes/history/${encodeURIComponent(id)}`,
-    {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      cache: 'no-store',
-    },
-  );
-}
-
-export function updateTrainingMaxes(
-  program: string,
-  body: UpdateTrainingMaxesRequest,
-): Promise<TrainingMaxResponse[]> {
-  return apiFetch(
-    `/programs/${encodeURIComponent(program)}/training-maxes`,
-    {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      cache: 'no-store',
-    } as RequestInit,
-  );
-}
-
-export function fetchWorkout(
-  program: string,
-  workoutNum: number,
-): Promise<WorkoutResponse | null> {
-  return apiFetchNullable(
-    `/programs/${encodeURIComponent(program)}/workouts/${workoutNum}`,
-    { cache: 'no-store' },
-  );
-}
-
-export function fetchLiftRecords(
-  program: string,
-): Promise<LiftRecordResponse[]> {
-  return apiFetch(
-    `/programs/${encodeURIComponent(program)}/lift-records`,
-    { cache: 'no-store' },
-  );
-}
-
-export function createLiftRecord(
-  program: string,
-  body: CreateLiftRecordRequest,
-): Promise<LiftRecordResponse> {
-  return apiFetch(
-    `/programs/${encodeURIComponent(program)}/lift-records`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      cache: 'no-store',
-    },
-  );
-}
-
-export function updateLiftRecord(
-  program: string,
-  id: string,
-  body: UpdateLiftRecordRequest,
-): Promise<LiftRecordResponse> {
-  return apiFetch(
-    `/programs/${encodeURIComponent(program)}/lift-records/${encodeURIComponent(id)}`,
-    {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      cache: 'no-store',
-    },
-  );
-}
-
-export function recordBodyWeight(
-  program: string,
-  body: RecordBodyWeightRequest,
-): Promise<void> {
-  return apiFetch(
-    `/programs/${encodeURIComponent(program)}/body-weight`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      cache: 'no-store',
-    },
-  );
-}
-
-export function fetchLatestBodyWeight(
-  program: string,
-): Promise<BodyWeightResponse | null> {
-  return apiFetchNullable(
-    `/programs/${encodeURIComponent(program)}/body-weight/latest`,
-    { cache: 'no-store' },
-  );
-}
-
-export async function fetchStrengthGoals(
-  program: string,
-): Promise<StrengthGoalResponse[]> {
-  const path = `/programs/${encodeURIComponent(program)}/strength-goals`;
-  const authHeaders = await getAuthHeaders();
-  const res = await fetch(`${API_URL}${path}`, {
-    cache: 'no-store',
-    headers: authHeaders,
-  });
-  if (!res.ok) throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
-  return res.json() as Promise<StrengthGoalResponse[]>;
-}
-
-export async function upsertStrengthGoal(
-  program: string,
-  lift: string,
-  body: UpsertStrengthGoalRequest,
-): Promise<StrengthGoalResponse> {
-  const path = `/programs/${encodeURIComponent(program)}/strength-goals/${encodeURIComponent(lift)}`;
-  const authHeaders = await getAuthHeaders();
-  const res = await fetch(`${API_URL}${path}`, {
-    method: 'PUT',
-    cache: 'no-store',
-    headers: { 'Content-Type': 'application/json', ...authHeaders },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
-  return res.json() as Promise<StrengthGoalResponse>;
-}
-
-export async function deleteStrengthGoal(
-  program: string,
-  lift: string,
-): Promise<void> {
-  const path = `/programs/${encodeURIComponent(program)}/strength-goals/${encodeURIComponent(lift)}`;
-  const authHeaders = await getAuthHeaders();
-  const res = await fetch(`${API_URL}${path}`, {
-    method: 'DELETE',
-    cache: 'no-store',
-    headers: authHeaders,
-  });
-  // 404 is treated as success: the goal is already absent, which is the desired end state.
-  if (!res.ok && res.status !== 404) {
-    throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
-  }
-}
-
-export async function fetchLiftCatalog(program: string): Promise<string[]> {
-  const path = `/programs/${encodeURIComponent(program)}/lifts`;
-  const authHeaders = await getAuthHeaders();
-  const res = await fetch(`${API_URL}${path}`, { cache: 'no-store', headers: authHeaders });
-  if (!res.ok) throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
-  return res.json() as Promise<string[]>;
-}
-
-export function fetchLiftMetadata(lift: string): Promise<LiftMetadataResponse> {
-  return apiFetch<LiftMetadataResponse>(
-    `/lifts/${encodeURIComponent(lift)}/metadata`,
-    { cache: 'no-store' },
-  );
-}
-
-export function fetchUserSettings(): Promise<UserSettingsResponse> {
-  return apiFetch<UserSettingsResponse>('/users/me/settings', { cache: 'no-store' });
-}
-
-export function updateUserSettings(
-  body: UpdateUserSettingsRequest,
-): Promise<UserSettingsResponse> {
-  return apiFetch<UserSettingsResponse>('/users/me/settings', {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-    cache: 'no-store',
-  });
-}
-
-export function switchProgram(programId: string): Promise<SwitchProgramResponse> {
-  return apiFetch<SwitchProgramResponse>(
-    `/programs/${encodeURIComponent(programId)}/switch`,
-    { method: 'POST', headers: { 'Content-Type': 'application/json' }, cache: 'no-store' },
-  );
-}
-
-export function fetchCustomPrograms(): Promise<CustomProgramSummaryResponse[]> {
-  return apiFetch<CustomProgramSummaryResponse[]>('/programs/custom', { cache: 'no-store' });
-}
-
-export function fetchCustomProgram(id: string): Promise<CustomProgramResponse> {
-  return apiFetch<CustomProgramResponse>(
-    `/programs/custom/${encodeURIComponent(id)}`,
-    { cache: 'no-store' },
-  );
-}
-
-export function createCustomProgram(body: CreateCustomProgramRequest): Promise<CustomProgramResponse> {
-  return apiFetch<CustomProgramResponse>('/programs/custom', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-    cache: 'no-store',
-  });
-}
-
-export function updateCustomProgram(
-  id: string,
-  body: UpdateCustomProgramRequest,
-): Promise<CustomProgramResponse> {
-  return apiFetch<CustomProgramResponse>(`/programs/custom/${encodeURIComponent(id)}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-    cache: 'no-store',
-  });
-}
-
-export async function deleteCustomProgram(id: string): Promise<void> {
-  const authHeaders = await getAuthHeaders();
-  const path = `/programs/custom/${encodeURIComponent(id)}`;
-  const res = await fetch(`${API_URL}${path}`, {
-    method: 'DELETE',
-    headers: authHeaders,
-    cache: 'no-store',
-  });
-  if (!res.ok && res.status !== 404) {
-    throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
-  }
-}
-
+// Endpoints are defined once in @lifting-logbook/api-client. This module is a thin
+// wrapper that binds them to the server auth strategy above and re-exports the
+// subset used by Server Components / Server Actions.
+export const {
+  fetchCycleDashboard,
+  createCycle,
+  initializeCycle,
+  fetchProgramSpec,
+  fetchTrainingMaxes,
+  fetchTrainingMaxHistory,
+  updateTrainingMaxHistoryEntry,
+  updateTrainingMaxes,
+  fetchWorkout,
+  fetchLiftRecords,
+  createLiftRecord,
+  updateLiftRecord,
+  recordBodyWeight,
+  fetchLatestBodyWeight,
+  fetchStrengthGoals,
+  upsertStrengthGoal,
+  deleteStrengthGoal,
+  fetchLiftCatalog,
+  fetchLiftMetadata,
+  fetchUserSettings,
+  updateUserSettings,
+  switchProgram,
+  fetchCustomPrograms,
+  fetchCustomProgram,
+  createCustomProgram,
+  updateCustomProgram,
+  deleteCustomProgram,
+} = createApiClient({ baseUrl: API_URL, getAuthHeaders });

--- a/apps/web/lib/client-api.ts
+++ b/apps/web/lib/client-api.ts
@@ -1,21 +1,7 @@
 // Write operations called directly from the browser (Client Components).
 // Auth token is provided by ClerkApiInitializer via setAuthTokenGetter.
 
-import type {
-  CreateLiftOverrideRequest,
-  ImportCommitResponse,
-  ImportError,
-  ImportKind,
-  ImportLiftRecordsResponse,
-  ImportPreviewResponse,
-  LiftMetadataResponse,
-  LiftOverrideResponse,
-  CreateLiftRecordRequest,
-  LiftRecordResponse,
-  PatchLiftMetadataRequest,
-  RecordBodyWeightRequest,
-  UpdateLiftRecordRequest,
-} from '@lifting-logbook/types';
+import { createApiClient } from '@lifting-logbook/api-client';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3004';
 const isCloudRun = API_URL.startsWith('https://');
@@ -28,11 +14,16 @@ export function setAuthTokenGetter(fn: TokenGetter): void {
   _getToken = fn;
 }
 
-// AUTH HEADER INVARIANT — browser -> API calls send the Clerk JWT in `Authorization`
-// (there is no Cloud Run IAM hop on the client path, so no header collision). Do NOT
-// hand-build auth headers at call sites; route every client mutation through clientFetch
-// so it inherits getClientAuthHeaders(). The SERVER path uses a different header
-// (X-Clerk-Authorization) — see lib/api.ts. See CONTRIBUTING.md -> API auth headers.
+// ---------------------------------------------------------------------------
+// AUTH HEADER INVARIANT (browser path) — read before changing this strategy.
+//
+// Browser -> API calls send the Clerk JWT in `Authorization` (there is no Cloud Run
+// IAM hop on the client path, so no header collision). This is the ONLY thing the
+// browser wrapper does differently from the server one: every endpoint lives in
+// @lifting-logbook/api-client; this module just supplies the strategy below. The
+// SERVER path uses a different header (X-Clerk-Authorization) — see lib/api.ts.
+// See CONTRIBUTING.md -> API auth headers.
+// ---------------------------------------------------------------------------
 async function getClientAuthHeaders(): Promise<Record<string, string>> {
   if (devToken) return { Authorization: `Bearer ${devToken}` };
   if (_getToken) {
@@ -42,239 +33,20 @@ async function getClientAuthHeaders(): Promise<Record<string, string>> {
   return {};
 }
 
-async function clientFetch<T>(path: string, init?: RequestInit): Promise<T> {
-  const authHeaders = await getClientAuthHeaders();
-  const res = await fetch(`${API_URL}${path}`, {
-    ...init,
-    headers: { ...authHeaders, ...(init?.headers as Record<string, string> | undefined) },
-  });
-  if (!res.ok) {
-    throw new Error(`API ${res.status} ${res.statusText} for ${path}`);
-  }
-  if (res.status === 204) return undefined as T;
-  return res.json() as Promise<T>;
-}
-
-export function createLiftRecord(
-  program: string,
-  body: CreateLiftRecordRequest,
-): Promise<LiftRecordResponse> {
-  return clientFetch(
-    `/programs/${encodeURIComponent(program)}/lift-records`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      cache: 'no-store',
-    },
-  );
-}
-
-export function updateLiftRecord(
-  program: string,
-  id: string,
-  body: UpdateLiftRecordRequest,
-): Promise<LiftRecordResponse> {
-  return clientFetch(
-    `/programs/${encodeURIComponent(program)}/lift-records/${encodeURIComponent(id)}`,
-    {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      cache: 'no-store',
-    },
-  );
-}
-
-export function rescheduleWorkout(
-  program: string,
-  cycleNum: number,
-  workoutNum: number,
-  newDate: string,
-): Promise<void> {
-  return clientFetch<void>(
-    `/programs/${encodeURIComponent(program)}/cycles/${cycleNum}/workouts/${workoutNum}/reschedule`,
-    {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ newDate }),
-      cache: 'no-store',
-    },
-  );
-}
-
-export function skipWorkout(
-  program: string,
-  cycleNum: number,
-  workoutNum: number,
-  reason?: string,
-): Promise<void> {
-  return clientFetch<void>(
-    `/programs/${encodeURIComponent(program)}/cycles/${cycleNum}/workouts/${workoutNum}/skip`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(reason !== undefined ? { reason } : {}),
-      cache: 'no-store',
-    },
-  );
-}
-
-export function unskipWorkout(
-  program: string,
-  cycleNum: number,
-  workoutNum: number,
-): Promise<void> {
-  return clientFetch<void>(
-    `/programs/${encodeURIComponent(program)}/cycles/${cycleNum}/workouts/${workoutNum}/skip`,
-    { method: 'DELETE', cache: 'no-store' },
-  );
-}
-
-export function recordBodyWeight(
-  program: string,
-  body: RecordBodyWeightRequest,
-): Promise<void> {
-  return clientFetch(
-    `/programs/${encodeURIComponent(program)}/body-weight`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      cache: 'no-store',
-    },
-  );
-}
-
-export function upsertLiftOverride(
-  program: string,
-  cycleNum: number,
-  workoutNum: number,
-  body: CreateLiftOverrideRequest,
-): Promise<LiftOverrideResponse> {
-  return clientFetch(
-    `/programs/${encodeURIComponent(program)}/cycles/${cycleNum}/workouts/${workoutNum}/lift-overrides`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      cache: 'no-store',
-    },
-  );
-}
-
-export function patchLiftMetadata(
-  lift: string,
-  body: PatchLiftMetadataRequest,
-): Promise<LiftMetadataResponse> {
-  return clientFetch<LiftMetadataResponse>(
-    `/lifts/${encodeURIComponent(lift)}/metadata`,
-    {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-      cache: 'no-store',
-    },
-  );
-}
-
-export function deleteLiftOverride(
-  program: string,
-  cycleNum: number,
-  workoutNum: number,
-  lift: string,
-): Promise<void> {
-  return clientFetch<void>(
-    `/programs/${encodeURIComponent(program)}/cycles/${cycleNum}/workouts/${workoutNum}/lift-overrides/${encodeURIComponent(lift)}`,
-    { method: 'DELETE', cache: 'no-store' },
-  );
-}
-
-/**
- * Uploads a CSV file to the lift records import endpoint.
- * Returns a discriminated union so callers can handle validation errors gracefully
- * without catching exceptions.
- */
-export async function importLiftRecords(
-  program: string,
-  file: File,
-): Promise<
-  { ok: true; data: ImportLiftRecordsResponse } | { ok: false; errors: ImportError[] }
-> {
-  const authHeaders = await getClientAuthHeaders();
-  const form = new FormData();
-  form.append('file', file);
-  const res = await fetch(
-    `${API_URL}/programs/${encodeURIComponent(program)}/lift-records/import`,
-    { method: 'POST', body: form, headers: authHeaders, cache: 'no-store' },
-  );
-  if (res.status === 201) {
-    return { ok: true, data: (await res.json()) as ImportLiftRecordsResponse };
-  }
-  const body = (await res.json()) as { errors?: ImportError[] };
-  return {
-    ok: false,
-    errors: body.errors ?? [{ row: 0, message: `Unexpected error (HTTP ${res.status})` }],
-  };
-}
-
-function importUrl(program: string, mode: 'preview' | 'commit', destination?: ImportKind): string {
-  const params = new URLSearchParams({ mode });
-  if (destination) params.set('destination', destination);
-  return `${API_URL}/programs/${encodeURIComponent(program)}/import?${params.toString()}`;
-}
-
-/**
- * Smart Import — classify + preview a CSV without writing (#477). Pass a
- * `destination` to override the classifier (e.g. after a low-confidence pick).
- */
-export async function previewImport(
-  program: string,
-  file: File,
-  destination?: ImportKind,
-): Promise<ImportPreviewResponse> {
-  const authHeaders = await getClientAuthHeaders();
-  const form = new FormData();
-  form.append('file', file);
-  const res = await fetch(importUrl(program, 'preview', destination), {
-    method: 'POST',
-    body: form,
-    headers: authHeaders,
-    cache: 'no-store',
-  });
-  if (!res.ok) {
-    throw new Error(`Import preview failed (HTTP ${res.status})`);
-  }
-  return (await res.json()) as ImportPreviewResponse;
-}
-
-/**
- * Smart Import — commit a CSV to the chosen destination. The server re-parses the
- * file (never trusting any client payload) and writes idempotently. Returns a
- * discriminated union so callers handle validation errors without catching.
- */
-export async function commitImport(
-  program: string,
-  file: File,
-  destination: ImportKind,
-): Promise<
-  { ok: true; data: ImportCommitResponse } | { ok: false; errors: ImportError[] }
-> {
-  const authHeaders = await getClientAuthHeaders();
-  const form = new FormData();
-  form.append('file', file);
-  const res = await fetch(importUrl(program, 'commit', destination), {
-    method: 'POST',
-    body: form,
-    headers: authHeaders,
-    cache: 'no-store',
-  });
-  if (res.ok) {
-    return { ok: true, data: (await res.json()) as ImportCommitResponse };
-  }
-  const body = (await res.json().catch(() => ({}))) as { errors?: ImportError[] };
-  return {
-    ok: false,
-    errors: body.errors ?? [{ row: 0, message: `Unexpected error (HTTP ${res.status})` }],
-  };
-}
+// Endpoints are defined once in @lifting-logbook/api-client. This module is a thin
+// wrapper that binds them to the browser auth strategy above and re-exports the
+// subset of write operations invoked from Client Components.
+export const {
+  createLiftRecord,
+  updateLiftRecord,
+  rescheduleWorkout,
+  skipWorkout,
+  unskipWorkout,
+  recordBodyWeight,
+  upsertLiftOverride,
+  patchLiftMetadata,
+  deleteLiftOverride,
+  importLiftRecords,
+  previewImport,
+  commitImport,
+} = createApiClient({ baseUrl: API_URL, getAuthHeaders: getClientAuthHeaders });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.12.0",
+    "@lifting-logbook/api-client": "*",
     "@lifting-logbook/core": "*",
     "@lifting-logbook/types": "*",
     "@vercel/otel": "^1.0.0",

--- a/docs/diagrams/package-dependencies.md
+++ b/docs/diagrams/package-dependencies.md
@@ -9,6 +9,7 @@ graph TB
     subgraph packages["packages/"]
         Core["packages/core\npure domain logic\n(services · models · parsers)"]
         Types["packages/types\nshared TypeScript interfaces\n& API contracts"]
+        ApiClient["packages/api-client\ntyped REST client\n(pluggable auth strategy)"]
     end
 
     subgraph apps["apps/"]
@@ -19,11 +20,15 @@ graph TB
 
     API --> Core
     API --> Types
+    ApiClient --> Types
     Web --> Types
+    Web --> ApiClient
     Mobile --> Types
 ```
 
 `apps/web` and `apps/mobile` depend on `packages/types` for shared API contracts
 (request/response shapes) but not on `packages/core` — domain logic runs server-side only.
+`packages/api-client` is the single typed REST client shared by the web server and browser
+code (and, in future, mobile); each consumer supplies only the auth-header strategy.
 
 **See also:** [ADR-001: Monorepo Structure with Turborepo](../adr/ADR-001-monorepo-structure.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -326,6 +326,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@clerk/nextjs": "^6.12.0",
+        "@lifting-logbook/api-client": "*",
         "@lifting-logbook/core": "*",
         "@lifting-logbook/types": "*",
         "@vercel/otel": "^1.0.0",
@@ -5934,6 +5935,10 @@
     },
     "node_modules/@lifting-logbook/api": {
       "resolved": "apps/api",
+      "link": true
+    },
+    "node_modules/@lifting-logbook/api-client": {
+      "resolved": "packages/api-client",
       "link": true
     },
     "node_modules/@lifting-logbook/core": {
@@ -21002,6 +21007,13 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "packages/api-client": {
+      "name": "@lifting-logbook/api-client",
+      "version": "0.0.0",
+      "dependencies": {
+        "@lifting-logbook/types": "*"
       }
     },
     "packages/core": {

--- a/packages/api-client/jest.config.js
+++ b/packages/api-client/jest.config.js
@@ -1,0 +1,7 @@
+const base = require('../../jest.config.base.js');
+module.exports = {
+  ...base,
+  moduleNameMapper: {
+    '^@lifting-logbook/types$': '<rootDir>/../types/src/index.ts',
+  },
+};

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@lifting-logbook/api-client",
+  "version": "0.0.0",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "lint": "eslint src",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@lifting-logbook/types": "*"
+  }
+}

--- a/packages/api-client/src/index.test.ts
+++ b/packages/api-client/src/index.test.ts
@@ -1,0 +1,246 @@
+import { createApiClient } from './index';
+
+const AUTH = { Authorization: 'Bearer identity', 'X-Clerk-Authorization': 'Bearer clerk' };
+
+const mockFetch = jest.fn<Promise<Response>, [string, RequestInit?]>();
+
+function makeClient() {
+  return createApiClient({
+    baseUrl: 'http://api.test',
+    getAuthHeaders: async () => ({ ...AUTH }),
+  });
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  global.fetch = mockFetch as unknown as typeof fetch;
+});
+
+function lastCall(): [string, RequestInit] {
+  const calls = mockFetch.mock.calls;
+  const call = calls[calls.length - 1];
+  if (!call) throw new Error('fetch was not called');
+  return [call[0], call[1] ?? {}];
+}
+
+describe('createApiClient', () => {
+  describe('request plumbing', () => {
+    it('prefixes baseUrl and merges auth headers with a call-site header (auth-wins)', async () => {
+      mockFetch.mockResolvedValue(new Response(null, { status: 204 }));
+      const client = makeClient();
+      await client.rescheduleWorkout('5-3-1', 1, 2, '2026-07-01');
+
+      const [url, init] = lastCall();
+      expect(url).toBe('http://api.test/programs/5-3-1/cycles/1/workouts/2/reschedule');
+      expect(init.method).toBe('PATCH');
+      // Content-Type from the call site coexists with both injected auth headers.
+      expect(init.headers).toEqual({
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer identity',
+        'X-Clerk-Authorization': 'Bearer clerk',
+      });
+    });
+
+    it('auth headers override a colliding call-site Authorization header', async () => {
+      mockFetch.mockResolvedValue(new Response(JSON.stringify([]), { status: 200 }));
+      // A strategy that returns Authorization must win over anything a method set.
+      const client = createApiClient({
+        baseUrl: 'http://api.test',
+        getAuthHeaders: async () => ({ Authorization: 'Bearer WINS' }),
+      });
+      await client.fetchTrainingMaxes('5-3-1');
+      const [, init] = lastCall();
+      expect((init.headers as Record<string, string>).Authorization).toBe('Bearer WINS');
+    });
+
+    it('encodes path segments', async () => {
+      mockFetch.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = makeClient();
+      await client.fetchLiftMetadata('Front Squat/Variant');
+      const [url] = lastCall();
+      expect(url).toBe('http://api.test/lifts/Front%20Squat%2FVariant/metadata');
+    });
+
+    it('forwards the Next.js revalidate directive for cacheable reads', async () => {
+      mockFetch.mockResolvedValue(new Response(JSON.stringify([]), { status: 200 }));
+      const client = makeClient();
+      await client.fetchProgramSpec('5-3-1');
+      const [, init] = lastCall();
+      expect((init as { next?: { revalidate?: number } }).next).toEqual({ revalidate: 3600 });
+    });
+
+    it('throws the joined NestJS validation message on a 400', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ message: ['too short', 'must be a number'] }), {
+          status: 400,
+        }),
+      );
+      const client = makeClient();
+      await expect(client.fetchTrainingMaxes('5-3-1')).rejects.toThrow(
+        'too short; must be a number',
+      );
+    });
+
+    it('falls back to a generic message when the error body has no message field', async () => {
+      mockFetch.mockResolvedValue(new Response('not json', { status: 500, statusText: 'Boom' }));
+      const client = makeClient();
+      await expect(client.fetchTrainingMaxes('5-3-1')).rejects.toThrow(
+        'API 500 Boom for /programs/5-3-1/training-maxes',
+      );
+    });
+
+    it('returns undefined for a 204 No Content response', async () => {
+      mockFetch.mockResolvedValue(new Response(null, { status: 204 }));
+      const client = makeClient();
+      await expect(client.unskipWorkout('5-3-1', 1, 2)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('nullable reads', () => {
+    it('returns null on 404 instead of throwing', async () => {
+      mockFetch.mockResolvedValue(new Response('', { status: 404 }));
+      const client = makeClient();
+      await expect(client.fetchCycleDashboard('5-3-1')).resolves.toBeNull();
+    });
+
+    it('returns the parsed body on 200', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ program: '5-3-1', cycleNum: 3 }), { status: 200 }),
+      );
+      const client = makeClient();
+      await expect(client.fetchCycleDashboard('5-3-1')).resolves.toEqual({
+        program: '5-3-1',
+        cycleNum: 3,
+      });
+    });
+
+    it('throws on a non-404 error', async () => {
+      mockFetch.mockResolvedValue(new Response(JSON.stringify({ message: 'boom' }), { status: 500 }));
+      const client = makeClient();
+      await expect(client.fetchWorkout('5-3-1', 1)).rejects.toThrow('boom');
+    });
+  });
+
+  describe('idempotent deletes', () => {
+    it('resolves when the resource is already absent (404)', async () => {
+      mockFetch.mockResolvedValue(new Response('', { status: 404 }));
+      const client = makeClient();
+      await expect(client.deleteStrengthGoal('5-3-1', 'Squat')).resolves.toBeUndefined();
+    });
+
+    it('throws on a non-404 failure', async () => {
+      mockFetch.mockResolvedValue(new Response(JSON.stringify({ message: 'denied' }), { status: 403 }));
+      const client = makeClient();
+      await expect(client.deleteCustomProgram('p1')).rejects.toThrow('denied');
+    });
+  });
+
+  describe('importLiftRecords', () => {
+    const file = new File(['a,b\n1,2'], 'records.csv', { type: 'text/csv' });
+
+    it('returns ok:true with data on 201', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ imported: 2 }), { status: 201 }),
+      );
+      const client = makeClient();
+      const result = await client.importLiftRecords('5-3-1', file);
+      expect(result).toEqual({ ok: true, data: { imported: 2 } });
+      // FormData body must not carry a manual Content-Type (boundary is auto-set).
+      const [, init] = lastCall();
+      expect((init.headers as Record<string, string>)['Content-Type']).toBeUndefined();
+    });
+
+    it('returns ok:false with the server-reported row errors', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ errors: [{ row: 3, message: 'bad weight' }] }), {
+          status: 400,
+        }),
+      );
+      const client = makeClient();
+      const result = await client.importLiftRecords('5-3-1', file);
+      expect(result).toEqual({ ok: false, errors: [{ row: 3, message: 'bad weight' }] });
+    });
+
+    it('synthesizes a fallback error when the body omits errors', async () => {
+      mockFetch.mockResolvedValue(new Response(JSON.stringify({}), { status: 500 }));
+      const client = makeClient();
+      const result = await client.importLiftRecords('5-3-1', file);
+      expect(result).toEqual({
+        ok: false,
+        errors: [{ row: 0, message: 'Unexpected error (HTTP 500)' }],
+      });
+    });
+  });
+
+  describe('smart import (previewImport / commitImport)', () => {
+    const file = new File(['a,b\n1,2'], 'records.csv', { type: 'text/csv' });
+
+    it('previewImport POSTs to mode=preview and returns the parsed preview', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({ classification: {}, destination: 'training-maxes', preview: {}, errors: [] }),
+          { status: 200 },
+        ),
+      );
+      const client = makeClient();
+      const result = await client.previewImport('5-3-1', file);
+      const [url, init] = lastCall();
+      expect(url).toBe('http://api.test/programs/5-3-1/import?mode=preview');
+      expect(init.method).toBe('POST');
+      // FormData body must not carry a manual Content-Type.
+      expect((init.headers as Record<string, string>)['Content-Type']).toBeUndefined();
+      expect(result).toMatchObject({ destination: 'training-maxes' });
+    });
+
+    it('previewImport appends the destination override when supplied', async () => {
+      mockFetch.mockResolvedValue(new Response(JSON.stringify({ errors: [] }), { status: 200 }));
+      const client = makeClient();
+      await client.previewImport('5-3-1', file, 'strength-goals');
+      const [url] = lastCall();
+      expect(url).toBe('http://api.test/programs/5-3-1/import?mode=preview&destination=strength-goals');
+    });
+
+    it('previewImport throws on a non-ok response', async () => {
+      mockFetch.mockResolvedValue(new Response('', { status: 500 }));
+      const client = makeClient();
+      await expect(client.previewImport('5-3-1', file)).rejects.toThrow(
+        'Import preview failed (HTTP 500)',
+      );
+    });
+
+    it('commitImport returns ok:true with data on success', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ destination: 'training-maxes', created: 2, updated: 1, skipped: 0 }), {
+          status: 200,
+        }),
+      );
+      const client = makeClient();
+      const result = await client.commitImport('5-3-1', file, 'training-maxes');
+      const [url] = lastCall();
+      expect(url).toBe('http://api.test/programs/5-3-1/import?mode=commit&destination=training-maxes');
+      expect(result).toEqual({
+        ok: true,
+        data: { destination: 'training-maxes', created: 2, updated: 1, skipped: 0 },
+      });
+    });
+
+    it('commitImport returns ok:false with row errors on validation failure', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ errors: [{ row: 5, message: 'bad row' }] }), { status: 400 }),
+      );
+      const client = makeClient();
+      const result = await client.commitImport('5-3-1', file, 'lift-records');
+      expect(result).toEqual({ ok: false, errors: [{ row: 5, message: 'bad row' }] });
+    });
+
+    it('commitImport synthesizes a fallback error when the body is unparseable', async () => {
+      mockFetch.mockResolvedValue(new Response('not json', { status: 500 }));
+      const client = makeClient();
+      const result = await client.commitImport('5-3-1', file, 'lift-records');
+      expect(result).toEqual({
+        ok: false,
+        errors: [{ row: 0, message: 'Unexpected error (HTTP 500)' }],
+      });
+    });
+  });
+});

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,0 +1,471 @@
+import type {
+  BodyWeightResponse,
+  CreateCustomProgramRequest,
+  CreateLiftOverrideRequest,
+  CreateLiftRecordRequest,
+  CustomProgramResponse,
+  CustomProgramSummaryResponse,
+  CycleDashboardResponse,
+  ImportCommitResponse,
+  ImportError,
+  ImportKind,
+  ImportLiftRecordsResponse,
+  ImportPreviewResponse,
+  LiftMetadataResponse,
+  LiftOverrideResponse,
+  LiftingProgramSpecResponse,
+  LiftRecordResponse,
+  PatchLiftMetadataRequest,
+  RecordBodyWeightRequest,
+  StrengthGoalResponse,
+  SwitchProgramResponse,
+  TrainingMaxHistoryResponse,
+  TrainingMaxResponse,
+  UpdateCustomProgramRequest,
+  UpdateLiftRecordRequest,
+  UpdateTrainingMaxesRequest,
+  UpdateUserSettingsRequest,
+  UpsertStrengthGoalRequest,
+  UserSettingsResponse,
+  WorkoutResponse,
+} from '@lifting-logbook/types';
+
+// ---------------------------------------------------------------------------
+// @lifting-logbook/api-client
+//
+// One typed HTTP client for the lifting-logbook REST API, shared by the web
+// app's server and browser code (and, later, mobile). The ONLY axis on which
+// consumers differ is the auth-header strategy, so that is the one thing a
+// consumer supplies — see ApiClientConfig.getAuthHeaders. Everything else
+// (endpoints, DTOs, error handling, cache semantics) lives here so there is a
+// single source of truth and no call site can build a request the wrong way.
+//
+// Consolidates apps/web/lib/api.ts (server) and lib/client-api.ts (browser).
+// See issue #466 / flag 3 of the 2026-06-08 architecture review (#464).
+// ---------------------------------------------------------------------------
+
+export interface ApiClientConfig {
+  /** Absolute API base URL, e.g. `https://api.example.com` or `http://localhost:3004`. */
+  baseUrl: string;
+  /**
+   * Resolves the auth headers for a single request. The returned map is merged
+   * into every request with **auth-wins precedence** (see {@link createApiClient}),
+   * so a call site can never accidentally clobber `Authorization` /
+   * `X-Clerk-Authorization`. Server and browser supply different strategies:
+   *   - server: Clerk JWT in `X-Clerk-Authorization`, GCP identity token in
+   *     `Authorization` (Cloud Run IAM consumes `Authorization`);
+   *   - browser: Clerk JWT in plain `Authorization` (no IAM hop).
+   * Encapsulating the split here is the structural mitigation for flag 6 (#464).
+   */
+  getAuthHeaders: () => Promise<Record<string, string>>;
+}
+
+// RequestInit augmented with Next.js's ISR `next` extension. The package does not
+// depend on `next`, so the DOM `RequestInit` type does not model `next`; we model
+// it locally and forward it (the browser ignores the unknown field, Next.js reads
+// it on the server). Mirrors the `as RequestInit` cast the pre-consolidation code used.
+type FetchInit = RequestInit & { next?: { revalidate?: number; tags?: string[] } };
+
+const enc = encodeURIComponent;
+const JSON_HEADERS: Record<string, string> = { 'Content-Type': 'application/json' };
+
+// Smart-import endpoint path with mode + optional destination override. Returned
+// relative (rawFetch prepends baseUrl).
+function importPath(
+  program: string,
+  mode: 'preview' | 'commit',
+  destination?: ImportKind,
+): string {
+  const params = new URLSearchParams({ mode });
+  if (destination) params.set('destination', destination);
+  return `/programs/${enc(program)}/import?${params.toString()}`;
+}
+
+// NestJS ValidationPipe returns { statusCode, message: string | string[], error }.
+// Surface that detail so error UIs can show actionable text instead of just
+// "Request failed: 400".
+async function extractErrorMessage(res: Response, path: string): Promise<string> {
+  try {
+    const body = (await res.json()) as { message?: string | string[] };
+    if (Array.isArray(body.message)) return body.message.join('; ');
+    if (typeof body.message === 'string') return body.message;
+  } catch {
+    // fall through to generic
+  }
+  return `API ${res.status} ${res.statusText} for ${path}`;
+}
+
+export function createApiClient(config: ApiClientConfig) {
+  const { baseUrl, getAuthHeaders } = config;
+
+  async function rawFetch(path: string, init: FetchInit = {}): Promise<Response> {
+    const authHeaders = await getAuthHeaders();
+    const finalInit: FetchInit = {
+      ...init,
+      // auth-wins: spread auth headers last so a call site's init.headers can
+      // never override Authorization / X-Clerk-Authorization.
+      headers: { ...(init.headers as Record<string, string> | undefined), ...authHeaders },
+    };
+    return fetch(`${baseUrl}${path}`, finalInit as RequestInit);
+  }
+
+  // Throws a rich error on !ok; returns undefined on 204; otherwise parses JSON.
+  async function request<T>(path: string, init?: FetchInit): Promise<T> {
+    const res = await rawFetch(path, init);
+    if (!res.ok) throw new Error(await extractErrorMessage(res, path));
+    if (res.status === 204) return undefined as T;
+    return (await res.json()) as T;
+  }
+
+  // Like request but returns null on 404 (and 204) instead of throwing.
+  async function requestNullable<T>(path: string, init?: FetchInit): Promise<T | null> {
+    const res = await rawFetch(path, init);
+    if (res.status === 404 || res.status === 204) return null;
+    if (!res.ok) throw new Error(await extractErrorMessage(res, path));
+    return (await res.json()) as T;
+  }
+
+  // Void request that treats 404 as success — for idempotent deletes, where an
+  // already-absent resource is the desired end state.
+  async function requestVoidIdempotent(path: string, init?: FetchInit): Promise<void> {
+    const res = await rawFetch(path, init);
+    if (!res.ok && res.status !== 404) {
+      throw new Error(await extractErrorMessage(res, path));
+    }
+  }
+
+  return {
+    // -- Cycles ------------------------------------------------------------
+    fetchCycleDashboard(program: string): Promise<CycleDashboardResponse | null> {
+      return requestNullable(`/programs/${enc(program)}/cycles/current`, { cache: 'no-store' });
+    },
+    createCycle(programId: string): Promise<CycleDashboardResponse> {
+      return request(`/programs/${enc(programId)}/cycles`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({}),
+        cache: 'no-store',
+      });
+    },
+    initializeCycle(
+      programId: string,
+      options: { cycleDate?: string } = {},
+    ): Promise<CycleDashboardResponse> {
+      return request(`/programs/${enc(programId)}/cycles/initialize`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(options),
+        cache: 'no-store',
+      });
+    },
+
+    // -- Program spec ------------------------------------------------------
+    fetchProgramSpec(program: string): Promise<LiftingProgramSpecResponse[]> {
+      return request(`/programs/${enc(program)}/spec`, { next: { revalidate: 3600 } });
+    },
+
+    // -- Training maxes ----------------------------------------------------
+    fetchTrainingMaxes(program: string): Promise<TrainingMaxResponse[]> {
+      return request(`/programs/${enc(program)}/training-maxes`, { cache: 'no-store' });
+    },
+    fetchTrainingMaxHistory(program: string): Promise<TrainingMaxHistoryResponse> {
+      return request(`/programs/${enc(program)}/training-maxes/history`, { cache: 'no-store' });
+    },
+    updateTrainingMaxHistoryEntry(
+      program: string,
+      id: string,
+      body: { isPR?: boolean; goalMet?: boolean },
+    ): Promise<TrainingMaxHistoryResponse['entries'][number]> {
+      return request(
+        `/programs/${enc(program)}/training-maxes/history/${enc(id)}`,
+        { method: 'PATCH', headers: JSON_HEADERS, body: JSON.stringify(body), cache: 'no-store' },
+      );
+    },
+    updateTrainingMaxes(
+      program: string,
+      body: UpdateTrainingMaxesRequest,
+    ): Promise<TrainingMaxResponse[]> {
+      return request(`/programs/${enc(program)}/training-maxes`, {
+        method: 'PATCH',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(body),
+        cache: 'no-store',
+      });
+    },
+
+    // -- Workouts ----------------------------------------------------------
+    fetchWorkout(program: string, workoutNum: number): Promise<WorkoutResponse | null> {
+      return requestNullable(`/programs/${enc(program)}/workouts/${workoutNum}`, {
+        cache: 'no-store',
+      });
+    },
+    rescheduleWorkout(
+      program: string,
+      cycleNum: number,
+      workoutNum: number,
+      newDate: string,
+    ): Promise<void> {
+      return request(
+        `/programs/${enc(program)}/cycles/${cycleNum}/workouts/${workoutNum}/reschedule`,
+        { method: 'PATCH', headers: JSON_HEADERS, body: JSON.stringify({ newDate }), cache: 'no-store' },
+      );
+    },
+    skipWorkout(
+      program: string,
+      cycleNum: number,
+      workoutNum: number,
+      reason?: string,
+    ): Promise<void> {
+      return request(
+        `/programs/${enc(program)}/cycles/${cycleNum}/workouts/${workoutNum}/skip`,
+        {
+          method: 'POST',
+          headers: JSON_HEADERS,
+          body: JSON.stringify(reason !== undefined ? { reason } : {}),
+          cache: 'no-store',
+        },
+      );
+    },
+    unskipWorkout(program: string, cycleNum: number, workoutNum: number): Promise<void> {
+      return request(
+        `/programs/${enc(program)}/cycles/${cycleNum}/workouts/${workoutNum}/skip`,
+        { method: 'DELETE', cache: 'no-store' },
+      );
+    },
+
+    // -- Lift records ------------------------------------------------------
+    fetchLiftRecords(program: string): Promise<LiftRecordResponse[]> {
+      return request(`/programs/${enc(program)}/lift-records`, { cache: 'no-store' });
+    },
+    createLiftRecord(program: string, body: CreateLiftRecordRequest): Promise<LiftRecordResponse> {
+      return request(`/programs/${enc(program)}/lift-records`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(body),
+        cache: 'no-store',
+      });
+    },
+    updateLiftRecord(
+      program: string,
+      id: string,
+      body: UpdateLiftRecordRequest,
+    ): Promise<LiftRecordResponse> {
+      return request(`/programs/${enc(program)}/lift-records/${enc(id)}`, {
+        method: 'PATCH',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(body),
+        cache: 'no-store',
+      });
+    },
+    /**
+     * Uploads a CSV file to the lift-records import endpoint. Returns a
+     * discriminated union so callers can handle validation errors without
+     * catching exceptions. FormData sets its own multipart Content-Type
+     * boundary, so no Content-Type header is supplied here.
+     */
+    async importLiftRecords(
+      program: string,
+      file: File,
+    ): Promise<
+      { ok: true; data: ImportLiftRecordsResponse } | { ok: false; errors: ImportError[] }
+    > {
+      const form = new FormData();
+      form.append('file', file);
+      const res = await rawFetch(`/programs/${enc(program)}/lift-records/import`, {
+        method: 'POST',
+        body: form,
+        cache: 'no-store',
+      });
+      if (res.status === 201) {
+        return { ok: true, data: (await res.json()) as ImportLiftRecordsResponse };
+      }
+      const body = (await res.json()) as { errors?: ImportError[] };
+      return {
+        ok: false,
+        errors: body.errors ?? [{ row: 0, message: `Unexpected error (HTTP ${res.status})` }],
+      };
+    },
+
+    // -- Smart import (classify → preview → commit any CSV) ----------------
+    /**
+     * Smart Import — classify + preview a CSV without writing (#477). Pass a
+     * `destination` to override the classifier (e.g. after a low-confidence pick).
+     */
+    async previewImport(
+      program: string,
+      file: File,
+      destination?: ImportKind,
+    ): Promise<ImportPreviewResponse> {
+      const form = new FormData();
+      form.append('file', file);
+      const res = await rawFetch(importPath(program, 'preview', destination), {
+        method: 'POST',
+        body: form,
+        cache: 'no-store',
+      });
+      if (!res.ok) {
+        throw new Error(`Import preview failed (HTTP ${res.status})`);
+      }
+      return (await res.json()) as ImportPreviewResponse;
+    },
+    /**
+     * Smart Import — commit a CSV to the chosen destination. The server re-parses the
+     * file (never trusting any client payload) and writes idempotently. Returns a
+     * discriminated union so callers handle validation errors without catching.
+     */
+    async commitImport(
+      program: string,
+      file: File,
+      destination: ImportKind,
+    ): Promise<
+      { ok: true; data: ImportCommitResponse } | { ok: false; errors: ImportError[] }
+    > {
+      const form = new FormData();
+      form.append('file', file);
+      const res = await rawFetch(importPath(program, 'commit', destination), {
+        method: 'POST',
+        body: form,
+        cache: 'no-store',
+      });
+      if (res.ok) {
+        return { ok: true, data: (await res.json()) as ImportCommitResponse };
+      }
+      const body = (await res.json().catch(() => ({}))) as { errors?: ImportError[] };
+      return {
+        ok: false,
+        errors: body.errors ?? [{ row: 0, message: `Unexpected error (HTTP ${res.status})` }],
+      };
+    },
+
+    // -- Body weight -------------------------------------------------------
+    recordBodyWeight(program: string, body: RecordBodyWeightRequest): Promise<void> {
+      return request(`/programs/${enc(program)}/body-weight`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(body),
+        cache: 'no-store',
+      });
+    },
+    fetchLatestBodyWeight(program: string): Promise<BodyWeightResponse | null> {
+      return requestNullable(`/programs/${enc(program)}/body-weight/latest`, { cache: 'no-store' });
+    },
+
+    // -- Strength goals ----------------------------------------------------
+    fetchStrengthGoals(program: string): Promise<StrengthGoalResponse[]> {
+      return request(`/programs/${enc(program)}/strength-goals`, { cache: 'no-store' });
+    },
+    upsertStrengthGoal(
+      program: string,
+      lift: string,
+      body: UpsertStrengthGoalRequest,
+    ): Promise<StrengthGoalResponse> {
+      return request(`/programs/${enc(program)}/strength-goals/${enc(lift)}`, {
+        method: 'PUT',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(body),
+        cache: 'no-store',
+      });
+    },
+    deleteStrengthGoal(program: string, lift: string): Promise<void> {
+      return requestVoidIdempotent(`/programs/${enc(program)}/strength-goals/${enc(lift)}`, {
+        method: 'DELETE',
+        cache: 'no-store',
+      });
+    },
+
+    // -- Lift overrides ----------------------------------------------------
+    upsertLiftOverride(
+      program: string,
+      cycleNum: number,
+      workoutNum: number,
+      body: CreateLiftOverrideRequest,
+    ): Promise<LiftOverrideResponse> {
+      return request(
+        `/programs/${enc(program)}/cycles/${cycleNum}/workouts/${workoutNum}/lift-overrides`,
+        { method: 'POST', headers: JSON_HEADERS, body: JSON.stringify(body), cache: 'no-store' },
+      );
+    },
+    deleteLiftOverride(
+      program: string,
+      cycleNum: number,
+      workoutNum: number,
+      lift: string,
+    ): Promise<void> {
+      return request(
+        `/programs/${enc(program)}/cycles/${cycleNum}/workouts/${workoutNum}/lift-overrides/${enc(lift)}`,
+        { method: 'DELETE', cache: 'no-store' },
+      );
+    },
+
+    // -- Lifts / metadata --------------------------------------------------
+    fetchLiftCatalog(program: string): Promise<string[]> {
+      return request(`/programs/${enc(program)}/lifts`, { cache: 'no-store' });
+    },
+    fetchLiftMetadata(lift: string): Promise<LiftMetadataResponse> {
+      return request(`/lifts/${enc(lift)}/metadata`, { cache: 'no-store' });
+    },
+    patchLiftMetadata(lift: string, body: PatchLiftMetadataRequest): Promise<LiftMetadataResponse> {
+      return request(`/lifts/${enc(lift)}/metadata`, {
+        method: 'PATCH',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(body),
+        cache: 'no-store',
+      });
+    },
+
+    // -- User settings -----------------------------------------------------
+    fetchUserSettings(): Promise<UserSettingsResponse> {
+      return request('/users/me/settings', { cache: 'no-store' });
+    },
+    updateUserSettings(body: UpdateUserSettingsRequest): Promise<UserSettingsResponse> {
+      return request('/users/me/settings', {
+        method: 'PATCH',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(body),
+        cache: 'no-store',
+      });
+    },
+
+    // -- Programs (switch + custom) ---------------------------------------
+    switchProgram(programId: string): Promise<SwitchProgramResponse> {
+      return request(`/programs/${enc(programId)}/switch`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        cache: 'no-store',
+      });
+    },
+    fetchCustomPrograms(): Promise<CustomProgramSummaryResponse[]> {
+      return request('/programs/custom', { cache: 'no-store' });
+    },
+    fetchCustomProgram(id: string): Promise<CustomProgramResponse> {
+      return request(`/programs/custom/${enc(id)}`, { cache: 'no-store' });
+    },
+    createCustomProgram(body: CreateCustomProgramRequest): Promise<CustomProgramResponse> {
+      return request('/programs/custom', {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(body),
+        cache: 'no-store',
+      });
+    },
+    updateCustomProgram(
+      id: string,
+      body: UpdateCustomProgramRequest,
+    ): Promise<CustomProgramResponse> {
+      return request(`/programs/custom/${enc(id)}`, {
+        method: 'PUT',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(body),
+        cache: 'no-store',
+      });
+    },
+    deleteCustomProgram(id: string): Promise<void> {
+      return requestVoidIdempotent(`/programs/custom/${enc(id)}`, {
+        method: 'DELETE',
+        cache: 'no-store',
+      });
+    },
+  };
+}
+
+export type ApiClient = ReturnType<typeof createApiClient>;

--- a/packages/api-client/tsconfig.json
+++ b/packages/api-client/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true,
+    "lib": ["ES2020", "DOM"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "files": [],
   "references": [
+    { "path": "./packages/api-client" },
     { "path": "./packages/core" },
     { "path": "./packages/types" }
   ]


### PR DESCRIPTION
## Summary

`apps/web` had two near-duplicate HTTP clients — `lib/api.ts` (server) and `lib/client-api.ts` (browser) — calling identical endpoints with identical DTOs, differing only in their auth-header strategy. This extracts a new **`packages/api-client`** exporting `createApiClient({ baseUrl, getAuthHeaders })`: a single typed REST client that owns every endpoint, DTO, error-handling rule, and cache directive. The two `lib` files become thin wrappers that supply only the auth strategy.

This is **flag 3** of the 2026-06-08 architecture review ([#464](https://github.com/brownm09/lifting-logbook/issues/464)). It also delivers the structural half of **flag 6**: the `X-Clerk-Authorization` vs `Authorization` split is now encapsulated in the per-environment `getAuthHeaders` strategy, and the client merges auth headers with **auth-wins precedence**, so a call site can never clobber them.

### Design

- `createApiClient({ baseUrl, getAuthHeaders })` returns a fully-typed client (the union of all server + browser endpoints). Core request helpers handle: rich NestJS-validation error extraction, `404 → null` (nullable reads), `204 → undefined`, and `404`-tolerant idempotent deletes.
- `lib/api.ts` keeps `server-only` + the server strategy (Clerk JWT in `X-Clerk-Authorization`, GCP identity token in `Authorization` for the Cloud Run IAM hop) and re-exports its endpoint subset.
- `lib/client-api.ts` keeps `setAuthTokenGetter` + the browser strategy (Clerk JWT in plain `Authorization`) and re-exports its subset.
- Types remain sourced from `@lifting-logbook/types` (no duplication). All 30 call sites compile unchanged.

### Behaviour-neutral reconciliations (noted for review)
- Browser mutations now surface the **rich** NestJS validation message on error (previously generic) and handle `204` — strictly-superset behaviour, no call site asserts on the old message.
- `createCycle` / `initializeCycle` now pass explicit `cache: 'no-store'` (POST is never cached, so no behaviour change) for consistency with the fetch-cache standard.
- One production cast remains — `finalInit as RequestInit` in the client core — to forward Next.js's ISR `next` extension, which the DOM `RequestInit` type does not model (the package does not depend on `next`). It mirrors the `as RequestInit` cast the pre-consolidation code already used and is documented inline; it narrows a known framework extension, not a real type error.

## Acceptance criteria (#466)
- [x] New `packages/api-client` exporting a `createApiClient({ baseUrl, getAuthHeaders })` factory.
- [x] `lib/api.ts` and `lib/client-api.ts` reduced to thin auth-strategy wrappers over it.
- [x] Types still sourced from `@lifting-logbook/types` (no duplication).
- [x] Existing web Jest + Playwright suites pass.

## Testing

Full `npm test` from the repo root — **DB E2E not skipped** (Docker up; Testcontainers Postgres provisioned `programs.db.e2e.spec.ts`, PASS 24.4s):

- **Turbo: 12/12 tasks successful.**
- `@lifting-logbook/api`: **Tests: 345 passed, 0 skipped, 0 failed** (25 suites, incl. DB E2E)
- `@lifting-logbook/api-client`: **Tests: 15 passed, 0 skipped, 0 failed** (new — see below)
- `@lifting-logbook/web` (Jest): **Tests: 76 passed, 0 skipped, 0 failed** (13 suites)
- `@lifting-logbook/core`: **Tests: 174 passed, 0 skipped, 0 failed** (27 suites)
- `@lifting-logbook/eslint-rules` (node:test): **12 pass, 0 fail**
- `@lifting-logbook/types`: passWithNoTests
- **Aggregate: 610 Jest + 12 node:test passed, 0 skipped, 0 failed.**

Additional gates:
- Web Playwright E2E (`npm run test:e2e -w @lifting-logbook/web`): **14 passed (28.9s)** — exercises the new client end-to-end through every page.
- Isolated web typecheck (`tsc -p apps/web/tsconfig.json --noEmit`): clean (exit 0).
- `npm run build`: types/core/api-client/api build clean; web compiles + bundles (local `next build` static-export step fails only on missing Clerk publishable key — an env-only limitation; CI injects keys).
- Suppression grep, test-integrity grep, deleted-test check, coverage-threshold check: all clean.
- Lockfile: in sync (regeneration idempotent; +12 lines = new workspace registration).

### Coverage
New testable behaviour = the `packages/api-client` factory core. Added `src/index.test.ts` (15 cases): baseURL prefixing + auth-header merge (auth-wins), path encoding, `next.revalidate` forwarding, joined NestJS error + generic fallback, `204 → undefined`, nullable `404 → null` / parse / non-404 throw, idempotent-delete `404`-tolerance + non-404 throw, and `importLiftRecords` 201 / row-error / fallback paths. The two `lib` wrappers are behaviour-preserving; their plumbing is now covered by these tests.

## Docs reconciled
- `CONTRIBUTING.md` → API auth headers: updated to describe the shared client + auth-wins merge; flag-6 lint follow-up re-pointed at #464.
- `docs/diagrams/package-dependencies.md`: added the `packages/api-client` node + edges.
- `CLAUDE.md`: added `packages/api-client` to the Repository Layout.
- `.gitignore`: ignore Playwright `playwright-report/` + `test-results/` output (were untracked-but-not-ignored).

## Rebase / merge-integration onto #485 (Smart File Import)

After review, `main` advanced with #485 (Smart File Import wizard Phase 1), which added two browser-side import functions (`previewImport`, `commitImport`) + an `importUrl` helper to the *old* `clientFetch` structure in `lib/client-api.ts` — a semantic conflict with this consolidation. Resolved by rebasing onto #485 and **integrating both functions as methods on the `createApiClient` factory** (preserving #485's exact behavior: `mode`/`destination` query params, custom `Import preview failed` error, discriminated-union commit result), then re-exporting them from `lib/client-api.ts`. Added 6 factory unit tests for them. `.gitignore` conflict was a duplicate (both PRs ignored the same Playwright output dirs) — took main's.

### Re-verification after rebase (DB E2E not skipped)
- Full `npm test`: **12/12 turbo tasks**. api **357** / api-client **21** (15 + 6 import) / web-jest **78** (incl. #485's `ImportWizard.test.tsx` resolving the re-exports) / core **199** / eslint-rules 12 node:test / types passWithNoTests — **0 skipped, 0 failed**. DB E2E `programs.db.e2e.spec.ts` PASS (26.7s); `import.e2e.spec.ts` PASS.
- Playwright E2E: **15 passed** (14 + #485's `import.spec.ts`).
- Isolated web typecheck clean; suppression/integrity greps clean; lockfile stable.

## Review findings disposition

`/review 479` (2026-06-09) — two-Opus-subagent pass (correctness/security + reliability/perf/maintainability), all endpoints compared against `origin/main`. **0 blocking, 1 non-blocking.**

| Finding | Category | Disposition |
|---|---|---|
| New composite package `packages/api-client` missing from root `tsconfig.json` `references` (breaks `tsc -b` from root + IDE project-ref navigation) | maintainability (non-blocking) | **Fixed in `debc381`** (rebased) — added to root references; `tsc -b` from root verified clean. |

Correctness/security pass: **no findings** — auth-scheme split + auth-wins merge correct and test-covered; no behavioral drift across the endpoints; no secret leakage.
