### PR TITLE
[infra] Apply AR-504 / terraform-apply bounded retries to deploy.yml (prod parity with #498)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,10 +121,25 @@ jobs:
 
       - name: Terraform apply (staging)
         working-directory: ${{ env.TF_DIR }}
+        # Bounded retry absorbs transient GCP API 5xx / eventual-consistency
+        # during apply (a real CI red-run driver per the #498 diagnosis —
+        # docs/runbooks/staging-ci-flakiness.md; #504 applies it here for prod
+        # parity). terraform apply is re-runnable; a genuine config error fails
+        # both attempts and hard-fails.
         run: |
-          terraform apply -auto-approve \
-            -var-file=terraform.tfvars.staging \
-            -var="billing_account=${{ secrets.GCP_BILLING_ACCOUNT }}"
+          for attempt in 1 2; do
+            if terraform apply -auto-approve \
+                 -var-file=terraform.tfvars.staging \
+                 -var="billing_account=${{ secrets.GCP_BILLING_ACCOUNT }}"; then
+              exit 0
+            fi
+            if [ "${attempt}" -lt 2 ]; then
+              echo "Terraform apply attempt ${attempt} failed; retrying in 20s..."
+              sleep 20
+            fi
+          done
+          echo "::error title=Terraform apply failed::terraform apply (staging) failed on both attempts."
+          exit 1
 
       - name: Capture Terraform outputs
         id: tf-outputs
@@ -268,21 +283,29 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Bounded retry (Wandalen/wretry.action, pinned to v3.8.0 SHA) wraps the
+      # build+push to absorb transient Artifact Registry 504s on layer-blob
+      # push — the dominant real CI red-run driver per the #498 diagnosis
+      # (docs/runbooks/staging-ci-flakiness.md), applied here for prod parity
+      # (#504). Cached layers make a push-retry cheap. The wrapped
+      # docker/build-push-action@v6 config is unchanged; tags are
+      # comma-separated to keep wretry's forwarded `with` a flat parse.
       - name: Build and push API image
-        uses: docker/build-push-action@v6
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea  # v3.8.0
         with:
-          context: .
-          file: apps/api/Dockerfile
-          push: true
-          tags: |
-            ${{ steps.ar.outputs.repo }}/api:${{ github.sha }}
-            ${{ steps.ar.outputs.repo }}/api:latest
-          # Per-image cache scope (#407). Same rationale as the web builds
-          # below — isolates the API build cache from any other image flavor
-          # so a stale layer in one cannot poison another. `-v2` suffix forces
-          # a one-time miss on merge.
-          cache-from: type=gha,scope=api-deploy-v2
-          cache-to: type=gha,scope=api-deploy-v2,mode=max
+          action: docker/build-push-action@v6
+          attempt_limit: 3
+          attempt_delay: 15000
+          # Per-image cache scope (#407): isolates the API build cache from any
+          # other image flavor so a stale layer in one cannot poison another.
+          # `-v2` suffix forces a one-time miss on merge.
+          with: |
+            context: .
+            file: apps/api/Dockerfile
+            push: true
+            tags: ${{ steps.ar.outputs.repo }}/api:${{ github.sha }},${{ steps.ar.outputs.repo }}/api:latest
+            cache-from: type=gha,scope=api-deploy-v2
+            cache-to: type=gha,scope=api-deploy-v2,mode=max
 
       # ── Web image: per-env builds (ADR-025) ────────────────────────────────
       # Two builds with per-env NEXT_PUBLIC_* values. The staging tag is built
@@ -291,25 +314,29 @@ jobs:
 
       - name: Build and push web image (staging)
         if: needs.preflight.outputs.staging_enabled == 'true'
-        uses: docker/build-push-action@v6
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea  # v3.8.0
         with:
-          context: .
-          file: apps/web/Dockerfile
-          push: true
-          tags: |
-            ${{ steps.ar.outputs.repo }}/web:${{ github.sha }}-staging
-          build-args: |
-            NEXT_PUBLIC_API_URL=${{ steps.api-url-staging.outputs.url }}
-            NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ steps.clerk-pub-staging.outputs.key }}
+          action: docker/build-push-action@v6
+          attempt_limit: 3
+          attempt_delay: 15000
           # Per-env cache scope (#407). Previously both staging and prod web
           # builds shared an unscoped `type=gha`, which was suspected of
           # poisoning the cache across builds — three consecutive main runs
