### PR TITLE
[infra] Make staging GKE Helm steps non-blocking + self-heal stuck web release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -443,7 +443,24 @@ jobs:
             --from-literal=clerk-secret-key="$CLERK_KEY" \
             --dry-run=client -o yaml | kubectl apply -f -
 
+      # Same stuck-release self-heal as the web release below (#539), for the api release.
+      - name: Rollback stuck Helm API release (GKE staging)
+        if: needs.terraform-staging.outputs.gke_enabled == 'true'
+        run: |
+          STATUS=$(helm status api --namespace=staging --output=json 2>/dev/null \
+            | python3 -c "import sys,json; print(json.load(sys.stdin)['info']['status'])" 2>/dev/null || echo "not-found")
+          if [[ "$STATUS" == "pending-upgrade" || "$STATUS" == "pending-install" || "$STATUS" == "pending-rollback" ]]; then
+            echo "Rolling back stuck release: api (status=$STATUS)"
+            helm rollback api --namespace=staging || true
+          fi
+          # Pods carry `app: <fullname>` (chart sets fullnameOverride: "api"), not the
+          # app.kubernetes.io/* labels — select on app=api or this find-and-delete is a no-op.
+          kubectl get pods -n staging -l app=api -o json 2>/dev/null \
+            | python3 -c "import sys,json; [print(p['metadata']['name']) for p in json.load(sys.stdin).get('items',[]) if p.get('metadata',{}).get('deletionTimestamp')]" \
+            | xargs -r kubectl delete pod --force --grace-period=0 -n staging || true
+
       - name: Helm deploy API (GKE staging)
+        id: helm-deploy-api
         if: needs.terraform-staging.outputs.gke_enabled == 'true'
         # GKE is the optional 10%-traffic A/B target (ADR-009); Cloud Run below is the
         # real serving path. A GKE rollout problem must never fail this job — that would
@@ -459,7 +476,24 @@ jobs:
             --set gcp.kmsKeyName="${{ needs.terraform-staging.outputs.kms_key_name }}" \
             --set gcp.serviceAccountEmail="${{ needs.terraform-staging.outputs.api_wi_sa }}" \
             --set env.NODE_ENV=staging \
-            --wait --timeout=5m
+            --wait --timeout=10m --force
+
+      - name: Fetch GKE API pod logs on failure
+        if: steps.helm-deploy-api.outcome == 'failure'
+        run: |
+          echo "=== GKE API pod status ==="
+          kubectl get pods -n staging -l app=api 2>&1 || true
+          POD=$(kubectl get pods -n staging -l app=api \
+            --sort-by=.metadata.creationTimestamp \
+            -o jsonpath='{.items[-1].metadata.name}' 2>/dev/null || true)
+          if [[ -n "$POD" ]]; then
+            echo "=== Logs for pod: $POD ==="
+            kubectl logs -n staging "$POD" --tail=100 2>&1 || true
+            echo "=== Events for pod: $POD ==="
+            kubectl describe pod -n staging "$POD" 2>&1 | tail -40 || true
+          else
+            echo "No API pod found — Helm may have failed before pod creation"
+          fi
 
       # A prior run can leave the `web` Helm release wedged in a pending-* state with a
       # pod stuck in "Pending termination", which makes the next `helm upgrade --wait`
@@ -474,7 +508,9 @@ jobs:
             echo "Rolling back stuck release: web (status=$STATUS)"
             helm rollback web --namespace=staging || true
           fi
-          kubectl get pods -n staging -l app.kubernetes.io/instance=web -o json 2>/dev/null \
+          # Pods carry `app: <fullname>` (chart sets fullnameOverride: "web"), not the
+          # app.kubernetes.io/* labels — select on app=web or this find-and-delete is a no-op.
+          kubectl get pods -n staging -l app=web -o json 2>/dev/null \
             | python3 -c "import sys,json; [print(p['metadata']['name']) for p in json.load(sys.stdin).get('items',[]) if p.get('metadata',{}).get('deletionTimestamp')]" \
             | xargs -r kubectl delete pod --force --grace-period=0 -n staging || true
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -445,6 +445,10 @@ jobs:
 
       - name: Helm deploy API (GKE staging)
         if: needs.terraform-staging.outputs.gke_enabled == 'true'
+        # GKE is the optional 10%-traffic A/B target (ADR-009); Cloud Run below is the
+        # real serving path. A GKE rollout problem must never fail this job — that would
+        # skip smoke-test and the (Cloud-Run-only) production gate. Matches staging.yml.
+        continue-on-error: true
         run: |
           helm upgrade --install api ./infra/kubernetes/charts/api \
             --namespace=staging \
@@ -457,8 +461,27 @@ jobs:
             --set env.NODE_ENV=staging \
             --wait --timeout=5m
 
