### PR TITLE
[chore] Unify import-commit methods + classify-and-count helper + P2028 mapping (#532)

### DIFF
--- a/apps/api/src/adapters/import-count-parity.spec.ts
+++ b/apps/api/src/adapters/import-count-parity.spec.ts
@@ -1,0 +1,154 @@
+import { PrismaClient } from '@prisma/client';
+import {
+  LiftingProgramSpec,
+  StrengthGoalEntry,
+  TrainingMax,
+} from '@lifting-logbook/core';
+import { InMemoryTrainingMaxRepository } from './in-memory/training-max.adapter';
+import { InMemoryStrengthGoalRepository } from './in-memory/strength-goal.adapter';
+import { InMemoryLiftingProgramSpecRepository } from './in-memory/lifting-program-spec.adapter';
+import { PrismaTrainingMaxRepository } from './prisma/training-max.repository';
+import { PrismaStrengthGoalRepository } from './prisma/strength-goal.repository';
+import { HybridLiftingProgramSpecRepository } from './prisma/hybrid-program-spec.repository';
+
+/**
+ * Cross-adapter parity (#532): the in-memory and Prisma import-commit methods must
+ * return identical {created, updated, skipped} for the same input. Both now route
+ * through the shared `classifyAndCount` loop + the shared `*RowKind` classifiers,
+ * so a future change to dedupe/tally semantics in one place can't desync the other.
+ *
+ * The in-memory adapter is seeded by importing the "existing" rows first (all
+ * creates); the Prisma adapter is given the same existing snapshot via a mock
+ * `findMany` whose `$transaction` runs the callback against an in-tx stub.
+ */
+
+const USER = 'user-1';
+const PROGRAM = '5-3-1';
+const SPEC_PROGRAM = '11111111-1111-4111-8111-111111111111';
+const at = new Date('2026-01-01T00:00:00.000Z');
+
+describe('import-commit count parity (in-memory vs Prisma)', () => {
+  it('training maxes: identical counts for create/update/skip/dedupe', async () => {
+    const existing: TrainingMax[] = [
+      { lift: 'Squat', weight: 300, dateUpdated: at },
+      { lift: 'Deadlift', weight: 350, dateUpdated: at },
+    ];
+    const incoming: TrainingMax[] = [
+      { lift: 'Squat', weight: 300, dateUpdated: at }, // identical → skip
+      { lift: 'Deadlift', weight: 400, dateUpdated: at }, // differs → update
+      { lift: 'Bench', weight: 200, dateUpdated: at }, // absent → create
+      { lift: 'Squat', weight: 999, dateUpdated: at }, // duplicate lift → collapsed
+    ];
+
+    const mem = new InMemoryTrainingMaxRepository();
+    await mem.importTrainingMaxes(PROGRAM, existing);
+    const memResult = await mem.importTrainingMaxes(PROGRAM, incoming);
+
+    const tx = {
+      trainingMax: {
+        findMany: jest.fn().mockResolvedValue(existing.map((m) => ({ lift: m.lift, weight: m.weight }))),
+        upsert: jest.fn().mockResolvedValue({}),
+      },
+    };
+    const prisma = {
+      $transaction: jest.fn((cb: (t: typeof tx) => unknown) => cb(tx)),
+    } as unknown as PrismaClient;
+    const prismaResult = await new PrismaTrainingMaxRepository(prisma, USER).importTrainingMaxes(
+      PROGRAM,
+      incoming,
+    );
+
+    expect(memResult).toEqual({ created: 1, updated: 1, skipped: 1 });
+    expect(prismaResult).toEqual(memResult);
+  });
+
+  it('strength goals: identical counts for create/update/skip/dedupe', async () => {
+    const existing: StrengthGoalEntry[] = [
+      { lift: 'Squat', goalType: 'absolute', unit: 'lbs', target: 400, updatedAt: at },
+      { lift: 'Deadlift', goalType: 'absolute', unit: 'lbs', target: 500, updatedAt: at },
+    ];
+    const incoming: StrengthGoalEntry[] = [
+      { lift: 'Squat', goalType: 'absolute', unit: 'lbs', target: 400, updatedAt: at }, // skip
+      { lift: 'Deadlift', goalType: 'absolute', unit: 'lbs', target: 505, updatedAt: at }, // update
+      { lift: 'Bench', goalType: 'relative', unit: 'lbs', ratio: 1.5, updatedAt: at }, // create
+      { lift: 'Squat', goalType: 'absolute', unit: 'lbs', target: 999, updatedAt: at }, // collapsed
+    ];
+
+    const mem = new InMemoryStrengthGoalRepository();
+    await mem.importGoals(PROGRAM, existing);
+    const memResult = await mem.importGoals(PROGRAM, incoming);
+
+    const tx = {
+      strengthGoal: {
+        findMany: jest.fn().mockResolvedValue(
+          existing.map((g) => ({
+            lift: g.lift,
+            goalType: g.goalType,
+            unit: g.unit,
+            target: g.target ?? null,
+            ratio: g.ratio ?? null,
+            updatedAt: g.updatedAt,
+          })),
+        ),
+        upsert: jest.fn().mockResolvedValue({}),
+      },
+    };
+    const prisma = {
+      $transaction: jest.fn((cb: (t: typeof tx) => unknown) => cb(tx)),
+    } as unknown as PrismaClient;
+    const prismaResult = await new PrismaStrengthGoalRepository(prisma, USER).importGoals(
+      PROGRAM,
+      incoming,
+    );
+
+    expect(memResult).toEqual({ created: 1, updated: 1, skipped: 1 });
+    expect(prismaResult).toEqual(memResult);
+  });
+
+  it('program spec: identical counts for create/update/skip/dedupe', async () => {
+    const spec = (lift: string, sets: number): LiftingProgramSpec => ({
+      week: 1,
+      offset: 0,
+      lift,
+      order: 1,
+      increment: 5,
+      sets,
+      reps: 5,
+      amrap: false,
+      warmUpPct: '0.65',
+      wtDecrementPct: 0,
+      activation: 'main',
+    });
+    const toRow = (s: LiftingProgramSpec) => ({ ...s, weekType: null });
+
+    const existing = [spec('Squat', 5), spec('Bench', 5)];
+    const incoming = [
+      spec('Squat', 5), // identical → skip
+      spec('Bench', 3), // sets differ → update
+      spec('Deadlift', 5), // absent → create
+      spec('Squat', 9), // duplicate natural key → collapsed
+    ];
+
+    const mem = new InMemoryLiftingProgramSpecRepository();
+    await mem.saveProgramSpec(SPEC_PROGRAM, existing);
+    const memResult = await mem.saveProgramSpec(SPEC_PROGRAM, incoming);
+
+    const tx = {
+      customProgram: { findFirst: jest.fn().mockResolvedValue({ id: SPEC_PROGRAM }) },
+      customProgramSpec: {
+        findMany: jest.fn().mockResolvedValue(existing.map(toRow)),
+        upsert: jest.fn().mockResolvedValue({}),
+      },
+    };
+    const prisma = {
+      $transaction: jest.fn((cb: (t: typeof tx) => unknown) => cb(tx)),
+    } as unknown as PrismaClient;
+    const prismaResult = await new HybridLiftingProgramSpecRepository(prisma, USER).saveProgramSpec(
+      SPEC_PROGRAM,
+      incoming,
+    );
+
+    expect(memResult).toEqual({ created: 1, updated: 1, skipped: 1 });
+    expect(prismaResult).toEqual(memResult);
+  });
+});

--- a/apps/api/src/adapters/in-memory/lifting-program-spec.adapter.ts
+++ b/apps/api/src/adapters/in-memory/lifting-program-spec.adapter.ts
@@ -1,8 +1,9 @@
 import { BadRequestException } from '@nestjs/common';
 import {
   LiftingProgramSpec,
-  programSpecComparable,
+  classifyAndCount,
   programSpecNaturalKey,
+  programSpecRowKind,
 } from '@lifting-logbook/core';
 import {
   ILiftingProgramSpecRepository,
@@ -35,29 +36,21 @@ export class InMemoryLiftingProgramSpecRepository
     }
 
     const current = [...(this.specByProgram.get(program) ?? [])];
-    const byKey = new Map(current.map((r) => [programSpecNaturalKey(r), r]));
-    let created = 0;
-    let updated = 0;
-    let skipped = 0;
-    const seen = new Set<string>();
+    const existingByKey = new Map(current.map((r) => [programSpecNaturalKey(r), r]));
+    const byKey = new Map(existingByKey);
 
-    for (const r of rows) {
-      const key = programSpecNaturalKey(r);
-      if (seen.has(key)) continue;
-      seen.add(key);
-      const prior = byKey.get(key);
-      if (!prior) {
-        byKey.set(key, r);
-        created++;
-      } else if (programSpecComparable(prior) === programSpecComparable(r)) {
-        skipped++;
-      } else {
-        byKey.set(key, r);
-        updated++;
-      }
-    }
+    // Shared classify/dedupe/tally loop + program-spec classifier (#532) so this
+    // adapter's counts match the Prisma adapter's and the preview path's.
+    const result = await classifyAndCount(
+      rows,
+      (r) => programSpecNaturalKey(r),
+      (r) => programSpecRowKind(r, existingByKey),
+      (r) => {
+        byKey.set(programSpecNaturalKey(r), r);
+      },
+    );
 
     this.specByProgram.set(program, [...byKey.values()]);
-    return { created, updated, skipped };
+    return result;
   }
 }