-          # produced images missing /livez (then /healthz) from the standalone tree despite
-          # the route being on main. Scoping isolates per-image-flavor caches
-          # and the new name (`-v2`) forces a one-time miss on this PR's merge,
-          # rebuilding the next-build layer from scratch.
-          cache-from: type=gha,scope=web-staging-v2
-          cache-to: type=gha,scope=web-staging-v2,mode=max
+          # produced images missing /livez (then /healthz) from the standalone
+          # tree despite the route being on main. Scoping isolates per-image-
+          # flavor caches; the `-v2` suffix forced a one-time miss on merge.
+          # build-args stays newline-delimited (NAME=value pairs cannot be
+          # comma-split safely).
+          with: |
+            context: .
+            file: apps/web/Dockerfile
+            push: true
+            tags: ${{ steps.ar.outputs.repo }}/web:${{ github.sha }}-staging
+            build-args: |
+              NEXT_PUBLIC_API_URL=${{ steps.api-url-staging.outputs.url }}
+              NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ steps.clerk-pub-staging.outputs.key }}
+            cache-from: type=gha,scope=web-staging-v2
+            cache-to: type=gha,scope=web-staging-v2,mode=max
 
       # `:latest` is intentionally moved here from the (previously single) web
       # build. In staging-enabled mode this means the `:latest` tag in the
@@ -320,20 +347,24 @@ jobs:
       # uses the explicit `-staging` SHA tag — so the asymmetry is invisible
       # to the deploy pipeline itself.
       - name: Build and push web image (production)
-        uses: docker/build-push-action@v6
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea  # v3.8.0
         with:
-          context: .
-          file: apps/web/Dockerfile
-          push: true
-          tags: |
-            ${{ steps.ar.outputs.repo }}/web:${{ github.sha }}-prod
-            ${{ steps.ar.outputs.repo }}/web:latest
-          build-args: |
-            NEXT_PUBLIC_API_URL=${{ steps.api-url-prod.outputs.url }}
-            NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ steps.clerk-pub-prod.outputs.key }}
+          action: docker/build-push-action@v6
+          attempt_limit: 3
+          attempt_delay: 15000
           # Per-env cache scope (#407) — see staging build above for context.
-          cache-from: type=gha,scope=web-prod-v2
-          cache-to: type=gha,scope=web-prod-v2,mode=max
+          # build-args stays newline-delimited (NAME=value pairs cannot be
+          # comma-split safely).
+          with: |
+            context: .
+            file: apps/web/Dockerfile
+            push: true
+            tags: ${{ steps.ar.outputs.repo }}/web:${{ github.sha }}-prod,${{ steps.ar.outputs.repo }}/web:latest
+            build-args: |
+              NEXT_PUBLIC_API_URL=${{ steps.api-url-prod.outputs.url }}
+              NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ steps.clerk-pub-prod.outputs.key }}
+            cache-from: type=gha,scope=web-prod-v2
+            cache-to: type=gha,scope=web-prod-v2,mode=max
 
       # ── Copy images to production AR (#411) ────────────────────────────────
       # `steps.ar.outputs.repo` resolves to the *staging* AR in staging-enabled
@@ -367,21 +398,46 @@ jobs:
       # writes new tags in the prod AR. The prod CI/CD SA must have
       # `roles/artifactregistry.reader` on the staging AR for the read; if
       # this errors with permission denied, grant that role and rerun.
+      # Bounded retry: imagetools create is a registry-to-registry copy
+      # (staging AR → prod AR) exposed to the same transient AR 504s as the
+      # build/push steps (#498 / #504). The copy is idempotent (tag
+      # overwrite); a genuine permission/manifest error fails all attempts and
+      # hard-fails the deploy.
       - name: Copy API image to prod AR
         if: needs.preflight.outputs.staging_enabled == 'true'
         run: |
-          docker buildx imagetools create \
-            --tag ${{ steps.ar-prod.outputs.repo }}/api:${{ github.sha }} \
-            --tag ${{ steps.ar-prod.outputs.repo }}/api:latest \
-            ${{ steps.ar.outputs.repo }}/api:${{ github.sha }}
+          for attempt in 1 2 3; do
+            if docker buildx imagetools create \
+                 --tag ${{ steps.ar-prod.outputs.repo }}/api:${{ github.sha }} \
+                 --tag ${{ steps.ar-prod.outputs.repo }}/api:latest \
+                 ${{ steps.ar.outputs.repo }}/api:${{ github.sha }}; then
+              exit 0
+            fi
+            if [ "${attempt}" -lt 3 ]; then
+              echo "imagetools copy (API) attempt ${attempt} failed; retrying in 15s..."
+              sleep 15
+            fi
+          done
+          echo "::error title=Image copy failed::Copy API image to prod AR failed after 3 attempts."
+          exit 1
 
       - name: Copy web image to prod AR
         if: needs.preflight.outputs.staging_enabled == 'true'
         run: |
