### PR TITLE
[chore] Widen apps/web lint scope to include lib/ (#473)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint app",
+    "lint": "eslint app lib",
     "test": "jest --passWithNoTests",
     "test:e2e": "playwright test",
     "test:e2e:ci": "playwright test --reporter=github",


### PR DESCRIPTION
## Summary

The web workspace lint script was `eslint app`, so `apps/web/lib/*.ts` was **not** linted in CI. This left the `lifting-logbook/require-fetch-cache` rule (#471) running only against `apps/web/app` — the `fetch()` call sites in `lib/` were unguarded against regression. This widens the script to `eslint app lib`.

The root `eslint.config.js` already scopes the custom `lifting-logbook/*` rules to `apps/web/**/*.ts(x)`, so widening the CLI target is the only change needed for the rule to apply to `lib/`.

## Acceptance criteria

- [x] Web lint script now lints `apps/web/lib` (`eslint app lib`).
- [x] `require-fetch-cache` demonstrably fires on a deliberately-broken `fetch()` in `apps/web/lib` — verified, then reverted (see Testing).
- [x] No pre-existing lint violations introduced by the wider scope — `lib/`'s only `fetch()` (`gcp-identity-token.ts`) already passes `cache: 'no-store'`; clean lint confirmed.

## Testing

- **Clean scope:** `npm run lint -w @lifting-logbook/web` → `eslint app lib` passes with **0 violations**.
- **Probe (rule fires in lib/):** added a temporary `lib/_probe_473.ts` with a bare `fetch("https://example.com")` (no cache option) → lint reported:
  ```
  lib/_probe_473.ts
    2:10  error  fetch() must include an explicit cache option ...  lifting-logbook/require-fetch-cache
  ✖ 1 problem (1 error, 0 warnings)
  ```
  Probe then removed.
- No new testable behavior (lint-config scope change). Pre-commit `turbo lint` passed (7/7).
- Lockfile sync: `npm install --package-lock-only --ignore-scripts && git diff --exit-code package-lock.json` → clean (only a script-string change, no dependency change).
- **Suppression/test-integrity greps:** clean. The one `--passWithNoTests` grep match is the pre-existing `"test": "jest --passWithNoTests"` line shown as unchanged diff context — not introduced by this PR (the only changed line is the `lint` script).

Closes #473
Refs #494 (the no-raw-fetch rule that depends on this widened scope), #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)