### PR TITLE
[fix] Resync package-lock.json: Clerk drift reddening main (#500)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2599,11 +2599,11 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.5.0.tgz",
-      "integrity": "sha512-g1bjzqj7/mb6rnrQ5zr+ybjpilTIWADaCoHE1HnEAjQfbcdfn3gb9PPX0wJ1KWw8OOQEQYSjzXPzvofEB1j+ww==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.6.0.tgz",
+      "integrity": "sha512-/b0Ys437C21CyXhgHu4KcFHEQ3+CrBXlB6omQC5TPo9MfrhkMHRtg3LtYsSKp86mUM3IZnrwcll3ioo1kWobOA==",
       "dependencies": {
-        "@clerk/shared": "^4.15.0",
+        "@clerk/shared": "^4.16.0",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -2612,9 +2612,9 @@
       }
     },
     "node_modules/@clerk/backend/node_modules/@clerk/shared": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.15.0.tgz",
-      "integrity": "sha512-uX8nfLb69m8mA6KWKWfuPSwoVNDRyUdufeCeTEZsdZxbRUsEYT/c0KWFN28IOQCtK09tpVtzrUHvW44v5Dc5OA==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.16.0.tgz",
+      "integrity": "sha512-McccBHpv457pMbBMKKSLHuxqCSFe4YFAta1IngBX/uomdtogCDF++K8+dxZWxdYmWd+IrOVydIlLf3JzvEmLJA==",
       "dependencies": {
         "@tanstack/query-core": "^5.100.6",
         "dequal": "2.0.3",


### PR DESCRIPTION
## Summary

Closes #500. `main` is red for every open PR. Upstream published `@clerk/backend@3.6.0` and `@clerk/shared@4.16.0`, both accepted by the existing caret ranges in `package.json` (`^3.5.0` / `^4.15.0`), but the committed lockfile still pinned `3.5.0` / `4.15.0`. `npm ci` therefore refuses to install (lock out of sync), failing every PR's required checks at install/setup:

- **Lint & Test** — the lockfile-sync verify step
- **DB Integration Tests** — `npm ci`
- **Build & Push Images** — `npm ci` in the Docker builder
- **Staging Integration Tests** — cascades (build-images skipped → deploy-prereq guard)

This is the [ADR-036](https://github.com/brownm09/dev-env/blob/main/docs/adr/036-lockfile-drift-prevention.md) drift class (same as #432/#433), triggered purely by an upstream publish — no local dependency edit.

## Change
Pure lockfile resync (`npm install`) — bumps the two transitive Clerk packages to the latest their existing caret ranges already allow. **No `package.json` change.**

## Testing
```
Tests: api-client 21, core 199, web 78, api 357 — 12/12 workspace test tasks passed, 0 skipped, 0 failed
```
Run via `turbo run test` (Windows, Node 20.11.1, Docker up) after `npm install` brought `node_modules` to the new versions — confirms the bump is semver-safe.

Additional verification:
- Regenerated lockfile is a **stable fixed point**: a second `npm install --package-lock-only` produces an identical file (md5 match), so the CI drift check (`npm install --package-lock-only && git diff --exit-code`) will pass.
- `package.json` confirmed unchanged (`git diff --exit-code package.json …/package.json`).

Suppression / test-integrity greps against `origin/main`: clean. Lockfile is the only changed file.

## Sequencing
This must merge first — it unblocks the four required checks for every other open PR (#496, #497, #499). Those PRs then update-branch to pick up the synced lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)