### PR TITLE
[chore] Apply terraform fmt to cloud-run.tf and main.tf

### DIFF
--- a/infra/terraform/cloud-run.tf
+++ b/infra/terraform/cloud-run.tf
@@ -9,8 +9,8 @@ locals {
   # CI/CD overwrites this via gcloud run deploy; lifecycle.ignore_changes prevents Terraform
   # from reverting it on subsequent applies.
   placeholder_image = "us-docker.pkg.dev/cloudrun/container/hello:latest"
-  api_image = var.image_tag == "bootstrap" ? local.placeholder_image : "${var.artifact_registry_region}-docker.pkg.dev/${var.project_id}/${var.app_name}/api:${local.image_tag}"
-  web_image = var.image_tag == "bootstrap" ? local.placeholder_image : "${var.artifact_registry_region}-docker.pkg.dev/${var.project_id}/${var.app_name}/web:${local.image_tag}"
+  api_image         = var.image_tag == "bootstrap" ? local.placeholder_image : "${var.artifact_registry_region}-docker.pkg.dev/${var.project_id}/${var.app_name}/api:${local.image_tag}"
+  web_image         = var.image_tag == "bootstrap" ? local.placeholder_image : "${var.artifact_registry_region}-docker.pkg.dev/${var.project_id}/${var.app_name}/web:${local.image_tag}"
 
   # Cloud Run min instances. var.cloud_run_min_instances overrides the per-environment
   # default when set (use 0 in production for scale-to-zero / single-user deploys).

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -38,7 +38,7 @@ provider "google-beta" {
 }
 
 locals {
-  env_suffix = var.environment == "production" ? "prod" : "stg"
+  env_suffix  = var.environment == "production" ? "prod" : "stg"
   name_prefix = "${var.app_name}-${local.env_suffix}"
 }
 
@@ -46,15 +46,15 @@ locals {
 
 resource "google_project_service" "required_apis" {
   for_each = toset([
-    "container.googleapis.com",          # GKE
-    "run.googleapis.com",                # Cloud Run
-    "sqladmin.googleapis.com",           # Cloud SQL
-    "cloudkms.googleapis.com",           # Cloud KMS (ADR-014)
-    "artifactregistry.googleapis.com",   # Artifact Registry
-    "compute.googleapis.com",            # VPC, Load Balancer
-    "servicenetworking.googleapis.com",  # Private service networking (Cloud SQL)
-    "secretmanager.googleapis.com",      # Secret Manager
-    "vpcaccess.googleapis.com",          # Serverless VPC Access (Cloud Run connector)
+    "container.googleapis.com",         # GKE
+    "run.googleapis.com",               # Cloud Run
+    "sqladmin.googleapis.com",          # Cloud SQL
+    "cloudkms.googleapis.com",          # Cloud KMS (ADR-014)
+    "artifactregistry.googleapis.com",  # Artifact Registry
+    "compute.googleapis.com",           # VPC, Load Balancer
+    "servicenetworking.googleapis.com", # Private service networking (Cloud SQL)
+    "secretmanager.googleapis.com",     # Secret Manager
+    "vpcaccess.googleapis.com",         # Serverless VPC Access (Cloud Run connector)
     "iam.googleapis.com",
     "cloudresourcemanager.googleapis.com",
   ])
@@ -208,7 +208,7 @@ resource "google_secret_manager_secret" "database_url" {
 }
 
 resource "google_secret_manager_secret_version" "database_url" {
-  secret = google_secret_manager_secret.database_url.id
+  secret      = google_secret_manager_secret.database_url.id
   secret_data = "postgresql://${google_sql_user.app.name}:${random_password.db_password.result}@${google_sql_database_instance.main.private_ip_address}:5432/${var.db_name}"
 }
 
@@ -221,7 +221,7 @@ resource "google_secret_manager_secret" "system_database_url" {
 }
 
 resource "google_secret_manager_secret_version" "system_database_url" {
-  secret = google_secret_manager_secret.system_database_url.id
+  secret      = google_secret_manager_secret.system_database_url.id
   secret_data = "postgresql://${google_sql_user.app.name}:${random_password.db_password.result}@${google_sql_database_instance.main.private_ip_address}:5432/${var.db_name}_system"
 }
 


### PR DESCRIPTION
## Summary

Fixes pre-existing `terraform fmt` drift in `infra/terraform/` — whitespace alignment only, no behavior change. Surfaced (and scope-guarded out) during #397 / PR #522.

- `cloud-run.tf` — aligned `api_image` / `web_image` locals.
- `main.tf` — aligned `env_suffix` local and the `required_apis` `for_each` comment column.

## Verification

- `terraform fmt -check` → exits 0 (clean).
- `git diff -w` → empty (whitespace-only; no value or logic change).
- `terraform validate` → "Success! The configuration is valid."
- No application or test code touched (Terraform HCL formatting only) — the `npm test` suite is unaffected and is exercised by CI on this PR. Existing tests must pass.

## Risk audit (Pass 3)

- **Security / Observability / Performance / Resilience / Data integrity** — N/A (whitespace-only formatting; no logic, resources, or values change).
- **Testing** — N/A (no behavior); `terraform fmt -check` + `validate` are the relevant checks.

Closes #525