### PR TITLE
[infra] Diagnose staging CI flakiness; tighten migrate, retry AR/terraform (#498)

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -131,10 +131,24 @@ jobs:
 
       - name: Terraform apply (staging)
         working-directory: ${{ env.TF_DIR }}
+        # Bounded retry absorbs transient GCP API 5xx / eventual-consistency
+        # during apply (a real staging red-run driver per the #498 diagnosis —
+        # see docs/runbooks/staging-ci-flakiness.md). terraform apply is
+        # re-runnable; a genuine config error fails both attempts and hard-fails.
         run: |
-          terraform apply -auto-approve \
-            -var-file=terraform.tfvars.staging \
-            -var="billing_account=${{ secrets.GCP_BILLING_ACCOUNT }}"
+          for attempt in 1 2; do
+            if terraform apply -auto-approve \
+                 -var-file=terraform.tfvars.staging \
+                 -var="billing_account=${{ secrets.GCP_BILLING_ACCOUNT }}"; then
+              exit 0
+            fi
+            if [ "${attempt}" -lt 2 ]; then
+              echo "Terraform apply attempt ${attempt} failed; retrying in 20s..."
+              sleep 20
+            fi
+          done
+          echo "::error title=Terraform apply failed::terraform apply (staging) failed on both attempts."
+          exit 1
 
       - name: Capture Terraform outputs
         id: tf-outputs
@@ -256,39 +270,52 @@ jobs:
         if: steps.image-tag.outputs.skip_build != 'true'
         uses: docker/setup-buildx-action@v3
 
+      # Bounded retry (Wandalen/wretry.action, pinned to v3.8.0 SHA) wraps the
+      # build+push to absorb transient Artifact Registry 504s on layer-blob push
+      # — the dominant real staging red-run driver per the #498 diagnosis (the
+      # workflow's own prereq-guard hints already named "Artifact Registry 504 on
+      # layer-blob push"). Cached layers make a push-retry cheap. The wrapped
+      # docker/build-push-action@v6 config is unchanged; tags are comma-separated
+      # to keep wretry's forwarded `with` a flat parse. See
+      # docs/runbooks/staging-ci-flakiness.md.
       - name: Build and push API image
         if: steps.image-tag.outputs.skip_build != 'true'
-        uses: docker/build-push-action@v6
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea  # v3.8.0
         with:
-          context: .
-          file: apps/api/Dockerfile
-          push: true
-          tags: |
-            ${{ steps.ar.outputs.repo }}/api:${{ github.event.pull_request.head.sha }}
-            ${{ steps.ar.outputs.repo }}/api:pr-${{ github.event.pull_request.number }}
+          action: docker/build-push-action@v6
+          attempt_limit: 3
+          attempt_delay: 15000
           # Per-image cache scope (#407). Isolates the PR-branch API build
           # from the deploy.yml main-branch API cache, mirroring the web scoping.
-          cache-from: type=gha,scope=api-pr-v2
-          cache-to: type=gha,scope=api-pr-v2,mode=max
+          with: |
+            context: .
+            file: apps/api/Dockerfile
+            push: true
+            tags: ${{ steps.ar.outputs.repo }}/api:${{ github.event.pull_request.head.sha }},${{ steps.ar.outputs.repo }}/api:pr-${{ github.event.pull_request.number }}
+            cache-from: type=gha,scope=api-pr-v2
+            cache-to: type=gha,scope=api-pr-v2,mode=max
 
       - name: Build and push web image
         if: steps.image-tag.outputs.skip_build != 'true'
-        uses: docker/build-push-action@v6
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea  # v3.8.0
         with:
-          context: .
-          file: apps/web/Dockerfile
-          push: true
-          tags: |
-            ${{ steps.ar.outputs.repo }}/web:${{ github.event.pull_request.head.sha }}
-            ${{ steps.ar.outputs.repo }}/web:pr-${{ github.event.pull_request.number }}
-          build-args: |
-            NEXT_PUBLIC_API_URL=${{ steps.api-url.outputs.url }}
-            NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ steps.clerk-pub-key.outputs.key }}
+          action: docker/build-push-action@v6
+          attempt_limit: 3
+          attempt_delay: 15000
           # Scoped cache (#407). Isolates PR-branch builds from the deploy.yml
           # main-branch web caches so a stale layer in one workflow cannot
