### PR TITLE
[infra] Add read-only plan service account for plan-production (#545 Phase 1)

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -134,6 +134,14 @@ gcloud storage buckets add-iam-policy-binding gs://lifting-logbook-prod-tfstate 
 gcloud storage buckets add-iam-policy-binding gs://lifting-logbook-prod-tfstate \
   --member="serviceAccount:lifting-logbook-prod-cicd@lifting-logbook-prod.iam.gserviceaccount.com" \
   --role="roles/storage.objectAdmin"
+
+# Grant the production read-only PLAN SA access (#545) — run after the production
+# terraform apply that creates lifting-logbook-prod-plan. objectViewer (not
+# objectAdmin): plan-production reads state to compute the diff but runs
+# `terraform plan -lock=false`, so it never writes the state lock.
+gcloud storage buckets add-iam-policy-binding gs://lifting-logbook-prod-tfstate \
+  --member="serviceAccount:lifting-logbook-prod-plan@lifting-logbook-prod.iam.gserviceaccount.com" \
+  --role="roles/storage.objectViewer"
 ```
 
 These grants are idempotent — safe to re-run. They persist independently of Terraform state.
@@ -287,6 +295,7 @@ In the GitHub repository → **Settings → Secrets and variables → Actions**:
 | `GCP_STAGING_SERVICE_ACCOUNT` | staging `terraform output cicd_service_account_email` |
 | `GCP_PROD_WORKLOAD_IDENTITY_PROVIDER` | production `terraform output workload_identity_provider` |
 | `GCP_PROD_SERVICE_ACCOUNT` | production `terraform output cicd_service_account_email` |
+| `GCP_PROD_PLAN_SERVICE_ACCOUNT` | production `terraform output cicd_plan_service_account_email` (#545 — read-only SA for the `plan-production` job; set after the apply that creates it, then wire it in via #545 Phase 2) |
 | `GCP_BILLING_ACCOUNT` | your billing account ID (used by terraform apply in CI) |
 | `TF_STATE_BUCKET` | `lifting-logbook-prod-tfstate` |
 

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -460,3 +460,48 @@ resource "google_service_account_iam_member" "cicd_wif_binding" {
   role               = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/brownm09/lifting-logbook"
 }
+
+# ─── IAM — read-only plan service account (#545) ─────────────────────────────
+#
+# A least-privilege identity for the read-only `plan-production` CI job, which
+# runs `terraform plan` against prod on every merge to surface the blast radius
+# before the production approval gate (#542 / #544). It deliberately lacks the
+# write/apply authority of `cicd` (roles/owner): it can refresh state and read,
+# but cannot mutate prod or change IAM.
+#
+# Caveat — this is NOT a zero-secret identity. Prod manages
+# google_secret_manager_secret_version resources (database_url, clerk keys, …),
+# and `terraform plan` refreshes them by reading the version payload — which
+# roles/viewer does not grant, hence roles/secretmanager.secretAccessor below.
+# So this SA can still READ prod secret values during a plan refresh; it simply
+# cannot write anything. A truly secretless plan is not achievable while the
+# config manages secret versions in state.
+#
+# Created in both workspaces for parity; currently consumed only by prod's
+# plan-production job (the staging copy is unused — there is no plan-staging
+# job). The CI cutover that points plan-production at this SA lands separately
+# (#545 Phase 2), after the SA exists in prod and its secret is set.
+resource "google_service_account" "cicd_plan" {
+  account_id   = "${local.name_prefix}-plan"
+  display_name = "${var.app_name} CI/CD plan, read-only (${var.environment})"
+}
+
+resource "google_project_iam_member" "cicd_plan_roles" {
+  for_each = toset([
+    # Broad read for `terraform plan` to refresh every managed resource.
+    "roles/viewer",
+    # Required so plan can refresh google_secret_manager_secret_version
+    # resources (roles/viewer covers metadata but not versions.access). See
+    # the caveat above — this is the one grant that lets the SA read secrets.
+    "roles/secretmanager.secretAccessor",
+  ])
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.cicd_plan.email}"
+}
+
+resource "google_service_account_iam_member" "cicd_plan_wif_binding" {
+  service_account_id = google_service_account.cicd_plan.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/brownm09/lifting-logbook"
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -38,6 +38,11 @@ output "cicd_service_account_email" {
   value       = google_service_account.cicd.email
 }
 
+output "cicd_plan_service_account_email" {
+  description = "Read-only plan service account email (#545) — set as the GCP_PROD_PLAN_SERVICE_ACCOUNT secret so the plan-production CI job authenticates with least privilege."
+  value       = google_service_account.cicd_plan.email
+}
+
 output "workload_identity_provider" {
   description = "Workload Identity Federation provider resource name (used in GitHub Actions)"
   value       = google_iam_workload_identity_pool_provider.github.name


### PR DESCRIPTION
## Summary

**Phase 1 of #545** (Terraform only — does **not** touch CI; #545 stays open for the Phase 2 cutover).

Follow-up from the [#544 review](https://github.com/brownm09/lifting-logbook/pull/544#issuecomment-4720925150) (finding 2). The read-only `plan-production` job authenticates with the **write-capable** prod CI SA (`lifting-logbook-prod-cicd`, `roles/owner`) and now runs on every merge — widening that identity's exposure from "deploys" to "every merge." This adds a dedicated least-privilege identity for the plan job to use instead.

### Changes
- **`google_service_account.cicd_plan`** (`${name_prefix}-plan` → `lifting-logbook-prod-plan` / `-stg-plan`, ≤30 chars) with:
  - `roles/viewer` — broad read for `terraform plan` refresh.
  - `roles/secretmanager.secretAccessor` — **required**: prod manages 5 `google_secret_manager_secret_version` resources; `terraform plan` refreshes them by reading the payload, which `roles/viewer` does not grant. Without it the advisory plan fails / shows spurious drift.
  - a `roles/iam.workloadIdentityUser` binding on the **existing shared** GitHub WIF pool — so **no new WIF provider and no new provider secret** are needed.
- **`outputs.tf`** — `cicd_plan_service_account_email`.
- **`docs/deploy.md`** — the new `GCP_PROD_PLAN_SERVICE_ACCOUNT` secret row (§5) and the out-of-band `objectViewer` state-bucket grant (§2).

### Honest caveat (documented in the SA comment + commit)
This is **not** a zero-secret identity: the `secretAccessor` grant means the SA can still **read** prod secret values during a plan refresh. It is strictly less than `roles/owner` — no write/apply, no `setIamPolicy` — but a truly secretless plan isn't achievable while the config manages secret versions in state. The net win is dropping `plan-production` off the owner-level identity.

### Rollout (this PR is step 1 of 4)
1. **This PR** — adds the SA to Terraform. Merging it makes the SA part of `main`; it applies to prod on the **next gated `deploy-production` approval** (an expected, now-visible `plan-production` diff: the new SA + 2 IAM bindings).
2. **You (manual):** after that apply — run the §2 `gcloud … objectViewer` grant, then `gh secret set GCP_PROD_PLAN_SERVICE_ACCOUNT --body "$(terraform output -raw cicd_plan_service_account_email)"`.
3. **#545 Phase 2 PR** — points `plan-production` at the new secret with `terraform plan -lock=false`, then closes #545.

The SA is created in both workspaces for parity but is currently consumed only by prod (no `plan-staging` job; the staging copy is unused).

## Testing

This change is **Terraform + docs only** — no app code, no `.github/`. Verification is the Terraform toolchain, not `npm test`:
- **`terraform fmt -check -diff`** — clean (no diff).
- **`terraform init -backend=false` + `terraform validate`** — `Success! The configuration is valid.`
- **`npm test` not applicable to this change:** `git diff origin/main` is limited to `infra/terraform/` + `docs/` (3 files, +59 lines); every file the suite exercises is byte-identical to `origin/main`. That app code was last run green minutes ago in #546's pre-merge suite (`Tasks: 12 successful, 12 total`; API `394 passed, 0 skipped, 0 failed`).
- **Suppression / test-integrity greps:** N/A — JS/TS-targeted patterns don't apply to `.tf`/`.md`; no test files, no `package.json`/lockfile change.

### Post-merge end-to-end verification
On the next gated prod deploy, confirm the `plan-production` summary shows exactly the new SA + 2 IAM bindings as the add diff, and that `deploy-production` applies them cleanly on approval.

## Risk audit (Pass 3)
- **Security** — the point of the change (least-privilege plan identity); documented caveat that refresh still reads secret payloads.
- **Data integrity / migrations** — IAM-only; no data or schema. Applies through the normal gated prod apply, now with plan visibility (#544) in front of it. Rollback: revert the PR; an orphaned unused SA is harmless and removable.
- **Resilience** — additive; no behavior change to existing jobs. The plan-production cutover that *consumes* this SA is deferred to Phase 2, so this PR cannot break the current pipeline.
- **Observability / Performance / Testing** — N/A (no runtime, app, or hot-path change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
