### PR TITLE
[fix] Resync package-lock.json: @clerk/backend 3.6.1, @clerk/shared 4.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2599,11 +2599,11 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.6.0.tgz",
-      "integrity": "sha512-/b0Ys437C21CyXhgHu4KcFHEQ3+CrBXlB6omQC5TPo9MfrhkMHRtg3LtYsSKp86mUM3IZnrwcll3ioo1kWobOA==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.6.1.tgz",
+      "integrity": "sha512-LkfekzF/0UMXacX+17xy3ExRraO0mm+thXejC8Q32gWHd1wLdxK3YXDsLDF00E1r1InWBKIt2ZOxs6hTwZPJjA==",
       "dependencies": {
-        "@clerk/shared": "^4.16.0",
+        "@clerk/shared": "^4.17.0",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -2612,9 +2612,9 @@
       }
     },
     "node_modules/@clerk/backend/node_modules/@clerk/shared": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.16.0.tgz",
-      "integrity": "sha512-McccBHpv457pMbBMKKSLHuxqCSFe4YFAta1IngBX/uomdtogCDF++K8+dxZWxdYmWd+IrOVydIlLf3JzvEmLJA==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.17.0.tgz",
+      "integrity": "sha512-YeQ+6zDmqyor1mPHjZx18j+LssL6Pobvid8hb7HQMioSo8sGDBEVi/Z12bs+gUhe9KbdP+ygHsKOqqeGAPuPZA==",
       "dependencies": {
         "@tanstack/query-core": "^5.100.6",
         "dequal": "2.0.3",


### PR DESCRIPTION
## Summary

CI is red on **every open PR and the next `main` run**: the `Lint & Test` package-lock sync guard fails and `DB Integration Tests` `npm ci` exits `EUSAGE` with:

```
Invalid: lock file's @clerk/backend@3.6.0 does not satisfy @clerk/backend@3.6.1
Invalid: lock file's @clerk/shared@4.16.0 does not satisfy @clerk/shared@4.17.0
```

`apps/api` / `apps/web` declare `@clerk/backend` with caret ranges (`^3.4.4` / `^3.4.13`). Clerk published `3.6.1` / `4.17.0` after #501 resynced the lock to `3.6.0` / `4.16.0` (~hours earlier), so `npm install --package-lock-only` now resolves the newer patches and the committed lock drifted out of sync — the ADR-036 floating-range drift class (recurrence of #432/#433/#501).

Regenerated the lockfile with `npm install --package-lock-only` — a 7-line change bumping the two `@clerk/*` entries (version + resolved + integrity). No `package.json` change.

## Testing
- `npm install --package-lock-only --ignore-scripts && git diff --exit-code package-lock.json` → **clean** (the exact CI sync-guard command); regeneration is stable at 7 lines.
- Pre-commit `turbo run lint`: **7 successful, 7 total** — passes.
- Lockfile-only change (no source/test edits); full Jest suite covers no changed surface. CI's `Lint & Test` + `DB Integration Tests` are the authoritative gate here and will go green on the resynced lock.

## Review findings disposition
N/A — mechanical lockfile regeneration; no logic change. (No `/review` findings expected; will note any if raised.)
