### PR TITLE
[infra] Harden prod promote: auth-secret preflight + web served-surface smoke (#490)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -690,6 +690,42 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_PROD_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_PROD_SERVICE_ACCOUNT }}
 
+      # ── Pre-promote auth-secret validation (#490 item 2 / #382) ────────────
+      # Fail fast BEFORE any production mutation (terraform apply, migrate, Cloud
+      # Run / Helm deploy) if a serve-gating auth secret is absent or still the
+      # Terraform placeholder. GCP Secret Manager is already the single source of
+      # truth — every surface (Cloud Run --update-secrets, the k8s Secret sync,
+      # the web build-arg) fetches from it rather than holding its own copy — so
+      # the only failure mode left is "the source value was never populated".
+      # #382 was exactly that: a missing prod clerk-secret-key, caught only after
+      # the web service was already serving auth 500s in prod. This surfaces it at
+      # promote time instead. It aggregates all failures (does not stop at the
+      # first) and never echoes a secret value. Scope is the two auth secrets
+      # whose absence breaks the served surface; the DB-url and OTel-header
+      # secrets keep their own per-step `[ -n ]` guards later in the job.
+      - name: Validate production auth secrets (pre-promote)
+        run: |
+          MISSING=0
+          for SECRET in \
+            lifting-logbook-prod-clerk-secret-key \
+            lifting-logbook-prod-clerk-publishable-key; do
+            VALUE=$(gcloud secrets versions access latest \
+              --secret="$SECRET" \
+              --project="${{ vars.GCP_PROD_PROJECT_ID }}" 2>/dev/null || true)
+            if [ -z "$VALUE" ]; then
+              echo "::error title=Missing production secret::$SECRET is absent or has no accessible version. Populate it in GCP Secret Manager (docs/deploy.md Step 4) before promoting."
+              MISSING=1
+            elif [ "$VALUE" = "REPLACE_ME" ]; then
+              echo "::error title=Placeholder production secret::$SECRET is still the Terraform placeholder (REPLACE_ME). Set the real value in GCP Secret Manager (docs/deploy.md Step 4) before promoting."
+              MISSING=1
+            fi
+          done
+          if [ "$MISSING" -ne 0 ]; then
+            echo "Production auth-secret preflight failed — aborting before any production mutation. See the errors above." >&2
+            exit 1
+          fi
+          echo "Production auth secrets present and non-placeholder — proceeding."
+
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v4
         with:
@@ -882,6 +918,57 @@ jobs:
             --set-env-vars="API_URL=${{ steps.tf-prod.outputs.cloud_run_api_url }}" \
             --update-secrets="CLERK_SECRET_KEY=lifting-logbook-prod-clerk-secret-key:latest" \
             --quiet
+
+      # ── Production web served-surface smoke (#490 item 3 / #382 / #407) ────
+      # Verify the *live* prod web surface through the real Cloud Run ingress
+      # after deploy, using the same two-probe shape the staging smoke uses (the
+      # smoke-test job): /livez (Next.js runtime, owned by app code) and /sign-in
+      # (Clerk auth flow, owned by middleware). Staging exercises this before the
+      # promote gate, but prod previously had only the DB-backed API /readyz smoke
+      # above — the web served surface was never re-checked in prod, so both
+      # failure classes this catches reached production undetected:
+      #   #382 — missing prod clerk-secret-key → web cannot serve auth (/sign-in)
+      #   #407 — GFE intercepts /healthz before the container → probe /livez
+      # The prod web service is --allow-unauthenticated, so no ID token is needed
+      # (unlike the IAM-gated API /readyz above). A non-200 fails the deploy loudly
+      # rather than surfacing days later; roll back the web revision per
+      # docs/deploy.md on failure (automated rollback is a tracked follow-up). Runs
+      # before the OTel steps below so telemetry rollout never gates this check.
+      - name: Smoke test Cloud Run production — /livez (web runtime)
+        run: |
+          # %/ strips a trailing slash so $BASE_URL/livez is never double-slashed.
+          BASE_URL="${{ steps.tf-prod.outputs.cloud_run_web_url }}"
+          BASE_URL="${BASE_URL%/}"
+          # Allow up to 3 minutes for the new web revision to become healthy.
+          for i in $(seq 1 18); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/livez" || true)
+            if [ "$STATUS" = "200" ]; then
+              echo "Production /livez returned 200 — OK"
+              exit 0
+            fi
+            echo "/livez attempt $i: got $STATUS, retrying in 10s..."
+            sleep 10
+          done
+          echo "Production /livez smoke FAILED — Next.js runtime not serving 200 (probe owned by app code, distinct from the Clerk auth flow). Roll back the web revision per docs/deploy.md." && exit 1
+
+      - name: Smoke test Cloud Run production — /sign-in (Clerk auth flow)
+        run: |
+          BASE_URL="${{ steps.tf-prod.outputs.cloud_run_web_url }}"
+          BASE_URL="${BASE_URL%/}"
+          # The runtime is already up (/livez passed immediately before this step).
+          # /sign-in should respond within seconds; if Clerk middleware cannot serve
+          # 200 in 60s the #382 auth-outage class has occurred, and fast failure
+          # improves operator turnaround.
+          for i in $(seq 1 6); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/sign-in" || true)
+            if [ "$STATUS" = "200" ]; then
+              echo "Production /sign-in returned 200 — OK"
+              exit 0
+            fi
+            echo "/sign-in attempt $i: got $STATUS, retrying in 10s..."
+            sleep 10
+          done
+          echo "Production /sign-in smoke FAILED — runtime healthy but Clerk auth flow not serving 200 (check the prod clerk-secret-key and the middleware matcher). Roll back the web revision per docs/deploy.md." && exit 1
 
       # ── OTel Collector (observability — #474) ──────────────────────────────
       # Mirror of the staging step (see deploy-staging) — deployed LAST in the job,

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -703,23 +703,41 @@ jobs:
       # first) and never echoes a secret value. Scope is the two auth secrets
       # whose absence breaks the served surface; the DB-url and OTel-header
       # secrets keep their own per-step `[ -n ]` guards later in the job.
+      #
+      # Error-message diligence (CLAUDE.md; the #395 transient-504 incident): a
+      # non-zero gcloud exit is NOT assumed to mean "secret absent". stdout (the
+      # secret) is captured to a shell var and stderr to a file, then the failure
+      # is classified — only a NOT_FOUND error is reported as missing; anything
+      # else is reported as "inaccessible (transient or IAM), re-run if transient".
+      # The secret value itself never touches disk; only the error text does.
       - name: Validate production auth secrets (pre-promote)
         run: |
           MISSING=0
+          ERR_FILE="$RUNNER_TEMP/secret_stderr"
           for SECRET in \
             lifting-logbook-prod-clerk-secret-key \
             lifting-logbook-prod-clerk-publishable-key; do
-            VALUE=$(gcloud secrets versions access latest \
+            if VALUE=$(gcloud secrets versions access latest \
               --secret="$SECRET" \
-              --project="${{ vars.GCP_PROD_PROJECT_ID }}" 2>/dev/null || true)
-            if [ -z "$VALUE" ]; then
-              echo "::error title=Missing production secret::$SECRET is absent or has no accessible version. Populate it in GCP Secret Manager (docs/deploy.md Step 4) before promoting."
-              MISSING=1
-            elif [ "$VALUE" = "REPLACE_ME" ]; then
-              echo "::error title=Placeholder production secret::$SECRET is still the Terraform placeholder (REPLACE_ME). Set the real value in GCP Secret Manager (docs/deploy.md Step 4) before promoting."
+              --project="${{ vars.GCP_PROD_PROJECT_ID }}" 2>"$ERR_FILE"); then
+              if [ -z "$VALUE" ]; then
+                echo "::error title=Empty production secret::$SECRET resolved to an empty value. Set the real value in GCP Secret Manager (docs/deploy.md Step 4) before promoting."
+                MISSING=1
+              elif [ "$VALUE" = "REPLACE_ME" ]; then
+                echo "::error title=Placeholder production secret::$SECRET is still the Terraform placeholder (REPLACE_ME). Set the real value in GCP Secret Manager (docs/deploy.md Step 4) before promoting."
+                MISSING=1
+              fi
+            else
+              ERR=$(cat "$ERR_FILE" 2>/dev/null || true)
+              if printf '%s' "$ERR" | grep -qi "NOT_FOUND"; then
+                echo "::error title=Missing production secret::$SECRET does not exist in GCP Secret Manager. Create and populate it (docs/deploy.md Step 4) before promoting."
+              else
+                echo "::error title=Production secret inaccessible::Could not read $SECRET — possibly a transient Secret Manager error or an IAM/permission problem, NOT necessarily a missing secret. Re-run if transient; otherwise verify the prod CI/CD service account's secretmanager.versions.access grant. Detail: $ERR"
+              fi
               MISSING=1
             fi
           done
+          rm -f "$ERR_FILE"
           if [ "$MISSING" -ne 0 ]; then
             echo "Production auth-secret preflight failed — aborting before any production mutation. See the errors above." >&2
             exit 1

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -347,6 +347,21 @@ pending Prisma migrations to prod — it sits in front of the in-VPC migrate job
 DB-backed `/readyz` smoke ([ADR-027](adr/ADR-027-deploy-pipeline-migrations.md)) — so approve
 it deliberately, after sanity-checking staging.
 
+Once approved, `deploy-production` self-guards at two boundaries (issue
+[#490](https://github.com/brownm09/lifting-logbook/issues/490)):
+
+- **Pre-promote auth-secret check** — before any prod mutation, the job fails fast if
+  `lifting-logbook-prod-clerk-secret-key` or `…-clerk-publishable-key` is absent, empty, or still
+  the `REPLACE_ME` placeholder ([Step 4](#step-4--sign-up-for-clerk-and-create-two-apps)). This
+  prevents the [#382](https://github.com/brownm09/lifting-logbook/issues/382) auth-outage class
+  (a missing secret reaching a live prod web revision). A "secret inaccessible" error (as opposed
+  to "missing"/"placeholder") usually means a transient Secret Manager blip or an IAM gap — re-run
+  the deploy if transient.
+- **Post-deploy web smoke** — after the prod web Cloud Run deploy, the job probes `/livez`
+  (Next.js runtime) and `/sign-in` (Clerk auth flow) through the Cloud Run ingress. A non-200
+  fails the run; the revision is already live, so **roll back the web revision** (see
+  [Rolling back](#rolling-back)) if it fails.
+
 **From the GitHub UI:** open the Deploy workflow run, click **Review deployments**, select
 `production`, and approve.
 


### PR DESCRIPTION
## Summary

Closes the residual gaps for **issue #490 items 2 and 3** with two fail-fast guards in `deploy.yml`'s `deploy-production` job. Both mirror patterns already reviewed and shipped elsewhere in the pipeline (the staging `clerk-check` gate and the staging smoke job).

> **Reconciliation note (#490 was largely already shipped).** The ~50 PRs since the retro windows already addressed most of #490. This PR adds only the genuine residual gaps; #481 (merged mid-session) further moved the prod web-deploy anchor, so this is rebased on current `main`.

### Item 2 — Validate production auth secrets (pre-promote)
GCP Secret Manager is already the single source of truth — every surface (Cloud Run `--update-secrets`, the k8s Secret sync, the web build-arg) *fetches* from it rather than holding its own copy, so the only failure mode left is **the source value was never populated**. [#382](https://github.com/brownm09/lifting-logbook/issues/382) was exactly that: a missing prod `clerk-secret-key`, caught only after the web service was already serving auth 500s in prod.

The new step runs **right after prod auth and before any prod mutation** (terraform apply / migrate / deploy), asserting `clerk-secret-key` and `clerk-publishable-key` are present and not the `REPLACE_ME` placeholder. It **aggregates** all failures (doesn't stop at the first) and **never echoes** a secret value. DB-url and OTel-header secrets keep their own per-step `[ -n ]` guards later in the job.

### Item 3 — Production web served-surface smoke
Prod previously had only the DB-backed API `/readyz` smoke ([#460](https://github.com/brownm09/lifting-logbook/issues/460)); the **web served surface was never re-checked in prod**. This adds `/livez` (Next.js runtime) + `/sign-in` (Clerk auth flow) probes after the prod web Cloud Run deploy, the same two-probe shape the staging smoke uses. It catches both classes that previously reached prod undetected:
- **#382** — missing prod `clerk-secret-key` → web cannot serve auth (`/sign-in` fails)
- **#407** — GFE intercepts `/healthz` before the container → probe `/livez`

The prod web service is `--allow-unauthenticated`, so no ID token is needed (unlike the IAM-gated API `/readyz`). Runs before the OTel steps so telemetry rollout never gates it.

## Acceptance criteria
- [x] A missing or `REPLACE_ME` prod auth secret aborts the deploy **before** any prod mutation, with an aggregated, value-free error
- [x] Prod web `/livez` + `/sign-in` are probed through the real Cloud Run ingress after the web deploy; a non-200 fails the deploy
- [x] New steps ordered correctly in `deploy-production` (preflight after auth; smokes after web deploy, before OTel) — verified by parsing the rendered workflow
- [x] No change to staging behavior or to production-only (non-staging) mode

## Testing
This is a **CI-workflow-only** change (`.github/workflows/deploy.yml`); it touches no application, build, or test code, so the Jest suite does not exercise it. Verification performed:

1. **YAML parse + step-order inspection** — loaded the rendered workflow and confirmed `deploy-production` step order: `Authenticate → Validate production auth secrets (pre-promote) → Set up Terraform → … → Deploy web to Cloud Run → /livez smoke → /sign-in smoke → OTel → Print URLs`.
2. **Pattern parity** — both guards are line-for-line consistent with the already-shipped staging `clerk-check` gate and the staging `smoke-test` job (`/livez` + `/sign-in`, `BASE_URL%/` trailing-slash strip, retry loops).
3. **Full suite (no incidental breakage)** via `turbo run test` (Windows, Node 20.11.1, Docker up): `Tests: api-client 21, core 199, api 357, web 78 — 12/12 workspace test tasks passed, 0 skipped, 0 failed`.

The behavioral guards run only inside the real prod deploy (require GCP + Cloud Run) and cannot be exercised locally; they fail loudly by design and roll-back guidance points to `docs/deploy.md`.

Suppression / test-integrity greps against `origin/main`: clean. No `package.json`/lockfile changes.

## Scope
Part of umbrella **#490** (items 2 and 3 of 4). Item 1 is [#496](https://github.com/brownm09/lifting-logbook/pull/496); item 4 (staging Cloud SQL flakiness, #344) needs GCP-runtime root-cause work and is being refined as tracking, not code. #490 stays open until item 4 is dispositioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review findings disposition

`/review` on this PR surfaced 0 blocking, 3 non-blocking findings + 1 question ([review comment](https://github.com/brownm09/lifting-logbook/pull/497#issuecomment-4671126086)):

1. **[reliability] Preflight mis-diagnosed transient/IAM gcloud errors as "secret absent"** — **fixed in `ceaaf9d`.** stdout (secret) now captured to a shell var and stderr to a file; failure is classified — only `NOT_FOUND` reports "missing", anything else reports "inaccessible (transient/IAM), re-run if transient". Secret value never touches disk.
2. **[documentation] docs/deploy.md not updated for the new gate + smoke** — **fixed in `ceaaf9d`.** Added a note to *Ongoing operations → Approving a production deploy* describing both new self-guards.
3. **[maintainability] `clerk-publishable-key` check redundant with build-images** — **accepted (intentional).** Kept deliberately so the preflight is a single, complete "auth secrets present" assertion at the promote boundary; `build-images` runs in a separate job under different auth, so this is defense-in-depth, not dead weight. No code change.
4. **[question] Smoke targets `cloud_run_web_url`, not a custom-domain GLB** — **accepted (option a).** The Cloud Run URL exercises Google Frontend (so it catches the #407 `/healthz`-intercept class); single-user prod has no fronting GLB today. Adding a custom-domain probe is noted for if/when a GLB is introduced. No code change.
