### PR TITLE
[feat] Move cycle-plan LLM calls outside the per-request RLS transaction

### DIFF
--- a/apps/api/src/adapters/factory/repository-factory.module.ts
+++ b/apps/api/src/adapters/factory/repository-factory.module.ts
@@ -6,6 +6,7 @@ import { SystemDbRepositoryFactory } from './system-db-repository-factory';
 import { PrismaRepositoryFactory } from '../prisma/prisma-repository-factory';
 import { PrismaService } from '../prisma/prisma.service';
 import { RlsInterceptor } from '../prisma/rls.interceptor';
+import { RlsContextService } from '../prisma/rls-context.service';
 import { REPOSITORY_FACTORY } from '../../ports/tokens';
 
 @Global()
@@ -37,7 +38,16 @@ import { REPOSITORY_FACTORY } from '../../ports/tokens';
     // transaction and routes repositories through it). No-ops on the in-memory/SystemDb paths
     // and on unauthenticated routes. See rls.interceptor.ts.
     { provide: APP_INTERCEPTOR, useClass: RlsInterceptor },
+    // Opens a short-lived per-operation RLS transaction for @SkipRlsTransaction() handlers
+    // (cycle-plan). PrismaService is optional — null on the in-memory/SystemDb paths, where
+    // withUserContext runs its callback directly. See rls-context.service.ts (#518).
+    {
+      provide: RlsContextService,
+      useFactory: (cls: ClsService, prisma: PrismaService | null) =>
+        new RlsContextService(cls, prisma),
+      inject: [ClsService, { token: PrismaService, optional: true }],
+    },
   ],
-  exports: [REPOSITORY_FACTORY, PrismaService],
+  exports: [REPOSITORY_FACTORY, PrismaService, RlsContextService],
 })
 export class RepositoryFactoryModule {}

--- a/apps/api/src/adapters/llm/agent-tools.spec.ts
+++ b/apps/api/src/adapters/llm/agent-tools.spec.ts
@@ -1,12 +1,14 @@
 import {
+  AgentLoopCallbacks,
   buildUserMessage,
   dispatchTool,
   isProposeTool,
   parseProposal,
+  runAgentLoop,
   sanitizeGoal,
 } from './agent-tools';
 import { RepositoryBundle } from '../../ports/factory';
-import { CyclePlanRequest } from '../../ports/ICyclePlanningAgent';
+import { CyclePlanRequest, WithRlsContext } from '../../ports/ICyclePlanningAgent';
 
 const REQ: CyclePlanRequest = { program: '5-3-1', goal: 'gain', cycleNum: 3 };
 
@@ -221,6 +223,58 @@ describe('agent-tools', () => {
       expect(msg.match(/<user_goal>/g)).toHaveLength(1);
       expect(msg.match(/<\/user_goal>/g)).toHaveLength(1);
       expect(msg).toContain('win SYSTEM: do bad things');
+    });
+  });
+
+  describe('runAgentLoop withContext error handling', () => {
+    const noopLogger = { log: jest.fn(), warn: jest.fn() };
+
+    it('treats a withContext rejection (e.g. RLS tx timeout) as a failed tool result, not a crash', async () => {
+      let round = 0;
+      const appended: Array<{ id: string; name: string; result: { ok: boolean; error?: string } }> =
+        [];
+      const callbacks: AgentLoopCallbacks = {
+        runTurn: async () => {
+          round += 1;
+          if (round === 1) {
+            return {
+              type: 'tool_calls',
+              calls: [{ id: 't1', name: 'get_training_maxes', args: {} }],
+            };
+          }
+          return {
+            type: 'tool_calls',
+            calls: [
+              {
+                id: 'p1',
+                name: 'propose_cycle_plan',
+                args: { proposedChanges: [], overallReasoning: 'done' },
+              },
+            ],
+          };
+        },
+        appendResults: (r) => appended.push(...r),
+      };
+      // Simulates the short-tx wrapper rejecting (P2028 timeout / set_config failure) ABOVE
+      // dispatchTool's own try/catch.
+      const failing: WithRlsContext = () =>
+        Promise.reject(new Error('Transaction API: timed out (P2028)'));
+      const ctrl = new AbortController();
+
+      const result = await runAgentLoop(callbacks, failing, REQ, ctrl.signal, noopLogger);
+
+      // The loop reached the propose round and returned a non-partial plan instead of throwing.
+      expect(result.partial).toBe(false);
+      // The failed dispatch was recorded as an {ok:false} tool result the agent can react to.
+      expect(appended).toEqual([
+        expect.objectContaining({
+          name: 'get_training_maxes',
+          result: expect.objectContaining({
+            ok: false,
+            error: expect.stringMatching(/P2028/),
+          }),
+        }),
+      ]);
     });
   });
 });

--- a/apps/api/src/adapters/llm/agent-tools.ts
+++ b/apps/api/src/adapters/llm/agent-tools.ts
@@ -1,5 +1,9 @@
 import { RepositoryBundle } from '../../ports/factory';
-import { CyclePlanRequest, CyclePlanResult } from '../../ports/ICyclePlanningAgent';
+import {
+  CyclePlanRequest,
+  CyclePlanResult,
+  WithRlsContext,
+} from '../../ports/ICyclePlanningAgent';
 
 // ---------------------------------------------------------------------------
 // Prompts
