### PR TITLE
[fix] Retry staging e2e auth bootstrap so a Clerk-load flake can't red the required gate

### DIFF
--- a/apps/web/e2e/staging.setup.ts
+++ b/apps/web/e2e/staging.setup.ts
@@ -34,42 +34,75 @@ async function globalSetup() {
       `Test user ${email} not found in Clerk. Create the account in the staging Clerk dashboard first.`,
     );
   }
-  const { token } = await clerkBackend.signInTokens.createSignInToken({
-    userId: users[0].id,
-    expiresInSeconds: 60,
-  });
+  const userId = users[0].id;
 
   fs.mkdirSync(path.dirname(AUTH_FILE), { recursive: true });
 
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
+  // A cold Cloud Run web revision plus hosted Clerk SDK init routinely exceeds the
+  // 30s `waitForFunction` default, and playwright's `retries` covers tests only — a
+  // transient miss in globalSetup fails the entire run with no retry (#541). So retry
+  // the browser auth-bootstrap explicitly here, with a generous Clerk-load budget and
+  // a fresh sign-in token per attempt (tokens are short-lived, so reusing one across a
+  // slow retry would itself fail).
+  const CLERK_LOAD_TIMEOUT_MS = 90_000;
+  const SETUP_ATTEMPTS = 3;
 
-  // Inject Clerk testing token to bypass bot-detection in this browser context.
-  await setupClerkTestingToken({ page });
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= SETUP_ATTEMPTS; attempt++) {
+    const browser = await chromium.launch();
+    try {
+      const page = await browser.newPage();
 
-  // Navigate to /sign-in to load Clerk's JS SDK into the page context.
-  await page.goto(`${stagingUrl}/sign-in`);
+      // Inject Clerk testing token to bypass bot-detection in this browser context.
+      await setupClerkTestingToken({ page });
 
-  // Wait for Clerk to finish initializing before calling client-side SDK methods.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  await page.waitForFunction(() => !!(window as any).Clerk?.loaded);
+      // Navigate to /sign-in to load Clerk's JS SDK into the page context.
+      await page.goto(`${stagingUrl}/sign-in`, { waitUntil: 'domcontentloaded' });
 
-  // Sign in using the ticket strategy — no UI interaction, no factor-two required.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  await page.evaluate(async (ticket: string) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const cl = (window as any).Clerk;
-    const result = await cl.client.signIn.create({ strategy: 'ticket', ticket });
-    await cl.setActive({ session: result.createdSessionId });
-  }, token);
+      // Wait for Clerk to finish initializing before calling client-side SDK methods.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await page.waitForFunction(() => !!(window as any).Clerk?.loaded, undefined, {
+        timeout: CLERK_LOAD_TIMEOUT_MS,
+      });
 
-  // Navigate to the home page to confirm the session cookie is persisted and
-  // the user is no longer redirected to sign-in.
-  await page.goto(`${stagingUrl}/`);
-  await expect(page).not.toHaveURL(/\/sign-in/, { timeout: 15_000 });
+      // Create the sign-in token fresh per attempt. Sign-in tokens bypass all auth
+      // factors including MFA — the UI email/password flow cannot complete when the
+      // account has factor-two (TOTP/SMS) enabled.
+      const { token } = await clerkBackend.signInTokens.createSignInToken({
+        userId,
+        expiresInSeconds: 60,
+      });
 
-  await page.context().storageState({ path: AUTH_FILE });
-  await browser.close();
+      // Sign in using the ticket strategy — no UI interaction, no factor-two required.
+      await page.evaluate(async (ticket: string) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const cl = (window as any).Clerk;
+        const result = await cl.client.signIn.create({ strategy: 'ticket', ticket });
+        await cl.setActive({ session: result.createdSessionId });
+      }, token);
+
+      // Navigate to the home page to confirm the session cookie is persisted and
+      // the user is no longer redirected to sign-in.
+      await page.goto(`${stagingUrl}/`);
+      await expect(page).not.toHaveURL(/\/sign-in/, { timeout: 15_000 });
+
+      await page.context().storageState({ path: AUTH_FILE });
+      await browser.close();
+      return;
+    } catch (err) {
+      lastErr = err;
+      await browser.close();
+      if (attempt < SETUP_ATTEMPTS) {
+        console.warn(
+          `[staging.setup] auth bootstrap attempt ${attempt}/${SETUP_ATTEMPTS} failed: ${(err as Error).message} — retrying`,
+        );
+      }
+    }
+  }
+
+  throw new Error(
+    `[staging.setup] auth bootstrap failed after ${SETUP_ATTEMPTS} attempts: ${(lastErr as Error)?.message}`,
+  );
 }
 
 export default globalSetup;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2600,11 +2600,11 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.7.0.tgz",
