### PR TITLE
[chore] Extract terraform setup+init into a tf-init composite action (#546)

### DIFF
--- a/.github/actions/tf-init/action.yml
+++ b/.github/actions/tf-init/action.yml
@@ -1,0 +1,58 @@
+name: Terraform setup + init
+description: >-
+  Set up Terraform and run a bounded-retry `terraform init` + workspace
+  select/new against the shared GCS backend. Factored out of deploy.yml and
+  staging.yml so the terraform-staging, plan-production, and deploy-production
+  jobs initialize Terraform identically (issue #546) — drift between hand-copied
+  init blocks would break the plan↔apply init parity the production
+  plan-visibility gate relies on (#542 / #544).
+
+  GCP authentication (google-github-actions/auth) stays in the calling job: it
+  is a trivial step, and deploy-production needs it positioned before its
+  auth-secret preflight, ahead of this action.
+
+inputs:
+  workspace:
+    description: Terraform workspace to select (created if absent). e.g. staging, production.
+    required: true
+  state-bucket:
+    description: GCS bucket holding Terraform state — pass the TF_STATE_BUCKET secret value.
+    required: true
+  tf-dir:
+    description: Directory containing the Terraform root module.
+    required: false
+    default: infra/terraform
+  terraform-version:
+    description: Version constraint passed to hashicorp/setup-terraform.
+    required: false
+    default: "~> 1.7"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Terraform
+      uses: hashicorp/setup-terraform@v4
+      with:
+        terraform_version: ${{ inputs.terraform-version }}
+        terraform_wrapper: false
+
+    - name: Terraform init (${{ inputs.workspace }})
+      shell: bash
+      working-directory: ${{ inputs.tf-dir }}
+      # Bounded retry absorbs transient GCP API 5xx / GCS backend
+      # eventual-consistency blips on init and workspace select (issue #509).
+      run: |
+        for attempt in 1 2; do
+          if terraform init \
+               -backend-config="bucket=${{ inputs.state-bucket }}" \
+               -backend-config="prefix=terraform/state" && \
+             (terraform workspace select ${{ inputs.workspace }} || terraform workspace new ${{ inputs.workspace }}); then
+            exit 0
+          fi
+          if [ "${attempt}" -lt 2 ]; then
+            echo "Terraform init/workspace attempt ${attempt} failed; retrying in 20s..."
+            sleep 20
+          fi
+        done
+        echo "::error title=Terraform init failed::terraform init/workspace select (${{ inputs.workspace }}) failed on both attempts."
+        exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,31 +105,11 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_STAGING_SERVICE_ACCOUNT }}
 
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v4
+      - name: Terraform setup + init (staging)
+        uses: ./.github/actions/tf-init
         with:
-          terraform_version: "~> 1.7"
-          terraform_wrapper: false
-
-      - name: Terraform init (staging)
-        working-directory: ${{ env.TF_DIR }}
-        # Bounded retry absorbs transient GCP API 5xx / GCS backend
-        # eventual-consistency blips on init and workspace select (issue #509).
-        run: |
-          for attempt in 1 2; do
-            if terraform init \
-                 -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}" \
-                 -backend-config="prefix=terraform/state" && \
-               (terraform workspace select staging || terraform workspace new staging); then
-              exit 0
-            fi
-            if [ "${attempt}" -lt 2 ]; then
-              echo "Terraform init/workspace attempt ${attempt} failed; retrying in 20s..."
-              sleep 20
-            fi
-          done
-          echo "::error title=Terraform init failed::terraform init/workspace select (staging) failed on both attempts."
-          exit 1
+          workspace: staging
+          state-bucket: ${{ secrets.TF_STATE_BUCKET }}
 
       - name: Terraform apply (staging)
         working-directory: ${{ env.TF_DIR }}
@@ -713,43 +693,26 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_PROD_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_PROD_SERVICE_ACCOUNT }}
 
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v4
+      - name: Terraform setup + init (production)
+        uses: ./.github/actions/tf-init
         with:
-          terraform_version: "~> 1.7"
-          terraform_wrapper: false
+          workspace: production
+          state-bucket: ${{ secrets.TF_STATE_BUCKET }}
 
