### PR TITLE
[chore] Add no-raw-fetch-outside-api-client ESLint rule (flag 6) (#494)

### DIFF
--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -31,10 +31,16 @@ export async function GET() {
     return NextResponse.json({ ok: true, userId, apiCheck: 'skipped' });
   }
 
+  /* eslint-disable lifting-logbook/no-raw-fetch-outside-api-client --
+     Deliberate exception: this deployment probe calls the backend /health directly with a
+     GCP identity token for Cloud Run IAM *only* — it intentionally omits Clerk JWT forwarding
+     (see the comment above re: dev-mode JWT TTL). Routing through the typed api-client would
+     add X-Clerk-Authorization and change the auth semantics this probe specifically verifies. */
   const res = await fetch(`${API_URL}/health`, {
     headers: { Authorization: `Bearer ${identityToken}` },
     cache: 'no-store',
   });
+  /* eslint-enable lifting-logbook/no-raw-fetch-outside-api-client */
 
   if (!res.ok) {
     return NextResponse.json(

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,6 +31,11 @@ module.exports = [
     },
     rules: {
       'lifting-logbook/require-fetch-cache': 'error',
+      // Forbid raw fetch() to the API and hand-built auth headers outside the typed api-client.
+      // The rule allowlists the two wrapper modules (lib/api.ts, lib/client-api.ts) and the
+      // metadata-server fetch (lib/gcp-identity-token.ts) internally. See
+      // tools/eslint-rules/no-raw-fetch-outside-api-client.js.
+      'lifting-logbook/no-raw-fetch-outside-api-client': 'error',
     },
   },
   // Enforce test coverage for error-swallowing fallbacks in Server Components and

--- a/tools/eslint-rules/README.md
+++ b/tools/eslint-rules/README.md
@@ -99,10 +99,41 @@ Deliberate non-flags (cannot be verified statically, so left to code review):
   (`{ next: { revalidate: 60 } } as RequestInit`) **is** unwrapped to the object
   literal underneath and inspected.
 
-> **Lint-scope caveat.** The web workspace lint script is `eslint app`, so
-> `apps/web/lib/*.ts` is not currently linted in CI — this rule only effectively
-> runs against `apps/web/app`. Widening that scope is tracked in
-> [#473](https://github.com/brownm09/lifting-logbook/issues/473).
+> **Lint scope.** The web workspace lint script is `eslint app lib`, so this rule
+> runs against both `apps/web/app` and `apps/web/lib` in CI. (`lib/` coverage was
+> added in [#473](https://github.com/brownm09/lifting-logbook/issues/473) — before
+> that the script was `eslint app` and `lib/` fetch sites were unguarded.)
+
+### `lifting-logbook/no-raw-fetch-outside-api-client`
+
+Scoped to `apps/web/**/*.{ts,tsx}` (spec/test files ignored) via
+[`eslint.config.js`](../../eslint.config.js). #466/#479 consolidated all web HTTP
+access into [`packages/api-client`](../../packages/api-client)'s
+`createApiClient({ baseUrl, getAuthHeaders })`, which owns the
+`X-Clerk-Authorization` (server, Cloud Run IAM) vs `Authorization` (browser) split
+and merges auth headers with auth-wins precedence. This rule (flag 6 of the
+2026-06-08 architecture review, [#464](https://github.com/brownm09/lifting-logbook/issues/464)
+/ [#494](https://github.com/brownm09/lifting-logbook/issues/494)) prevents a raw
+`fetch()` to the API — written the "obvious" way — from bypassing the client and
+403-ing behind Cloud Run IAM.
+
+It flags:
+
+- **Bare `fetch(...)` calls** — `fetch(url, …)` (not `something.fetch(…)`). API
+  calls must go through the typed client.
+- **Hand-built auth headers** — an object literal with a static property keyed
+  `Authorization` or `X-Clerk-Authorization` (compared case-insensitively). These
+  headers are owned by the api-client; constructing them elsewhere is the footgun.
+
+Allowlisted files (checked by filename inside the rule, not via `eslint.config.js`):
+
+- `apps/web/lib/api.ts` and `apps/web/lib/client-api.ts` — the two
+  `createApiClient()` wrapper modules that legitimately set auth headers.
+- `apps/web/lib/gcp-identity-token.ts` — fetches the **GCP metadata server** (not
+  the API) and builds a `Metadata-Flavor` header, not an auth header.
+
+`packages/api-client` is outside the `apps/web` lint scope, so the `fetch()` inside
+`createApiClient()` is never seen by this rule.
 
 ## Adding a new rule
 

--- a/tools/eslint-rules/index.js
+++ b/tools/eslint-rules/index.js
@@ -2,10 +2,12 @@
 
 const noUncoveredErrorFallback = require('./no-uncovered-error-fallback');
 const requireFetchCache = require('./require-fetch-cache');
+const noRawFetchOutsideApiClient = require('./no-raw-fetch-outside-api-client');
 
 module.exports = {
   rules: {
     'no-uncovered-error-fallback': noUncoveredErrorFallback,
     'require-fetch-cache': requireFetchCache,
+    'no-raw-fetch-outside-api-client': noRawFetchOutsideApiClient,
   },
 };

--- a/tools/eslint-rules/no-raw-fetch-outside-api-client.js
+++ b/tools/eslint-rules/no-raw-fetch-outside-api-client.js
@@ -1,0 +1,88 @@
+'use strict';
+
+// Forbid raw fetch() to the API and hand-built auth headers in apps/web outside the typed
+// api-client. Flag 6 of the 2026-06-08 architecture review (#464 / #494).
+//
+// #466/#479 consolidated all web HTTP access into packages/api-client's createApiClient(),
+// which encapsulates the X-Clerk-Authorization (server, Cloud Run IAM) vs Authorization
+// (browser) split and merges auth headers with auth-wins precedence. Nothing yet *prevents* a
+// future contributor from writing a raw fetch() to the API the "obvious" way and getting a 403
+// behind Cloud Run IAM. This rule is the lint-rule half of flag 6 (the loud-comment half
+// already lives in the wrappers + CONTRIBUTING.md).
+//
+// Two detectors, both scoped to apps/web by eslint.config.js:
+//   1. bare `fetch(...)` calls — must go through the typed client instead;
+//   2. object-literal properties keyed `Authorization` / `X-Clerk-Authorization` — these
+//      headers are owned by the api-client; hand-building them elsewhere is the footgun.
+//
+// Allowlisted files (they ARE the wrappers / a legitimate non-API fetch):
+//   - apps/web/lib/api.ts, apps/web/lib/client-api.ts — the two createApiClient() wrappers.
+//   - apps/web/lib/gcp-identity-token.ts — fetches the GCP metadata server (not the API) and
+//     builds a `Metadata-Flavor` header, not an auth header.
+// packages/api-client lives outside the apps/web lint scope, so the actual fetch() inside
+// createApiClient() is never seen by this rule.
+
+const ALLOWLISTED_SUFFIXES = [
+  'apps/web/lib/api.ts',
+  'apps/web/lib/client-api.ts',
+  'apps/web/lib/gcp-identity-token.ts',
+];
+
+// Header names are compared case-insensitively (HTTP headers are case-insensitive).
+const AUTH_HEADER_NAMES = new Set(['authorization', 'x-clerk-authorization']);
+
+function isAllowlisted(filename) {
+  if (!filename) return false;
+  const normalized = filename.replace(/\\/g, '/');
+  return ALLOWLISTED_SUFFIXES.some((suffix) => normalized.endsWith(suffix));
+}
+
+// Returns the lower-cased static property name, or null for spreads / computed / non-static keys.
+function staticPropName(prop) {
+  if (prop.type !== 'Property' || prop.computed) return null;
+  const key = prop.key;
+  const name = key.type === 'Identifier' ? key.name : key.type === 'Literal' ? key.value : null;
+  return typeof name === 'string' ? name.toLowerCase() : null;
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Forbid raw fetch() to the API and hand-built Authorization / X-Clerk-Authorization headers in apps/web outside packages/api-client. Route API calls through the typed client (createApiClient).',
+    },
+    schema: [],
+    messages: {
+      rawFetch:
+        'Do not call fetch() directly in apps/web. Route API calls through the typed client in packages/api-client (via lib/api.ts / lib/client-api.ts) so Cloud Run IAM / Clerk auth headers are applied with auth-wins precedence. A raw fetch() to the API 403s behind Cloud Run IAM.',
+      authHeader:
+        'Do not hand-build an "{{ name }}" header in apps/web. The typed api-client owns Authorization / X-Clerk-Authorization (auth-wins merge); constructing it manually bypasses that and risks a 403 behind Cloud Run IAM.',
+    },
+  },
+  create(context) {
+    const filename = context.filename || (context.getFilename && context.getFilename());
+    if (isAllowlisted(filename)) return {};
+
+    return {
+      CallExpression(node) {
+        // Only bare `fetch(...)`, not `something.fetch(...)`.
+        if (node.callee.type === 'Identifier' && node.callee.name === 'fetch') {
+          context.report({ node, messageId: 'rawFetch' });
+        }
+      },
+      ObjectExpression(node) {
+        for (const prop of node.properties) {
+          const name = staticPropName(prop);
+          if (name && AUTH_HEADER_NAMES.has(name)) {
+            context.report({
+              node: prop,
+              messageId: 'authHeader',
+              data: { name: name === 'authorization' ? 'Authorization' : 'X-Clerk-Authorization' },
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/tools/eslint-rules/no-raw-fetch-outside-api-client.test.js
+++ b/tools/eslint-rules/no-raw-fetch-outside-api-client.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const test = require('node:test');
+
+const rule = require('./no-raw-fetch-outside-api-client');
+
+// RuleTester needs a TS-aware parser; resolved from the monorepo root devDependency, matching
+// require-fetch-cache.test.js. Filenames are virtual (no type-aware `project`), so the rule's
+// filename-allowlist check is exercised purely on the passed `filename`.
+const tsParser = require('@typescript-eslint/parser');
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser: tsParser,
+    parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+  },
+});
+
+test('no-raw-fetch-outside-api-client', () => {
+  tester.run('no-raw-fetch-outside-api-client', rule, {
+    valid: [
+      // Calls through the typed client are the sanctioned path.
+      { code: 'apiClient.fetchCycleDashboard(id);', filename: 'apps/web/app/page.ts' },
+      // Member `.fetch` is not a bare fetch() call.
+      { code: 'client.fetch(url);', filename: 'apps/web/app/page.ts' },
+      // A non-auth header object outside the wrappers is fine.
+      { code: "const h = { 'Content-Type': 'application/json' };", filename: 'apps/web/app/page.ts' },
+      // Allowlisted wrapper modules legitimately call fetch() and set auth headers.
+      { code: "fetch(url, { cache: 'no-store' });", filename: 'apps/web/lib/api.ts' },
+      { code: 'const h = { Authorization: `Bearer ${t}` };', filename: 'apps/web/lib/client-api.ts' },
+      // gcp-identity-token.ts is allowlisted: metadata-server fetch + Metadata-Flavor header.
+      {
+        code: "fetch(metadataUrl, { headers: { 'Metadata-Flavor': 'Google' }, cache: 'no-store' });",
+        filename: 'apps/web/lib/gcp-identity-token.ts',
+      },
+    ],
+    invalid: [
+      // Bare fetch() in a non-wrapper file.
+      {
+        code: "fetch('https://api.example.com/x', { cache: 'no-store' });",
+        filename: 'apps/web/app/page.ts',
+        errors: [{ messageId: 'rawFetch' }],
+      },
+      {
+        code: 'fetch(url);',
+        filename: 'apps/web/app/history/page.ts',
+        errors: [{ messageId: 'rawFetch' }],
+      },
+      // Hand-built auth headers outside the wrappers.
+      {
+        code: 'const h = { Authorization: `Bearer ${t}` };',
+        filename: 'apps/web/app/page.ts',
+        errors: [{ messageId: 'authHeader' }],
+      },
+      {
+        code: "const h = { 'X-Clerk-Authorization': v };",
+        filename: 'apps/web/app/page.ts',
+        errors: [{ messageId: 'authHeader' }],
+      },
+    ],
+  });
+});

--- a/tools/eslint-rules/package.json
+++ b/tools/eslint-rules/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "test": "node --test no-uncovered-error-fallback.test.js require-fetch-cache.test.js",
+    "test": "node --test no-uncovered-error-fallback.test.js require-fetch-cache.test.js no-raw-fetch-outside-api-client.test.js",
     "lint": "echo \"(no lint for eslint-rules workspace)\" && exit 0"
   },
   "dependencies": {},


### PR DESCRIPTION
## Summary

Adds the lint-rule half of **flag 6** from the 2026-06-08 architecture review (#464). The structural half shipped in #466/#479 — both web HTTP clients were consolidated into `packages/api-client`'s `createApiClient({ baseUrl, getAuthHeaders })`, which owns the `X-Clerk-Authorization` (server, Cloud Run IAM) vs `Authorization` (browser) split and merges auth headers with auth-wins precedence. But nothing *prevented* a future contributor from writing a raw `fetch()` to the API the "obvious" way and getting a 403 behind Cloud Run IAM. This rule closes that gap. (The "loud comment template" alternative from flag 6 already exists in both wrappers + CONTRIBUTING.md — this is the lint-rule half.)

## What the rule does

`tools/eslint-rules/no-raw-fetch-outside-api-client.js`, scoped to `apps/web/**/*.{ts,tsx}` (spec/test ignored) via `eslint.config.js`. Two detectors:

1. **Bare `fetch(...)` calls** — `fetch(url, …)` (not `something.fetch(…)`). API calls must go through the typed client.
2. **Hand-built auth headers** — an object literal with a static property keyed `Authorization` / `X-Clerk-Authorization` (case-insensitive). These headers are owned by the api-client.

**Allowlisted files** (checked by filename inside the rule): the two wrapper modules `lib/api.ts`, `lib/client-api.ts`, and `lib/gcp-identity-token.ts` (which fetches the GCP **metadata server**, not the API, and builds a `Metadata-Flavor` header). `packages/api-client` is outside the `apps/web` scope, so the real `fetch()` inside `createApiClient()` is never seen.

Mirrors the AST approach and RuleTester harness of the existing `require-fetch-cache` rule. Registered in `index.js`, wired into `eslint.config.js`, test file added to the `package.json` test script, and documented in `tools/eslint-rules/README.md`. Also updated the README's `require-fetch-cache` "lint-scope caveat" note, which became stale when #473 widened the scope to `eslint app lib`.

## Depends on #473

The rule must run on `apps/web/lib/` to be effective; #473 (merged) widened the web lint script to `eslint app lib`. This branch was cut after #473 landed.

## Suppression justification (ADR-026 Rule 1)

One `eslint-disable` added — **`apps/web/app/api/health/route.ts:34-39`** (the `fetch(\`${API_URL}/health\`, { headers: { Authorization: … } })` block). This deployment health probe (used by staging integration test 5) deliberately calls the backend `/health` directly with a **GCP identity token for Cloud Run IAM only** and intentionally omits Clerk JWT forwarding — the file comment explains why (Clerk dev-mode JWTs have a 60s TTL the backend rejects). Routing it through `createApiClient` would add `X-Clerk-Authorization` and change the exact auth semantics the probe verifies. The disable is scoped to that block (the rest of the file stays guarded); the invariant it relies on is that this probe's auth is GCP-IAM-only by design. This is a new error introduced by this branch's new rule (not pre-existing), so it is exempted with justification per ADR-026, not filed.

## Testing

- **Rule unit tests:** `npm test -w @lifting-logbook/eslint-rules` → all pass (the new `no-raw-fetch-outside-api-client` RuleTester suite covers: client calls / `.fetch` member / non-auth headers / the three allowlisted files = valid; bare `fetch()` in `app/` + hand-built `Authorization` / `X-Clerk-Authorization` = invalid). `Tests: 13 passed, 0 skipped, 0 failed.`
- **Full web lint (false-positive sweep):** `npm run lint -w @lifting-logbook/web` (`eslint app lib`) → the rule surfaced exactly one real call site (the health probe above), now exempted; clean afterward.
- Pre-commit `turbo lint` passed (7/7). Lockfile sync check clean (no dependency change). Test-integrity grep clean.

## Acceptance criteria (#494)

- [x] Custom ESLint rule in `tools/eslint-rules/` flags direct `fetch()` to the API / hand-built auth headers in `apps/web` outside the wrapper modules + `packages/api-client`.
- [x] Follows the rule-authoring steps in `tools/eslint-rules/README.md` (registered, wired, RuleTester suite, documented).
- [x] Scope coordinated with #473 (widened lint scope, merged first).

## Review findings disposition

**Reviewed 2026-06-11 by `claude-opus-4-8` — 0 blocking, 0 non-blocking findings.** Nothing to disposition. (`reviewed-by-claude` applied.)

Closes #494
Refs #464, #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)
