### PR TITLE
[chore] Add Terraform .gitignore coverage (#549)

### DIFF
--- a/infra/terraform/.gitignore
+++ b/infra/terraform/.gitignore
@@ -1,0 +1,29 @@
+# Terraform working files — never commit these (#549).
+# Surfaced while implementing #545: `terraform init`/`plan` leaves an untracked
+# `.terraform/` provider-plugin dir that a stray `git add -A` could commit.
+#
+# Deliberately NOT ignored (must stay tracked):
+#   - .terraform.lock.hcl        provider lock file (Terraform best practice)
+#   - terraform.tfvars.staging   committed env config, referenced by deploy.yml
+#   - terraform.tfvars.production committed env config, referenced by deploy.yml
+
+# Local provider plugins / module cache
+.terraform/
+
+# State (this project uses a remote GCS backend, but guard against local state)
+*.tfstate
+*.tfstate.*
+
+# Crash logs
+crash.log
+crash.*.log
+
+# Local override files (not used by CI; ignore if present)
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Terraform CLI config
+.terraformrc
+terraform.rc


### PR DESCRIPTION
## Summary

Closes #549.

The repo had **no** `.gitignore` coverage for Terraform working files. In a worktree where `terraform init`/`plan` had run, `git status` showed `?? infra/terraform/.terraform/` as untracked **and not ignored** — a stray `git add -A` could commit the multi-MB provider plugin directory or, worse, local `*.tfstate`. Surfaced while implementing #545 (its `terraform init`/`validate` created the untracked `.terraform/`).

Adds `infra/terraform/.gitignore` with the standard Terraform ignores: `.terraform/`, `*.tfstate`/`*.tfstate.*`, crash logs, `*override.tf[.json]`, and `.terraformrc`/`terraform.rc`.

**Deliberately kept tracked** (called out in the file's header comment):
- `.terraform.lock.hcl` — the provider lock file is committed per Terraform best practice.
- `terraform.tfvars.staging` / `terraform.tfvars.production` — committed env config referenced by `deploy.yml`.

## Testing

Config-only change, no app code.
- **`terraform validate`** → `Success! The configuration is valid.`
- **`git status`** no longer lists `infra/terraform/.terraform/` (now ignored); only the new `.gitignore` shows.
- **`git check-ignore`** confirms: `.terraform/` is ignored; `.terraform.lock.hcl`, `terraform.tfvars.staging`, and `terraform.tfvars.production` are **not** ignored (stay tracked).
- No `npm test` impact (no app code); suppression/integrity/lockfile checks N/A (no JS/TS, no `package.json`).

## Risk audit (Pass 3)
- **Data integrity** — the only real risk would be ignoring something that *should* be tracked; explicitly verified the lock file + both tfvars remain trackable. No state or config is removed from git.
- **Testing / Observability / Security / Resilience / Performance** — N/A (a `.gitignore` addition; no runtime, app, or infra-resource change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