-          # silently poison the other.
-          cache-from: type=gha,scope=web-pr-v2
-          cache-to: type=gha,scope=web-pr-v2,mode=max
+          # silently poison the other. build-args stays newline-delimited (values
+          # are NAME=value pairs that cannot be comma-split safely).
+          with: |
+            context: .
+            file: apps/web/Dockerfile
+            push: true
+            tags: ${{ steps.ar.outputs.repo }}/web:${{ github.event.pull_request.head.sha }},${{ steps.ar.outputs.repo }}/web:pr-${{ github.event.pull_request.number }}
+            build-args: |
+              NEXT_PUBLIC_API_URL=${{ steps.api-url.outputs.url }}
+              NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ steps.clerk-pub-key.outputs.key }}
+            cache-from: type=gha,scope=web-pr-v2
+            cache-to: type=gha,scope=web-pr-v2,mode=max
 
   # ── 3a. Deploy API (staging) ──────────────────────────────────────────────
   # Split into per-service jobs so they run in parallel within a single PR.
@@ -327,41 +354,42 @@ jobs:
       # Run Job (created by terraform-staging) before the API revision goes live,
       # so staging exercises the same migrate path as prod (#460). Terraform
       # applies a placeholder image, so set the real image, then execute + wait.
-      # continue-on-error matches the staging Cloud Run deploy below: staging
-      # Cloud SQL connectivity is intermittently flaky (#498), and the Staging
-      # Integration Tests are the authoritative gate — a transient migrate blip
-      # should not hard-fail the job before they run. A genuine migration failure
-      # still surfaces as an integration-test failure (missing tables).
+      #
+      # This step previously carried continue-on-error against an assumed
+      # "staging Cloud SQL connectivity flakiness". The #498 diagnosis
+      # (gcloud telemetry, 2026-06-10) found NO such flakiness: 0 migrate
+      # task-failures across 46 runs, all recent API revisions healthy, and no
+      # connection-exhaustion/auth/timeout errors in Cloud SQL logs. The only
+      # DB-side error class observed is schema drift (`relation … does not exist`)
+      # — exactly what continue-on-error would MASK. So the masking is removed:
+      # a bounded retry absorbs the rare transient blip (prisma migrate deploy is
+      # idempotent), and a genuine migration failure now hard-fails the deploy.
+      # See docs/runbooks/staging-ci-flakiness.md and ADR-027.
       - name: Run database migrations (staging)
         id: migrate
-        continue-on-error: true
         run: |
           gcloud run jobs update lifting-logbook-stg-migrate \
             --image="${{ needs.build-images.outputs.ar_repo }}/api:${{ needs.build-images.outputs.image_tag }}" \
             --region="${{ env.REGION }}" \
             --project="${{ vars.GCP_STAGING_PROJECT_ID }}" \
             --quiet
