### PR TITLE
[infra] Scope the lockfile-drift gate to pull_request so upstream in-range floats can't redden main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,19 @@ jobs:
             ${{ runner.os }}-turbo-
 
       - name: Verify package-lock.json is in sync with package.json
+        # PR-scoped on purpose (issue #523). This is Layer 2 of the lockfile-drift
+        # defense (issue #435): it catches a contributor editing package.json without
+        # regenerating the lockfile — a PR-time mistake. On a `push` to `main` it would
+        # instead recompute the ideal tree from the LIVE registry, so any caret dep
+        # (direct OR transitive, e.g. a @clerk/shared in-range patch) publishing upstream
+        # would redden `main` with no contributor action (#432/#433/#501/#516/#520). The
+        # `npm ci` step below still runs on every push and catches install-breaking drift
+        # (the EUSAGE class). See ADR-036 for the PR-scoped enforcement rationale.
+        if: github.event_name == 'pull_request'
         run: |
-          # Layer 2 of the lockfile-drift defense (see issue #435). Regenerate the
-          # lockfile metadata from package.json without touching node_modules, then
-          # fail with a clear message if it differs from the committed lockfile.
-          # This surfaces drift before the cryptic `npm ci` EUSAGE error fires below.
+          # Regenerate the lockfile metadata from package.json without touching
+          # node_modules, then fail with a clear message if it differs from the committed
+          # lockfile. This surfaces drift before the cryptic `npm ci` EUSAGE error below.
           npm install --package-lock-only --ignore-scripts
           if ! git diff --exit-code package-lock.json; then
             echo "::error::package-lock.json is out of sync with package.json."


### PR DESCRIPTION
## Summary

Scopes the `ci.yml` **"Verify package-lock.json is in sync"** step (Layer 2 of the lockfile-drift defense, issue #435) to `pull_request` only, so it no longer runs on `push` to `main`.

**Why:** on `main` that step recomputes the ideal dependency tree from the **live npm registry**, so any caret dependency — direct *or transitive* — that publishes an in-range version upstream makes the regenerated lockfile differ from the committed one and reddens `main` with **no contributor action**. This has recurred repeatedly (#432, #433, #501, the #516 detour, #520). The #520 trigger (`@clerk/shared` 4.17.0→4.17.1) was a *transitive* float under `@clerk/backend`'s own `^4.17.1`, which is why pinning the direct `@clerk/*` deps would not close it.

The step's legitimate purpose is a **PR-time** check — "you edited `package.json` without regenerating the lockfile." That enforcement is unchanged on PRs. On `main`, the `npm ci` step immediately below still runs on every push and catches genuinely install-breaking drift (the EUSAGE class), so install-integrity on `main` is preserved.

Single-file change: one step-level `if: github.event_name == 'pull_request'` guard plus an expanded inline comment recording the rationale. The workflow `on:` still includes `push` — only this one latest-in-range step becomes PR-scoped.

## Acceptance criteria

- [x] The `Verify package-lock.json is in sync` step runs only on `pull_request`.
- [x] `main` no longer fails this step on an upstream in-range float with no dependency edit.
- [x] PR enforcement unchanged — a PR editing `package.json` without regenerating the lockfile still fails this step.
- [x] `npm ci` on `main` still guards install-breaking drift.
- [x] ADR-036 enforcement-context update — companion dev-env PR (linked below once opened).

## Testing

Workflow-only change — touches no application code, so the jest suites cannot be affected by it; the run below is a baseline sanity check.

- YAML validation: `ci.yml` parses (js-yaml); `on:` still `{pull_request, push}`; the gate step carries `if: github.event_name == 'pull_request'` and retains its `run` block.
- `npm test` (repo root): **12/12 turbo tasks successful**; API `Tests: 375 passed, 0 skipped, 0 failed (28 suites)`; full `npm test` green (2m47s). No suite was affected by the YAML change.

Suppression grep: N/A (no source changed). Test-integrity grep: N/A (no test files changed). Lockfile-sync (`npm install --package-lock-only`): N/A — `package.json` not touched.

## Risk audit (Plan-then-optimize Pass 3)

- **Testing** — N/A: CI-config change, no testable code behavior.
- **Observability** — N/A.
- **Security** — none: relaxes a *self-inflicted* `main` gate only; PR-time enforcement is unchanged, and no secret/authz surface is touched.
- **Resilience / rollback** — `npm ci` on `main` still catches install-breaking drift; rollback is reverting the one-line `if:`.
- **Performance** — negligible: removes one `npm install --package-lock-only` from each `main` push.
- **Data integrity / migrations** — N/A.

**ADR-warrant:** YES — changes ADR-036 Layer-2 enforcement context. The ADR update lands in the companion dev-env PR; this PR is referenced there as the precedent.

Supersedes #520 (already resolved by #516; `main` carries `@clerk/backend` 3.7.0 and CI is green) and structurally prevents that class from recurring.

Closes #523

## Review findings disposition

- `/review` (claude-opus-4-8) returned a **clean review — 0 blocking, 0 non-blocking findings** ([comment](https://github.com/brownm09/lifting-logbook/pull/524#issuecomment-4685409702)). Nothing to fix or file.
