### PR TITLE
[infra] Add scheduled merge-ready PR digest workflow

### DIFF
--- a/.github/scripts/merge-ready-digest.mjs
+++ b/.github/scripts/merge-ready-digest.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// merge-ready-digest.mjs — selector for the scheduled deployment-queue digest (#538).
+//
+// A PR is "merge-ready" when it is not a draft, is MERGEABLE, its merge state is
+// CLEAN, and its check rollup has zero FAILURE/PENDING entries — i.e. it is green
+// and waiting only on a deliberate in-session merge (auto-merge is off by design,
+// ADR-031). This mirrors the local on-demand ~/.claude/scripts/merge-ready.sh so
+// the scheduled digest and the manual check agree.
+//
+// Reads the JSON array emitted by:
+//   gh pr list --state open --json number,title,isDraft,mergeable,mergeStateStatus,statusCheckRollup
+// and writes the sticky-comment markdown body (including the upsert marker) to stdout.
+
+import { readFileSync } from 'node:fs';
+
+const MARKER = '<!-- merge-ready-digest -->';
+
+// statusCheckRollup entries are a mix of CheckRun (has `conclusion`/`status`) and
+// StatusContext (has `state`). Treat anything not clearly passing/failing as
+// pending so an in-flight or unreported check never counts as merge-ready.
+const PASS = new Set(['SUCCESS', 'NEUTRAL', 'SKIPPED']);
+const FAIL = new Set([
+  'FAILURE',
+  'ERROR',
+  'TIMED_OUT',
+  'CANCELLED',
+  'ACTION_REQUIRED',
+  'STARTUP_FAILURE',
+]);
+
+function rollup(checks = []) {
+  const c = { ok: 0, pending: 0, fail: 0 };
+  for (const x of checks) {
+    const s = x.conclusion || x.status || x.state || '';
+    if (PASS.has(s)) c.ok++;
+    else if (FAIL.has(s)) c.fail++;
+    else c.pending++; // QUEUED, IN_PROGRESS, PENDING, EXPECTED, '' ...
+  }
+  return c;
+}
+
+const file = process.argv[2];
+if (!file) {
+  console.error('usage: merge-ready-digest.mjs <prs.json>');
+  process.exit(2);
+}
+
+const prs = JSON.parse(readFileSync(file, 'utf8'));
+
+const ready = [];
+const waiting = [];
+for (const p of prs) {
+  if (p.isDraft) continue;
+  const c = rollup(p.statusCheckRollup);
+  const isReady =
+    p.mergeable === 'MERGEABLE' &&
+    p.mergeStateStatus === 'CLEAN' &&
+    c.fail === 0 &&
+    c.pending === 0;
+  (isReady ? ready : waiting).push({ ...p, c });
+}
+
+const lines = [MARKER, '## 🚦 Deployment queue', ''];
+
+if (ready.length === 0) {
+  lines.push('✅ **Queue clear** — no PRs are merge-ready right now.');
+} else {
+  lines.push(
+    `**${ready.length} PR${ready.length === 1 ? '' : 's'} merge-ready** (green + mergeable, nothing pending):`,
+  );
+  lines.push('');
+  for (const p of ready) {
+    lines.push(`- #${p.number} ${p.title} — ✅ ${p.c.ok} checks`);
+  }
+}
+
+if (waiting.length) {
+  lines.push('');
+  lines.push(
+    `<details><summary>⏳ ${waiting.length} open, not yet merge-ready</summary>`,
+  );
+  lines.push('');
+  for (const p of waiting) {
+    lines.push(
+      `- #${p.number} ${p.title} — \`${p.mergeStateStatus}\`/\`${p.mergeable}\` (${p.c.ok}✓ ${p.c.pending}… ${p.c.fail}✗)`,
+    );
+  }
+  lines.push('');
+  lines.push('</details>');
+}
+
+lines.push('');
+lines.push(
+  '<sub>Auto-maintained by `.github/workflows/merge-ready-digest.yml` (#538) — edited in place, no notifications.</sub>',
+);
+
+process.stdout.write(lines.join('\n') + '\n');

--- a/.github/scripts/merge-ready-digest.mjs
+++ b/.github/scripts/merge-ready-digest.mjs
@@ -28,9 +28,12 @@ const FAIL = new Set([
   'STARTUP_FAILURE',
 ]);
 
