### PR TITLE
[docs] Reconcile ADR-006/009/010/015 with code; flag RLS isolation gap (#495)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -137,16 +137,16 @@ monorepo/
 | [ADR-003](adr/ADR-003-per-user-data-store-config.md)          | Per-User Data Store Configuration                             | Accepted |
 | [ADR-004](adr/ADR-004-multi-data-store-adapters.md)           | Multi-Data-Store Adapter Strategy                             | Accepted |
 | [ADR-005](adr/ADR-005-authentication-strategy.md)             | Authentication Strategy                                       | Accepted |
-| [ADR-006](adr/ADR-006-rest-and-graphql-dual-transport.md)     | Dual Transport Layer — REST and GraphQL                       | Accepted |
+| [ADR-006](adr/ADR-006-rest-and-graphql-dual-transport.md)     | Dual Transport Layer — REST and GraphQL                       | Accepted · GraphQL not implemented |
 | [ADR-007](adr/ADR-007-nextjs-app-router-web-frontend.md)      | Next.js App Router for Web Frontend                           | Accepted |
 | [ADR-008](adr/ADR-008-mobile-strategy.md)                     | Mobile Client Strategy — React Native to Native Kotlin        | Accepted |
-| [ADR-009](adr/ADR-009-infrastructure-kubernetes-cloud-run.md) | Infrastructure — GKE Autopilot Primary, Cloud Run Comparison  | Accepted |
-| [ADR-010](adr/ADR-010-multi-tenancy-data-isolation.md)        | Multi-Tenancy Data Isolation Strategy                         | Accepted |
+| [ADR-009](adr/ADR-009-infrastructure-kubernetes-cloud-run.md) | Infrastructure — GKE Autopilot Primary, Cloud Run Comparison  | Accepted · 90/10 split not wired |
+| [ADR-010](adr/ADR-010-multi-tenancy-data-isolation.md)        | Multi-Tenancy Data Isolation Strategy                         | Accepted · RLS not implemented ([#511](https://github.com/brownm09/lifting-logbook/issues/511)) |
 | [ADR-011](adr/ADR-011-api-server-nestjs-and-express.md)       | API Server — NestJS Primary with Express Legacy Comparison    | Accepted |
 | [ADR-012](adr/ADR-012-analytics-and-ab-testing.md)            | Analytics and A/B Testing — Firebase Analytics and Optimizely | Accepted |
 | [ADR-013](adr/ADR-013-testing-strategy.md)                    | Testing Strategy                                              | Accepted |
 | [ADR-014](adr/ADR-014-credential-encryption-at-rest.md)       | Credential Encryption at Rest                                 | Accepted |
-| [ADR-015](adr/ADR-015-graphql-dataloader-design.md)           | GraphQL DataLoader Design                                     | Accepted |
+| [ADR-015](adr/ADR-015-graphql-dataloader-design.md)           | GraphQL DataLoader Design                                     | Accepted · deferred (no GraphQL yet) |
 | [ADR-016](adr/ADR-016-cycle-planning-agent.md)                | Cycle Planning Agent                                          | Accepted |
 | [ADR-017](adr/ADR-017-training-max-history-table.md)          | Training Max History — Dedicated Table vs. Derived            | Accepted |
 | [ADR-018](adr/ADR-018-observability-stack.md)                 | Observability Stack — OpenTelemetry + Grafana Cloud           | Accepted |

--- a/docs/adr/ADR-006-rest-and-graphql-dual-transport.md
+++ b/docs/adr/ADR-006-rest-and-graphql-dual-transport.md
@@ -4,6 +4,7 @@
 **Date:** 2026-04-03
 **Reviewed:** 2026-04-07
 **Review outcome:** Pass with gaps — open items: [#40](https://github.com/brownm09/lifting-logbook/issues/40)
+**Implementation status (2026-06-10):** REST transport implemented; **GraphQL transport not implemented** — the API is REST-only (no `@nestjs/graphql`, no resolvers, no schema in the codebase). The dual-transport *decision* stands as accepted design; the GraphQL half remains unbuilt. ([#40](https://github.com/brownm09/lifting-logbook/issues/40) closed the GraphQL *design* in ADR-015, not its implementation.) Surfaced by the 2026-06-08 architecture review ([#464](https://github.com/brownm09/lifting-logbook/issues/464)) and reconciled in [#495](https://github.com/brownm09/lifting-logbook/issues/495).
 
 ---
 

--- a/docs/adr/ADR-009-infrastructure-kubernetes-cloud-run.md
+++ b/docs/adr/ADR-009-infrastructure-kubernetes-cloud-run.md
@@ -4,6 +4,7 @@
 **Date:** 2026-04-03
 **Reviewed:** 2026-04-07
 **Review outcome:** Pass
+**Implementation status (2026-06-10):** Partially implemented — both GKE and Cloud Run deploy the same image, but the **90/10 Cloud Load Balancer traffic split (below) is not wired**: there are no weighted `google_compute_backend_service` backends, URL-map split rules, or Ingress canary annotations in `infra/`. Each target is reachable independently today; the A/B traffic-split mechanism is unimplemented. Surfaced by the 2026-06-08 architecture review ([#464](https://github.com/brownm09/lifting-logbook/issues/464)) and reconciled in [#495](https://github.com/brownm09/lifting-logbook/issues/495).
 
 ---
 

--- a/docs/adr/ADR-010-multi-tenancy-data-isolation.md
+++ b/docs/adr/ADR-010-multi-tenancy-data-isolation.md
@@ -4,6 +4,7 @@
 **Date:** 2026-04-03
 **Reviewed:** 2026-04-07
 **Review outcome:** Pass
+**Implementation status (2026-06-10):** Partially implemented — application-level `user_id` scoping is enforced in every repository (the live isolation boundary). The Postgres **RLS defense-in-depth layer described in the Decision below is NOT implemented**: no `ENABLE ROW LEVEL SECURITY` / `CREATE POLICY` migrations exist and no Prisma middleware sets `app.current_user_id`. Isolation is currently **single-layer**. Surfaced by the 2026-06-08 architecture review ([#464](https://github.com/brownm09/lifting-logbook/issues/464)); implementing-or-deferring the RLS layer is tracked in [#511](https://github.com/brownm09/lifting-logbook/issues/511).
 
 ---
 
@@ -42,6 +43,14 @@ CREATE POLICY user_isolation ON workouts
 
 The application sets `app.current_user_id` at the start of each database session via Prisma
 middleware, so RLS enforcement happens at the database level independent of application logic.
+
+> **⚠ Implementation status (2026-06-10):** The RLS layer described in this section is **not yet
+> implemented**. No migration enables RLS or creates the `user_isolation` policies, and no Prisma
+> middleware/extension sets `app.current_user_id`. The live isolation boundary is application-level
+> `user_id` scoping in the repositories *only* — the database-enforced second layer does not exist.
+> Implementing it (or formally deciding to accept single-layer scoping) is tracked in
+> [#511](https://github.com/brownm09/lifting-logbook/issues/511). The decision to *use* RLS as
+> defense-in-depth stands; this note records that the code has not yet caught up.
 
 ---
 

--- a/docs/adr/ADR-015-graphql-dataloader-design.md
+++ b/docs/adr/ADR-015-graphql-dataloader-design.md
@@ -3,6 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-04-09
 **Closes:** [#40](https://github.com/brownm09/lifting-logbook/issues/40)
+**Implementation status (2026-06-10):** Deferred — no GraphQL resolvers or DataLoaders exist in the codebase (the API is REST-only; see [ADR-006](ADR-006-rest-and-graphql-dual-transport.md)). This document is a prerequisite *design spec* that intentionally predates implementation: it fixes the required request-scoped lifecycle before any resolver is written. It applies once the GraphQL transport is built. Reconciled in [#495](https://github.com/brownm09/lifting-logbook/issues/495).
 
 ---
 


### PR DESCRIPTION
## Summary

Reconciles the three ADR-drift items flagged by the 2026-06-08 architecture review (#464). The review's central warning was that "the ADRs describe an intended system the code may not fully match — the most dangerous failure mode for good docs: they become confidently wrong." Each item was verified against the code; an **Implementation status** line (the signal the review recommended) was added to each affected ADR so the decision text stays intact while the implementation reality is explicit.

### Verified findings

| Item | ADR | Verdict | Evidence |
|---|---|---|---|
| GraphQL transport | ADR-006, ADR-015 | **Absent** | No `@nestjs/graphql`/`apollo`/`graphql` deps, no `*.resolver.ts`, no schema, no `GraphQLModule`/DataLoader. API is REST-only (20 REST controllers). #40 closed the *design*, not the implementation. |
| 90/10 GKE↔Cloud Run split | ADR-009 | **Aspirational** | Only design comments in `gke.tf`/`cloud-run.tf`; no weighted `google_compute_backend_service`, URL-map split, or Ingress canary in `infra/`. |
| RLS defense-in-depth | ADR-010 | **🚨 Absent — isolation gap** | Zero `ENABLE ROW LEVEL SECURITY`/`CREATE POLICY`/`current_setting('app.current_user_id')` across all 17 migrations; no `$use`/`$extends`/`SET LOCAL` in `prisma.service.ts`. Live isolation is single-layer (per-repository `userId` scoping). |

### Changes

- **ADR-006** — Implementation-status line: REST live, GraphQL unbuilt; decision stands.
- **ADR-015** — Implementation-status line: Deferred; design spec predating implementation.
- **ADR-009** — Implementation-status line: both targets deploy, traffic split not wired.
- **ADR-010** — Implementation-status line **+ a corrective callout** in the Decision prose (which claimed RLS "is enabled in Postgres … via Prisma middleware"). The RLS layer is not implemented; isolation is single-layer.
- **docs/README.md** — ADR index Status column annotated for the four affected ADRs.

### RLS finding escalated (not just a doc fix)

ADR-010 justifies RLS as protecting against "application bugs that might otherwise leak cross-user data." That backstop does not exist — a single missing `where: { userId }` would leak across tenants. Per #495's explicit instruction ("if the middleware is missing, spin off a separate implementation/security issue"), filed **#511** to implement Postgres RLS (policies + a per-request `SET LOCAL app.current_user_id` Prisma extension) **or** formally defer with an ADR decision. Added to project #2 (API Implementation epic). **RLS is not implemented in this PR** — out of scope for a docs reconcile.

## Acceptance criteria (#495)

- [x] GraphQL (ADR-006/015) confirmed absent and reconciled.
- [x] 90/10 split (ADR-009) confirmed aspirational and reconciled.
- [x] RLS (ADR-010) verified — middleware **and** policies absent → spun off security issue #511 (multi-tenant isolation gap), per the issue's instruction.
- [x] `docs/adr-references.md` checked — no ADR reference *sets* changed (status-only edits), so no update needed.

## Testing

No new testable behavior — coverage gate N/A; this is a docs reconciliation + a security-issue spin-off. Pre-commit `turbo lint` passed (7/7). Suppression and test-integrity greps on the diff: both clean (markdown-only). No `package.json` change → lockfile check N/A.

Closes #495
Refs #464, #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)