-      - name: Terraform init (production)
-        working-directory: ${{ env.TF_DIR }}
-        # Same bounded-retry init + workspace select as deploy-production
-        # (absorbs transient GCP 5xx / GCS backend eventual-consistency, #509).
+      - name: Note setup/init failure in the run summary
+        if: failure()
+        # plan-production is advisory: even when setup/init fails, the approver
+        # must get a heading + note in the run summary (never a silently-empty
+        # one) before reaching the gate (#544 review). tf-init still exits 1, so
+        # the job ends red — advisory to the deploy (deploy-production's `if:`
+        # does not reference plan-production).
         run: |
-          for attempt in 1 2; do
-            if terraform init \
-                 -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}" \
-                 -backend-config="prefix=terraform/state" && \
-               (terraform workspace select production || terraform workspace new production); then
-              exit 0
-            fi
-            if [ "${attempt}" -lt 2 ]; then
-              echo "Terraform init/workspace attempt ${attempt} failed; retrying in 20s..."
-              sleep 20
-            fi
-          done
-          # Init failure is the one path that stops before the plan step writes
-          # its summary, so emit the same heading + advisory banner here — the
-          # approver must never face the gate with a silently-empty summary
-          # (#544 review). Still exit 1: init failure is a real auth/backend
-          # fault worth a red job, and is advisory to the deploy regardless
-          # (deploy-production's `if:` does not reference plan-production).
           {
             echo "## Production Terraform plan (read-only — review before approving)"
             echo ""
-            echo ":warning: \`terraform init (production)\` failed on both attempts — no blast-radius summary is available for this run."
+            echo ":warning: \`terraform setup/init (production)\` failed — no blast-radius summary is available for this run."
             echo "This is advisory and does **not** block \`deploy-production\`. Inspect the \"Terraform init (production)\" step log, and review the apply output during the gated deploy before approving."
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "::error title=Terraform init failed::terraform init/workspace select (production) failed on both attempts."
-          exit 1
 
       - name: Terraform plan (production)
         working-directory: ${{ env.TF_DIR }}
@@ -917,31 +880,11 @@ jobs:
           fi
           echo "Production auth secrets present and non-placeholder — proceeding."
 
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v4
+      - name: Terraform setup + init (production)
+        uses: ./.github/actions/tf-init
         with:
-          terraform_version: "~> 1.7"
-          terraform_wrapper: false
-
-      - name: Terraform init (production)
-        working-directory: ${{ env.TF_DIR }}
-        # Bounded retry absorbs transient GCP API 5xx / GCS backend
-        # eventual-consistency blips on init and workspace select (issue #509).
-        run: |
-          for attempt in 1 2; do
-            if terraform init \
-                 -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}" \
-                 -backend-config="prefix=terraform/state" && \
-               (terraform workspace select production || terraform workspace new production); then
-              exit 0
-            fi
-            if [ "${attempt}" -lt 2 ]; then
-              echo "Terraform init/workspace attempt ${attempt} failed; retrying in 20s..."
-              sleep 20
-            fi
-          done
-          echo "::error title=Terraform init failed::terraform init/workspace select (production) failed on both attempts."
-          exit 1
+          workspace: production
+          state-bucket: ${{ secrets.TF_STATE_BUCKET }}
 
       - name: Terraform apply (production)
         working-directory: ${{ env.TF_DIR }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -115,31 +115,11 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_STAGING_SERVICE_ACCOUNT }}
 
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v4
+      - name: Terraform setup + init (staging)
+        uses: ./.github/actions/tf-init
         with:
-          terraform_version: "~> 1.7"
-          terraform_wrapper: false
-
-      - name: Terraform init (staging)
-        working-directory: ${{ env.TF_DIR }}
-        # Bounded retry absorbs transient GCP API 5xx / GCS backend
-        # eventual-consistency blips on init and workspace select (issue #509).
-        run: |
-          for attempt in 1 2; do
-            if terraform init \
-                 -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}" \
-                 -backend-config="prefix=terraform/state" && \
-               (terraform workspace select staging || terraform workspace new staging); then
-              exit 0
-            fi
-            if [ "${attempt}" -lt 2 ]; then
-              echo "Terraform init/workspace attempt ${attempt} failed; retrying in 20s..."
-              sleep 20
-            fi
-          done
-          echo "::error title=Terraform init failed::terraform init/workspace select (staging) failed on both attempts."
-          exit 1
+          workspace: staging
+          state-bucket: ${{ secrets.TF_STATE_BUCKET }}
 
       - name: Terraform apply (staging)
         working-directory: ${{ env.TF_DIR }}


