### PR TITLE
[infra] RLS production cutover: runtime lifting_app role + pooled DATABASE_URL

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -522,6 +522,58 @@ The non-Prisma `user_data_source` table (managed outside Prisma) lives in
 `infra/migrations/`; both scripts apply `infra/migrations/001_create_user_data_source.sql`
 after the Prisma migrations.
 
+### Row-Level Security cutover — two-role split (#517)
+
+The app database enforces per-tenant isolation with Postgres Row-Level Security (migration
+`20260611000000_enable_rls`, ADR-010). RLS is **bypassed by `cloudsqlsuperuser` members**, so the
+runtime and the migrator connect as **different roles**:
+
+- **Runtime** (`google_sql_user.app_rls`, `lifting_app`) — `NOSUPERUSER NOBYPASSRLS`. The Cloud
+  Run services and the GKE API pods read `lifting-logbook-<env>-database-url`, which connects as
+  this role (so the policies enforce) and carries `?connection_limit=N` to cap the Prisma pool.
+- **Migrator** (`google_sql_user.app`, `lifting-logbook-app`) — the owner/superuser. The migrate
+  Cloud Run Job reads the separate `lifting-logbook-<env>-migrator-database-url` so it can run DDL
+  and data migrations (which `FORCE ROW LEVEL SECURITY` would otherwise filter to zero rows).
+
+`connection_limit` is derived in `infra/terraform/main.tf` (`local.db_connection_limit`) from the
+tier's `max_connections` and the Cloud Run maxScale; staging divides by an extra factor because the
+ADR-009 GKE A/B deployment shares the same pool. `max_connections` is the tier default (not a flag)
+— verify it before prod with `SELECT setting FROM pg_settings WHERE name='max_connections';`.
+
+**First-apply contingency.** The `lifting_app` role is created idempotently by the enable_rls
+migration (with no password). The first `terraform apply` per workspace that adds
+`google_sql_user.app_rls` may need a one-time import so Terraform adopts the existing role instead
+of failing to recreate it:
+
+```bash
+terraform import google_sql_user.app_rls "<project>/<instance>/lifting_app"   # per workspace
+```
+
+**Staging validation gate (run after the staging deploy, before any prod cutover):**
+
+```bash
+# 1. App connects as the NOBYPASSRLS role (must print: lifting_app | f)
+#    via the Cloud SQL Auth Proxy (scripts/migrate-staging-db.sh sets one up on :5434)
+psql "$STG_RUNTIME_URL" -c "SELECT current_user, pg_has_role('lifting_app','cloudsqlsuperuser','member');"
+# 2. With the GUC unset, a userId table returns ZERO rows (fail-closed proof)
+psql "$STG_RUNTIME_URL" -c "SELECT count(*) FROM training_max;"   # expect 0
+# 3. Connection count stays within the pool budget under load
+psql "$STG_RUNTIME_URL" -c "SELECT count(*) FROM pg_stat_activity;"
+```
+
+Then soak staging ≥24h before approving the production deploy.
+
+**Rolling back the cutover.** Re-point the runtime back to the owner role by adding a new version of
+the `database-url` secret with the old `postgresql://lifting-logbook-app:…` value, then redeploy the
+API (Cloud Run resolves `:latest` at deploy time):
+
+```bash
+gcloud secrets versions add lifting-logbook-prod-database-url --data-file=- --project=lifting-logbook-prod   # paste owner URL
+# then redeploy the API revision (see Rolling back, above)
+```
+
+The migrate Job is unaffected by a rollback (it uses the separate migrator secret).
+
 ### OTel Collector / Grafana Cloud telemetry
 
 **The deploy pipeline deploys the OTel Collector DaemonSet automatically (#474).** On every

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -540,20 +540,37 @@ tier's `max_connections` and the Cloud Run maxScale; staging divides by an extra
 ADR-009 GKE A/B deployment shares the same pool. `max_connections` is the tier default (not a flag)
 — verify it before prod with `SELECT setting FROM pg_settings WHERE name='max_connections';`.
 
-**First-apply contingency.** The `lifting_app` role is created idempotently by the enable_rls
-migration (with no password). The first `terraform apply` per workspace that adds
-`google_sql_user.app_rls` may need a one-time import so Terraform adopts the existing role instead
-of failing to recreate it:
+**First-apply: import is required, not optional.** The `lifting_app` role was already created by the
+`enable_rls` migration (with no password) in both staging and production — confirmed live before this
+change. So `terraform plan` will show a `create` for `google_sql_user.app_rls`, and an unguarded
+`terraform apply` will **fail** with `409 ALREADY_EXISTS` (the Cloud SQL API does not upsert users).
+The deploy pipeline's CI `terraform apply` has no path to recover from this on its own, so the import
+must be run **before** the first apply that introduces `app_rls`, once per workspace, against the same
+GCS-backed remote state the pipeline uses (not a throwaway local state):
 
 ```bash
-terraform import google_sql_user.app_rls "<project>/<instance>/lifting_app"   # per workspace
+cd infra/terraform
+terraform init -backend-config="bucket=lifting-logbook-tfstate" -backend-config="prefix=terraform/state"
+terraform workspace select staging   # then repeat for production before the prod cutover
+terraform import google_sql_user.app_rls "<project>/<instance>/lifting_app"
 ```
+
+After the import, `terraform plan` shows only a password set on the adopted role (no create), and the
+pipeline apply proceeds cleanly. (If a future fresh environment has *not* run `enable_rls` yet, the
+role won't exist and the import is skipped — but that is not the case for the current staging/prod
+cutover.)
 
 **Staging validation gate (run after the staging deploy, before any prod cutover):**
 
+`$STG_RUNTIME_URL` must point at the **proxy**, as the `lifting_app` role — the value stored in the
+`database-url` secret has the Cloud SQL **private IP** as its host, which is unreachable from a local
+machine, so do not use the raw secret value. Start the proxy with `scripts/migrate-staging-db.sh`
+(listens on `127.0.0.1:5434`), then construct the URL with the proxy host and the runtime password:
+
 ```bash
+# Password is the random_password.app_rls_password value; read it once from the secret and rewrite host:
+#   STG_RUNTIME_URL="postgresql://lifting_app:<password>@127.0.0.1:5434/<db_name>?sslmode=disable"
 # 1. App connects as the NOBYPASSRLS role (must print: lifting_app | f)
-#    via the Cloud SQL Auth Proxy (scripts/migrate-staging-db.sh sets one up on :5434)
 psql "$STG_RUNTIME_URL" -c "SELECT current_user, pg_has_role('lifting_app','cloudsqlsuperuser','member');"
 # 2. With the GUC unset, a userId table returns ZERO rows (fail-closed proof)
 psql "$STG_RUNTIME_URL" -c "SELECT count(*) FROM training_max;"   # expect 0

--- a/infra/terraform/cloud-run.tf
+++ b/infra/terraform/cloud-run.tf
@@ -300,11 +300,15 @@ resource "google_cloud_run_v2_job" "migrate" {
           "npx prisma migrate deploy --schema=prisma/schema.prisma && npx prisma migrate status --schema=prisma/schema.prisma"
         ]
 
+        # Migrator connection (#517): connects as the owner/superuser role via the
+        # dedicated migrator secret, NOT the runtime database_url (which now connects as
+        # the NOBYPASSRLS lifting_app role). Migrations run DDL + data migrations that
+        # FORCE ROW LEVEL SECURITY would otherwise block.
         env {
           name = "DATABASE_URL"
           value_source {
             secret_key_ref {
-              secret  = google_secret_manager_secret.database_url.secret_id
+              secret  = google_secret_manager_secret.migrator_database_url.secret_id
               version = "latest"
             }
           }

--- a/infra/terraform/cloud-run.tf
+++ b/infra/terraform/cloud-run.tf
@@ -28,7 +28,9 @@ resource "google_cloud_run_v2_service" "api" {
 
     scaling {
       min_instance_count = local.cloud_run_min_instances
-      max_instance_count = var.environment == "production" ? 10 : 3
+      # Single source of truth shared with the RLS pool-sizing formula (main.tf
+      # local.db_connection_limit) so maxScale and connection_limit cannot drift (#517).
+      max_instance_count = local.api_max_instances
     }
 
     vpc_access {

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -40,6 +40,21 @@ provider "google-beta" {
 locals {
   env_suffix  = var.environment == "production" ? "prod" : "stg"
   name_prefix = "${var.app_name}-${local.env_suffix}"
+
+  # ─── Prisma connection-pool sizing for the RLS cutover (#517) ────────────────
+  # Cap per-instance Prisma pool so the aggregate across every app instance stays
+  # well under Cloud SQL max_connections (which is the tier default — not a flag —
+  # so it is verified against `SHOW max_connections` at the staging gate before prod):
+  #   db-f1-micro (staging) ≈ 25 ; db-g1-small (prod) ≈ 50.
+  # api_max_instances mirrors the Cloud Run maxScale literal in cloud-run.tf.
+  # consumer_factor: staging runs BOTH Cloud Run and the GKE A/B deployment
+  # (ADR-009) against the same DATABASE_URL, so it shares the pool ×2; prod is
+  # Cloud-Run-only (enable_gke=false). The 0.8 factor reserves headroom for the
+  # migrator job, the system DB, and the superuser-reserved connections.
+  api_max_instances   = var.environment == "production" ? 10 : 3
+  db_max_connections  = var.environment == "production" ? 50 : 25
+  db_consumer_factor  = var.environment == "production" ? 1 : 2
+  db_connection_limit = floor(local.db_max_connections * 0.8 / (local.api_max_instances * local.db_consumer_factor))
 }
 
 # ─── GCP APIs ────────────────────────────────────────────────────────────────
@@ -197,6 +212,32 @@ resource "google_sql_user" "app" {
   password = random_password.db_password.result
 }
 
+# ─── Runtime (NOBYPASSRLS) application role — RLS cutover (#517) ───────────────
+# google_sql_user.app above is a Cloud SQL built-in user and therefore a member of
+# cloudsqlsuperuser, which BYPASSES Row-Level Security — so the policies shipped in
+# migration 20260611000000_enable_rls are inert while the app connects as that role.
+# This second role connects the *runtime* (Cloud Run + GKE) as a NOSUPERUSER /
+# NOBYPASSRLS login so the per-tenant policies actually enforce isolation. The
+# *migrator* (Cloud Run Job) keeps using google_sql_user.app — migrations run DDL and
+# data-migrations that RLS would otherwise block (FORCE ROW LEVEL SECURITY).
+#
+# The "lifting_app" role itself is created idempotently by the enable_rls migration
+# (with no password — none is in version control); Terraform owns only its password.
+# CONTINGENCY: because the SQL migration may have already created the role, the first
+# `terraform apply` per workspace can need a one-time
+#   terraform import google_sql_user.app_rls "<project>/<instance>/lifting_app"
+# before apply, so Terraform adopts the existing role instead of failing to re-create it.
+resource "random_password" "app_rls_password" {
+  length  = 32
+  special = false
+}
+
+resource "google_sql_user" "app_rls" {
+  name     = "lifting_app"
+  instance = google_sql_database_instance.main.name
+  password = random_password.app_rls_password.result
+}
+
 # ─── Secret Manager ──────────────────────────────────────────────────────────
 
 resource "google_secret_manager_secret" "database_url" {
@@ -207,9 +248,13 @@ resource "google_secret_manager_secret" "database_url" {
   depends_on = [google_project_service.required_apis]
 }
 
+# Runtime DATABASE_URL — connects as the NOBYPASSRLS lifting_app role (#517) so RLS
+# policies enforce, and caps the Prisma pool via ?connection_limit so the aggregate
+# across all app instances stays under Cloud SQL max_connections. The migrate Job uses
+# a SEPARATE secret (migrator_database_url, below) that still connects as the owner.
 resource "google_secret_manager_secret_version" "database_url" {
   secret      = google_secret_manager_secret.database_url.id
-  secret_data = "postgresql://${google_sql_user.app.name}:${random_password.db_password.result}@${google_sql_database_instance.main.private_ip_address}:5432/${var.db_name}"
+  secret_data = "postgresql://${google_sql_user.app_rls.name}:${random_password.app_rls_password.result}@${google_sql_database_instance.main.private_ip_address}:5432/${var.db_name}?connection_limit=${local.db_connection_limit}"
 }
 
 resource "google_secret_manager_secret" "system_database_url" {
@@ -223,6 +268,24 @@ resource "google_secret_manager_secret" "system_database_url" {
 resource "google_secret_manager_secret_version" "system_database_url" {
   secret      = google_secret_manager_secret.system_database_url.id
   secret_data = "postgresql://${google_sql_user.app.name}:${random_password.db_password.result}@${google_sql_database_instance.main.private_ip_address}:5432/${var.db_name}_system"
+}
+
+# Migrator DATABASE_URL — used ONLY by the migrate Cloud Run Job (#517). Connects as
+# the owner/superuser role (google_sql_user.app), which can run DDL and data migrations
+# that RLS would otherwise block. No connection_limit: the job runs once with a single
+# connection. The api workload SA already holds project-level secretmanager.secretAccessor
+# (gke.tf api_workload_roles), so no per-secret IAM grant is required.
+resource "google_secret_manager_secret" "migrator_database_url" {
+  secret_id = "${local.name_prefix}-migrator-database-url"
+  replication {
+    auto {}
+  }
+  depends_on = [google_project_service.required_apis]
+}
+
+resource "google_secret_manager_secret_version" "migrator_database_url" {
+  secret      = google_secret_manager_secret.migrator_database_url.id
+  secret_data = "postgresql://${google_sql_user.app.name}:${random_password.db_password.result}@${google_sql_database_instance.main.private_ip_address}:5432/${var.db_name}"
 }
 
 resource "google_secret_manager_secret" "clerk_secret_key" {

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -46,7 +46,9 @@ locals {
   # well under Cloud SQL max_connections (which is the tier default — not a flag —
   # so it is verified against `SHOW max_connections` at the staging gate before prod):
   #   db-f1-micro (staging) ≈ 25 ; db-g1-small (prod) ≈ 50.
-  # api_max_instances mirrors the Cloud Run maxScale literal in cloud-run.tf.
+  # api_max_instances is the single source of truth for the Cloud Run API maxScale:
+  # google_cloud_run_v2_service.api.scaling.max_instance_count references this local
+  # (cloud-run.tf), so the scaling cap and this pool-sizing formula cannot drift apart.
   # consumer_factor: staging runs BOTH Cloud Run and the GKE A/B deployment
   # (ADR-009) against the same DATABASE_URL, so it shares the pool ×2; prod is
   # Cloud-Run-only (enable_gke=false). The 0.8 factor reserves headroom for the


### PR DESCRIPTION
## Summary

Activates the Row-Level Security policies shipped in #511 (ADR-010) in staging and production by making the **runtime** connect as a `NOBYPASSRLS` role. Today both environments connect as `lifting-logbook-app` — a Cloud SQL built-in user and `cloudsqlsuperuser` member that **bypasses RLS** — so the per-tenant policies are inert (confirmed live: both `*-database-url` secrets resolve to `postgresql://lifting-logbook-app:…`, no `connection_limit`). Also sizes the Prisma connection pool for the small Cloud SQL tiers.

> ⚠️ **Production cutover is human-gated.** Merging performs the **staging** cutover via the normal pipeline. Production requires the manual deploy approval **and** explicit go-ahead after the staging validation gate + ≥24h soak. Do **not** enable auto-merge.

## Design — two roles, two secrets

The migrate Cloud Run Job and the runtime services currently share one `database_url` secret/role. Migrations must run as an owner/superuser (DDL + data migrations; under `FORCE ROW LEVEL SECURITY` a non-bypass role with the GUC unset filters every row), while the runtime must be `NOBYPASSRLS`. So the single role is split, not renamed:

- **Runtime** — new `google_sql_user.app_rls` (`lifting_app`, `NOSUPERUSER NOBYPASSRLS`). The Cloud Run services + GKE API pods keep reading the existing `…-database-url` secret, whose value now connects as `lifting_app` and carries `?connection_limit=N`.
- **Migrator** — unchanged `google_sql_user.app` (`lifting-logbook-app`, owner). The migrate Job now reads a new `…-migrator-database-url` secret.

A rejected alternative — renaming the one shared user (the original plan) or `ALTER ROLE … NOBYPASSRLS` — would point the **migrate Job** at the non-privileged role and break migrations.

## Changes (infra + docs only — no app code)

- `infra/terraform/main.tf` — `random_password.app_rls_password` + `google_sql_user.app_rls`; repoint `database_url` version to `lifting_app` + `?connection_limit`; new `migrator_database_url` secret + version; `local.db_connection_limit` sizing.
- `infra/terraform/cloud-run.tf` — migrate Job `DATABASE_URL` → `migrator_database_url`.
- `docs/deploy.md` — two-role split, import contingency, staging validation gate, cutover rollback.

`api_workload` already holds **project-level** `secretmanager.secretAccessor` (gke.tf), so the migrator secret needs no new IAM grant.

### Connection-pool sizing
`local.db_connection_limit = floor(max_connections × 0.8 / (api_max_instances × consumer_factor))`. `max_connections` is the tier default (not a flag): db-f1-micro ≈ 25 (staging), db-g1-small ≈ 50 (prod). `consumer_factor` is 2 on staging (Cloud Run **and** the GKE A/B share the pool, ADR-009) and 1 on prod (`enable_gke=false`). Computed: **staging 3, prod 4**. Verified against `SHOW max_connections` at the staging gate before prod.

## First-apply contingency (operational)

`lifting_app` is created idempotently by the enable_rls migration (no password). The first `terraform apply` per workspace that adds `google_sql_user.app_rls` may need a one-time import so Terraform adopts the existing role rather than failing to recreate it:

```
terraform import google_sql_user.app_rls "<project>/<instance>/lifting_app"   # per workspace
```

If `terraform plan` (staging) shows a clean create with no conflict, no import is needed. **This is the one thing to watch on the staging apply.**

## Staging validation gate (post-merge, before prod)

1. `SELECT current_user, pg_has_role('lifting_app','cloudsqlsuperuser','member')` → `lifting_app | f`
2. With the GUC unset, a `userId` table returns **zero** rows (fail-closed proof)
3. Authenticated GET to a user-data endpoint returns the caller's rows
4. `pg_stat_activity` count stays within the pool budget under load

Then **≥24h soak**, then the manual production gate.

## Testing

Infra-only; no Jest-testable code. `terraform fmt` clean and **`terraform validate` → Success** (offline `-backend=false`). Per-workspace `terraform plan` review (must show **no destroy** of `google_sql_user.app` and no instance replacement) is part of the gated apply. Pre-PR greps (suppression / test-integrity) clean; no `package.json` change (lockfile N/A).

**Tests: N/A — infrastructure-only change; validation is `terraform validate` + the staging validation gate above.**

## Risk

- **Resilience/rollback** — non-destructive apply (no user replace, existing password untouched → live connections undisturbed). Rollback = re-point `database-url` to the owner URL + redeploy (documented in `docs/deploy.md`). Migrate Job unaffected.
- **Data integrity** — migrator/runtime split keeps data migrations running with BYPASSRLS (e.g. #531-style row DELETEs); runtime enforces isolation. No schema change.
- **Security** — this *is* the fix: DB-level tenant isolation now enforced. Passwords stay in Secret Manager.

Closes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review findings disposition

`/review` (claude-opus-4-8) on this PR surfaced **1 blocking, 3 non-blocking**. All addressed:

- **[blocking][reliability]** First `terraform apply` would 409 because `lifting_app` already exists (enable_rls ran in both envs) and the CI apply can't self-import — **fixed in `34d379f`**: `docs/deploy.md` reworded from "may need" → required, with the explicit `init` + `workspace select` + `import` sequence against the shared remote state to run before the first apply.
- **[non-blocking][security]** Runtime still carries owner/superuser creds via `SYSTEM_DATABASE_URL` (unused on the Prisma path, but bypasses RLS) — **filed #534** and deferred to keep this gated cutover non-destructive (removing it spans Cloud Run + GKE helm + api-service.yaml).
- **[non-blocking][maintainability]** `api_max_instances` duplicated the Cloud Run maxScale literal → drift risk vs the pool formula — **fixed in `34d379f`**: `cloud-run.tf` `max_instance_count` now references `local.api_max_instances` (single source of truth).
- **[non-blocking][documentation]** `$STG_RUNTIME_URL` undefined / would point at an unreachable private IP — **fixed in `34d379f`**: `docs/deploy.md` now defines it (proxy host `127.0.0.1:5434`, `lifting_app`, `sslmode=disable`).

`terraform fmt` clean and `terraform validate` → Success after the fixes.