-function rollup(checks = []) {
+function rollup(checks) {
   const c = { ok: 0, pending: 0, fail: 0 };
-  for (const x of checks) {
+  // `?? []` (not a default param) so a `statusCheckRollup: null` — which gh can emit
+  // for a degenerate head-ref state — counts as zero checks instead of throwing and
+  // killing the whole digest run.
+  for (const x of checks ?? []) {
     const s = x.conclusion || x.status || x.state || '';
     if (PASS.has(s)) c.ok++;
     else if (FAIL.has(s)) c.fail++;

--- a/.github/workflows/merge-ready-digest.yml
+++ b/.github/workflows/merge-ready-digest.yml
@@ -63,9 +63,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # Find an existing digest comment by marker (last one wins if somehow >1).
+          # Find this workflow's own sticky comment by marker. Pick `first` (oldest):
+          # the digest comment is created on the first run when the issue has no
+          # comments, so it is comment #1 and stays on page 1 of the ascending-order
+          # listing forever. `first` also makes the upsert immune to a later human
+          # comment that happens to quote the marker (which `last` would hijack).
           CID=$(gh api "repos/${{ github.repository }}/issues/${QUEUE_ISSUE}/comments?per_page=100" \
-            --jq "[.[] | select(.body | contains(\"${MARKER}\")) | .id] | last // empty")
+            --jq "[.[] | select(.body | contains(\"${MARKER}\")) | .id] | first // empty")
           if [ -n "$CID" ]; then
             echo "Updating existing digest comment $CID"
             node -e "const fs=require('fs');process.stdout.write(JSON.stringify({body:fs.readFileSync('body.md','utf8')}))" > payload.json

--- a/.github/workflows/merge-ready-digest.yml
+++ b/.github/workflows/merge-ready-digest.yml
@@ -1,0 +1,76 @@
+name: Merge-ready digest
+
+# Surfaces the deployment queue (#538): which open PRs are green + mergeable and
+# waiting only on a deliberate in-session merge. Auto-merge is off by design
+# (ADR-031), so this replaces hand-polling. GitHub-Actions-based (not a Claude
+# scheduled task) so it has no dependency on a local OAuth token — it keeps
+# working regardless of .credentials.json state.
+#
+# Delivery: a single sticky comment (found by an HTML-comment marker) is upserted
+# on the pinned "Deployment queue" tracking issue (#552). Editing a comment in
+# place sends no notifications, so this is quiet even when it runs hourly; when the
+# queue is clear the comment says so rather than going stale.
+
+on:
+  schedule:
+    # Hourly 09:00–18:00 ET, Mon–Fri. GitHub cron is UTC-only: 13:00–22:00 UTC is
+    # the EDT (summer) window. During EST (Nov–Mar) the same cron fires at
+    # 14:00–23:00 UTC / 10:00–19:00 ET — a one-hour DST shift that is acceptable
+    # for a passive digest.
+    - cron: '0 13-22 * * 1-5'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+# Serialize so a schedule tick and a manual dispatch cannot both create the
+# sticky comment before either has found the other's. cancel-in-progress: false —
+# the second run still needs to finish its upsert.
+concurrency:
+  group: merge-ready-digest
+  cancel-in-progress: false
+
+env:
+  QUEUE_ISSUE: '552'
+  MARKER: '<!-- merge-ready-digest -->'
+
+jobs:
+  digest:
+    name: Upsert deployment-queue digest
+    runs-on: ubuntu-latest
+    # The whole pipeline runs in <30s; 5 minutes bounds transient GitHub API hangs
+    # without burning the default 6h timeout.
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Compute merge-ready PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh pr list --repo "${{ github.repository }}" --state open --limit 100 \
+            --json number,title,isDraft,mergeable,mergeStateStatus,statusCheckRollup \
+            > prs.json
+          node .github/scripts/merge-ready-digest.mjs prs.json > body.md
+          echo '--- digest body ---'
+          cat body.md
+
+      - name: Upsert sticky comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Find an existing digest comment by marker (last one wins if somehow >1).
+          CID=$(gh api "repos/${{ github.repository }}/issues/${QUEUE_ISSUE}/comments?per_page=100" \
+            --jq "[.[] | select(.body | contains(\"${MARKER}\")) | .id] | last // empty")
+          if [ -n "$CID" ]; then
+            echo "Updating existing digest comment $CID"
+            node -e "const fs=require('fs');process.stdout.write(JSON.stringify({body:fs.readFileSync('body.md','utf8')}))" > payload.json
+            gh api -X PATCH "repos/${{ github.repository }}/issues/comments/${CID}" --input payload.json > /dev/null
+          else
+            echo "Creating new digest comment"
+            gh issue comment "${QUEUE_ISSUE}" --repo "${{ github.repository }}" --body-file body.md
+          fi


### PR DESCRIPTION
## Summary

Surfaces the **deployment queue** without hand-polling. Auto-merge is off by design ([ADR-031](https://github.com/brownm09/lifting-logbook/blob/main/docs/adr/ADR-031-auto-merge-disabled.md)), so green PRs waiting on a deliberate in-session merge have to be tracked manually. This adds a scheduled GitHub Actions workflow that upserts a sticky comment on the pinned **🚦 Deployment queue** tracking issue (#552) listing which open PRs are green + mergeable + nothing pending.

GitHub-Actions-based (not a Claude scheduled task) so it has **no dependency on a local OAuth token** — it keeps working regardless of `.credentials.json` state.

## Changes

- **`.github/scripts/merge-ready-digest.mjs`** — pure selector mirroring the local `~/.claude/scripts/merge-ready.sh` logic: a PR is merge-ready when `!isDraft && mergeable==MERGEABLE && mergeStateStatus==CLEAN` and the check rollup has zero `FAILURE`/`PENDING`. Standalone so it can be run/tested locally.
- **`.github/workflows/merge-ready-digest.yml`** — hourly 09:00–18:00 ET (Mon–Fri) via `cron: '0 13-22 * * 1-5'` (EDT window; header documents the one-hour EST/DST shift is acceptable) + `workflow_dispatch`. Least-privilege `GITHUB_TOKEN` (`issues: write`). Marker-based comment **upsert** — editing in place sends no notifications, so it is quiet even hourly and never goes stale (says "queue clear" when empty).

## Delivery-channel decision

The issue left the channel open (sticky comment / Slack / step-summary). Chose the **sticky tracking-issue comment**: needs no extra secret (Slack would), is passively visible (step-summary requires opening the run), and is naturally quiet (edit-in-place = no pings).

## Testing

No app code; nothing for the jest suites to cover. Verified the selector locally:

- **Live:** ran against `gh pr list` output (0 open PRs currently) → emits the "queue clear" body.
- **Synthetic fixture** covering every case → correct selection:
  - ✅ ready (CLEAN/MERGEABLE, all checks pass) and a StatusContext-`state` variant → both listed as merge-ready
  - ❌ failing check, pending/in-progress check, CONFLICTING/DIRTY → excluded from ready, shown under "not yet merge-ready"
  - draft → excluded entirely

`Tests: N/A (CI workflow + standalone node selector; no jest-testable app code).` Pre-commit `turbo run lint` passed 7/7. Suppression + test-integrity greps clean; no `package.json` change.

Post-merge I'll trigger one `workflow_dispatch` run to confirm the comment upserts on #552.

## Acceptance criteria

- [x] Scheduled workflow runs hourly during the chosen work-hours window, Mon–Fri
- [x] Correctly lists merge-ready PRs and excludes draft/blocked/pending ones (fixture-verified)
- [x] Notifies via the chosen channel only when there is ≥1 merge-ready PR (sticky comment; edit-in-place is non-notifying; "clear" state shown rather than going stale)
- [x] Timezone/hours and delivery channel confirmed and documented in the workflow

Closes #538

---

## Review findings disposition

`/review` (high-effort, 7-angle) run on #553. Two independent finder passes (shell/upsert logic + node selector). Findings:

| # | Finding | Disposition |
|---|---------|-------------|
| 1 | `rollup(p.statusCheckRollup)` throws if gh emits `statusCheckRollup: null` (JS default param only covers `undefined`) — would kill the whole digest run | **Fixed in `e3c9c38`** — `checks ?? []` + null-fixture test |
| 2 | Comment lookup used `\| last`; a later human comment quoting the marker could be hijacked/overwritten; pagination could miss the sticky comment | **Fixed in `e3c9c38`** — switched to `\| first` (oldest = the bot's own comment #1, always page 1) |
| 3 | A zero-checks PR is classified merge-ready ("✅ 0 checks") | **Not fixed (intended)** — correct semantics (nothing blocking) and matches the reference `merge-ready.sh`; real PRs here always carry required checks, so a CLEAN+MERGEABLE PR has passed them. |
| 4 | A PR title containing `</details>` breaks the collapsible block | **Not fixed (cosmetic)** — rare, self-heals when the title changes; no logic/security impact. |