-          docker buildx imagetools create \
-            --tag ${{ steps.ar-prod.outputs.repo }}/web:${{ github.sha }}-prod \
-            --tag ${{ steps.ar-prod.outputs.repo }}/web:latest \
-            ${{ steps.ar.outputs.repo }}/web:${{ github.sha }}-prod
+          for attempt in 1 2 3; do
+            if docker buildx imagetools create \
+                 --tag ${{ steps.ar-prod.outputs.repo }}/web:${{ github.sha }}-prod \
+                 --tag ${{ steps.ar-prod.outputs.repo }}/web:latest \
+                 ${{ steps.ar.outputs.repo }}/web:${{ github.sha }}-prod; then
+              exit 0
+            fi
+            if [ "${attempt}" -lt 3 ]; then
+              echo "imagetools copy (web) attempt ${attempt} failed; retrying in 15s..."
+              sleep 15
+            fi
+          done
+          echo "::error title=Image copy failed::Copy web image to prod AR failed after 3 attempts."
+          exit 1
 
       # Auth context invariant: build-images now ends with the prod CI/CD SA
       # active (the auth swap above for the imagetools copy is not restored).
@@ -752,14 +808,30 @@ jobs:
 
       - name: Terraform apply (production)
         working-directory: ${{ env.TF_DIR }}
+        # Bounded retry absorbs transient GCP API 5xx / eventual-consistency
+        # during apply (the same real CI driver as staging — #498 / #504,
+        # docs/runbooks/staging-ci-flakiness.md). init + workspace select run
+        # once; only the re-runnable apply retries. A genuine config error
+        # fails both attempts and hard-fails the prod deploy — failure
+        # semantics unchanged (AC #3 of #504).
         run: |
           terraform init \
             -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}" \
             -backend-config="prefix=terraform/state"
           terraform workspace select production || terraform workspace new production
-          terraform apply -auto-approve \
-            -var-file=terraform.tfvars.production \
-            -var="billing_account=${{ secrets.GCP_BILLING_ACCOUNT }}"
+          for attempt in 1 2; do
+            if terraform apply -auto-approve \
+                 -var-file=terraform.tfvars.production \
+                 -var="billing_account=${{ secrets.GCP_BILLING_ACCOUNT }}"; then
+              exit 0
+            fi
+            if [ "${attempt}" -lt 2 ]; then
+              echo "Terraform apply attempt ${attempt} failed; retrying in 20s..."
+              sleep 20
+            fi
+          done
+          echo "::error title=Terraform apply failed::terraform apply (production) failed on both attempts."
+          exit 1
 
       - name: Capture production Terraform outputs
         id: tf-prod