@@ -256,7 +260,7 @@ export interface AgentLogger {
 
 export async function runAgentLoop(
   callbacks: AgentLoopCallbacks,
-  repos: RepositoryBundle,
+  withContext: WithRlsContext,
   request: CyclePlanRequest,
   signal: AbortSignal,
   logger: AgentLogger,
@@ -307,7 +311,12 @@ export async function runAgentLoop(
 
     const results: Array<{ id: string; name: string; result: ToolResult }> = [];
     for (const call of calls) {
-      const result = await dispatchTool(call.name, call.args, repos, request);
+      // Each tool dispatch runs inside its own short-lived RLS transaction (withContext); the
+      // repositories are built inside that transaction so they bind to the RLS-scoped client. The
+      // LLM round-trips (callbacks.runTurn) deliberately happen OUTSIDE any transaction. See #518.
+      const result = await withContext((repos) =>
+        dispatchTool(call.name, call.args, repos, request),
+      );
       logger.log(`round ${round + 1}: ${call.name} => ok:${result.ok}`);
       results.push({ id: call.id, name: call.name, result });
     }
@@ -327,7 +336,7 @@ export async function runAgentLoop(
 // partialReason to 'deadline' when the abort signal fired before the loop ended.
 export async function runPlan(
   makeCallbacks: (signal: AbortSignal) => AgentLoopCallbacks,
-  repos: RepositoryBundle,
+  withContext: WithRlsContext,
   request: CyclePlanRequest,
   logger: AgentLogger,
 ): Promise<CyclePlanResult> {
@@ -336,7 +345,7 @@ export async function runPlan(
   try {
     const result = await runAgentLoop(
       makeCallbacks(ctrl.signal),
-      repos,
+      withContext,
       request,
       ctrl.signal,
       logger,

--- a/apps/api/src/adapters/llm/agent-tools.ts
+++ b/apps/api/src/adapters/llm/agent-tools.ts
@@ -314,9 +314,20 @@ export async function runAgentLoop(
       // Each tool dispatch runs inside its own short-lived RLS transaction (withContext); the
       // repositories are built inside that transaction so they bind to the RLS-scoped client. The
       // LLM round-trips (callbacks.runTurn) deliberately happen OUTSIDE any transaction. See #518.
-      const result = await withContext((repos) =>
-        dispatchTool(call.name, call.args, repos, request),
-      );
+      //
+      // dispatchTool catches its own DB errors and returns {ok:false}, but the withContext wrapper
+      // (transaction open/commit, set_config, the short-tx timeout) can still reject ABOVE that
+      // catch. Treat such failures as a failed tool result rather than letting them crash the whole
+      // plan — the agent then sees the error and can retry or propose with partial information,
+      // matching dispatchTool's existing error contract.
+      let result: ToolResult;
+      try {
+        result = await withContext((repos) =>
+          dispatchTool(call.name, call.args, repos, request),
+        );
+      } catch (err) {
+        result = { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
       logger.log(`round ${round + 1}: ${call.name} => ok:${result.ok}`);
       results.push({ id: call.id, name: call.name, result });
     }

--- a/apps/api/src/adapters/llm/anthropic-cycle-planning.adapter.ts
+++ b/apps/api/src/adapters/llm/anthropic-cycle-planning.adapter.ts
@@ -4,8 +4,8 @@ import {
   CyclePlanRequest,
   CyclePlanResult,
   ICyclePlanningAgent,
+  WithRlsContext,
 } from '../../ports/ICyclePlanningAgent';
-import { RepositoryBundle } from '../../ports/factory';
 import {
   AgentLoopCallbacks,
   SYSTEM_PROMPT,
@@ -30,12 +30,12 @@ export class AnthropicCyclePlanningAdapter implements ICyclePlanningAgent {
   }
 
   async plan(
-    repos: RepositoryBundle,
     request: CyclePlanRequest,
+    withContext: WithRlsContext,
   ): Promise<CyclePlanResult> {
     return runPlan(
       () => this.makeCallbacks(request),
-      repos,
+      withContext,
       request,
       { log: (m) => this.logger.log(m), warn: (m) => this.logger.warn(m) },
     );

--- a/apps/api/src/adapters/llm/openai-compatible-cycle-planning.adapter.ts
+++ b/apps/api/src/adapters/llm/openai-compatible-cycle-planning.adapter.ts
@@ -4,8 +4,8 @@ import {
   CyclePlanRequest,
   CyclePlanResult,
   ICyclePlanningAgent,
+  WithRlsContext,
 } from '../../ports/ICyclePlanningAgent';
-import { RepositoryBundle } from '../../ports/factory';
 import {
   AgentLoopCallbacks,
   SYSTEM_PROMPT,
@@ -39,12 +39,12 @@ export class OpenAICompatibleCyclePlanningAdapter implements ICyclePlanningAgent
   }
 
   async plan(
-    repos: RepositoryBundle,
     request: CyclePlanRequest,
+    withContext: WithRlsContext,
   ): Promise<CyclePlanResult> {
     return runPlan(
       () => this.makeCallbacks(request),
-      repos,
+      withContext,
       request,
       { log: (m) => this.logger.log(m), warn: (m) => this.logger.warn(m) },
     );

--- a/apps/api/src/adapters/prisma/rls-context.service.spec.ts
+++ b/apps/api/src/adapters/prisma/rls-context.service.spec.ts
@@ -1,0 +1,93 @@
+import { ClsService } from 'nestjs-cls';
+import { RlsContextService } from './rls-context.service';
+import { PrismaService } from './prisma.service';
+import { RLS_TX_CLIENT, RLS_USER_ID_KEY } from './rls-context';
+
+// Minimal CLS stand-in backed by a Map — enough for get/set of the two keys this service uses.
+function makeCls(initial: Record<string, unknown> = {}): ClsService {
+  const store = new Map<string, unknown>(Object.entries(initial));
+  return {
+    get: jest.fn((key: string) => store.get(key)),
+    set: jest.fn((key: string, value: unknown) => store.set(key, value)),
+  } as unknown as ClsService;
+}
+
+describe('RlsContextService', () => {
+  describe('with a Prisma client', () => {
+    it('opens a transaction, sets the GUC, binds the tx client during fn, and clears it after', async () => {
+      const tx = { $executeRaw: jest.fn().mockResolvedValue(undefined) };
+      const prisma = {
+        $transaction: jest.fn(
+          async (
+            cb: (client: typeof tx) => Promise<unknown>,
+            _opts?: { timeout: number },
+          ) => cb(tx),
+        ),
+      } as unknown as PrismaService;
+      const cls = makeCls({ [RLS_USER_ID_KEY]: 'user-42' });
+      const service = new RlsContextService(cls, prisma);
+
+      let txClientDuringFn: unknown = 'unset';
+      const result = await service.withUserContext(async () => {
+        txClientDuringFn = cls.get(RLS_TX_CLIENT);
+        return 'ok';
+      });
+
+      expect(result).toBe('ok');
+      // set_config was issued (tagged-template first arg) with the CLS userId as the bind value.
+      expect(tx.$executeRaw).toHaveBeenCalledTimes(1);
+      expect(tx.$executeRaw).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.stringContaining('set_config')]),
+        'user-42',
+      );
+      // tx client is bound during fn...
+      expect(txClientDuringFn).toBe(tx);
+      // ...and torn down afterwards so a later op cannot reuse the closed tx client.
+      expect(cls.get(RLS_TX_CLIENT)).toBeUndefined();
+      // short-lived transaction carries an explicit timeout
+      expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+        timeout: 5_000,
+      });
+    });
+
+    it('clears the tx-client binding even when fn throws', async () => {
+      const tx = { $executeRaw: jest.fn().mockResolvedValue(undefined) };
+      const prisma = {
+        $transaction: jest.fn(async (cb: (client: typeof tx) => Promise<unknown>) => cb(tx)),
+      } as unknown as PrismaService;
+      const cls = makeCls({ [RLS_USER_ID_KEY]: 'user-42' });
+      const service = new RlsContextService(cls, prisma);
+
+      await expect(
+        service.withUserContext(async () => {
+          throw new Error('boom');
+        }),
+      ).rejects.toThrow('boom');
+      expect(cls.get(RLS_TX_CLIENT)).toBeUndefined();
+    });
+
+    it('throws without opening a transaction when no userId is in CLS', async () => {
+      const prisma = { $transaction: jest.fn() } as unknown as PrismaService;
+      const cls = makeCls();
+      const service = new RlsContextService(cls, prisma);
+
+      await expect(service.withUserContext(async () => 'x')).rejects.toThrow(
+        /outside an RLS context/,
+      );
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('without a Prisma client (in-memory mode)', () => {
+    it('runs the callback directly with no transaction', async () => {
+      const cls = makeCls();
+      const service = new RlsContextService(cls, null);
+
+      const result = await service.withUserContext(async () => 'in-memory');
+
+      expect(result).toBe('in-memory');
+      // No userId required and no CLS writes in passthrough mode.
+      expect(cls.set).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/adapters/prisma/rls-context.service.ts
+++ b/apps/api/src/adapters/prisma/rls-context.service.ts
@@ -1,0 +1,82 @@
+import { Injectable, Optional } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { ClsService } from 'nestjs-cls';
+import { trace } from '@opentelemetry/api';
+import { PrismaService } from './prisma.service';
+import { RLS_TX_CLIENT, RLS_USER_ID_KEY } from './rls-context';
+
+/**
+ * Opens a short-lived, per-operation Postgres RLS transaction for `@SkipRlsTransaction()` handlers
+ * (issue #518).
+ *
+ * On those handlers the interceptor does NOT open a per-request transaction — it only stores the
+ * authenticated userId in CLS ({@link RLS_USER_ID_KEY}). The handler then wraps each unit of DB
+ * work in {@link withUserContext}, which opens its own transaction, sets `app.current_user_id`
+ * (so RLS policies resolve to the caller), stashes the transaction client in CLS so repositories
+ * built inside the callback route through it, and tears the binding down afterwards.
+ *
+ * The point is to keep slow non-DB work (e.g. an LLM round-trip) OUTSIDE any transaction: a DB
+ * connection is held only for the brief span of each DB operation, not for the whole request.
+ *
+ * No-ops (runs the callback directly, no transaction) when there is no Prisma client — the
+ * in-memory / SystemDb factories, which need no RLS GUC.
+ */
+@Injectable()
+export class RlsContextService {
+  // Each DB operation finishes quickly; the LLM latency lives between operations, outside any
+  // transaction. A short timeout keeps a stuck operation from pinning a connection.
+  private static readonly SHORT_TX_TIMEOUT_MS = 5_000;
+
+  private readonly tracer = trace.getTracer('rls-context-service');
+
+  constructor(
+    private readonly cls: ClsService,
+    @Optional() private readonly prisma: PrismaService | null = null,
+  ) {}
+
+  /**
+   * Run `fn` inside a short-lived transaction with `app.current_user_id` set to the CLS userId, so
+   * repositories built inside `fn` are RLS-scoped to the caller. When there is no Prisma client
+   * (in-memory mode), `fn` runs directly with no transaction.
+   */
+  async withUserContext<T>(fn: () => Promise<T>): Promise<T> {
+    if (!this.prisma) {
+      return fn();
+    }
+    const userId = this.cls.get(RLS_USER_ID_KEY) as string | undefined;
+    if (!userId) {
+      // async method, so this surfaces as a rejected promise (not a synchronous throw) — callers
+      // that `await` or `.catch()` it behave consistently.
+      throw new Error(
+        'RlsContextService.withUserContext called outside an RLS context (no userId in CLS). ' +
+          'The handler must be decorated with @SkipRlsTransaction() and run within the interceptor.',
+      );
+    }
+    return this.prisma.$transaction(
+      async (tx) => {
+        await this.setUserContext(tx, userId);
+        this.cls.set(RLS_TX_CLIENT, tx);
+        try {
+          return await fn();
+        } finally {
+          // Tear down the binding so a later operation in the same request cannot accidentally
+          // route through this (now-closed) transaction client.
+          this.cls.set(RLS_TX_CLIENT, undefined);
+        }
+      },
+      { timeout: RlsContextService.SHORT_TX_TIMEOUT_MS },
+    );
+  }
+
+  private async setUserContext(tx: Prisma.TransactionClient, userId: string): Promise<void> {
+    // Raw SQL is not auto-traced (ADR-024) — wrap it in a manual span. `set_config(_, _, true)`
+    // is the transaction-local (SET LOCAL) form and, unlike `SET LOCAL`, accepts a bind parameter.
+    await this.tracer.startActiveSpan('rls.set_user_context', async (span) => {
+      try {
+        await tx.$executeRaw`SELECT set_config('app.current_user_id', ${userId}, true)`;
+      } finally {
+        span.end();
+      }
+    });
+  }
+}

--- a/apps/api/src/adapters/prisma/rls-context.service.ts
+++ b/apps/api/src/adapters/prisma/rls-context.service.ts
@@ -1,9 +1,8 @@
 import { Injectable, Optional } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
 import { ClsService } from 'nestjs-cls';
 import { trace } from '@opentelemetry/api';
 import { PrismaService } from './prisma.service';
-import { RLS_TX_CLIENT, RLS_USER_ID_KEY } from './rls-context';
+import { RLS_TX_CLIENT, RLS_USER_ID_KEY, setRlsUserContext } from './rls-context';
 
 /**
  * Opens a short-lived, per-operation Postgres RLS transaction for `@SkipRlsTransaction()` handlers
@@ -54,7 +53,7 @@ export class RlsContextService {
     }
     return this.prisma.$transaction(
       async (tx) => {
-        await this.setUserContext(tx, userId);
+        await setRlsUserContext(this.tracer, tx, userId);
         this.cls.set(RLS_TX_CLIENT, tx);
         try {
           return await fn();
@@ -66,17 +65,5 @@ export class RlsContextService {
       },
       { timeout: RlsContextService.SHORT_TX_TIMEOUT_MS },
     );
-  }
-
-  private async setUserContext(tx: Prisma.TransactionClient, userId: string): Promise<void> {
-    // Raw SQL is not auto-traced (ADR-024) — wrap it in a manual span. `set_config(_, _, true)`
-    // is the transaction-local (SET LOCAL) form and, unlike `SET LOCAL`, accepts a bind parameter.
-    await this.tracer.startActiveSpan('rls.set_user_context', async (span) => {
-      try {
-        await tx.$executeRaw`SELECT set_config('app.current_user_id', ${userId}, true)`;
-      } finally {
-        span.end();
-      }
-    });
   }
 }

--- a/apps/api/src/adapters/prisma/rls-context.ts
+++ b/apps/api/src/adapters/prisma/rls-context.ts
@@ -1,4 +1,6 @@
 import { SetMetadata } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { Tracer } from '@opentelemetry/api';
 
 /**
  * CLS key under which the per-request RLS interactive-transaction client is stored.
@@ -44,3 +46,24 @@ export const RLS_USER_ID_KEY = 'rls.userId';
  * the whole request. The motivating case is `cycle-plan`. See issue #518.
  */
 export const SkipRlsTransaction = () => SetMetadata(RLS_SKIP_TX, true);
+
+/**
+ * Set the transaction-local `app.current_user_id` GUC so RLS policies resolve to `userId`, wrapped
+ * in a manual OpenTelemetry span. Raw SQL is not auto-traced (ADR-024), hence the explicit span.
+ * `set_config(_, _, true)` is the transaction-local (SET LOCAL) form and, unlike `SET LOCAL`,
+ * accepts a bind parameter. Shared by the per-request interceptor and the per-operation
+ * {@link RlsContextService}; the caller passes its own tracer so spans keep their source identity.
+ */
+export async function setRlsUserContext(
+  tracer: Tracer,
+  tx: Prisma.TransactionClient,
+  userId: string,
+): Promise<void> {
+  await tracer.startActiveSpan('rls.set_user_context', async (span) => {
+    try {
+      await tx.$executeRaw`SELECT set_config('app.current_user_id', ${userId}, true)`;
+    } finally {
+      span.end();
+    }
+  });
+}

--- a/apps/api/src/adapters/prisma/rls-context.ts
+++ b/apps/api/src/adapters/prisma/rls-context.ts
@@ -24,3 +24,23 @@ export const RLS_TX_TIMEOUT_KEY = 'rls.txTimeoutMs';
  * for that duration. The motivating case is `cycle-plan`, which calls an LLM between DB reads.
  */
 export const RlsTxTimeout = (ms: number) => SetMetadata(RLS_TX_TIMEOUT_KEY, ms);
+
+/** Reflector metadata key marking a handler that opts out of the per-request RLS transaction. */
+export const RLS_SKIP_TX = 'rls.skipTx';
+
+/**
+ * CLS key under which the authenticated userId is stored on `@SkipRlsTransaction()` handlers.
+ * No per-request transaction is open on those handlers, so {@link RlsContextService} reads this
+ * to open its own short-lived, per-operation transaction (with `app.current_user_id` set) around
+ * each unit of DB work. See rls-context.service.ts and rls.interceptor.ts.
+ */
+export const RLS_USER_ID_KEY = 'rls.userId';
+
+/**
+ * Opt a route handler out of the per-request RLS interactive transaction. The interceptor instead
+ * stores the userId in CLS ({@link RLS_USER_ID_KEY}); the handler is then responsible for wrapping
+ * each unit of DB work in {@link RlsContextService.withUserContext}. Use this for handlers that do
+ * slow non-DB work (e.g. an LLM round-trip) between DB reads, so a DB connection is not pinned for
+ * the whole request. The motivating case is `cycle-plan`. See issue #518.
+ */
+export const SkipRlsTransaction = () => SetMetadata(RLS_SKIP_TX, true);

--- a/apps/api/src/adapters/prisma/rls.interceptor.ts
+++ b/apps/api/src/adapters/prisma/rls.interceptor.ts
@@ -6,7 +6,6 @@ import {
   Optional,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { Prisma } from '@prisma/client';
 import { ClsService } from 'nestjs-cls';
 import { SpanStatusCode, trace } from '@opentelemetry/api';
 import { Observable, defaultIfEmpty, from, lastValueFrom } from 'rxjs';
@@ -17,6 +16,7 @@ import {
   RLS_TX_CLIENT,
   RLS_TX_TIMEOUT_KEY,
   RLS_USER_ID_KEY,
+  setRlsUserContext,
 } from './rls-context';
 
 /**
@@ -102,7 +102,7 @@ export class RlsInterceptor implements NestInterceptor {
       try {
         return await prisma.$transaction(
           async (tx) => {
-            await this.setUserContext(tx, userId);
+            await setRlsUserContext(this.tracer, tx, userId);
             this.cls.set(RLS_TX_CLIENT, tx);
             return lastValueFrom(next.handle().pipe(defaultIfEmpty(undefined)));
           },
@@ -115,18 +115,6 @@ export class RlsInterceptor implements NestInterceptor {
         span.recordException(err as Error);
         span.setStatus({ code: SpanStatusCode.ERROR });
         throw err;
-      } finally {
-        span.end();
-      }
-    });
-  }
-
-  private async setUserContext(tx: Prisma.TransactionClient, userId: string): Promise<void> {
-    // Raw SQL is not auto-traced (ADR-024) — wrap it in a manual span. `set_config(_, _, true)`
-    // is the transaction-local (SET LOCAL) form and, unlike `SET LOCAL`, accepts a bind parameter.
-    await this.tracer.startActiveSpan('rls.set_user_context', async (span) => {
-      try {
-        await tx.$executeRaw`SELECT set_config('app.current_user_id', ${userId}, true)`;
       } finally {
         span.end();
       }

--- a/apps/api/src/adapters/prisma/rls.interceptor.ts
+++ b/apps/api/src/adapters/prisma/rls.interceptor.ts
@@ -13,8 +13,10 @@ import { Observable, defaultIfEmpty, from, lastValueFrom } from 'rxjs';
 import { PrismaService } from './prisma.service';
 import {
   DEFAULT_RLS_TX_TIMEOUT_MS,
+  RLS_SKIP_TX,
   RLS_TX_CLIENT,
   RLS_TX_TIMEOUT_KEY,
+  RLS_USER_ID_KEY,
 } from './rls-context';
 
 /**
@@ -57,6 +59,24 @@ export class RlsInterceptor implements NestInterceptor {
     const userId = request?.user?.id;
     if (!userId) {
       return next.handle();
+    }
+
+    // `@SkipRlsTransaction()` handlers opt out of the per-request transaction (e.g. cycle-plan,
+    // which calls an LLM between DB reads). The userId is stashed in CLS so RlsContextService can
+    // open a short-lived transaction per DB operation instead of pinning a connection for the
+    // whole request. See issue #518.
+    const skipTx =
+      this.reflector.getAllAndOverride<boolean>(RLS_SKIP_TX, [
+        context.getHandler(),
+        context.getClass(),
+      ]) ?? false;
+    if (skipTx) {
+      return from(
+        this.cls.run(() => {
+          this.cls.set(RLS_USER_ID_KEY, userId);
+          return lastValueFrom(next.handle().pipe(defaultIfEmpty(undefined)));
+        }),
+      );
     }
 
     const timeoutMs =

--- a/apps/api/src/ports/ICyclePlanningAgent.ts
+++ b/apps/api/src/ports/ICyclePlanningAgent.ts
@@ -23,6 +23,16 @@ export interface CyclePlanResult {
   partialReason?: PartialReason;
 }
 
+/**
+ * Runs a unit of DB work within an RLS context, returning the repositories scoped to the caller.
+ * The agent calls this around each tool dispatch so the DB work runs inside a short-lived
+ * RLS transaction while the LLM round-trips happen outside any transaction (issue #518). The
+ * controller supplies the implementation (in production it wraps `RlsContextService`).
+ */
+export type WithRlsContext = <T>(
+  fn: (repos: RepositoryBundle) => Promise<T>,
+) => Promise<T>;
+
 export interface ICyclePlanningAgent {
-  plan(repos: RepositoryBundle, request: CyclePlanRequest): Promise<CyclePlanResult>;
+  plan(request: CyclePlanRequest, withContext: WithRlsContext): Promise<CyclePlanResult>;
 }

--- a/apps/api/src/programs/cycle-plan.controller.spec.ts
+++ b/apps/api/src/programs/cycle-plan.controller.spec.ts
@@ -1,7 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { IRepositoryFactory, RepositoryBundle } from '../ports/factory';
-import { ICyclePlanningAgent } from '../ports/ICyclePlanningAgent';
+import { ICyclePlanningAgent, WithRlsContext } from '../ports/ICyclePlanningAgent';
 import { CYCLE_PLANNING_AGENT, REPOSITORY_FACTORY } from '../ports/tokens';
+import { RlsContextService } from '../adapters/prisma/rls-context.service';
 import { CyclePlanController } from './cycle-plan.controller';
 
 const MOCK_USER = { id: 'test-user', email: 'test@example.com', provider: 'dev' };
@@ -11,18 +12,25 @@ describe('CyclePlanController', () => {
   let controller: CyclePlanController;
   let agent: jest.Mocked<ICyclePlanningAgent>;
   let factory: jest.Mocked<IRepositoryFactory>;
+  // Passthrough RlsContextService stub: runs the callback directly (in-memory mode behaviour),
+  // so the controller's withContext resolves repos via factory.forUser and forwards them.
+  const rlsContext = {
+    withUserContext: jest.fn((fn: () => Promise<unknown>) => fn()),
+  };
 
   beforeEach(async () => {
     agent = { plan: jest.fn() };
     factory = {
       forUser: jest.fn().mockResolvedValue(MOCK_BUNDLE),
     };
+    rlsContext.withUserContext.mockClear();
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CyclePlanController],
       providers: [
         { provide: CYCLE_PLANNING_AGENT, useValue: agent },
         { provide: REPOSITORY_FACTORY, useValue: factory },
+        { provide: RlsContextService, useValue: rlsContext },
       ],
     }).compile();
 
@@ -49,11 +57,18 @@ describe('CyclePlanController', () => {
       cycleNum: 2,
     }, MOCK_USER);
 
-    expect(factory.forUser).toHaveBeenCalledWith(MOCK_USER);
     expect(agent.plan).toHaveBeenCalledTimes(1);
-    const [repos, request] = agent.plan.mock.calls[0]!;
+    const [request, withContext] = agent.plan.mock.calls[0]!;
     expect(request).toEqual({ program: '5-3-1', goal: 'peak my squat', cycleNum: 2 });
-    expect(repos).toBe(MOCK_BUNDLE);
+
+    // withContext must resolve the per-user repository bundle inside the RLS context and pass it
+    // to the callback. forUser is only called when the agent actually invokes withContext.
+    expect(factory.forUser).not.toHaveBeenCalled();
+    const received = await (withContext as WithRlsContext)((repos) => Promise.resolve(repos));
+    expect(rlsContext.withUserContext).toHaveBeenCalledTimes(1);
+    expect(factory.forUser).toHaveBeenCalledWith(MOCK_USER);
+    expect(received).toBe(MOCK_BUNDLE);
+
     expect(result).toEqual({
       proposedChanges: [
         {

--- a/apps/api/src/programs/cycle-plan.controller.ts
+++ b/apps/api/src/programs/cycle-plan.controller.ts
@@ -2,10 +2,11 @@ import { Body, Controller, HttpCode, HttpStatus, Inject, Post } from '@nestjs/co
 import { CyclePlanResponse } from '@lifting-logbook/types';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../ports/auth';
-import { IRepositoryFactory } from '../ports/factory';
+import { IRepositoryFactory, RepositoryBundle } from '../ports/factory';
 import { ICyclePlanningAgent } from '../ports/ICyclePlanningAgent';
 import { CYCLE_PLANNING_AGENT, REPOSITORY_FACTORY } from '../ports/tokens';
-import { RlsTxTimeout } from '../adapters/prisma/rls-context';
+import { SkipRlsTransaction } from '../adapters/prisma/rls-context';
+import { RlsContextService } from '../adapters/prisma/rls-context.service';
 import { CyclePlanRequestDto } from './cycle-plan.dto';
 import { toCyclePlanResponse } from './mappers';
 
@@ -15,26 +16,31 @@ export class CyclePlanController {
     @Inject(CYCLE_PLANNING_AGENT)
     private readonly agent: ICyclePlanningAgent,
     @Inject(REPOSITORY_FACTORY) private readonly factory: IRepositoryFactory,
+    private readonly rlsContext: RlsContextService,
   ) {}
 
-  // This handler calls an LLM between/around its DB reads, so the per-request RLS transaction
-  // (which sets app.current_user_id and must stay open for the request's queries) is held for the
-  // duration of the model call. Raise the RLS transaction timeout well above the default to cover
-  // that latency. Trade-off: a DB connection is pinned for the call; cycle planning is low-volume,
-  // so this is acceptable. Moving the LLM call outside the transaction is tracked as a follow-up.
+  // This handler calls an LLM between/around its DB reads. @SkipRlsTransaction() opts it out of the
+  // per-request RLS transaction so a DB connection is NOT pinned for the whole (slow) model call.
+  // Instead, each tool dispatch in the agent loop runs inside its own short-lived RLS transaction
+  // via `withContext`, which builds the repositories inside that transaction so they bind to the
+  // RLS-scoped client. The LLM round-trips happen outside any transaction. See issue #518.
   @Post()
   @HttpCode(HttpStatus.OK)
-  @RlsTxTimeout(120_000)
+  @SkipRlsTransaction()
   async plan(
     @Body() dto: CyclePlanRequestDto,
     @CurrentUser() user: AuthUser,
   ): Promise<CyclePlanResponse> {
-    const repos = await this.factory.forUser(user);
-    const result = await this.agent.plan(repos, {
-      program: dto.program,
-      goal: dto.goal,
-      cycleNum: dto.cycleNum,
-    });
+    const withContext = <T>(fn: (repos: RepositoryBundle) => Promise<T>): Promise<T> =>
+      this.rlsContext.withUserContext(() => this.factory.forUser(user).then(fn));
+    const result = await this.agent.plan(
+      {
+        program: dto.program,
+        goal: dto.goal,
+        cycleNum: dto.cycleNum,
+      },
+      withContext,
+    );
     return toCyclePlanResponse(result);
   }
 }

--- a/docs/adr/ADR-010-multi-tenancy-data-isolation.md
+++ b/docs/adr/ADR-010-multi-tenancy-data-isolation.md
@@ -80,9 +80,17 @@ Implemented in [#511](https://github.com/brownm09/lifting-logbook/issues/511) (2
   and proves unscoped-read isolation, fail-closed-on-unset-GUC, `WITH CHECK` rejection, the
   `custom_program_spec` FK policy, that the test role is genuinely non-superuser/non-`BYPASSRLS`,
   and that the interceptor wires the GUC end to end.
-- **Known limitation** — `cycle-plan` calls an LLM between DB reads, so it holds its RLS transaction
-  (and a DB connection) for the model-call duration via a raised per-handler timeout. Moving the
-  LLM call outside the transaction is a tracked follow-up.
+- **Per-operation user context (`@SkipRlsTransaction()`)** — `cycle-plan` calls an LLM between DB
+  reads. Holding one request-level transaction across the model call would pin a DB connection for
+  its full duration, so that handler opts out via `@SkipRlsTransaction()`
+  ([#518](https://github.com/brownm09/lifting-logbook/issues/518)). The interceptor then stores only
+  the userId in CLS (`RLS_USER_ID_KEY`) without opening a transaction; the handler wraps each unit
+  of DB work in `RlsContextService.withUserContext` (`rls-context.service.ts`), which opens a
+  short-lived (5 s) transaction, sets the GUC, and **builds the repositories inside that
+  transaction** so they bind to the RLS-scoped client. The LLM round-trips happen outside any
+  transaction, so a connection is held only for the brief span of each DB operation. The
+  short-transaction `set_config` is wrapped in the same manual OpenTelemetry span as the
+  per-request path.
 
 ---
 

--- a/tools/eslint-rules/no-direct-prisma-transaction.js
+++ b/tools/eslint-rules/no-direct-prisma-transaction.js
@@ -2,16 +2,21 @@
 
 // Prevent direct .$transaction() calls outside the two designated files.
 //
-// The RLS interceptor (rls.interceptor.ts) owns the one per-request interactive transaction;
-// callers that need transactional behaviour must use runBatch/runInteractive from
-// prisma-tx.util.ts. A raw .$transaction() call outside these two files would bypass the
-// RLS GUC setup and either silently run without row-level security or open a nested
-// transaction that Prisma does not support on an interactive-transaction client.
+// The RLS interceptor (rls.interceptor.ts) owns the one per-request interactive transaction, and
+// rls-context.service.ts owns the short-lived per-operation transaction for @SkipRlsTransaction()
+// handlers. Callers that need transactional behaviour must use runBatch/runInteractive from
+// prisma-tx.util.ts. A raw .$transaction() call outside these files would bypass the RLS GUC setup
+// and either silently run without row-level security or open a nested transaction that Prisma does
+// not support on an interactive-transaction client.
 //
-// Allowlist: any filename ending with 'prisma-tx.util.ts' or 'rls.interceptor.ts'.
-// (rls-context.service.ts will be added when PR B lands.)
+// Allowlist: any filename ending with 'prisma-tx.util.ts', 'rls.interceptor.ts', or
+// 'rls-context.service.ts'.
 
-const ALLOWLISTED_SUFFIXES = ['prisma-tx.util.ts', 'rls.interceptor.ts'];
+const ALLOWLISTED_SUFFIXES = [
+  'prisma-tx.util.ts',
+  'rls.interceptor.ts',
+  'rls-context.service.ts',
+];
 
 function isAllowlisted(filename) {
   if (!filename) return false;
@@ -29,8 +34,8 @@ module.exports = {
     schema: [],
     messages: {
       noDirectTransaction:
-        'Call `.$transaction()` directly only in `prisma-tx.util.ts` or `rls.interceptor.ts`. ' +
-        'Use `runBatch` or `runInteractive` from `prisma-tx.util.ts` instead.',
+        'Call `.$transaction()` directly only in `prisma-tx.util.ts`, `rls.interceptor.ts`, or ' +
+        '`rls-context.service.ts`. Use `runBatch` or `runInteractive` from `prisma-tx.util.ts` instead.',
     },
   },
   create(context) {

--- a/tools/eslint-rules/no-direct-prisma-transaction.test.js
+++ b/tools/eslint-rules/no-direct-prisma-transaction.test.js
@@ -27,6 +27,11 @@ test('no-direct-prisma-transaction', () => {
         code: 'await prisma.$transaction(async (tx) => {});',
         filename: 'apps/api/src/adapters/prisma/rls.interceptor.ts',
       },
+      // Allowlisted: rls-context.service.ts owns the per-operation short-lived transaction (#518).
+      {
+        code: 'await this.prisma.$transaction(async (tx) => {}, { timeout: 5000 });',
+        filename: 'apps/api/src/adapters/prisma/rls-context.service.ts',
+      },
       // Non-$transaction member calls are unaffected.
       {
         code: 'prisma.$connect();',


### PR DESCRIPTION
## Summary

Closes #518 (RLS hardening follow-up from #516; resolves the "known limitation" recorded in ADR-010).

The `cycle-plan` handler calls an LLM between DB reads. Under the per-request RLS design ([#511](https://github.com/brownm09/lifting-logbook/issues/511)) it held **one** interactive transaction — and therefore one DB connection — for the full model-call duration, papered over with `@RlsTxTimeout(120_000)`.

This PR moves the LLM round-trips outside any transaction:

- **`@SkipRlsTransaction()`** (new decorator) — the interceptor stores only the userId in CLS (`RLS_USER_ID_KEY`) and does **not** open a transaction for that handler.
- **`RlsContextService.withUserContext`** (new) — opens a short-lived (5 s) transaction, sets `app.current_user_id`, stashes the tx client in CLS, runs the callback, and tears the binding down. No Prisma client (in-memory mode) → runs the callback directly.
- **The agent loop wraps each tool dispatch** in `withContext`; the LLM `runTurn` calls happen between dispatches, outside any transaction. A connection is held only for each brief DB operation.

### Why `withContext` *provides* the repos (correctness, not style)

`PrismaRepositoryFactory.forUser()` binds its repositories to the CLS tx client **at construction time**. For RLS to actually enforce under the `NOBYPASSRLS` `lifting_app` role (PR C / #517), the repos used by a tool dispatch must be built **inside** the short transaction so they bind to the GUC-carrying tx client. A single pre-built bundle would bind to the base client and **fail closed (zero rows)** once RLS is live. So `plan(request, withContext)` replaces `plan(repos, request)`, and `withContext((repos) => …)` builds the bundle per-operation inside the tx.

## Changes

- `adapters/prisma/rls-context.ts` — add `RLS_SKIP_TX`, `RLS_USER_ID_KEY`, `@SkipRlsTransaction()`, and shared `setRlsUserContext(tracer, tx, userId)` helper
- `adapters/prisma/rls-context.service.ts` *(new)* — `RlsContextService` + unit tests; passthrough when no Prisma client
- `adapters/prisma/rls.interceptor.ts` — skip-tx branch (store userId in CLS, no tx); use shared `setRlsUserContext`
- `adapters/factory/repository-factory.module.ts` — provide + export `RlsContextService`
- `ports/ICyclePlanningAgent.ts` — `WithRlsContext` type; `plan(request, withContext)`
- `adapters/llm/agent-tools.ts` — `runAgentLoop`/`runPlan` take `withContext`; per-tool dispatch wrapped in try/catch (graceful degradation)
- `adapters/llm/{anthropic,openai-compatible}-cycle-planning.adapter.ts` — forward `withContext`
- `programs/cycle-plan.controller.ts` — `@SkipRlsTransaction()`; build `withContext`
- `tools/eslint-rules/no-direct-prisma-transaction.{js,test.js}` — allowlist `rls-context.service.ts`
- `docs/adr/ADR-010-multi-tenancy-data-isolation.md` — document the per-operation context

## Testing

```
npm run lint                         → Tasks: 7 successful
node --test tools/eslint-rules/no-direct-prisma-transaction.test.js → 1 pass
npm test -w @lifting-logbook/api     → Test Suites: 29 passed, Tests: 380 passed, 0 skipped, 0 failed
```

New tests: `rls-context.service.spec.ts` (tx open + GUC set; tx-client bound during fn and cleared after, incl. on throw; throws when no userId; passthrough with no Prisma client); `agent-tools.spec.ts` `runAgentLoop` regression (a `withContext` rejection becomes a failed tool result, not a plan crash); `cycle-plan.controller.spec.ts` updated for the `(request, withContext)` signature.

## Review findings disposition

`/review` (high effort, 7 finder angles): 1 confirmed correctness finding fixed, 2 cleanup findings addressed, plus rejected false positives.

- **[fixed in `8500b28`] Unguarded `withContext` dispatch crashed the whole plan on a tx error/timeout.** The per-tool `await withContext(...)` in `runAgentLoop` was not wrapped in try/catch; the `withContext` wrapper (short-tx open/commit, `set_config`, the 5 s timeout — down from 120 s) can reject *above* `dispatchTool`'s own try/catch, and the rejection propagated uncaught through `runPlan` (no catch) to a 500. Now caught and surfaced as an `{ok:false}` tool result, matching `dispatchTool`'s contract so the agent degrades gracefully. Regression test added.
- **[fixed in `8500b28`] Duplicated `setUserContext`.** The new service duplicated the interceptor's `set_config` + OTel-span logic (introduced by this PR). Extracted to a shared `setRlsUserContext(tracer, tx, userId)` in `rls-context.ts`; both call sites use it. Removed the now-unused `Prisma` import from the interceptor.
- **[accepted] `forUser` rebuilt per tool dispatch (~15 repo objects/call).** Required for RLS tx-binding correctness (repos must bind to the per-op tx client); cycle-plan is low-volume; in-memory factory memoizes per user. Documented tradeoff, not a regression.
- **[accepted] `RlsTxTimeout` export no longer used by any handler.** Retained as a general per-handler timeout-override extension point for the per-request RLS path (documented, type-safe); removing it would drop a legitimate capability, not just dead code.
- **[accepted] Per-tool reads now in separate snapshots** (vs one request-snapshot before). Acceptable for a read-only planning agent over the caller's own data; the user reviews proposed changes before anything is applied.
- **[rejected — false positive] "test passes `null` for prisma at `rls-context.service.spec.ts`".** Misread: the no-userId test uses `new RlsContextService(cls, prisma)` (line 72); only the in-memory passthrough test uses `null` (line 84). Confirmed by the passing suite.

## Risk-dimension audit

- **Testing** — unit + controller + loop-regression specs above.
- **Observability** — short-tx `set_config` wrapped in the shared `rls.set_user_context` OTel span (ADR-024).
- **Security** — RLS enforcement strengthened (per-operation GUC); userId from CLS, never logged.
- **Resilience** — tool-dispatch failures (incl. 5 s tx timeout) now degrade to failed tool results instead of crashing the plan; `withUserContext` rejects (async) outside an RLS context; in-memory passthrough preserves dev/CI behaviour.
- **Performance** — primary goal: a DB connection is no longer pinned for the model-call duration.
- **Data integrity / multi-tenant isolation** — no schema change; repos built **inside** the short tx so they bind to the GUC-carrying client (the key invariant for PR C).

## Suppression / test-integrity check

Only suppression-grep match is the pre-existing `agent.plan.mock.calls[0]!` idiom (non-null on a jest mock-call array; the `!` predates this PR, only the destructure target changed). New files contain **no** non-null assertions. No skip markers, deleted tests, or lowered thresholds. No `package.json` change → no lockfile drift.

## Sequencing

**PR B** in the RLS follow-up sequence. **PR A (#519)** merged. **PR C (#517, production cutover)** requires this stable in staging ≥24 h before the manual production deploy.