### PR DESCRIPTION
## Summary

Closes #546.

Follow-up from the [#544 review](https://github.com/brownm09/lifting-logbook/pull/544#issuecomment-4720925150) (finding 3). The bounded-retry `terraform init` + workspace-select block was hand-copied across **4** CI call sites — `terraform-staging`, `plan-production`, and `deploy-production` in `deploy.yml`, plus `terraform-staging` in `staging.yml`. Drift between copies would break the plan↔apply init parity the production plan-visibility gate relies on (#542 / #544), and the #509 retry tuning had to be kept in sync by hand.

### Changes
1. **New composite action `.github/actions/tf-init`** — bundles `hashicorp/setup-terraform@v4` (`~> 1.7`, `terraform_wrapper: false`) + the bounded-retry `terraform init` / `workspace select|new` loop, parameterized by `workspace` and `state-bucket` (with `tf-dir` / `terraform-version` defaults). The init/retry/backend logic is lifted **verbatim**; only `${{ inputs.workspace }}` is substituted. One shared definition now *guarantees* the staging/plan/apply init parity going forward.
2. **All 4 call sites converted** to a single `uses: ./.github/actions/tf-init` step.
3. **GCP auth stays per-job** (not bundled into the action) — it is a trivial 4-line step, and `deploy-production` needs it positioned *before* its auth-secret preflight, ahead of init. This also keeps #545's eventual plan-SA cutover a one-line edit to plan-production's auth step.
4. **plan-production's #544 advisory banner** (summary-on-init-failure) moved from inside the init block to a dedicated `if: failure()` step after the action. Behavior is preserved exactly: on a setup/init fault the banner is written, the job ends red, and it stays advisory (deploy-production's `if:` never references plan-production, so the deploy is unaffected).

### Design notes (GitHub Actions constraints)
- Composite actions don't inherit workflow-level `env`, so `tf-dir` is an explicit input (defaulting to `infra/terraform`).
- Composite actions can't reference secrets by dynamic name — the caller passes the `TF_STATE_BUCKET` **value** via `with: state-bucket:`.
- `setup-terraform` (PATH) and `google-github-actions/auth` (ADC via `GITHUB_ENV`) both export to the job, so the jobs' subsequent `terraform plan`/`apply` steps work unchanged.

No runtime behavior change — net −19 lines.

## Testing

`npm test` — full suite, run from the main checkout (this branch was developed in a nested git worktree under `.claude/worktrees/` with no local `node_modules`; module resolution there climbs to the main repo and produces spurious failures — same posture as #544). This branch changes **only** `.github/` (2 workflows + 1 new action); `git diff origin/main` shows just `deploy.yml` + `staging.yml` (the new `action.yml` is the only added file), so every file `npm test` exercises is byte-identical to `origin/main`.

- **Result:** `Tasks: 12 successful, 12 total`. API: `Test Suites: 34 passed, 34 total` / `Tests: 394 passed, 394 total` (0 skipped, 0 failed). No skips, no suppressions.
- **YAML validity:** `yaml.safe_load` parses all 3 files (`action.yml`, `deploy.yml`, `staging.yml`). Confirmed `hashicorp/setup-terraform` and raw `terraform init` now appear **only** in the composite action; 4 `uses: ./.github/actions/tf-init` call sites; deploy-production ordering preserved (auth → preflight → tf-init → apply).
- **Pre-PR greps:** suppression / test-integrity / deleted-tests all clean; no `package.json` change (lockfile check N/A).
- **Coverage gate:** N/A — CI-workflow YAML only, no app code. `actionlint` not available locally.

### Post-merge end-to-end verification
On the next `main` deploy run + a staging deploy: confirm `terraform-staging`, `plan-production`, and `deploy-production` all init via the composite action and still select the correct workspace (the plan-production summary and the prod apply prove init succeeded).

## Risk audit (Pass 3)
- **Testing** — N/A (CI YAML; no unit-testable code). Verified by YAML lint + structural diff + the full suite for non-regression.
- **Security** — no change; auth unchanged; secret *value* passed via `with:` is masked by GHA log redaction as before.
- **Resilience** — bounded-retry init preserved byte-for-byte; plan-production failure path preserved via `if: failure()`. Rollback: revert the PR.
- **Observability / Performance / Data integrity** — N/A (no runtime, app, or schema change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
