### PR TITLE
[chore] Regenerate package-lock.json for in-range Clerk bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2599,11 +2599,11 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.6.1.tgz",
-      "integrity": "sha512-LkfekzF/0UMXacX+17xy3ExRraO0mm+thXejC8Q32gWHd1wLdxK3YXDsLDF00E1r1InWBKIt2ZOxs6hTwZPJjA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.7.0.tgz",
+      "integrity": "sha512-tdURxlfJ8sYR+zM6bUNsG4/BpxH7MV66E5NmHbjIoggUm48SdVoBtKUSjxT0uVa8MpdYHqPk/I0mMdI/EC1B/g==",
       "dependencies": {
-        "@clerk/shared": "^4.17.0",
+        "@clerk/shared": "^4.17.1",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -2612,9 +2612,9 @@
       }
     },
     "node_modules/@clerk/backend/node_modules/@clerk/shared": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.17.0.tgz",
-      "integrity": "sha512-YeQ+6zDmqyor1mPHjZx18j+LssL6Pobvid8hb7HQMioSo8sGDBEVi/Z12bs+gUhe9KbdP+ygHsKOqqeGAPuPZA==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.17.1.tgz",
+      "integrity": "sha512-9Ej2bLA7pWY1e07/PHmPNtQwiV1594rwacNYbppoDUPq9yRkBRZ+pDcpySkfpokS5YXvOUv6aFoPPbEMbQUVgw==",
       "dependencies": {
         "@tanstack/query-core": "^5.100.6",
         "dequal": "2.0.3",


### PR DESCRIPTION
## Summary

The `ci.yml` lockfile-drift gate (Layer 2, #435: `npm install --package-lock-only --ignore-scripts` + `git diff --exit-code package-lock.json`) began failing on `main` because Clerk published in-range patch versions since the committed lockfile was written:

- `@clerk/backend` 3.6.1 → 3.7.0
- `@clerk/shared` 4.17.0 → 4.17.1

`package.json` already admits these via `^` ranges, so `npm ci` still succeeds (the locked 3.6.1 satisfies the ranges) — but the stricter "latest-in-range" drift gate trips. This refreshes the lockfile to the latest in-range versions. Same class as #432 / #433 / #501.

This is a **prerequisite** to unblock #397 (and any other open PR), whose CI was going red on this gate through no fault of its own.

## Changes

- `package-lock.json` only — `@clerk/backend` 3.7.0, `@clerk/shared` 4.17.1 (7 lines). **No `package.json` change.**

## Testing

`npm test` from repo root (Docker up; full API DB E2E via Testcontainers):

`Tests: api 366 passed; core / web / api-client cache-hit green — Tasks: 12 successful, 12 total; 0 failed, 0 skipped.`

Lockfile-drift gate re-verified clean after the regen: `npm install --package-lock-only --ignore-scripts && git diff --exit-code package-lock.json` exits 0.

## Risk audit (Pass 3)

- **Testing** — full suite green on the new versions.
- **Security** — Clerk patch bumps; no range widening, no new deps.
- **Resilience/rollback** — revert restores the prior lockfile.
- **Data integrity / Observability / Performance / Accessibility** — N/A (lockfile metadata only).

Closes #520