-      "integrity": "sha512-tdURxlfJ8sYR+zM6bUNsG4/BpxH7MV66E5NmHbjIoggUm48SdVoBtKUSjxT0uVa8MpdYHqPk/I0mMdI/EC1B/g==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.7.1.tgz",
+      "integrity": "sha512-2CeOUZJQ0aKZ51fdaoCEh8ffOC7KD5w9Q8HZXw0AnEWuxFiplyyhwDo/ixFWYueQULWOehjzRNR89YEQTwuY0w==",
       "dependencies": {
-        "@clerk/shared": "^4.17.1",
+        "@clerk/shared": "^4.18.0",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -2613,9 +2613,9 @@
       }
     },
     "node_modules/@clerk/backend/node_modules/@clerk/shared": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.17.1.tgz",
-      "integrity": "sha512-9Ej2bLA7pWY1e07/PHmPNtQwiV1594rwacNYbppoDUPq9yRkBRZ+pDcpySkfpokS5YXvOUv6aFoPPbEMbQUVgw==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.18.0.tgz",
+      "integrity": "sha512-WHqnq1dUUjBFrrnptQEpRpoP3H2Pag00E2MP6+aHfJICNjqSSZU3NecOpcKeizYr77hFG38jqV9jcIyB5UpmBQ==",
       "dependencies": {
         "@tanstack/query-core": "^5.100.6",
         "dequal": "2.0.3",


### PR DESCRIPTION
## Summary

`Staging Integration Tests` is a **required** status check, but its Playwright `globalSetup` (`apps/web/e2e/staging.setup.ts`) waited for `window.Clerk.loaded` at the **30s default** — and playwright's `retries: 2` covers **tests only, not `globalSetup`**. A cold Cloud Run web revision plus hosted Clerk SDK init routinely exceeds 30s, so a single transient miss failed the whole run with **no retry**, blocking unrelated PRs (#541 — the exact flake that reddened #540's first run).

## Change (`apps/web/e2e/staging.setup.ts`)

- Wrap the browser auth-bootstrap (goto → wait-for-Clerk → ticket sign-in → verify) in a **3-attempt retry loop**, recreating the browser each attempt — closing the gap that `retries` leaves in `globalSetup`.
- Raise the Clerk-load `waitForFunction` timeout **30s → 90s** (`CLERK_LOAD_TIMEOUT_MS`).
- **Create the sign-in token fresh per attempt** — tokens are 60s-lived, so reusing one across a slow retry would itself fail.
- Use `waitUntil: 'domcontentloaded'` on the `/sign-in` nav and log a warning between attempts.
- Removed one genuinely-**unused** `eslint-disable` directive in the touched block.

## Testing

This is the staging E2E auth-bootstrap, which runs **only in CI against live staging** (it needs `STAGING_WEB_URL` + Clerk secrets) — it is not locally runnable, so verification is the CI run on this PR (the `Staging Integration Tests` job).

- `npx eslint e2e/staging.setup.ts` — **clean** (0 errors, 0 warnings; the prior unused-directive warning is removed).
- `npx tsc --noEmit -p apps/web/tsconfig.json` — **no errors** for the changed file.
- Suppression grep: **net reduction** — no new suppressions; the two remaining `eslint-disable @typescript-eslint/no-explicit-any` directives are pre-existing and required for `window as any` Clerk-SDK access (the third, unused one, was removed).
- Test-integrity grep: clean. No `package.json` change.

## Coverage gate

N/A — this hardens existing test infrastructure (a flaky setup); no new product behavior. The fix's effect is observable only as the `Staging Integration Tests` job becoming resilient to a transient Clerk-load miss.

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also folded in: package-lock.json sync (unrelated to #541)

CI went red overnight on an **upstream `@clerk` caret float** (`@clerk/backend` 3.7.0→3.7.1, transitive `@clerk/shared` 4.17.1→4.18.0 published; `npm ci` rebuilds from the live registry → committed lockfile no longer satisfied `package.json`, `EUSAGE` at install). This blocked *every* PR and `main` — the ADR-036 Rule 3 "CI-red-on-pushed-branch → regenerate and commit" case. Regenerated `package-lock.json` (lockfile-only, no `package.json` edit; `npm ci --dry-run` exits 0 locally). Folded here rather than a separate PR since every PR pays the full required-check cost regardless.