-          gcloud run jobs execute lifting-logbook-stg-migrate \
-            --region="${{ env.REGION }}" \
-            --project="${{ vars.GCP_STAGING_PROJECT_ID }}" \
-            --wait
-
-      # The migrate step above is continue-on-error (Cloud SQL flakiness, #498), so a genuine
-      # migration failure would otherwise vanish into a green run. Surface it loudly: a workflow
-      # warning annotation plus a job-summary block. Advisory only — the Staging Integration
-      # Tests remain the authoritative gate — but it stops a real failure being swallowed
-      # silently. See ADR-027 and CLAUDE.md -> Error Message Diligence.
-      - name: Surface swallowed migration failure (staging)
-        if: steps.migrate.outcome == 'failure'
-        run: |
-          echo "::warning title=Staging migration failed (swallowed by continue-on-error)::The in-VPC Prisma migrate job exited non-zero. This may be transient Cloud SQL flakiness (#498) or a genuine migration failure - confirm the Staging Integration Tests below actually exercise the migrated tables before trusting this run."
-          {
-            echo "### :warning: Staging migration failed (swallowed by continue-on-error)"
-            echo ""
-            echo "The in-VPC Prisma migrate job exited non-zero. \`continue-on-error\` kept the pipeline green per #498 (intermittent staging Cloud SQL connectivity)."
-            echo ""
-            echo "If this is **not** transient flakiness, the staging schema may be stale. Verify the integration tests touched the affected tables, then re-run or investigate. See ADR-027."
-          } >> "$GITHUB_STEP_SUMMARY"
+          # Bounded retry: idempotent migrate deploy succeeds on retry after a
+          # transient blip; a genuine failure exhausts all attempts and hard-fails.
+          for attempt in 1 2 3; do
+            if gcloud run jobs execute lifting-logbook-stg-migrate \
+                 --region="${{ env.REGION }}" \
+                 --project="${{ vars.GCP_STAGING_PROJECT_ID }}" \
+                 --wait; then
+              echo "Migrate succeeded on attempt ${attempt}."
+              exit 0
+            fi
+            if [ "${attempt}" -lt 3 ]; then
+              echo "Migrate attempt ${attempt} failed; retrying in $((attempt * 15))s..."
+              sleep $((attempt * 15))
+            fi
+          done
+          echo "::error title=Staging migration failed::The in-VPC Prisma migrate job exited non-zero on all 3 attempts. This is a genuine migration/schema failure, not transient flakiness (#498 diagnosis). See ADR-027 and docs/runbooks/staging-ci-flakiness.md."
+          exit 1
 
       - name: Set up GKE credentials
         if: needs.terraform-staging.outputs.gke_enabled == 'true'
@@ -471,8 +499,12 @@ jobs:
       - name: Deploy API to Cloud Run (staging)
         id: deploy-api
         if: steps.clerk-check.outputs.configured == 'true'
-        # Cloud SQL connectivity issues tracked in #498. continue-on-error allows the
-        # job to complete so the log-fetch step below can capture the crash reason.
+        # continue-on-error is retained here (NOT for Cloud SQL flakiness — the
+        # #498 diagnosis found none) so a failed revision still lets the log-fetch
+        # step below capture the container crash reason; the integration-test gate
+        # then fails the run. A "container did not start" here is most likely an
+        # image/startup or Artifact Registry issue, not connectivity. See
+        # docs/runbooks/staging-ci-flakiness.md.
         continue-on-error: true
         run: |
           gcloud run deploy lifting-logbook-stg-api \
@@ -661,7 +693,7 @@ jobs:
             exit 1
           fi
           if [[ "$API_DEPLOYED" != "true" ]]; then
-            echo "::error::Cloud Run API deploy failed — integration tests cannot run. Check the 'Fetch Cloud Run API logs on failure' step in the Deploy API (staging) job. Tracked in #498."
+            echo "::error::Cloud Run API deploy failed — integration tests cannot run. Check the 'Fetch Cloud Run API logs on failure' step in the Deploy API (staging) job (commonly an image/startup error or an Artifact Registry push issue — not Cloud SQL connectivity, per the #498 diagnosis). See docs/runbooks/staging-ci-flakiness.md."
             exit 1
           fi
 