+      # A prior run can leave the `web` Helm release wedged in a pending-* state with a
+      # pod stuck in "Pending termination", which makes the next `helm upgrade --wait`
+      # deadline out (#539). Roll back a stuck release and force-delete any
+      # terminating pods first so the deploy below can proceed. Ported from staging.yml.
+      - name: Rollback stuck Helm web release (GKE staging)
+        if: needs.terraform-staging.outputs.gke_enabled == 'true'
+        run: |
+          STATUS=$(helm status web --namespace=staging --output=json 2>/dev/null \
+            | python3 -c "import sys,json; print(json.load(sys.stdin)['info']['status'])" 2>/dev/null || echo "not-found")
+          if [[ "$STATUS" == "pending-upgrade" || "$STATUS" == "pending-install" || "$STATUS" == "pending-rollback" ]]; then
+            echo "Rolling back stuck release: web (status=$STATUS)"
+            helm rollback web --namespace=staging || true
+          fi
+          kubectl get pods -n staging -l app.kubernetes.io/instance=web -o json 2>/dev/null \
+            | python3 -c "import sys,json; [print(p['metadata']['name']) for p in json.load(sys.stdin).get('items',[]) if p.get('metadata',{}).get('deletionTimestamp')]" \
+            | xargs -r kubectl delete pod --force --grace-period=0 -n staging || true
+
       - name: Helm deploy web (GKE staging)
         if: needs.terraform-staging.outputs.gke_enabled == 'true'
+        # Optional A/B target (see "Helm deploy API" above) — never gate the job on it.
+        continue-on-error: true
         run: |
           # API_URL is the cluster-internal endpoint for server-side calls; PUBLIC_API_URL
           # is the browser-facing (external) endpoint injected into window.__PUBLIC_CONFIG__
@@ -475,7 +498,7 @@ jobs:
             --set env.NODE_ENV=staging \
             --set env.API_URL="$API_CLUSTER_URL" \
             --set env.PUBLIC_API_URL="${{ needs.terraform-staging.outputs.cloud_run_api_url }}" \
-            --wait --timeout=5m
+            --wait --timeout=10m
 
       # Cloud Run: A/B comparison target (10% traffic — ADR-009)
       - name: Deploy API to Cloud Run (staging)
@@ -536,6 +559,8 @@ jobs:
 
       - name: Helm deploy otel-collector (GKE staging)
         if: needs.terraform-staging.outputs.gke_enabled == 'true'
+        # Telemetry must never gate serving traffic (see the OTel section header above).
+        continue-on-error: true
         run: |
           helm upgrade --install otel-collector ./infra/kubernetes/charts/otel-collector \
             --namespace=staging \

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -436,7 +436,7 @@ jobs:
             helm rollback api --namespace=staging || true
           fi
           # Force-delete API pods stuck in Terminating — they block helm --wait on the next upgrade.
-          kubectl get pods -n staging -l app.kubernetes.io/instance=api -o json 2>/dev/null \
+          kubectl get pods -n staging -l app=api -o json 2>/dev/null \
             | python3 -c "import sys,json; [print(p['metadata']['name']) for p in json.load(sys.stdin).get('items',[]) if p.get('metadata',{}).get('deletionTimestamp')]" \
             | xargs -r kubectl delete pod --force --grace-period=0 -n staging || true
 
@@ -462,8 +462,8 @@ jobs:
         if: steps.helm-deploy-api.outcome == 'failure'
         run: |
           echo "=== GKE API pod status ==="
