### PR TITLE
[infra] Cut plan-production over to the read-only plan SA (#545 Phase 2)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -691,7 +691,11 @@ jobs:
         uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_PROD_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_PROD_SERVICE_ACCOUNT }}
+          # Least-privilege read-only identity for the advisory plan (#545): viewer
+          # + secretmanager.secretAccessor + storage.objectViewer on the state bucket
+          # — no write/apply/setIamPolicy. The write-capable GCP_PROD_SERVICE_ACCOUNT
+          # is used only by deploy-production's gated apply.
+          service_account: ${{ secrets.GCP_PROD_PLAN_SERVICE_ACCOUNT }}
 
       - name: Terraform setup + init (production)
         uses: ./.github/actions/tf-init
@@ -722,11 +726,15 @@ jobs:
         # add/change/destroy summary + resource addresses are written to the run
         # summary so the approver can read the prod blast radius before approving
         # (#542). Never echoes a secret; -input=false avoids any prompt hang.
+        # -lock=false: the read-only plan SA (#545) has no state-bucket write, so it
+        # cannot acquire the .tflock. plan-production runs early (needs build-images
+        # only) with no concurrent prod-state writer, so skipping the advisory lock
+        # is safe and keeps the identity strictly read-only.
         run: |
           PLAN_OUT="$RUNNER_TEMP/prod-plan.txt"
           PLANNED=0
           for attempt in 1 2; do
-            if terraform plan -no-color -input=false \
+            if terraform plan -no-color -input=false -lock=false \
                  -var-file=terraform.tfvars.production \
                  -var="billing_account=${{ secrets.GCP_BILLING_ACCOUNT }}" \
                  > "$PLAN_OUT" 2>&1; then


### PR DESCRIPTION
## Summary

Phase 2 (final) of #545 — the CI cutover. The advisory `plan-production` job in `deploy.yml` now authenticates with the **dedicated read-only identity** created in Phase 1 (PR #548), instead of the write-capable prod CI service account.

- `service_account` → `${{ secrets.GCP_PROD_PLAN_SERVICE_ACCOUNT }}` (`lifting-logbook-prod-plan@lifting-logbook-prod.iam.gserviceaccount.com`): `roles/viewer` + `roles/secretmanager.secretAccessor` + `roles/storage.objectViewer` on the state bucket — **no** write / apply / `setIamPolicy` / owner.
- Adds `-lock=false` to `terraform plan`: the read-only SA has no state-bucket write and cannot acquire the `.tflock`. `plan-production` runs early (`needs: build-images` only) with no concurrent prod-state writer, so skipping the advisory lock is safe and is what keeps the identity strictly read-only.

`deploy-production`'s gated `terraform apply` is unchanged — it still uses the write-capable `GCP_PROD_SERVICE_ACCOUNT`. This narrows the read-only plan job (which now runs on every merge) from `roles/owner` to least privilege, the security finding from the #544 review.

## Pre-merge gates completed (verified against live GCP/GitHub)

The three manual gates from the phased rollout are done and audited:

| Gate | Verified |
|---|---|
| Prod apply (run [27654624051](https://github.com/brownm09/lifting-logbook/actions/runs/27654624051), `f574e87`) | ✅ SA `lifting-logbook-prod-plan` created; `roles/viewer` + `roles/secretmanager.secretAccessor`; WIF `workloadIdentityUser` on `attribute.repository/brownm09/lifting-logbook` |
| State-bucket grant | ✅ `roles/storage.objectViewer` on `gs://lifting-logbook-prod-tfstate` (read-only, not objectAdmin) |
| GitHub secret | ✅ `GCP_PROD_PLAN_SERVICE_ACCOUNT` set |

## Testing

CI-YAML-only change; no app code, test files, or `package.json` touched.

- `python -c "import yaml; yaml.safe_load(...)"` → **deploy.yml: YAML OK**
- Pre-commit `turbo run lint` → **7/7 successful**
- Diff is exactly two changes: the `service_account` input and `-lock=false` on the plan step.
- **End-to-end verification is the first post-merge `Deploy` run** (same posture as #544/#545 Phase 1): its `plan-production` job authenticates as the read-only SA and must still emit the add/change/destroy run-summary. Because the job is **advisory** (#544), any residual permission gap degrades the summary rather than blocking `deploy-production` — roles can be iterated in a fast follow if a gap surfaces.

No new testable behavior (CI config); coverage gate N/A. No suppressions / test-integrity changes. Lockfile unchanged.

## Risk

- **Security** — this is the improvement: drops the on-every-merge plan job from `roles/owner` to read-only. Documented caveat (carried from Phase 1): `secretAccessor` means the SA can *read* prod secret payloads during plan refresh — strictly less than owner, but not zero-secret; a secretless plan isn't possible while the config manages `google_secret_manager_secret_version` resources.
- **Resilience / rollback** — plan stays advisory; revert this PR to restore the previous identity. The Phase 1 SA + bindings are additive and harmless if this is reverted.

Closes #545