@@ -794,7 +826,7 @@ jobs:
             } else if (!clerkConfigured) {
               body = '⚠️ **Staging integration tests skipped** — `lifting-logbook-stg-clerk-secret-key` in GCP Secret Manager is still the placeholder value. Follow [docs/deploy.md Step 4](https://github.com/${{ github.repository }}/blob/${{ github.event.pull_request.head.sha }}/docs/deploy.md#step-4--sign-up-for-clerk-and-create-two-apps) to configure the staging Clerk secret key, then re-run CI.';
             } else if (!cloudRunApiDeployed) {
-              body = `⚠️ **Staging integration tests skipped** — Cloud Run API deploy failed (container did not start). Check the "Fetch Cloud Run API logs on failure" step in the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for the crash reason. Tracked in [#498](https://github.com/${{ github.repository }}/issues/498).`;
+              body = `⚠️ **Staging integration tests skipped** — Cloud Run API deploy failed (container did not start). Check the "Fetch Cloud Run API logs on failure" step in the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for the crash reason — commonly an image/startup error or an Artifact Registry push issue, not Cloud SQL connectivity (see the [#498](https://github.com/${{ github.repository }}/issues/498) diagnosis and \`docs/runbooks/staging-ci-flakiness.md\`).`;
             } else if (testResult === 'success') {
               body = `✅ **Staging integration tests passed**\n\n🔗 [Staging environment](${webUrl})`;
             } else if (testResult === 'failure') {

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -368,15 +368,17 @@ jobs:
       - name: Run database migrations (staging)
         id: migrate
         run: |
-          gcloud run jobs update lifting-logbook-stg-migrate \
-            --image="${{ needs.build-images.outputs.ar_repo }}/api:${{ needs.build-images.outputs.image_tag }}" \
-            --region="${{ env.REGION }}" \
-            --project="${{ vars.GCP_STAGING_PROJECT_ID }}" \
-            --quiet
-          # Bounded retry: idempotent migrate deploy succeeds on retry after a
-          # transient blip; a genuine failure exhausts all attempts and hard-fails.
+          # Bounded retry covering BOTH the job-image update and the execute:
+          # each is idempotent (same image ref; idempotent migrate deploy), so a
+          # transient blip on either call succeeds on retry, while a genuine
+          # failure exhausts all attempts and hard-fails (no masking).
           for attempt in 1 2 3; do
-            if gcloud run jobs execute lifting-logbook-stg-migrate \
+            if gcloud run jobs update lifting-logbook-stg-migrate \
+                 --image="${{ needs.build-images.outputs.ar_repo }}/api:${{ needs.build-images.outputs.image_tag }}" \
+                 --region="${{ env.REGION }}" \
+                 --project="${{ vars.GCP_STAGING_PROJECT_ID }}" \
+                 --quiet \
+               && gcloud run jobs execute lifting-logbook-stg-migrate \
                  --region="${{ env.REGION }}" \
                  --project="${{ vars.GCP_STAGING_PROJECT_ID }}" \
                  --wait; then

--- a/docs/adr/ADR-027-deploy-pipeline-migrations.md
+++ b/docs/adr/ADR-027-deploy-pipeline-migrations.md
@@ -139,6 +139,32 @@ break-glass / first-time-bootstrap path, not the steady-state mechanism.
 - **Self-hosted runner on the VPC.** Rejected: a standing runner is far more operational
   surface than a per-deploy job for a single-maintainer project.
 
+## Addendum — 2026-06-10: staging migrate `continue-on-error` removed (#498)
+
+When this ADR shipped, the staging pipeline's `Run database migrations (staging)` step (and the
+Cloud Run API deploy step) carried `continue-on-error: true`, justified as tolerating
+"intermittent staging Cloud SQL connectivity flakiness", with the Staging Integration Tests as
+the authoritative gate. [#498](https://github.com/brownm09/lifting-logbook/issues/498) was filed
+to track that untracked root cause.
+
+A read-only GCP diagnosis (gcloud telemetry, 2026-06-10) **did not corroborate the Cloud SQL
+premise**: 0 migrate task-failures across the last 46 executions, all recent Cloud Run API
+revisions healthy, and no connection-exhaustion / auth / connect-timeout errors in the staging
+Cloud SQL logs over 7 days. The only DB-side error class observed was schema drift
+(`relation "public.custom_lift" does not exist`) — precisely the failure mode the migrate
+`continue-on-error` could **mask**. The genuine staging red-run driver was upstream: transient
+Artifact Registry 504s on image push and Terraform apply transients (the #395 misleading-error
+chain through the `Verify deploy prerequisites` guard).
+
+**Change:** the migrate step's `continue-on-error` is **removed**. A bounded 3-attempt retry now
+absorbs the rare transient blip (`prisma migrate deploy` is idempotent), and a genuine
+migration/schema failure **hard-fails the deploy** rather than being swallowed — restoring the
+fail-safe ordering this ADR's Decision intended. The "Surface swallowed migration failure" step
+is removed (nothing is swallowed now). Bounded retries were also added to the real driver (AR
+build/push, Terraform apply). The Cloud Run API deploy step keeps `continue-on-error` solely so
+its log-fetch step can capture a crash reason; the integration-test gate still fails the run.
+Full evidence and re-triage guidance: [`docs/runbooks/staging-ci-flakiness.md`](../runbooks/staging-ci-flakiness.md).
+
 ## References
 
 - [Prisma — Deploying database changes with Prisma Migrate](https://www.prisma.io/docs/orm/prisma-migrate/workflows/development-and-production#production-and-testing-environments) — establishes `prisma migrate deploy` as the production/CI command (applies pending migrations, never resets, no prompts); the basis for the job's command.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -17,6 +17,7 @@ For severity levels, escalation paths, and the incident response checklist, see
 | [Database unreachable](database-unreachable.md) | DB connection errors in structured logs | SEV1 |
 | [Auth provider outage](auth-provider-outage.md) | 401/403 surge + Clerk status incident | SEV2 |
 | [Deploy regression rollback](deploy-regression-rollback.md) | Error rate spike correlated with recent deploy | SEV2 |
+| [Staging CI flakiness](staging-ci-flakiness.md) | `staging.yml` red runs that pass on re-run | SEV3 |
 
 ---
 

--- a/docs/runbooks/staging-ci-flakiness.md
+++ b/docs/runbooks/staging-ci-flakiness.md
@@ -1,0 +1,87 @@
+# Runbook: Staging CI Flakiness (staging.yml red runs)
+
+**Triggers:** `staging.yml` runs go red/yellow on transient causes; re-running failed jobs goes
+green; `Verify deploy prerequisites` fails with "deploy-api did not succeed"
+**Default severity:** SEV3 — CI signal only; production is unaffected
+**Dashboard:** GitHub Actions → Staging workflow runs
+
+---
+
+## Symptom
+
+- A `staging.yml` run fails, but re-running the failed jobs (no code change) goes green.
+- The `Staging Integration Tests → Verify deploy prerequisites` step errors with
+  `deploy-api did not succeed (result: skipped|cancelled)`.
+- The `Build & Push Images` job failed on `Build and push API/web image`.
+- `Terraform apply (staging)` failed transiently.
+
+## Likely causes
+
+Ordered by observed probability (the [#498](https://github.com/brownm09/lifting-logbook/issues/498)
+diagnosis, 2026-06-10):
+
+1. **Artifact Registry 504 on layer-blob push** during `Build & Push Images`. This is the
+   dominant driver. When the build job fails, `deploy-api` is skipped (`needs: build-images`), and
+   the `Verify deploy prerequisites` guard then fails — the message talks about *deploy
+   prerequisites*, but the true cause is one job upstream (the #395 misleading-error chain).
+2. **Terraform apply transient** — a GCP API 5xx or eventual-consistency hiccup during
+   `terraform apply (staging)`.
+3. **Genuine failure** — a real build break, a real migration/schema error, or a real Terraform
+   config error. These should *not* be re-run blindly; read the logs.
+
+**NOT a likely cause: staging Cloud SQL connectivity.** The #498 diagnosis found the staging
+Cloud SQL instance (`lifting-logbook-stg-db-913df97c`, `db-f1-micro`, ALWAYS-on, ZONAL,
+private-IP) healthy: 0 migrate task-failures across 46 runs, all recent Cloud Run API revisions
+healthy, and no connection-exhaustion / auth / connect-timeout errors in 7 days of Cloud SQL
+logs. The historical `continue-on-error` on the migrate/deploy steps was added against this
+*assumed* cause; the migrate step no longer tolerates failure (see Mitigations below).
+
+## Diagnosis
+
+1. Identify which job actually failed (not just the guard that reported it):
+   ```bash
+   gh run view <run-id> --json jobs \
+     --jq '.jobs[] | select(.conclusion=="failure") | {name, steps: [.steps[] | select(.conclusion=="failure") | .name]}'
+   ```
+   If the failing job is `Build & Push Images` or `Terraform (staging)`, the prereq-guard failure
+   is a downstream symptom, not the cause.
+2. Confirm Cloud SQL is healthy before suspecting connectivity:
+   ```bash
+   # ERROR-severity Cloud SQL logs (should be empty / only schema-drift, not connect errors)
+   gcloud logging read 'resource.type="cloudsql_database" AND resource.labels.database_id="lifting-logbook-staging:lifting-logbook-stg-db-913df97c" AND severity>=ERROR' \
+     --project=lifting-logbook-staging --freshness=3d --limit=20 \
+     --format="value(timestamp,severity,textPayload)"
+   # Migrate job execution health (failedCount should be empty/0)
+   gcloud run jobs executions list --job=lifting-logbook-stg-migrate \
+     --region=us-central1 --project=lifting-logbook-staging \
+     --format="table(metadata.name,status.succeededCount,status.failedCount)" --limit=15
+   ```
+3. For a build failure, open the `Build and push API/web image` step log and look for
+   `5xx`/`504` on a layer-blob `PUT` to `*-docker.pkg.dev`.
+
+## Remediation
+
+The pipeline now self-heals the transient classes; manual action is the exception:
+
+1. **AR build/push + Terraform apply** are wrapped in bounded retries
+   (`Wandalen/wretry.action`, 3 attempts on the build steps; a 2-attempt shell loop on
+   `terraform apply`). A single transient 504 no longer reds the run.
+2. **Migrate** runs a bounded 3-attempt retry and then **hard-fails** — there is no longer a
+   `continue-on-error` masking it. A red migrate step is a *genuine* migration/schema failure:
+   read the step log, fix the migration (or `prisma migrate resolve` via
+   `scripts/migrate-staging-db.sh`), do not blindly re-run.
+3. If a transient still slips past the retries, re-run only the failed jobs:
+   ```bash
+   gh run rerun <run-id> --failed
+   ```
+4. If AR 504s become frequent/sustained (not transient), check Artifact Registry status and the
+   repo's region health; consider raising the retry attempt limit as a stopgap.
+
+## Escalation
+
+- Sustained (non-transient) Artifact Registry failures → GCP support / status page; this is
+  outside the repo's control.
+- A genuine migration failure that blocks staging → follow [ADR-027](../adr/ADR-027-deploy-pipeline-migrations.md)
+  recovery (forward-only; `prisma migrate resolve` for a failed row).
+- If Cloud SQL connectivity *does* start failing (contradicting the #498 diagnosis), reopen #498
+  with the new `gcloud logging` evidence and re-evaluate connector / tier provisioning.


### PR DESCRIPTION
## Summary

Issue #498 was filed to track an *assumed* "intermittent staging Cloud SQL connectivity flakiness" — the rationale for `continue-on-error` on the staging migrate + Cloud Run deploy steps. A read-only GCP diagnosis (`gcloud`, `lifting-logbook-staging`) **does not corroborate that premise**, and this PR re-scopes the fix accordingly (Error Message Diligence; the issue's own AC allowed "an explicit decision … with documented rationale").

### Diagnosis (full evidence: [#498 comment](https://github.com/brownm09/lifting-logbook/issues/498#issuecomment-4673917094))
- **Cloud SQL is healthy**: instance `db-f1-micro` ALWAYS-on/RUNNABLE; connector `min-instances=2` (always warm); **0** migrate task-failures across the last 46 executions; all 10 recent API revisions healthy; **no** connection-exhaustion / auth / connect-timeout errors in 7 days of logs. Only benign INFO disconnects, one planned 06-07 maintenance restart, and `relation … does not exist` **schema drift** (the class the migrate `continue-on-error` could *mask*).
- **Real red-run driver**: transient **Artifact Registry 504s on layer-blob push** + **Terraform apply** transients, cascading into the `Verify deploy prerequisites` guard (the #395 misleading-error chain). The workflow's own guard messages already named AR-504.

### Changes
- **Migrate step tightened** (`staging.yml`): removed `continue-on-error`; added a bounded **3-attempt retry** (covers both the job-image `update` and the `execute`, both idempotent) — transient blips absorb, genuine migration/schema failures **hard-fail**. Removed the now-moot "Surface swallowed migration failure" step.
- **Bounded retries on the real driver**: `Wandalen/wretry.action` (pinned to commit `e68c23e…`, v3.8.0) wrapping both `docker/build-push-action@v6` steps (config + #407 cache scoping preserved); a 2-attempt shell loop on `terraform apply`.
- **Reworded** residual `#498` narrative refs to reflect the diagnosis (image/startup + AR, not connectivity). Kept `continue-on-error` on the Cloud Run API deploy step solely for crash-log capture.
- **Docs**: ADR-027 addendum (migrate `continue-on-error` reversal) + new `docs/runbooks/staging-ci-flakiness.md`.

### Acceptance criteria
- [x] Root cause identified & documented — Cloud SQL is *not* the cause; real driver is AR-504 + terraform transients ([evidence](https://github.com/brownm09/lifting-logbook/issues/498#issuecomment-4673917094), runbook).
- [x] Fix/mitigation applied — migrate hard-fails after bounded retry; AR/terraform retries added.
- [x] `#344` refs re-pointed to `#498` — already shipped in 8786bc8 (#499); zero `#344` refs remain.

### Out of scope (follow-up)
- #504 — apply the same AR-504 / terraform-apply retries to `deploy.yml` (prod parity), held out per the ~75% scope guard.

## Testing
Change is **workflow YAML + docs only** (no app code) → per the project coverage table, refactor/docs-only requires no new tests; existing tests must pass.
- `turbo run lint`: **7 successful, 7 total** (FULL TURBO) — passes.
- `staging.yml` validated: parses as YAML (python `yaml.safe_load`) and the `wretry` nested `with:` blocks parse to the correct forwarded `docker/build-push-action` inputs (incl. web `build-args`).
- Full `npm test` (Jest, Testcontainers/Docker) not run: the diff touches no TypeScript/JS and no test files; the suite covers none of the changed surface. **Authoritative end-to-end verification is this PR's own `staging.yml` run** (the workflow runs on PRs, exercising every edited step).
- Pre-PR suppression + test-integrity greps: clean. No `package.json`/lockfile change (lockfile-sync check N/A). Rebased onto #507 (clerk lockfile resync) so CI install is unblocked.

## Review findings disposition
- **[reliability] migrate `update` outside the retry loop** ([#505 review](https://github.com/brownm09/lifting-logbook/pull/505#issuecomment-4674015525)) — **Fixed in `234d91c`**: moved `gcloud run jobs update` inside the bounded retry loop (chained with `execute` via `&&`; both idempotent), so a transient blip on the update is also retried.
- **[question] `wretry` + GHA `type=gha` cache export under the wrapper** — **Verified via this PR's own staging `Build & Push Images` log** (checked for cache export working / no `ACTIONS_CACHE_URL` warning). Disposition: confirmed working — no code change needed. (If the log had shown broken cache export, fallback was a raw `docker buildx --push` retry loop.)
- *Behavior-change note (not a finding):* removing the migrate `continue-on-error` means a genuine migrate failure now fails the `deploy-api` job (previously masked); intended — `Staging Integration Tests` retains `if: always()` and still gates. Documented in the step comment + ADR-027 addendum.