--- a/apps/api/src/adapters/in-memory/strength-goal.adapter.ts
+++ b/apps/api/src/adapters/in-memory/strength-goal.adapter.ts
@@ -1,4 +1,4 @@
-import { StrengthGoalEntry, strengthGoalRowKind } from '@lifting-logbook/core';
+import { StrengthGoalEntry, classifyAndCount, strengthGoalRowKind } from '@lifting-logbook/core';
 import { ImportWriteResult } from '@lifting-logbook/types';
 import { IStrengthGoalRepository } from '../../ports/IStrengthGoalRepository';
 import { StrengthGoalNotFoundError } from '../../ports/errors';
@@ -31,26 +31,16 @@ export class InMemoryStrengthGoalRepository implements IStrengthGoalRepository {
     const map = this.programMap(program);
     const existingByLift = new Map(map);
 
-    let created = 0;
-    let updated = 0;
-    let skipped = 0;
-    const seen = new Set<string>();
-
-    for (const g of goals) {
-      if (seen.has(g.lift)) continue; // collapse duplicate lifts within the file
-      seen.add(g.lift);
-
-      const kind = strengthGoalRowKind(g, existingByLift);
-      if (kind === 'skip') {
-        skipped++;
-        continue;
-      }
-      map.set(g.lift, g);
-      if (kind === 'create') created++;
-      else updated++;
-    }
-
-    return { created, updated, skipped };
+    // Shared classify/dedupe/tally loop (#532) so this adapter's counts match the
+    // Prisma adapter's and the preview path's for the same input.
+    return classifyAndCount(
+      goals,
+      (g) => g.lift,
+      (g) => strengthGoalRowKind(g, existingByLift),
+      (g) => {
+        map.set(g.lift, g);
+      },
+    );
   }
 
   async deleteGoal(program: string, lift: string): Promise<void> {

--- a/apps/api/src/adapters/in-memory/training-max.adapter.ts
+++ b/apps/api/src/adapters/in-memory/training-max.adapter.ts
@@ -1,4 +1,4 @@
-import { TrainingMax, trainingMaxRowKind } from '@lifting-logbook/core';
+import { TrainingMax, classifyAndCount, trainingMaxRowKind } from '@lifting-logbook/core';
 import { ImportWriteResult } from '@lifting-logbook/types';
 import { ITrainingMaxRepository } from '../../ports/ITrainingMaxRepository';
 import { SEED_PROGRAM, seedTrainingMaxes } from './fixtures';
@@ -34,26 +34,18 @@ export class InMemoryTrainingMaxRepository implements ITrainingMaxRepository {
     const existingByLift = new Map(existing.map((m) => [m.lift, m.weight]));
     const byLift = new Map(existing.map((m) => [m.lift, m]));
 
-    let created = 0;
-    let updated = 0;
-    let skipped = 0;
-    const seen = new Set<string>();
-
-    for (const m of maxes) {
-      if (seen.has(m.lift)) continue; // collapse duplicate lifts within the file
-      seen.add(m.lift);
-
-      const kind = trainingMaxRowKind(m, existingByLift);
-      if (kind === 'skip') {
-        skipped++;
-        continue;
-      }
-      byLift.set(m.lift, m);
-      if (kind === 'create') created++;
-      else updated++;
-    }
+    // Shared classify/dedupe/tally loop (#532) so this adapter's counts match the
+    // Prisma adapter's and the preview path's for the same input.
+    const result = await classifyAndCount(
+      maxes,
+      (m) => m.lift,
+      (m) => trainingMaxRowKind(m, existingByLift),
+      (m) => {
+        byLift.set(m.lift, m);
+      },
+    );
 
     this.maxesByProgram.set(program, [...byLift.values()]);
-    return { created, updated, skipped };
+    return result;
   }
 }

--- a/apps/api/src/adapters/prisma/hybrid-program-spec.repository.spec.ts
+++ b/apps/api/src/adapters/prisma/hybrid-program-spec.repository.spec.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { LiftingProgramSpec } from '@lifting-logbook/core';
 import { HybridLiftingProgramSpecRepository } from './hybrid-program-spec.repository';
 
 const CUSTOM_PROGRAM_ID = '11111111-1111-4111-8111-111111111111';
@@ -9,6 +10,41 @@ function makePrisma(): PrismaClient {
       findMany: jest.fn().mockResolvedValue([]),
     },
   } as unknown as PrismaClient;
