### PR TITLE
[docs] Document saveTrainingMaxes upsert/no-delete contract on the port

### DIFF
--- a/apps/api/src/ports/ITrainingMaxRepository.ts
+++ b/apps/api/src/ports/ITrainingMaxRepository.ts
@@ -3,5 +3,16 @@ import { TrainingMax } from '@lifting-logbook/core';
 export interface ITrainingMaxRepository {
   getTrainingMaxes(program: string): Promise<TrainingMax[]>;
 
+  /**
+   * Upserts the given training maxes for a program, keyed by lift. Lifts that
+   * are not present in `maxes` are left untouched — this is an upsert, NOT a
+   * full replace, so callers may safely pass a subset of a program's lifts.
+   *
+   * Both adapters must honour this contract: the Prisma adapter upserts each
+   * row by `(userId, program, lift)`, and the in-memory adapter merges by lift.
+   * A full-replace implementation here would silently wipe omitted lifts on a
+   * partial Smart Import (#477) — the divergence fixed in #485. There is
+   * intentionally no delete-via-save path.
+   */
   saveTrainingMaxes(program: string, maxes: TrainingMax[]): Promise<void>;
 }


### PR DESCRIPTION
## Summary

Documents the `saveTrainingMaxes` contract on `ITrainingMaxRepository`: it is an **upsert per-lift** — lifts absent from the argument are preserved, there is no delete-via-save path.

### Background

This PR was opened to fix a real divergence: the in-memory adapter did a destructive full-replace while the Prisma adapter upserts per-lift, so a partial training-max import would wipe omitted lifts in dev/tests. Investigation was done on a worktree cut one commit behind `origin/main` — so it showed the *old* buggy code.

It turns out **[#485](https://github.com/brownm09/lifting-logbook/pull/485) (merged `46f9f9c`) already fixed the behavior** during its own `/code-review`: the in-memory adapter now upserts per-lift, and `apps/api/src/programs/import.e2e.spec.ts` already has the regression test (`"preserves training maxes for lifts absent from a partial import"`) exercising the real import commit path.

The behavioral fix and the test are therefore **already in `main`** — this PR's adapter change and adapter spec were redundant and have been dropped. The one thing #485 did *not* add is documentation of the contract on the port interface. This PR keeps only that: an interface-level JSDoc so the invariant the #485 review had to rediscover is written down and cannot be silently reintroduced by a future implementer.

## Change

- `apps/api/src/ports/ITrainingMaxRepository.ts` — JSDoc on `saveTrainingMaxes` documenting upsert/no-delete semantics and naming both adapters' obligations.

Docs-only; **no behavior change**.

## Testing

No code path changes — a JSDoc comment on an interface. `turbo run lint` passes (pre-commit hook, 6/6 packages). The behavioral coverage already lives in `import.e2e.spec.ts` (added by #485).

### Risk-dimension audit
All dimensions **N/A** — interface documentation only; no runtime, schema, security, or performance surface touched.

Closes #491