--- a/docs/runbooks/staging-ci-flakiness.md
+++ b/docs/runbooks/staging-ci-flakiness.md
@@ -65,7 +65,11 @@ The pipeline now self-heals the transient classes; manual action is the exceptio
 
 1. **AR build/push + Terraform apply** are wrapped in bounded retries
    (`Wandalen/wretry.action`, 3 attempts on the build steps; a 2-attempt shell loop on
-   `terraform apply`). A single transient 504 no longer reds the run.
+   `terraform apply`). A single transient 504 no longer reds the run. The same hardening was
+   applied to `deploy.yml` (the push-to-`main` prod + staging-promote pipeline) for parity
+   ([#504](https://github.com/brownm09/lifting-logbook/issues/504)) — including bounded retries on
+   the two `terraform apply` steps, all three `docker/build-push-action` builds, and the two
+   `imagetools` staging-AR→prod-AR copies, which are exposed to the same transient AR 504s.
 2. **Migrate** runs a bounded 3-attempt retry and then **hard-fails** — there is no longer a
    `continue-on-error` masking it. A red migrate step is a *genuine* migration/schema failure:
    read the step log, fix the migration (or `prisma migrate resolve` via


### PR DESCRIPTION
## Summary

Mirrors the [#498](https://github.com/brownm09/lifting-logbook/issues/498) staging.yml hardening (merged in [#505](https://github.com/brownm09/lifting-logbook/pull/505)) into **`deploy.yml`** — the push-to-`main` production + staging-promote pipeline. `deploy.yml` shares the same `docker/build-push-action` build/push and `terraform apply` steps as `staging.yml`, so it is exposed to the **identical transient failure classes** the #498 diagnosis identified as the real CI red-run drivers — **Artifact Registry 504s on layer-blob push** and **GCP API 5xx / eventual-consistency during `terraform apply`** — but did not receive the retry treatment in the #498 PR (scoped to `staging.yml` per the ~75% scope guard).

## Changes (`.github/workflows/deploy.yml`)

| Step(s) | Treatment |
|---|---|
| Build & push **API**, **web-staging**, **web-prod** (3 steps) | Wrapped with `Wandalen/wretry.action` @ `e68c23e…` (v3.8.0, same pinned SHA as `staging.yml`), 3 attempts / 15s delay. Each step's `with` config, per-image GHA cache scope (#407), and `if:` guard preserved; tags comma-separated to keep wretry's forwarded `with` a flat parse; `build-args` kept newline-delimited. |
| `terraform apply` **(staging)** + **(production)** (2 steps) | 2-attempt shell retry, 20s backoff. For production, `init` + `workspace select` stay **outside** the loop; only the re-runnable `apply` retries. |
| `imagetools` **API copy** + **web copy** to prod AR (2 steps) | 3-attempt shell retry, 15s backoff. *Beyond the literal AC bullets* — these registry-to-registry copies (`docker buildx imagetools create`, staging AR → prod AR) are pure registry I/O and exposed to the same AR-504 class, so prod-parity intent covers them. ~12 lines; well within the scope guard. |

**Failure semantics unchanged (AC #3):** every retry loop hard-fails after attempts exhaust (`exit 1` + `::error::`). A genuine build break, config error, or permission/manifest error fails all attempts and reds the deploy exactly as before. Retries fire only on failure; the happy path is unchanged, and cached layers make a push-retry cheap.

Runbook [`docs/runbooks/staging-ci-flakiness.md`](docs/runbooks/staging-ci-flakiness.md) updated with a deploy.yml parity note so it stays accurate.

## Acceptance criteria

- [x] `deploy.yml` build/push steps retry transient AR 504s (bounded, cached layers keep retries cheap).
- [x] `deploy.yml` `terraform apply` retries transient GCP API 5xx (both staging-promote and production).
- [x] No change to prod deploy *failure* semantics for genuine errors (retries exhaust → hard-fail).

## Testing

`deploy.yml` runs **`on: push` to `main` only** — it is **not** triggered by pull requests, so this PR cannot self-verify via a live pipeline run (unlike #505, which ran `staging.yml` on its own PR). Verification performed:

- **`actionlint`** (dockerized `rhysd/actionlint:latest`): **clean on all changed lines** — zero errors/warnings on the edited steps (expression syntax, `needs` refs, and the wretry forwarded `with` block all valid). The only output is three **pre-existing** SC2129 *style* nits on the unchanged `Capture Terraform outputs` `>> "$GITHUB_OUTPUT"` blocks (lines 147/839/1097) — not in this diff; out of scope.
- **YAML parse** (PyYAML, utf-8): OK. Structural counts confirmed: 3 wretry-wrapped builds (0 direct `build-push-action` remaining), 2 terraform retry loops, 2 imagetools retry loops.
- **Structural parity** with the proven `staging.yml` pattern from #505, whose identical wretry-`with`-forwarding structure was verified end-to-end by #505's own live staging run (Build & Push cache-export confirmed, Deploy + Terraform + Integration Tests green).
- **Pre-commit** `turbo run lint`: 7/7 passed.

No automated workflow-YAML unit tests exist in this repo. Real-world exercise of these retry paths occurs on the next merge to `main` (the prod pipeline); the changes are behavior-preserving on the happy path, so a green next-deploy is the expected outcome.

Pre-PR gates: suppression grep clean; test-integrity grep clean; no `package.json` touched (lockfile check N/A); no test files affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review findings disposition

`/review` (claude-opus-4-8) — **0 blocking, 1 non-blocking**:

- **[reliability] `terraform init` / `workspace select` not covered by the retry** — **filed [#509](https://github.com/brownm09/lifting-logbook/issues/509)** (covers both `staging.yml` and `deploy.yml`). Deliberately deferred: the #504 AC named `terraform apply` specifically, and the same boundary exists in the already-merged `staging.yml` (#505); #509 completes the hardening consistently across both workflows rather than diverging here.