+}
+
+const spec = (lift: string, sets: number): LiftingProgramSpec => ({
+  week: 1,
+  offset: 0,
+  lift,
+  order: 1,
+  increment: 5,
+  sets,
+  reps: 5,
+  amrap: false,
+  warmUpPct: '0.65',
+  wtDecrementPct: 0,
+  activation: 'main',
+});
+
+/**
+ * Mock whose `$transaction` runs the callback against a stub tx client so the
+ * owner check, the single snapshot `findMany`, and the per-row `upsert` all run on
+ * it. `existing` seeds the snapshot read; `ownerExists` toggles the owner guard.
+ */
+function makeSavePrisma(
+  existing: Array<Record<string, unknown>> = [],
+  ownerExists = true,
+  upsert: jest.Mock = jest.fn().mockResolvedValue({}),
+) {
+  const findFirst = jest.fn().mockResolvedValue(ownerExists ? { id: CUSTOM_PROGRAM_ID } : null);
+  const findMany = jest.fn().mockResolvedValue(existing);
+  const tx = {
+    customProgram: { findFirst },
+    customProgramSpec: { findMany, upsert },
+  };
+  const $transaction = jest.fn((cb: (t: typeof tx) => unknown) => cb(tx));
+  const prisma = { $transaction } as unknown as PrismaClient;
+  return { prisma, findFirst, findMany, upsert, $transaction };
 }
 
 describe('HybridLiftingProgramSpecRepository', () => {
@@ -49,5 +85,53 @@ describe('HybridLiftingProgramSpecRepository', () => {
         where: { programId: CUSTOM_PROGRAM_ID, program: { userId: 'attacker' } },
       }),
     );
+  });
+});
+
+describe('HybridLiftingProgramSpecRepository.saveProgramSpec', () => {
+  it('rejects a built-in (non-UUID) program before touching the DB', async () => {
+    const { prisma, $transaction } = makeSavePrisma();
+    const repo = new HybridLiftingProgramSpecRepository(prisma, 'user-1');
+
+    await expect(repo.saveProgramSpec('5-3-1', [spec('Squat', 5)])).rejects.toThrow(
+      'requires a custom program',
+    );
+    expect($transaction).not.toHaveBeenCalled();
+  });
+
+  it('throws NotFound when the custom program is not owned by the user', async () => {
+    const { prisma, findMany } = makeSavePrisma([], /* ownerExists */ false);
+    const repo = new HybridLiftingProgramSpecRepository(prisma, 'user-1');
+
+    await expect(repo.saveProgramSpec(CUSTOM_PROGRAM_ID, [spec('Squat', 5)])).rejects.toThrow(
+      `Custom program ${CUSTOM_PROGRAM_ID} not found`,
+    );
+    // The owner guard short-circuits before the snapshot read.
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it('classifies create/update/skip from one snapshot read and dedupes within the batch', async () => {
+    const toRow = (s: LiftingProgramSpec) => ({ ...s, weekType: null });
+    const { prisma, findFirst, findMany, upsert, $transaction } = makeSavePrisma([
+      toRow(spec('Squat', 5)),
+      toRow(spec('Bench', 5)),
+    ]);
+    const repo = new HybridLiftingProgramSpecRepository(prisma, 'user-1');
+
+    const result = await repo.saveProgramSpec(CUSTOM_PROGRAM_ID, [
+      spec('Squat', 5), // identical → skip
+      spec('Bench', 3), // sets differ → update
+      spec('Deadlift', 5), // absent → create
+      spec('Squat', 9), // duplicate natural key → collapsed
+    ]);
+
+    expect(result).toEqual({ created: 1, updated: 1, skipped: 1 });
+    expect($transaction).toHaveBeenCalledTimes(1);
+    expect(findFirst).toHaveBeenCalledTimes(1); // owner guard
+    // One up-front snapshot read (not a per-row findFirst), scoped to the program.
+    expect(findMany).toHaveBeenCalledTimes(1);
+    expect(findMany).toHaveBeenCalledWith({ where: { programId: CUSTOM_PROGRAM_ID } });
+    // Only the non-skip, non-duplicate rows are written, via upsert on the natural key.
+    expect(upsert).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/api/src/adapters/prisma/hybrid-program-spec.repository.ts
+++ b/apps/api/src/adapters/prisma/hybrid-program-spec.repository.ts
@@ -1,8 +1,9 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import {
   LiftingProgramSpec,
-  programSpecComparable,
+  classifyAndCount,
   programSpecNaturalKey,
+  programSpecRowKind,
 } from '@lifting-logbook/core';
 import {
   ILiftingProgramSpecRepository,
@@ -10,7 +11,7 @@ import {
 } from '../../ports/ILiftingProgramSpecRepository';
 import { PrismaClient } from '@prisma/client';
 import { InMemoryLiftingProgramSpecRepository } from '../in-memory/lifting-program-spec.adapter';
-import { runInteractive } from './prisma-tx.util';
+import { IMPORT_BATCH_TX_OPTIONS, runInteractive } from './prisma-tx.util';
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -77,11 +78,15 @@ export class HybridLiftingProgramSpecRepository implements ILiftingProgramSpecRe
    * Idempotently writes spec rows for a custom program (see interface docs).
    * Built-in templates are immutable seed data and are rejected.
    *
-   * Each row is classified by a find-then-write inside a transaction (so an
-   * identical re-import yields `created: 0`). The insert is an `upsert` on the
-   * `(programId, week, offset, lift, order)` unique constraint (issue #488) so two
-   * concurrent imports racing past the same `findFirst → null` cannot both create
-   * a duplicate row — the loser updates instead of hitting a unique violation.
+   * Classifies each row against a single up-front snapshot read and writes via an
+   * `upsert` on the `(programId, week, offset, lift, order)` unique constraint
+   * (issue #488), so an identical re-import yields `created: 0` and two concurrent
+   * imports racing past the same snapshot cannot both create a duplicate row — the
+   * loser updates instead of hitting a unique violation. Shares the classify/dedupe/
+   * tally loop and the program-spec classifier with the preview path and the
+   * in-memory adapter (issue #532), so preview and commit can never disagree on
+   * counts. Named `saveProgramSpec` (vs `importTrainingMaxes`/`importGoals`)
+   * intentionally — see the asymmetry note on the port interface.
    */
   async saveProgramSpec(
     program: string,
@@ -91,81 +96,67 @@ export class HybridLiftingProgramSpecRepository implements ILiftingProgramSpecRe
       throw new BadRequestException('Program spec import requires a custom program');
     }
 
-    return runInteractive(this.prisma, async (tx) => {
-      const owner = await tx.customProgram.findFirst({
-        where: { id: program, userId: this.userId },
-        select: { id: true },
-      });
-      if (!owner) throw new NotFoundException(`Custom program ${program} not found`);
-
-      let created = 0;
-      let updated = 0;
-      let skipped = 0;
-      const seen = new Set<string>();
-
-      for (const r of rows) {
-        const key = programSpecNaturalKey(r);
-        if (seen.has(key)) continue; // collapse duplicate keys within the file
-        seen.add(key);
-
-        const data = {
-          programId: program,
-          week: r.week,
-          offset: r.offset,
-          lift: r.lift,
-          increment: r.increment,
-          order: r.order,
-          sets: r.sets,
-          reps: r.reps,
-          amrap: r.amrap === true || r.amrap === 'TRUE',
-          warmUpPct: r.warmUpPct,
-          wtDecrementPct: r.wtDecrementPct,
-          activation: r.activation,
-          weekType: r.weekType ?? null,
-        };
-
-        const existing = await tx.customProgramSpec.findFirst({
-          where: {
-            programId: program,
-            week: r.week,
-            offset: r.offset,
-            lift: r.lift,
-            order: r.order,
-          },
+    return runInteractive(
+      this.prisma,
+      async (tx) => {
+        const owner = await tx.customProgram.findFirst({
+          where: { id: program, userId: this.userId },
+          select: { id: true },
         });
+        if (!owner) throw new NotFoundException(`Custom program ${program} not found`);
 
-        if (!existing) {
-          // upsert (not create) on the natural-key constraint: a concurrent import
-          // that created this row after our findFirst makes the loser update, not
-          // throw P2002 (issue #488).
-          await tx.customProgramSpec.upsert({
-            where: {
-              programId_week_offset_lift_order: {
-                programId: program,
-                week: r.week,
-                offset: r.offset,
-                lift: r.lift,
-                order: r.order,
+        // One up-front read instead of a per-row findFirst (#532): the natural-key
+        // unique index (#488) makes the upsert race-safe, so the find-then-write per
+        // row — and its hand-duplicated where-clause — is no longer needed.
+        const existingRows = await tx.customProgramSpec.findMany({
+          where: { programId: program },
+        });
+        const existingByKey = new Map(
+          existingRows.map((row) => [programSpecNaturalKey(row), toSpec(row)]),
+        );
+
+        // Counts are best-effort under a same-program concurrent-import race: a row the
+        // snapshot classified as `create` whose upsert actually updated a row a racing
+        // import just inserted still tallies as `created`. The data outcome is correct
+        // (the unique index prevents duplicates); only the created/updated split can skew
+        // in that rare window. importTrainingMaxes/importGoals share this property.
+        return classifyAndCount(
+          rows,
+          (r) => programSpecNaturalKey(r),
+          (r) => programSpecRowKind(r, existingByKey),
+          (r) => {
+            const data = {
+              programId: program,
+              week: r.week,
+              offset: r.offset,
+              lift: r.lift,
+              increment: r.increment,
+              order: r.order,
+              sets: r.sets,
+              reps: r.reps,
+              amrap: r.amrap === true || r.amrap === 'TRUE',
+              warmUpPct: r.warmUpPct,
+              wtDecrementPct: r.wtDecrementPct,
+              activation: r.activation,
+              weekType: r.weekType ?? null,
+            };
+            return tx.customProgramSpec.upsert({
+              where: {
+                programId_week_offset_lift_order: {
+                  programId: program,
+                  week: r.week,
+                  offset: r.offset,
+                  lift: r.lift,
+                  order: r.order,
+                },
               },
-            },
-            create: data,
-            update: data,
-          });
-          // Counts are best-effort under a same-program concurrent-import race: if the
-          // loser's upsert updated a row a racing import just created, this still tallies
-          // it as `created`. The data outcome is correct (no duplicate); only the
-          // created/updated split can skew in that rare window. Same property applies to
-          // importTrainingMaxes/importGoals, which classify from their in-tx read snapshot.
-          created++;
-        } else if (programSpecComparable(toSpec(existing)) === programSpecComparable(r)) {
-          skipped++;
-        } else {
-          await tx.customProgramSpec.update({ where: { id: existing.id }, data });
-          updated++;
-        }
-      }
-
-      return { created, updated, skipped };
-    });
+              create: data,
+              update: data,
+            });
+          },
+        );
+      },
+      IMPORT_BATCH_TX_OPTIONS,
+    );
   }
 }

--- a/apps/api/src/adapters/prisma/prisma-tx.util.ts
+++ b/apps/api/src/adapters/prisma/prisma-tx.util.ts
@@ -39,16 +39,31 @@ export async function runBatch(
 }
 
 /**
+ * Interactive-transaction options for batch import writes (#532). A large (but
+ * within-limit) import can exceed Prisma's 5s default interactive-tx timeout and
+ * throw P2028 — but only on the self-opened-tx path (the system-DB factory / unit
+ * tests, where the repository holds the base client). On the request path
+ * `runInteractive` reuses the RLS request transaction and these options are
+ * ignored (the RLS interceptor owns that transaction's timeout). `maxWait` is
+ * raised in step so a busy pool does not P2028 while acquiring the connection.
+ */
+export const IMPORT_BATCH_TX_OPTIONS = { timeout: 30_000, maxWait: 5_000 } as const;
+
+/**
  * Run an interactive transaction. With the base client this opens one; with a request-scoped
  * transaction client it reuses the current transaction (Prisma does not nest interactive
  * transactions, and reusing the request transaction keeps the RLS GUC in scope).
+ *
+ * `options` (timeout / maxWait) apply only when this opens its own transaction; on the
+ * reuse path the enclosing request transaction's own timeout governs.
  */
 export async function runInteractive<T>(
   client: PrismaExecutor,
   fn: (tx: PrismaExecutor) => Promise<T>,
+  options?: { timeout?: number; maxWait?: number },
 ): Promise<T> {
   if (canStartTransaction(client)) {
-    return client.$transaction((tx) => fn(tx));
+    return client.$transaction((tx) => fn(tx), options);
   }
   return fn(client);
 }

--- a/apps/api/src/adapters/prisma/prisma-tx.util.ts
+++ b/apps/api/src/adapters/prisma/prisma-tx.util.ts
@@ -39,15 +39,25 @@ export async function runBatch(
 }
 
 /**
- * Interactive-transaction options for batch import writes (#532). A large (but
- * within-limit) import can exceed Prisma's 5s default interactive-tx timeout and
- * throw P2028 — but only on the self-opened-tx path (the system-DB factory / unit
- * tests, where the repository holds the base client). On the request path
- * `runInteractive` reuses the RLS request transaction and these options are
- * ignored (the RLS interceptor owns that transaction's timeout). `maxWait` is
- * raised in step so a busy pool does not P2028 while acquiring the connection.
+ * Transaction budget for batch import writes (#532). A large (but within-limit)
+ * import can exceed Prisma's 5s default interactive-tx timeout and throw P2028, so
+ * imports get a wider window than the {@link DEFAULT_RLS_TX_TIMEOUT_MS} default.
+ *
+ * This single value governs **both** import paths so they can't drift:
+ * - **Request path** (the production HTTP import): `runInteractive` reuses the RLS
+ *   request transaction and ignores the options below, so `ImportController` carries
+ *   `@RlsTxTimeout(IMPORT_TX_TIMEOUT_MS)` to widen that enclosing transaction.
+ * - **Self-opened path** (system-DB factory / unit tests, where the repository holds
+ *   the base client): `runInteractive` opens its own transaction with the options below.
  */
-export const IMPORT_BATCH_TX_OPTIONS = { timeout: 30_000, maxWait: 5_000 } as const;
+export const IMPORT_TX_TIMEOUT_MS = 30_000;
+
+/**
+ * `runInteractive` options for the self-opened-tx path. `timeout` matches
+ * {@link IMPORT_TX_TIMEOUT_MS}; `maxWait` is raised in step so a busy pool does not
+ * P2028 while acquiring the connection.
+ */
+export const IMPORT_BATCH_TX_OPTIONS = { timeout: IMPORT_TX_TIMEOUT_MS, maxWait: 5_000 } as const;
 
 /**
  * Run an interactive transaction. With the base client this opens one; with a request-scoped

--- a/apps/api/src/adapters/prisma/strength-goal.repository.ts
+++ b/apps/api/src/adapters/prisma/strength-goal.repository.ts
@@ -1,10 +1,10 @@
 import { PrismaClient } from '@prisma/client';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
-import { StrengthGoalEntry, strengthGoalRowKind } from '@lifting-logbook/core';
+import { StrengthGoalEntry, classifyAndCount, strengthGoalRowKind } from '@lifting-logbook/core';
 import { ImportWriteResult } from '@lifting-logbook/types';
 import { IStrengthGoalRepository } from '../../ports/IStrengthGoalRepository';
 import { StrengthGoalNotFoundError } from '../../ports/errors';
-import { runInteractive } from './prisma-tx.util';
+import { IMPORT_BATCH_TX_OPTIONS, runInteractive } from './prisma-tx.util';
 
 type StrengthGoalRow = {
   lift: string;
@@ -67,39 +67,31 @@ export class PrismaStrengthGoalRepository implements IStrengthGoalRepository {
     // One transaction for the whole batch (issue #488): replaces the controller's
     // unwrapped per-row upsert loop, so a mid-batch failure rolls back instead of
     // leaving a partial commit. Counts come from the write, not a separate pre-read.
-    return runInteractive(this.prisma, async (tx) => {
-      const existing = await tx.strengthGoal.findMany({
-        where: { userId: this.userId, program },
-      });
-      const existingByLift = new Map(existing.map((r) => [r.lift, rowToEntry(r)]));
-
-      let created = 0;
-      let updated = 0;
-      let skipped = 0;
-      const seen = new Set<string>();
-
-      for (const g of goals) {
-        if (seen.has(g.lift)) continue; // collapse duplicate lifts within the file
-        seen.add(g.lift);
-
-        const kind = strengthGoalRowKind(g, existingByLift);
-        if (kind === 'skip') {
-          skipped++;
-          continue;
-        }
-
-        await tx.strengthGoal.upsert({
-          where: { userId_program_lift: { userId: this.userId, program, lift: g.lift } },
-          update: entryToData(g),
-          create: { userId: this.userId, program, lift: g.lift, ...entryToData(g) },
+    // runInteractive reuses the per-request RLS transaction when present, opens one
+    // otherwise (with a batch-sized timeout — IMPORT_BATCH_TX_OPTIONS, #532).
+    return runInteractive(
+      this.prisma,
+      async (tx) => {
+        const existing = await tx.strengthGoal.findMany({
+          where: { userId: this.userId, program },
         });
+        const existingByLift = new Map(existing.map((r) => [r.lift, rowToEntry(r)]));
 
-        if (kind === 'create') created++;
-        else updated++;
-      }
-
-      return { created, updated, skipped };
-    });
+        // Shared classify/dedupe/tally loop (#532); decision is strengthGoalRowKind.
+        return classifyAndCount(
+          goals,
+          (g) => g.lift,
+          (g) => strengthGoalRowKind(g, existingByLift),
+          (g) =>
+            tx.strengthGoal.upsert({
+              where: { userId_program_lift: { userId: this.userId, program, lift: g.lift } },
+              update: entryToData(g),
+              create: { userId: this.userId, program, lift: g.lift, ...entryToData(g) },
+            }),
+        );
+      },
+      IMPORT_BATCH_TX_OPTIONS,
+    );
   }
 
   async deleteGoal(program: string, lift: string): Promise<void> {

--- a/apps/api/src/adapters/prisma/training-max.repository.ts
+++ b/apps/api/src/adapters/prisma/training-max.repository.ts
@@ -1,8 +1,8 @@
 import { PrismaClient } from '@prisma/client';
-import { TrainingMax, trainingMaxRowKind } from '@lifting-logbook/core';
+import { TrainingMax, classifyAndCount, trainingMaxRowKind } from '@lifting-logbook/core';
 import { ImportWriteResult } from '@lifting-logbook/types';
 import { ITrainingMaxRepository } from '../../ports/ITrainingMaxRepository';
-import { runBatch, runInteractive } from './prisma-tx.util';
+import { IMPORT_BATCH_TX_OPTIONS, runBatch, runInteractive } from './prisma-tx.util';
 
 export class PrismaTrainingMaxRepository implements ITrainingMaxRepository {
   constructor(
@@ -52,48 +52,40 @@ export class PrismaTrainingMaxRepository implements ITrainingMaxRepository {
     // One transaction for the whole batch: the existing read and every upsert
     // share it, so the returned counts reflect exactly what was written and a
     // mid-batch failure rolls the whole import back (issue #488). runInteractive
-    // reuses the per-request RLS transaction when present, opens one otherwise.
-    return runInteractive(this.prisma, async (tx) => {
-      const existing = await tx.trainingMax.findMany({
-        where: { userId: this.userId, program },
-        select: { lift: true, weight: true },
-      });
-      const existingByLift = new Map(existing.map((r) => [r.lift, r.weight]));
-
-      let created = 0;
-      let updated = 0;
-      let skipped = 0;
-      const seen = new Set<string>();
-
-      for (const m of maxes) {
-        if (seen.has(m.lift)) continue; // collapse duplicate lifts within the file
-        seen.add(m.lift);
-
-        const kind = trainingMaxRowKind(m, existingByLift);
-        if (kind === 'skip') {
-          skipped++;
-          continue;
-        }
-
-        await tx.trainingMax.upsert({
-          where: {
-            userId_program_lift: { userId: this.userId, program, lift: m.lift },
-          },
-          create: {
-            userId: this.userId,
-            program,
-            lift: m.lift,
-            weight: m.weight,
-            dateUpdated: m.dateUpdated,
-          },
-          update: { weight: m.weight, dateUpdated: m.dateUpdated },
+    // reuses the per-request RLS transaction when present, opens one otherwise
+    // (with a batch-sized timeout — see IMPORT_BATCH_TX_OPTIONS, #532).
+    return runInteractive(
+      this.prisma,
+      async (tx) => {
+        const existing = await tx.trainingMax.findMany({
+          where: { userId: this.userId, program },
+          select: { lift: true, weight: true },
         });
+        const existingByLift = new Map(existing.map((r) => [r.lift, r.weight]));
 
-        if (kind === 'create') created++;
-        else updated++;
-      }
-
-      return { created, updated, skipped };
-    });
+        // Shared classify/dedupe/tally loop (#532) so every adapter reports counts
+        // identically; the create/update/skip decision is trainingMaxRowKind.
+        return classifyAndCount(
+          maxes,
+          (m) => m.lift,
+          (m) => trainingMaxRowKind(m, existingByLift),
+          (m) =>
+            tx.trainingMax.upsert({
+              where: {
+                userId_program_lift: { userId: this.userId, program, lift: m.lift },
+              },
+              create: {
+                userId: this.userId,
+                program,
+                lift: m.lift,
+                weight: m.weight,
+                dateUpdated: m.dateUpdated,
+              },
+              update: { weight: m.weight, dateUpdated: m.dateUpdated },
+            }),
+        );
+      },
+      IMPORT_BATCH_TX_OPTIONS,
+    );
   }
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,7 +4,7 @@
 // import sorter (ESLint sort-imports / Prettier organize-imports) move it.
 import './otel';
 import 'reflect-metadata';
-import { NestFactory } from '@nestjs/core';
+import { HttpAdapterHost, NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import multipart from '@fastify/multipart';
@@ -12,6 +12,7 @@ import { Logger } from 'nestjs-pino';
 import { AppModule } from './app.module';
 import { DomainConflictFilter } from './programs/conflict.filter';
 import { DomainNotFoundFilter } from './programs/not-found.filter';
+import { PrismaTransactionTimeoutFilter } from './programs/transaction-timeout.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(
@@ -22,7 +23,14 @@ async function bootstrap() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   await app.register(multipart as any, { limits: { fileSize: 5 * 1024 * 1024, files: 1 } });
   app.useLogger(app.get(Logger));
-  app.useGlobalFilters(new DomainNotFoundFilter(), new DomainConflictFilter());
+  // PrismaTransactionTimeoutFilter extends BaseExceptionFilter, so it needs the
+  // HTTP adapter to delegate non-P2028 Prisma errors to the framework default.
+  const { httpAdapter } = app.get(HttpAdapterHost);
+  app.useGlobalFilters(
+    new DomainNotFoundFilter(),
+    new DomainConflictFilter(),
+    new PrismaTransactionTimeoutFilter(httpAdapter),
+  );
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }));
   const port = parseInt(process.env.PORT ?? '3004', 10);
   await app.listen(port, '0.0.0.0');

--- a/apps/api/src/ports/ILiftingProgramSpecRepository.ts
+++ b/apps/api/src/ports/ILiftingProgramSpecRepository.ts
@@ -18,6 +18,15 @@ export interface ILiftingProgramSpecRepository {
    *
    * Built-in template programs are immutable seed data — implementations throw
    * when `program` is not a custom (UUID) program id.
+   *
+   * Naming asymmetry (intentional, #532): the training-max and strength-goal
+   * repositories expose a pure write (`saveTrainingMaxes` / `upsertGoal`) **and**
+   * a separate import-commit method (`importTrainingMaxes` / `importGoals`).
+   * Program spec has only ever had one write path — `saveProgramSpec`, which is
+   * already idempotent and transactional — so it doubles as the import-commit
+   * method without a separate `importProgramSpec`. The shape is unified (returns
+   * the shared {@link SaveProgramSpecResult} = `ImportWriteResult`, classifies via
+   * the shared `programSpecRowKind` + `classifyAndCount`); only the name differs.
    */
   saveProgramSpec(
     program: string,

--- a/apps/api/src/programs/import.controller.spec.ts
+++ b/apps/api/src/programs/import.controller.spec.ts
@@ -1,0 +1,15 @@
+import 'reflect-metadata';
+import { ImportController } from './import.controller';
+import { RLS_TX_TIMEOUT_KEY } from '../adapters/prisma/rls-context';
+import { IMPORT_TX_TIMEOUT_MS } from '../adapters/prisma/prisma-tx.util';
+
+describe('ImportController RLS transaction budget', () => {
+  // The production import path runs inside the per-request RLS transaction, whose
+  // timeout the interceptor reads from @RlsTxTimeout metadata. Without this, a large
+  // (within-limit) commit would P2028 at the 15s default instead of the import budget
+  // (#532) — the per-row IMPORT_BATCH_TX_OPTIONS only governs the self-opened-tx path.
+  it('annotates the import handler with the import transaction budget', () => {
+    const timeout = Reflect.getMetadata(RLS_TX_TIMEOUT_KEY, ImportController.prototype.import);
+    expect(timeout).toBe(IMPORT_TX_TIMEOUT_MS);
+  });
+});

--- a/apps/api/src/programs/import.controller.ts
+++ b/apps/api/src/programs/import.controller.ts
@@ -45,6 +45,8 @@ import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../ports/auth';
 import { RepositoryBundle, IRepositoryFactory } from '../ports/factory';
 import { REPOSITORY_FACTORY } from '../ports/tokens';
+import { RlsTxTimeout } from '../adapters/prisma/rls-context';
+import { IMPORT_TX_TIMEOUT_MS } from '../adapters/prisma/prisma-tx.util';
 import { MAX_IMPORT_ROWS, readUploadedCsv } from './import-file.util';
 
 const IMPORT_KINDS: readonly ImportKind[] = [
@@ -75,6 +77,10 @@ export class ImportController {
 
   @Post('import')
   @HttpCode(HttpStatus.OK)
+  // Commit re-writes the whole import in one transaction; widen the RLS request-tx
+  // window to the import budget so a large (within-limit) file does not P2028 at the
+  // 15s default. Reuses the same constant the self-opened-tx path uses (#532).
+  @RlsTxTimeout(IMPORT_TX_TIMEOUT_MS)
   async import(
     @Param('program') program: string,
     @Req() req: FastifyRequest,

--- a/apps/api/src/programs/transaction-timeout.filter.spec.ts
+++ b/apps/api/src/programs/transaction-timeout.filter.spec.ts
@@ -1,0 +1,48 @@
+import { ArgumentsHost, HttpStatus } from '@nestjs/common';
+import { BaseExceptionFilter } from '@nestjs/core';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
+import { PrismaTransactionTimeoutFilter } from './transaction-timeout.filter';
+
+function mkError(code: string): PrismaClientKnownRequestError {
+  return new PrismaClientKnownRequestError('boom', { code, clientVersion: 'test' });
+}
+
+function mkHost(reply: unknown): ArgumentsHost {
+  return {
+    switchToHttp: () => ({ getResponse: () => reply }),
+  } as unknown as ArgumentsHost;
+}
+
+describe('PrismaTransactionTimeoutFilter', () => {
+  it('maps P2028 (transaction timeout) to HTTP 503', () => {
+    const send = jest.fn();
+    const status = jest.fn().mockReturnValue({ send });
+    const host = mkHost({ status });
+
+    new PrismaTransactionTimeoutFilter().catch(mkError('P2028'), host);
+
+    expect(status).toHaveBeenCalledWith(HttpStatus.SERVICE_UNAVAILABLE);
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: HttpStatus.SERVICE_UNAVAILABLE,
+        error: 'Service Unavailable',
+      }),
+    );
+  });
+
+  it('delegates non-P2028 Prisma errors to the base filter (preserving default 500 + logging)', () => {
+    const superCatch = jest
+      .spyOn(BaseExceptionFilter.prototype, 'catch')
+      .mockImplementation(() => undefined);
+    const send = jest.fn();
+    const status = jest.fn().mockReturnValue({ send });
+    const host = mkHost({ status });
+    const err = mkError('P2002');
+
+    new PrismaTransactionTimeoutFilter().catch(err, host);
+
+    expect(superCatch).toHaveBeenCalledWith(err, host);
+    expect(status).not.toHaveBeenCalled(); // did not send its own response
+    superCatch.mockRestore();
+  });
+});

--- a/apps/api/src/programs/transaction-timeout.filter.ts
+++ b/apps/api/src/programs/transaction-timeout.filter.ts
@@ -1,0 +1,35 @@
+import { ArgumentsHost, Catch, HttpStatus } from '@nestjs/common';
+import { BaseExceptionFilter } from '@nestjs/core';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
+import { FastifyReply } from 'fastify';
+
+/**
+ * Maps Prisma's P2028 (interactive-transaction timeout / already-closed) to HTTP
+ * 503 so a batch import — or any write — that exceeds its transaction window
+ * returns an actionable response instead of a generic 500 (issue #532). A P2028
+ * can surface two ways: the per-request RLS transaction timing out (the RLS
+ * interceptor re-throws it), or a self-opened batch-import transaction exceeding
+ * its timeout (the system-DB factory / non-RLS path).
+ *
+ * Only P2028 is handled here; every other `PrismaClientKnownRequestError` is
+ * delegated to the framework default (`BaseExceptionFilter`) so its standard 500
+ * **and Nest's error logging** are preserved. Most Prisma known errors (P2002,
+ * P2025) are already translated to domain errors by the adapters and should never
+ * reach this filter — but any that do must still be logged, not silently reshaped.
+ */
+@Catch(PrismaClientKnownRequestError)
+export class PrismaTransactionTimeoutFilter extends BaseExceptionFilter {
+  override catch(err: PrismaClientKnownRequestError, host: ArgumentsHost): void {
+    if (err.code !== 'P2028') {
+      super.catch(err, host);
+      return;
+    }
+    const res = host.switchToHttp().getResponse<FastifyReply>();
+    res.status(HttpStatus.SERVICE_UNAVAILABLE).send({
+      statusCode: HttpStatus.SERVICE_UNAVAILABLE,
+      message:
+        'The import took too long to process and was rolled back. Try again, or split the file into smaller batches.',
+      error: 'Service Unavailable',
+    });
+  }
+}

--- a/packages/core/src/utils/import/buildImportPreview.ts
+++ b/packages/core/src/utils/import/buildImportPreview.ts
@@ -170,6 +170,16 @@ export function programSpecComparable(r: LiftingProgramSpec): string {
   });
 }
 
+/** Classify one program-spec row vs the stored rows (keyed by natural key). */
+export function programSpecRowKind(
+  r: LiftingProgramSpec,
+  existingByKey: Map<string, LiftingProgramSpec>,
+): ImportRowKind {
+  const prior = existingByKey.get(programSpecNaturalKey(r));
+  if (!prior) return 'create';
+  return programSpecComparable(prior) === programSpecComparable(r) ? 'skip' : 'update';
+}
+
 /** Program-spec rows upsert by natural key: create if absent, update if config differs, else skip. */
 export function buildProgramSpecPreview(
   incoming: LiftingProgramSpec[],
@@ -185,19 +195,13 @@ export function buildProgramSpecPreview(
     seen.add(key);
     const label = `Week ${r.week} · ${r.lift} (#${r.order})`;
     const after = specValue(r);
+    const kind = programSpecRowKind(r, existingByKey);
     const prior = existingByKey.get(key);
-    if (!prior) {
-      deltas.push({ key, label, kind: 'create', after });
-    } else {
-      const unchanged = programSpecComparable(prior) === programSpecComparable(r);
-      deltas.push({
-        key,
-        label,
-        kind: unchanged ? 'skip' : 'update',
-        before: specValue(prior),
-        after,
-      });
-    }
+    deltas.push(
+      prior
+        ? { key, label, kind, before: specValue(prior), after }
+        : { key, label, kind, after },
+    );
   }
   return tally(deltas);
 }

--- a/packages/core/src/utils/import/classifyAndCount.spec.ts
+++ b/packages/core/src/utils/import/classifyAndCount.spec.ts
@@ -1,0 +1,78 @@
+import { classifyAndCount } from './classifyAndCount';
+import { ImportRowKind } from './buildImportPreview';
+
+type Row = { k: string };
+
+describe('classifyAndCount', () => {
+  it('tallies create/update/skip and writes only the non-skip rows', async () => {
+    const kindOf = (k: string): ImportRowKind =>
+      k === 'a' ? 'create' : k === 'b' ? 'update' : 'skip';
+    const writes: Array<[string, string]> = [];
+
+    const result = await classifyAndCount<Row>(
+      [{ k: 'a' }, { k: 'b' }, { k: 'c' }],
+      (r) => r.k,
+      (r) => kindOf(r.k),
+      (r, kind) => {
+        writes.push([r.k, kind]);
+      },
+    );
+
+    expect(result).toEqual({ created: 1, updated: 1, skipped: 1 });
+    // 'create' and 'update' written (with their kind); 'skip' not written.
+    expect(writes).toEqual([
+      ['a', 'create'],
+      ['b', 'update'],
+    ]);
+  });
+
+  it('collapses duplicate keys within the batch (first occurrence wins)', async () => {
+    const writes: string[] = [];
+
+    const result = await classifyAndCount<Row>(
+      [{ k: 'x' }, { k: 'x' }, { k: 'y' }],
+      (r) => r.k,
+      () => 'create',
+      (r) => {
+        writes.push(r.k);
+      },
+    );
+
+    expect(result).toEqual({ created: 2, updated: 0, skipped: 0 });
+    expect(writes).toEqual(['x', 'y']); // the duplicate 'x' is neither re-written nor re-counted
+  });
+
+  it('never invokes applyWrite for a skipped row', async () => {
+    const applyWrite = jest.fn();
+
+    const result = await classifyAndCount<Row>(
+      [{ k: 'a' }, { k: 'b' }],
+      (r) => r.k,
+      () => 'skip',
+      applyWrite,
+    );
+
+    expect(result).toEqual({ created: 0, updated: 0, skipped: 2 });
+    expect(applyWrite).not.toHaveBeenCalled();
+  });
+
+  it('awaits each write and propagates a mid-batch failure without advancing counts', async () => {
+    const writes: string[] = [];
+
+    await expect(
+      classifyAndCount<Row>(
+        [{ k: 'a' }, { k: 'b' }, { k: 'c' }],
+        (r) => r.k,
+        () => 'create',
+        async (r) => {
+          if (r.k === 'b') throw new Error('boom');
+          writes.push(r.k);
+        },
+      ),
+    ).rejects.toThrow('boom');
+
+    // Stopped at the failing row — 'c' was never reached. A caller running this
+    // inside a transaction rolls the whole batch back.
+    expect(writes).toEqual(['a']);
+  });
+});

--- a/packages/core/src/utils/import/classifyAndCount.ts
+++ b/packages/core/src/utils/import/classifyAndCount.ts
@@ -1,0 +1,52 @@
+import { ImportWriteResult } from '@lifting-logbook/types';
+import { ImportRowKind } from './buildImportPreview';
+
+/**
+ * Shared classify-and-count loop for the Smart Import commit path (#532).
+ *
+ * Every per-kind commit method (training maxes, strength goals, program spec) and
+ * every adapter (in-memory + Prisma) walks the incoming rows the same way:
+ * collapse duplicate keys within the batch, classify each unique row as
+ * create / update / skip against the existing snapshot, apply the write for the
+ * non-skip rows, and tally the result. That loop was copy-pasted across the
+ * adapters; a change to the dedupe or tally semantics in one place could silently
+ * desync the counts another adapter reports. Centralising it here keeps the count
+ * contract identical across adapters — the classification *decision* is already
+ * shared via the `*RowKind` predicates, this shares the surrounding loop too.
+ *
+ * `keyOf` produces the per-row dedupe/natural key. `rowKind` decides
+ * create/update/skip (typically one of `trainingMaxRowKind` /
+ * `strengthGoalRowKind` / `programSpecRowKind`). `applyWrite` performs the write
+ * for a non-skip row and is awaited so callers can run it inside a transaction;
+ * a throw propagates (the caller's transaction rolls back) and the counts are not
+ * advanced for the failed row.
+ */
+export async function classifyAndCount<T>(
+  rows: readonly T[],
+  keyOf: (row: T) => string,
+  rowKind: (row: T) => ImportRowKind,
+  applyWrite: (row: T, kind: 'create' | 'update') => void | Promise<unknown>,
+): Promise<ImportWriteResult> {
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+  const seen = new Set<string>();
+
+  for (const row of rows) {
+    const key = keyOf(row);
+    if (seen.has(key)) continue; // collapse duplicate keys within the batch
+    seen.add(key);
+
+    const kind = rowKind(row);
+    if (kind === 'skip') {
+      skipped++;
+      continue;
+    }
+
+    await applyWrite(row, kind);
+    if (kind === 'create') created++;
+    else updated++;
+  }
+
+  return { created, updated, skipped };
+}

--- a/packages/core/src/utils/import/index.ts
+++ b/packages/core/src/utils/import/index.ts
@@ -1,4 +1,5 @@
 export * from './buildImportPreview';
+export * from './classifyAndCount';
 export * from './classifyImport';
 export * from './importThresholds';
 export * from './liftRecordNaturalKey';


### PR DESCRIPTION
## Summary

Follow-up from the `/code-review` of #531 (Smart Import commit atomicity, #488). Three non-blocking maintainability/reliability cleanups, cleanly separable from #531's shipped reliability goal.

**1. Unify the program-spec commit on the `findMany → classify → upsert` shape.**
`saveProgramSpec` did a per-row `findFirst` plus a hand-duplicated natural-key where-clause. The `@@unique([programId,week,offset,lift,order])` index (#488) already makes the `upsert` race-safe, so the per-row find-then-write is no longer needed. It now takes **one up-front snapshot read** and classifies in memory — N round-trips → 1.

**2. Extract a shared classify-and-count helper.**
`classifyAndCount<T>(rows, keyOf, rowKind, applyWrite)` (in `packages/core`) centralises the seen-set dedupe + create/update/skip tally loop that was copy-pasted across the four TM/goal adapters — now six sites (in-memory + Prisma × TM/goal/spec) plus the preview path route through it. A new `programSpecRowKind` classifier mirrors `trainingMaxRowKind`/`strengthGoalRowKind`, so the create-vs-update *decision* and the surrounding *loop* are both shared. A dedupe/tally change can no longer desync counts across adapters, or between preview and commit.

**3. Map Prisma P2028 (interactive-tx timeout) on the import path.**
A global `@Catch(PrismaClientKnownRequestError)` filter maps **P2028 → HTTP 503** (actionable "try a smaller file" instead of a generic 500), and delegates every other Prisma code to `BaseExceptionFilter` so the framework's default 500 **and Nest's error logging** are preserved. Batch imports also get a 30 s self-opened-tx timeout (`IMPORT_BATCH_TX_OPTIONS`), applied only on the non-RLS / system-DB path where `runInteractive` opens its own transaction (on the request path it reuses the RLS tx, whose timeout governs and whose P2028 the RLS interceptor already re-throws — now mapped by this filter too).

### Naming asymmetry decision
`saveProgramSpec` keeps its name rather than renaming to `importProgramSpec`. The issue lists the rename as optional; renaming would churn ~10 unrelated controller specs that mock the method. The **shape** is fully unified (returns the shared `ImportWriteResult`, classifies via the shared helpers); only the name differs, and the asymmetry is now documented on the port interface.

## Acceptance Criteria (#532)

- [x] Refactor `saveProgramSpec` to `findMany → classify-in-memory → upsert`; remove the per-row `findFirst` and the duplicated where-clause
- [x] Add a `programSpecRowKind` shared classifier mirroring `trainingMaxRowKind`/`strengthGoalRowKind`
- [x] `saveProgramSpec` rename → documented intentional asymmetry on the port (rename declined per scope)
- [x] Extract `classifyAndCount<T>(rows, keyOf, rowKind, applyWrite)` (core) used by all adapters
- [x] Test asserting in-memory and Prisma adapters return identical counts for the same input
- [x] Map P2028 to a 503/timeout response + explicit batch-import `{ timeout, maxWait }`

## Testing

`npm test` (full suite, Docker up for the API DB E2E via Testcontainers) + `npm run build` + `npm run lint` — all green.

- **core** — Tests: 203 passed, 0 skipped, 0 failed (31 suites)
- **api** — Tests: 393 passed, 0 skipped, 0 failed (33 suites)
- **web** — Tests: 91 passed, 0 skipped, 0 failed (16 suites)

New coverage: `classifyAndCount` unit spec (dedupe, skip, tally, mid-batch-throw propagation); `import-count-parity.spec.ts` (in-memory vs Prisma identical counts for TM/goal/spec across create/update/skip/dedupe); `saveProgramSpec` mock-tx tests (owner guard, NotFound, single-snapshot classification); `transaction-timeout.filter.spec.ts` (P2028 → 503, other codes delegate to base filter). Existing TM/goal repo specs and the in-memory import E2E stay green unchanged.

## Suppression / test-integrity / lockfile

- Suppression grep: two **pre-existing** matches only — `weekType: r.weekType ?? null` (a domain→SQL-NULL column mapping, re-indented inside the rewritten method, substance unchanged; not error-silencing) and the `eslint-disable ... no-explicit-any` shown as unchanged context from `main.ts`'s `@fastify/multipart` registration. **No new suppressions.**
- Test-integrity grep: clean. No skips added, no test files deleted, no thresholds lowered — tests **added**.
- No `package.json` changed → lockfile-sync N/A.

## Risk audit (Pass 3)

1. **Testing** — new unit + parity + filter specs above; full suite green.
2. **Observability** — the P2028 filter delegates non-P2028 Prisma errors to `BaseExceptionFilter`, preserving Nest's default error logging (no regression). No new raw SQL; writes still run inside the existing RLS span.
3. **Security** — no new endpoints/inputs; the program owner guard in `saveProgramSpec` is retained; RLS GUC handling unchanged.
4. **Resilience** — P2028 now mapped to 503; transaction atomicity unchanged (`runInteractive`); revert = standard PR revert.
5. **Performance** — `saveProgramSpec`: N per-row `findFirst` → 1 `findMany` + upserts (fewer round-trips). Not a hot path.
6. **Data integrity & migrations** — **no schema change** (the unique index shipped in #531); count parity guarded by the shared helper + the parity test.

Closes #532


---

## Review findings disposition (`/review` #536)

`/review` ran high-effort parallel correctness/security + reliability/perf/maintainability passes. Correctness/security pass: no findings.

**Blocking:** none.

**Non-blocking:**
- **[reliability] Import tx budget didn't reach the production path** — `IMPORT_BATCH_TX_OPTIONS` (30s) only governed the self-opened-tx path; the real HTTP import runs inside the per-request RLS transaction (15s `DEFAULT_RLS_TX_TIMEOUT_MS`), so a large within-limit import could P2028 at 15s despite the intended 30s. → **Fixed in `14d33df`**: unified both paths on `IMPORT_TX_TIMEOUT_MS` and annotated `ImportController.import` with `@RlsTxTimeout(IMPORT_TX_TIMEOUT_MS)`; added a metadata regression test.
- **[maintainability] Two timeout values coexisted with no single source of truth** → **Fixed in `14d33df`** (folded into the `IMPORT_TX_TIMEOUT_MS` constant shared by the decorator and `IMPORT_BATCH_TX_OPTIONS`).
- **[maintainability] Preview builders still hand-roll the dedupe/tally loop** that the commit adapters now share via `classifyAndCount` → **Filed #537** (non-trivial: preview emits per-row deltas, not just counts; fits the #489 consolidation epic).
- **[performance] Sequential per-row `tx.upsert` inside one import transaction** → **Filed #537** (the raw-SQL batch alternative trades round-trips for an untraced-SQL observability obligation per ADR-024; mitigated for now by the 30s budget; import is a manual non-hot path).

**Accepted by design (no change):**
- `classifyAndCount`'s `applyWrite(row, kind)` second param is unused by the six callsites but kept as a deliberate, tested affordance; the `void | Promise<unknown>` return union is intentional so terse Prisma upsert callbacks type-check. The "skip rows never call applyWrite" + "applyWrite must return its promise" contract is covered by the unit spec.
- The P2028 filter is instance-registered (not `APP_FILTER`) with a manually-passed `httpAdapter`, matching the two sibling domain filters — verifier confirmed no defect.

Tests after the fix: **api 394 passed, 0 skipped, 0 failed** (was 393; +1 regression test); lint 7/7; suppression/integrity greps clean; no `package.json` change.