-          kubectl get pods -n staging -l app.kubernetes.io/instance=api 2>&1 || true
-          POD=$(kubectl get pods -n staging -l app.kubernetes.io/instance=api \
+          kubectl get pods -n staging -l app=api 2>&1 || true
+          POD=$(kubectl get pods -n staging -l app=api \
             --sort-by=.metadata.creationTimestamp \
             -o jsonpath='{.items[-1].metadata.name}' 2>/dev/null || true)
           if [[ -n "$POD" ]]; then
@@ -596,7 +596,7 @@ jobs:
             echo "Rolling back stuck release: web (status=$STATUS)"
             helm rollback web --namespace=staging || true
           fi
-          kubectl get pods -n staging -l app.kubernetes.io/instance=web -o json 2>/dev/null \
+          kubectl get pods -n staging -l app=web -o json 2>/dev/null \
             | python3 -c "import sys,json; [print(p['metadata']['name']) for p in json.load(sys.stdin).get('items',[]) if p.get('metadata',{}).get('deletionTimestamp')]" \
             | xargs -r kubectl delete pod --force --grace-period=0 -n staging || true
 


### PR DESCRIPTION
## Summary

`deploy.yml`'s `deploy-staging` job ran the **optional GKE `web` Helm rollout** (ADR-009 A/B target — Cloud Run is the real serving path) with **no `continue-on-error:`**. A GKE rollout failure therefore failed the whole `deploy-staging` job → `smoke-test` skipped → the **Cloud-Run-only `deploy-production` approval gate became unreachable**. The rollout had been deadlining for days on a pod stuck in `Pending termination` (`context deadline exceeded` at `--wait --timeout=5m`) — pre-existing, unrelated to the recent RLS/import work (#533 infra-only, #536 api-only; neither touches the web chart).

This is the **current critical-path blocker for the #517 prod RLS cutover** — the prod gate cannot render for approval until staging CI is green.

The fix **ports the mitigation `staging.yml` already proved out** (divergence was by omission, not design):

- Add a **"Rollback stuck Helm web release (GKE staging)"** step that rolls back a `pending-*` Helm release and force-deletes terminating pods *before* the web deploy — directly clears the `#539` symptom.
- Add **`continue-on-error: true`** to the GKE **API / web / otel** Helm steps (matches `staging.yml`; honors the in-file rule that telemetry/optional rollouts must never gate serving traffic).
- Bump the web `--wait` timeout **5m → 10m** to match `staging.yml`.

**Unchanged (intentionally):** the Cloud Run staging deploy stays hard-required (real serving path + prod prerequisite); `smoke-test`'s `needs:`; and `deploy-production`'s `needs:` / `environment: production` human-approval gate. No app code, schema, or Terraform touched.

## Acceptance Criteria

- [x] GKE web rollout failure no longer fails `deploy-staging` (`continue-on-error` on GKE Helm steps)
- [x] Stuck `pending-*`/terminating-pod state self-heals before the web deploy
- [x] Cloud Run staging deploy + `smoke-test` remain prod prerequisites (unchanged)
- [x] `deploy-production` human-approval gate preserved exactly
- [x] Parity with `staging.yml` (the convention this matches)

## Testing

CI-workflow YAML change — no app code, so `npm test` is not the relevant gate.

- `js-yaml` parse of `.github/workflows/deploy.yml`: **valid YAML**.
- Pre-commit `turbo run lint`: **7/7 successful**.
- Suppression grep (`ts-ignore|ts-expect-error|eslint-disable|?? null`): **clean**.
- Test-integrity grep (`it.skip|xit|xdescribe|test.skip|describe.skip|.todo|pending|passWithNoTests|testPathIgnorePatterns`): **clean**.
- No `package.json` change → no lockfile-sync check needed.

**End-to-end verification (post-merge):** the next main `Deploy` run should show `Deploy (staging) = success` → `Smoke Test (staging) = success` → `Deploy (production) = waiting` (manual approval). The prod gate becoming *reachable* — not approved — is the success criterion. Approving it remains the separate, human-gated #517 step.

## Coverage gate

N/A — GitHub Actions workflow logic has no unit-test harness in this repo; verification is the post-merge deploy run above.

Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review findings disposition (`/code-review`, 3 finder angles + verify)

The CI-topology angle returned no findings — it confirmed end-to-end that `continue-on-error` makes `deploy-staging` conclude success → `smoke-test` runs (Cloud-Run-targeted) → `deploy-production` becomes reachable with its `environment: production` manual gate intact. The remaining findings were real and are all **fixed in `8100c48`**:

| # | Finding | Disposition |
|---|---------|-------------|
| 1 | **Stuck-pod selector inert** — `-l app.kubernetes.io/instance=web\|api` matches zero pods; both charts set `fullnameOverride`, so pods carry `app: web` / `app: api`. The force-delete (the part that clears the #539 "Pending termination" pod) was a permanent no-op. Existed verbatim in `staging.yml` too. | **Fixed in `8100c48`** — selectors corrected to `-l app=web` / `-l app=api` in the new `deploy.yml` step **and** in `staging.yml` (4 occurrences) so the self-heal is functional in both workflows (root cause). |
| 2 | **API path missing the stuck-release rollback** that `staging.yml`'s `deploy-api` has — the same wedge class left unguarded for the `api` release. | **Fixed in `8100c48`** — added "Rollback stuck Helm API release (GKE staging)" before the API Helm step. |
| 3 | **API Helm `--timeout=5m`, no `--force`** vs `staging.yml`'s `--timeout=10m --force`; the comment claimed parity it didn't have. | **Fixed in `8100c48`** — API step now `--wait --timeout=10m --force`. |
| 4 | **No API on-failure diagnostics** — `staging.yml` captures pod status/logs/events; `deploy.yml` produced none. | **Fixed in `8100c48`** — added `id: helm-deploy-api` + "Fetch GKE API pod logs on failure" step (correct `app=api` selector). |

Net effect: `deploy.yml`'s `deploy-staging` GKE handling now faithfully mirrors `staging.yml`'s proven pattern, with the latent selector bug corrected in both files.

---

## CI status / failure tracking

All required checks pass except **`Staging Integration Tests`**, which failed on a **pre-existing, branch-independent flake**: Playwright `globalSetup` timing out on the Clerk SDK load (`staging.setup.ts:55`, `window.Clerk.loaded` 30s) against a cold Cloud Run web revision — **not** caused by this PR (no `apps/web`/Clerk/Cloud-Run-web change; the GKE `web` deploy itself passed, in 10m55s). Tracked in **#541** and re-run requested. The same flake has hit unrelated recent branches (e.g. `chore/issue-532`, which passed on retry).

Notably, the GKE **web** Helm rollout (the #539 target) **passed this run** — the corrected selector + stuck-release self-heal cleared the path, so #539 is genuinely resolved, not merely decoupled.
