### PR TITLE
[infra] Surface prod Terraform plan before the production approval gate (#542)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -677,6 +677,131 @@ jobs:
             echo "API smoke test failed: expected 200 or 403, got $STATUS" && exit 1
           fi
 
+  # ── 4b. Plan production (read-only — surfaces the prod blast radius) ─────
+  # Runs `terraform plan` against the PRODUCTION workspace and writes the
+  # add/change/destroy counts + resource addresses to the run's job summary,
+  # BEFORE the gated deploy-production job. This closes the "context-free
+  # one-click approval" gap that let the RLS prod cutover (#517) apply unseen on
+  # 2026-06-15: an unrelated CI-fix merge (#540) made deploy-production reachable
+  # and a single approval applied a dormant prod-affecting Terraform diff (#533)
+  # whose blast radius was invisible at the gate. See #542.
+  #
+  # Safety: `terraform plan` is READ-ONLY — it refreshes state via GCP APIs and
+  # computes a diff; it cannot mutate prod even on failure. Un-gated (no
+  # `environment:`) so it never prompts and always runs ahead of the gate. Prod
+  # WIF creds are exposed only here on `push: main` (deploy.yml's sole trigger),
+  # never on untrusted PR runs — there is no `pull_request` trigger. No secret is
+  # echoed; only non-sensitive counts + resource addresses reach the summary.
+  plan-production:
+    name: Plan (production)
+    runs-on: ubuntu-latest
+    needs: [preflight, build-images]
+    # Mirror deploy-production's readiness: run whenever build-images succeeded,
+    # in both staging-enabled and production-only modes (always() tolerates the
+    # skipped staging chain).
+    if: always() && needs.build-images.result == 'success'
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Authenticate to GCP (production)
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_PROD_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_PROD_SERVICE_ACCOUNT }}
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "~> 1.7"
+          terraform_wrapper: false
+
+      - name: Terraform init (production)
+        working-directory: ${{ env.TF_DIR }}
+        # Same bounded-retry init + workspace select as deploy-production
+        # (absorbs transient GCP 5xx / GCS backend eventual-consistency, #509).
+        run: |
+          for attempt in 1 2; do
+            if terraform init \
+                 -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}" \
+                 -backend-config="prefix=terraform/state" && \
+               (terraform workspace select production || terraform workspace new production); then
+              exit 0
+            fi
+            if [ "${attempt}" -lt 2 ]; then
+              echo "Terraform init/workspace attempt ${attempt} failed; retrying in 20s..."
+              sleep 20
+            fi
+          done
+          echo "::error title=Terraform init failed::terraform init/workspace select (production) failed on both attempts."
+          exit 1
+
+      - name: Terraform plan (production)
+        working-directory: ${{ env.TF_DIR }}
+        # Read-only plan against the production workspace. Bounded retry absorbs
+        # transient GCP 5xx during the refresh phase (same driver as the apply
+        # retries — #498 / #504). On success the plan output is parsed and the
+        # add/change/destroy summary + resource addresses are written to the run
+        # summary so the approver can read the prod blast radius before approving
+        # (#542). Never echoes a secret; -input=false avoids any prompt hang.
+        run: |
+          PLAN_OUT="$RUNNER_TEMP/prod-plan.txt"
+          PLANNED=0
+          for attempt in 1 2; do
+            if terraform plan -no-color -input=false \
+                 -var-file=terraform.tfvars.production \
+                 -var="billing_account=${{ secrets.GCP_BILLING_ACCOUNT }}" \
+                 > "$PLAN_OUT" 2>&1; then
+              PLANNED=1
+              break
+            fi
+            if [ "${attempt}" -lt 2 ]; then
+              echo "Terraform plan attempt ${attempt} failed; retrying in 20s..."
+              sleep 20
+            fi
+          done
+
+          {
+            echo "## Production Terraform plan (read-only — review before approving)"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$PLANNED" -ne 1 ]; then
+            {
+              echo ":warning: \`terraform plan (production)\` failed on both attempts — no blast-radius summary is available for this run."
+              echo "This is advisory and does **not** block \`deploy-production\`. Inspect the \"Terraform plan (production)\" step log, and review the apply output during the gated deploy before approving."
+            } >> "$GITHUB_STEP_SUMMARY"
+            # Surface the tail of the failure for quick triage, then stop here
+            # without failing the job (advisory by design — see job header).
+            echo "::warning title=Prod plan unavailable::terraform plan (production) failed; deploy-production is unaffected (advisory)."
+            tail -n 30 "$PLAN_OUT" || true
+            exit 0
+          fi
+
+          # `Plan: N to add, N to change, N to destroy.` — present only when the
+          # plan is non-empty; "No changes" otherwise.
+          SUMMARY_LINE=$(grep -E '^Plan: [0-9]+ to add' "$PLAN_OUT" | tail -n 1 || true)
+          {
+            if [ -n "$SUMMARY_LINE" ]; then
+              echo "**${SUMMARY_LINE}**"
+              echo ""
+              echo ":rotating_light: This plan is **non-empty** — approving the \`production\` gate will \`terraform apply\` these changes to prod. A prod-affecting Terraform diff can ride in on an unrelated merge (the #542 / #517 incident). Confirm every address below is intended before approving."
+              echo ""
+              echo "<details><summary>Resource addresses</summary>"
+              echo ""
+              echo '```'
+              grep -E '^  # ' "$PLAN_OUT" || echo "(plan reported changes but no resource-address lines were parsed — read the full step log)"
+              echo '```'
+              echo ""
+              echo "</details>"
+            else
+              echo "**No changes.** The production Terraform state already matches \`main\`; approving will apply no infra changes."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
   # ── 5. Deploy to production (requires manual approval) ───────────────────
   # The `environment: production` reference below is the manual approval gate.
   # GitHub raises one required-reviewer prompt per job that targets a protected
@@ -694,7 +819,13 @@ jobs:
   deploy-production:
     name: Deploy (production)
     runs-on: ubuntu-latest
-    needs: [preflight, build-images, deploy-staging, smoke-test]
+    # plan-production is a needs (not just an upstream job) so the production
+    # approval gate does not prompt until the read-only prod plan summary exists
+    # in the run — the approver always sees the blast radius before clicking
+    # approve (#542). It is intentionally advisory: the `if:` below does NOT
+    # require plan-production to succeed, so a transient plan failure removes the
+    # summary for that run but never blocks the deploy.
+    needs: [preflight, build-images, deploy-staging, smoke-test, plan-production]
     # Only deploy when the pipeline is actually ready: build succeeded and,
     # when staging is enabled, the staging smoke test passed. `always()` lets
     # this run even though deploy-staging/smoke-test are skipped in

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -736,6 +736,18 @@ jobs:
               sleep 20
             fi
           done
+          # Init failure is the one path that stops before the plan step writes
+          # its summary, so emit the same heading + advisory banner here — the
+          # approver must never face the gate with a silently-empty summary
+          # (#544 review). Still exit 1: init failure is a real auth/backend
+          # fault worth a red job, and is advisory to the deploy regardless
+          # (deploy-production's `if:` does not reference plan-production).
+          {
+            echo "## Production Terraform plan (read-only — review before approving)"
+            echo ""
+            echo ":warning: \`terraform init (production)\` failed on both attempts — no blast-radius summary is available for this run."
+            echo "This is advisory and does **not** block \`deploy-production\`. Inspect the \"Terraform init (production)\" step log, and review the apply output during the gated deploy before approving."
+          } >> "$GITHUB_STEP_SUMMARY"
           echo "::error title=Terraform init failed::terraform init/workspace select (production) failed on both attempts."
           exit 1
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -347,6 +347,22 @@ pending Prisma migrations to prod — it sits in front of the in-VPC migrate job
 DB-backed `/readyz` smoke ([ADR-027](adr/ADR-027-deploy-pipeline-migrations.md)) — so approve
 it deliberately, after sanity-checking staging.
 
+**Read the production plan before approving.** Open the **`plan-production`** job in the run
+and read its job summary — a read-only `terraform plan` against the production workspace,
+finished before the gate prompts. The summary shows either **`No changes`** or a non-empty
+`Plan: N to add, N to change, N to destroy.` with the affected resource addresses. That is the
+exact blast radius `terraform apply (production)` will apply the moment you approve. **A
+prod-affecting Terraform diff can ride in on an unrelated merge** — the RLS database-role
+cutover ([#517](https://github.com/brownm09/lifting-logbook/issues/517)) applied on
+2026-06-15 behind a context-free one-click approval triggered by an unrelated CI-fix merge
+([#540](https://github.com/brownm09/lifting-logbook/issues/540)), because the cutover config
+([#533](https://github.com/brownm09/lifting-logbook/issues/533)) had sat dormant in `main`
+while `deploy-production` was skipped. If `plan-production` shows resources you did not expect,
+**do not approve** — investigate first. See
+[#542](https://github.com/brownm09/lifting-logbook/issues/542). (`plan-production` is advisory:
+if it fails transiently the deploy is not blocked, but no summary is available — review the
+apply output during the gated deploy instead.)
+
 Once approved, `deploy-production` self-guards at two boundaries (issue
 [#490](https://github.com/brownm09/lifting-logbook/issues/490)):
 


### PR DESCRIPTION
## Summary

Closes #542.

On 2026-06-15 an unrelated CI-fix merge (#540) made `deploy-production` reachable for the first time in days, and a one-click approval of the `production` gate executed the **entire RLS prod cutover** (#517) — a prod-affecting Terraform diff (#533) that had sat dormant in `main`, applied to staging only because `deploy-production` had been continuously skipped. The approval gate shows *that* a deploy is pending, not *what* `terraform apply (production)` will change, so the blast radius was invisible at the moment of approval.

This implements **Layer A** (the settled design in the issue comment): a **read-only** `plan-production` job in `deploy.yml` that surfaces the prod blast radius in the run *before* the approval gate.

### Changes

1. **New `plan-production` job** (`.github/workflows/deploy.yml`)
   - `needs: [preflight, build-images]`, un-gated (no `environment:`), `if: always() && needs.build-images.result == 'success'` — runs in both staging-enabled and production-only modes.
   - Mirrors `deploy-production`'s prod auth (`google-github-actions/auth@v3` with the prod WIF provider/SA) + `setup-terraform` + the bounded-retry `init` / `workspace select production` loop.
   - Runs `terraform plan -no-color -input=false` against the **production** workspace (read-only — cannot mutate prod) and writes the `Plan: N to add, N to change, N to destroy` line + resource addresses to `$GITHUB_STEP_SUMMARY`. A non-empty plan is flagged with the #542 incident context; an empty plan prints "No changes".
   - Runs only on `push: main` (deploy.yml's sole trigger), so prod creds are **never** exposed on untrusted PR runs.

2. **`plan-production` added to `deploy-production.needs`** — a job with an `environment:` gate does not prompt for approval until all `needs` complete, so this guarantees the plan summary exists before the approver is prompted. It stays **advisory**: `deploy-production`'s `if` (already `always()`-prefixed, unchanged) does not require `plan-production` to succeed, so a transient plan failure removes that run's summary but never blocks the deploy.

3. **`docs/deploy.md`** — the "Approving a production deploy" section now instructs the approver to read the `plan-production` summary before approving, with the #517/#540 incident context.

### Acceptance criteria
- [x] The `production` deploy approval has the `terraform plan` summary available to the approver (the gate cannot prompt until `plan-production` finishes).
- [x] Documented in `docs/deploy.md`, referencing the incident.
- [ ] *(Layer B, deferred follow-up in #542)* Posting the prod plan on the PR itself for `infra/terraform/**` changes — needs prod read creds on PR runs, a separate security tradeoff. Tracked in #542.

## Out of scope (follow-ups tracked in #542)
Layer B (plan on the PR), required-acknowledgment label for prod-affecting infra, and decoupling `terraform apply (production)` into a `workflow_dispatch` workflow.

## Testing

`npm test` — full suite. Run from the main checkout (this branch was developed in a nested git worktree under `.claude/worktrees/` that has no local `node_modules`; module resolution there climbs to the main repo and produces spurious resolution failures — a stale workspace `dist` for the core build and `react-dom/server` haste-map confusion for the web suite — neither a code defect nor present in CI). This branch changes **only** `.github/workflows/deploy.yml` and `docs/deploy.md`; every file exercised by `npm test` is byte-identical to `origin/main` (verified: `git diff origin/main` excluding `.github/` and `docs/` is empty), so the main-checkout run validates exactly this branch's tested code.

- **Result:** all 12 workspace tasks passed. API: `Tests: 394 passed, 0 skipped, 0 failed` (47s); web/core/types/mobile/api-client/eslint-rules all green. No skips, no suppressions, no test-integrity changes.
- **Coverage gate:** N/A — CI-workflow YAML + docs only; no unit-testable code. `terraform plan` is exercised end-to-end on the next `main` deploy run (verification below).
- **YAML validity:** `yaml.safe_load` parses `deploy.yml`; job wiring confirmed (`plan-production.needs: [preflight, build-images]`, `deploy-production.needs` includes `plan-production`).

### Post-merge end-to-end verification
On the next `main` Deploy run: confirm (a) `plan-production` runs un-gated and its job summary shows the add/change/destroy line + resource addresses; (b) the `production` approval prompt appears only **after** `plan-production` completes; (c) `deploy-production` still applies correctly after approval; (d) on a merge with an empty prod diff, the summary reads "No changes".

## Risk audit (Pass 3)
- **Security:** prod WIF creds run only on `push: main`, never on PRs; `terraform plan` is read-only; no secret is echoed (only non-sensitive add/change/destroy counts + resource addresses reach the summary).
- **Resilience:** bounded retry on init + plan; advisory — a plan failure does not block prod deploy.
- **Observability:** the job *is* the observability improvement (prod blast radius in the run summary).
- **Performance:** one short read-only job per merge, parallel to the staging chain.
- **Data integrity / Testing:** N/A — no apply, no migration, no app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review findings disposition

`/review` (claude-opus-4-8) raised **0 blocking, 3 non-blocking** findings ([review comment](https://github.com/brownm09/lifting-logbook/pull/544#issuecomment-4720925150)):

1. **[reliability]** init-failure path wrote no run-summary banner (approver could face the gate with a silently-empty summary) — **fixed in `110593d`**: the init-failure branch now emits the same heading + advisory note as the plan-failure path before `exit 1`.
2. **[security]** `plan-production` reuses the write-capable prod WIF SA and runs on every merge; a read-only plan SA would be tighter — **filed [#545](https://github.com/brownm09/lifting-logbook/issues/545)** (a new prod IAM/Terraform change, out of Layer A's scope).
3. **[maintainability]** the bounded-retry init block is now duplicated across 3 jobs — **filed [#546](https://github.com/brownm09/lifting-logbook/issues/546)** (composite-action refactor, out of scope).

### Testing addendum (commit `110593d`)
The review-fix commit changes **only** `.github/workflows/deploy.yml` (the init-failure summary branch) — not exercised by `npm test`. The branch still differs from `origin/main` only under `.github/` and `docs/`, so every file the test suite touches remains byte-identical to `origin/main`; the green run above (all 12 tasks; API `394 passed, 0 skipped, 0 failed`) still validates this branch's tested code. `deploy.yml` re-validated with `yaml.safe_load` after the edit. Lint passed in the pre-commit hook (`turbo run lint`: 7/7).
