### PR TITLE
[chore] Unify Smart Import preview/commit dedupe loop on a shared generator

### DIFF
--- a/apps/api/src/adapters/in-memory/lifting-program-spec.adapter.ts
+++ b/apps/api/src/adapters/in-memory/lifting-program-spec.adapter.ts
@@ -40,13 +40,15 @@ export class InMemoryLiftingProgramSpecRepository
     const byKey = new Map(existingByKey);
 
     // Shared classify/dedupe/tally loop + program-spec classifier (#532) so this
-    // adapter's counts match the Prisma adapter's and the preview path's.
+    // adapter's counts match the Prisma adapter's and the preview path's. The
+    // deduped key is handed back by the shared loop, so it is reused here rather
+    // than recomputed (#537).
     const result = await classifyAndCount(
       rows,
       (r) => programSpecNaturalKey(r),
       (r) => programSpecRowKind(r, existingByKey),
-      (r) => {
-        byKey.set(programSpecNaturalKey(r), r);
+      (r, _kind, key) => {
+        byKey.set(key, r);
       },
     );
 

--- a/packages/core/src/utils/import/buildImportPreview.ts
+++ b/packages/core/src/utils/import/buildImportPreview.ts
@@ -5,6 +5,7 @@ import {
   StrengthGoalEntry,
   TrainingMax,
 } from '../../models';
+import { classifyImportRows } from './classifyAndCount';
 import { liftRecordNaturalKey } from './liftRecordNaturalKey';
 
 /**
@@ -43,20 +44,20 @@ export function buildLiftRecordsPreview(
   existing: LiftRecord[],
 ): ImportPreview {
   const existingKeys = new Set(existing.map(liftRecordNaturalKey));
-  const seen = new Set<string>();
   const deltas: ImportDelta[] = [];
 
-  for (const r of incoming) {
-    const key = liftRecordNaturalKey(r);
-    if (seen.has(key)) continue;
-    seen.add(key);
+  for (const { row: r, kind, key } of classifyImportRows(
+    incoming,
+    liftRecordNaturalKey,
+    (_r, k) => (existingKeys.has(k) ? 'skip' : 'create'),
+  )) {
     const label = `${r.lift} · cycle ${r.cycleNum} workout ${r.workoutNum} set ${r.setNum}`;
     const value = `${r.weight} × ${r.reps}`;
-    if (existingKeys.has(key)) {
-      deltas.push({ key, label, kind: 'skip', before: value, after: value });
-    } else {
-      deltas.push({ key, label, kind: 'create', after: value });
-    }
+    deltas.push(
+      kind === 'skip'
+        ? { key, label, kind, before: value, after: value }
+        : { key, label, kind, after: value },
+    );
   }
   return tally(deltas);
 }
@@ -98,19 +99,19 @@ export function buildTrainingMaxPreview(
   existing: TrainingMax[],
 ): ImportPreview {
   const existingByLift = new Map(existing.map((m) => [m.lift, m.weight]));
-  const seen = new Set<string>();
   const deltas: ImportDelta[] = [];
 
-  for (const m of incoming) {
-    if (seen.has(m.lift)) continue;
-    seen.add(m.lift);
+  for (const { row: m, kind, key } of classifyImportRows(
+    incoming,
+    (m) => m.lift,
+    (m) => trainingMaxRowKind(m, existingByLift),
+  )) {
     const after = `${m.weight}`;
-    const kind = trainingMaxRowKind(m, existingByLift);
     const before = existingByLift.get(m.lift);
     deltas.push(
       before === undefined
-        ? { key: m.lift, label: m.lift, kind, after }
-        : { key: m.lift, label: m.lift, kind, before: `${before}`, after },
+        ? { key, label: m.lift, kind, after }
+        : { key, label: m.lift, kind, before: `${before}`, after },
     );
   }
   return tally(deltas);
@@ -128,19 +129,19 @@ export function buildStrengthGoalPreview(
   existing: StrengthGoalEntry[],
 ): ImportPreview {
   const existingByLift = new Map(existing.map((g) => [g.lift, g]));
-  const seen = new Set<string>();
   const deltas: ImportDelta[] = [];
 
-  for (const g of incoming) {
-    if (seen.has(g.lift)) continue;
-    seen.add(g.lift);
+  for (const { row: g, kind, key } of classifyImportRows(
+    incoming,
+    (g) => g.lift,
+    (g) => strengthGoalRowKind(g, existingByLift),
+  )) {
     const after = goalValue(g);
-    const kind = strengthGoalRowKind(g, existingByLift);
     const prior = existingByLift.get(g.lift);
     deltas.push(
       prior
-        ? { key: g.lift, label: g.lift, kind, before: goalValue(prior), after }
-        : { key: g.lift, label: g.lift, kind, after },
+        ? { key, label: g.lift, kind, before: goalValue(prior), after }
+        : { key, label: g.lift, kind, after },
     );
   }
   return tally(deltas);
@@ -186,16 +187,15 @@ export function buildProgramSpecPreview(
   existing: LiftingProgramSpec[],
 ): ImportPreview {
   const existingByKey = new Map(existing.map((r) => [programSpecNaturalKey(r), r]));
-  const seen = new Set<string>();
   const deltas: ImportDelta[] = [];
 
-  for (const r of incoming) {
-    const key = programSpecNaturalKey(r);
-    if (seen.has(key)) continue;
-    seen.add(key);
+  for (const { row: r, kind, key } of classifyImportRows(
+    incoming,
+    programSpecNaturalKey,
+    (r) => programSpecRowKind(r, existingByKey),
+  )) {
     const label = `Week ${r.week} · ${r.lift} (#${r.order})`;
     const after = specValue(r);
-    const kind = programSpecRowKind(r, existingByKey);
     const prior = existingByKey.get(key);
     deltas.push(
       prior

--- a/packages/core/src/utils/import/classifyAndCount.test.ts
+++ b/packages/core/src/utils/import/classifyAndCount.test.ts
@@ -1,7 +1,61 @@
-import { classifyAndCount } from './classifyAndCount';
+import { classifyAndCount, classifyImportRows } from './classifyAndCount';
 import { ImportRowKind } from './buildImportPreview';
 
 type Row = { k: string };
+
+describe('classifyImportRows', () => {
+  it('yields each unique row with its key and classification', () => {
+    const kindOf = (k: string): ImportRowKind =>
+      k === 'a' ? 'create' : k === 'b' ? 'update' : 'skip';
+
+    const out = [
+      ...classifyImportRows<Row>([{ k: 'a' }, { k: 'b' }, { k: 'c' }], (r) => r.k, (r) =>
+        kindOf(r.k),
+      ),
+    ];
+
+    expect(out).toEqual([
+      { row: { k: 'a' }, kind: 'create', key: 'a' },
+      { row: { k: 'b' }, kind: 'update', key: 'b' },
+      { row: { k: 'c' }, kind: 'skip', key: 'c' },
+    ]);
+  });
+
+  it('collapses duplicate keys within the batch (first occurrence wins)', () => {
+    const seen: Array<{ k: string }> = [];
+    const out = [
+      ...classifyImportRows<Row>(
+        [{ k: 'x' }, { k: 'x' }, { k: 'y' }],
+        (r) => r.k,
+        (r) => {
+          seen.push(r);
+          return 'create';
+        },
+      ),
+    ];
+
+    // The duplicate 'x' is neither yielded nor re-classified.
+    expect(out.map((c) => c.key)).toEqual(['x', 'y']);
+    expect(seen).toEqual([{ k: 'x' }, { k: 'y' }]);
+  });
+
+  it('passes the deduped key to the classifier so it need not recompute it', () => {
+    const keysSeenByClassifier: string[] = [];
+    const consumed = [
+      ...classifyImportRows<Row>(
+        [{ k: 'p' }, { k: 'q' }],
+        (r) => `key:${r.k}`,
+        (_r, key) => {
+          keysSeenByClassifier.push(key);
+          return 'create';
+        },
+      ),
+    ];
+
+    expect(consumed.map((c) => c.key)).toEqual(['key:p', 'key:q']);
+    expect(keysSeenByClassifier).toEqual(['key:p', 'key:q']);
+  });
+});
 
 describe('classifyAndCount', () => {
   it('tallies create/update/skip and writes only the non-skip rows', async () => {

--- a/packages/core/src/utils/import/classifyAndCount.ts
+++ b/packages/core/src/utils/import/classifyAndCount.ts
@@ -1,49 +1,80 @@
 import { ImportWriteResult } from '@lifting-logbook/types';
-import { ImportRowKind } from './buildImportPreview';
+import type { ImportRowKind } from './buildImportPreview';
+
+/** One deduped import row with its computed natural key and classification. */
+export interface ClassifiedRow<T> {
+  row: T;
+  kind: ImportRowKind;
+  key: string;
+}
+
+/**
+ * Shared dedupe + classify core for the Smart Import paths (#537).
+ *
+ * Both the count-only commit path (`classifyAndCount`) and the delta-producing
+ * preview path (`buildImportPreview`) walk the incoming rows the same way: collapse
+ * duplicate natural keys within the batch (first occurrence wins) and classify each
+ * unique row as create / update / skip. That loop used to be copy-pasted in both
+ * places, so a change to the dedupe semantics (e.g. first-wins → last-wins, or key
+ * normalization) had to be made twice or the two paths would silently disagree.
+ * Centralising it here makes that a one-place change — the per-row create/update/skip
+ * *decision* is already shared via the `*RowKind` predicates, this shares the
+ * surrounding dedupe loop too.
+ *
+ * `keyOf` produces the per-row dedupe/natural key; `rowKind` decides
+ * create/update/skip (the key is passed through so a classifier can reuse it
+ * instead of recomputing). Each yielded row carries the key it was deduped on so
+ * consumers never recompute it.
+ */
+export function* classifyImportRows<T>(
+  rows: readonly T[],
+  keyOf: (row: T) => string,
+  rowKind: (row: T, key: string) => ImportRowKind,
+): Generator<ClassifiedRow<T>> {
+  const seen = new Set<string>();
+  for (const row of rows) {
+    const key = keyOf(row);
+    if (seen.has(key)) continue; // collapse duplicate keys within the batch
+    seen.add(key);
+    yield { row, kind: rowKind(row, key), key };
+  }
+}
 
 /**
  * Shared classify-and-count loop for the Smart Import commit path (#532).
  *
- * Every per-kind commit method (training maxes, strength goals, program spec) and
- * every adapter (in-memory + Prisma) walks the incoming rows the same way:
- * collapse duplicate keys within the batch, classify each unique row as
- * create / update / skip against the existing snapshot, apply the write for the
- * non-skip rows, and tally the result. That loop was copy-pasted across the
- * adapters; a change to the dedupe or tally semantics in one place could silently
- * desync the counts another adapter reports. Centralising it here keeps the count
- * contract identical across adapters — the classification *decision* is already
- * shared via the `*RowKind` predicates, this shares the surrounding loop too.
+ * Walks the deduped/classified rows from {@link classifyImportRows}, applies the
+ * write for each non-skip row, and tallies the result, so every per-kind commit
+ * method (training maxes, strength goals, program spec) and every adapter
+ * (in-memory + Prisma) reports identical counts for the same input.
  *
- * `keyOf` produces the per-row dedupe/natural key. `rowKind` decides
- * create/update/skip (typically one of `trainingMaxRowKind` /
- * `strengthGoalRowKind` / `programSpecRowKind`). `applyWrite` performs the write
- * for a non-skip row and is awaited so callers can run it inside a transaction;
- * a throw propagates (the caller's transaction rolls back) and the counts are not
- * advanced for the failed row.
+ * `applyWrite` performs the write for a non-skip row and is awaited so callers can
+ * run it inside a transaction; a throw propagates (the caller's transaction rolls
+ * back) and the counts are not advanced for the failed row. The deduped natural
+ * `key` is passed as the third argument so an adapter that stores by key need not
+ * recompute it.
  */
 export async function classifyAndCount<T>(
   rows: readonly T[],
   keyOf: (row: T) => string,
   rowKind: (row: T) => ImportRowKind,
-  applyWrite: (row: T, kind: 'create' | 'update') => void | Promise<unknown>,
+  applyWrite: (
+    row: T,
+    kind: 'create' | 'update',
+    key: string,
+  ) => void | Promise<unknown>,
 ): Promise<ImportWriteResult> {
   let created = 0;
   let updated = 0;
   let skipped = 0;
-  const seen = new Set<string>();
 
-  for (const row of rows) {
-    const key = keyOf(row);
-    if (seen.has(key)) continue; // collapse duplicate keys within the batch
-    seen.add(key);
-
-    const kind = rowKind(row);
+  for (const { row, kind, key } of classifyImportRows(rows, keyOf, (r) => rowKind(r))) {
     if (kind === 'skip') {
       skipped++;
       continue;
     }
 
-    await applyWrite(row, kind);
+    await applyWrite(row, kind, key);
     if (kind === 'create') created++;
     else updated++;
   }


### PR DESCRIPTION
## Summary

Closes the maintainability follow-up from the #536 (#532) review: the commit path was already unified on `classifyAndCount`, but the **four preview builders** in `buildImportPreview.ts` still hand-rolled the identical `seen`-set dedupe + `*RowKind` + tally loop — so a future change to dedupe semantics (first-wins → last-wins, key normalization) had to be made in two places or the preview and commit counts would silently diverge.

Extract the dedupe+classify core as a **sync generator** `classifyImportRows()` that both paths consume:
- the count-only **commit** path (`classifyAndCount`) applies a write and tallies;
- the delta-producing **preview** builders emit a before→after `ImportDelta`.

A sync generator (not async) keeps the pure preview builders synchronous — no async ripple to their callers. The generator yields each deduped row with its computed natural **key**, so `classifyAndCount` now passes that key to `applyWrite` and the in-memory program-spec adapter reuses it instead of recomputing `programSpecNaturalKey()` (the recompute the issue called out).

This is **behaviour-preserving**: the create/update/skip *decision* still lives in the existing `*RowKind` predicates; only the surrounding loop moved.

## Changes
- `packages/core/src/utils/import/classifyAndCount.ts` — add + export `classifyImportRows<T>()` generator and `ClassifiedRow<T>`; rewrite `classifyAndCount` to consume it and pass `key` to `applyWrite`. `import type` for `ImportRowKind` to keep the new preview→classify runtime edge acyclic.
- `packages/core/src/utils/import/buildImportPreview.ts` — rewrite all four builders to consume the generator.
- `apps/api/src/adapters/in-memory/lifting-program-spec.adapter.ts` — reuse the yielded `key`.

## Latent test-integrity fix (called out)
`classifyAndCount.spec.ts` lived in `packages/core`, whose jest `testMatch` is `**/*.test.ts` — so the file **never ran** and the #532 tests in it were dead. Renamed `classifyAndCount.spec.ts` → `classifyAndCount.test.ts` (now executes) and added `classifyImportRows` generator unit tests. The rename surfaces in a `--diff-filter=D` test grep as a false positive (git tracks it as a rename `R`); no test was deleted — 4 previously-dead tests are now live plus 3 new ones.

## Deferred (part 2 of #537)
Batched writes for large imports — intentionally **not** done here. It trades per-row round-trips for a raw-SQL call site, which per ADR-024 is not auto-traced and must be manually spanned; import is a manual, non-hot path and #536 already widened the tx budget to 30s. Recorded as a decision comment on #537; revisit if Tempo/`pg_stat_activity` shows pressure.

## Testing
- `npm test -w @lifting-logbook/core` — **Tests: 210 passed, 0 skipped, 0 failed** (32 suites), incl. the now-live `classifyAndCount.test.ts` (7) and the behaviour-guarding `buildImportPreview.test.ts`.
- `npm test -w @lifting-logbook/api` — **Tests: 394 passed, 0 skipped, 0 failed** (34 suites, Docker/Testcontainers DB e2e up), incl. the cross-adapter `import-count-parity.spec.ts`.
- `npx turbo run build --filter=core --filter=api` clean; `npx turbo run lint --filter=core` clean. Suppression + test-integrity greps clean (no new suppressions; only the rename noted above). No `package.json` change.
- Pre-existing, unrelated: `apps/web` build fails locally on the documented Windows `@vercel/otel` declaration extraction issue (#373 class); this branch touches no `apps/web` files and CI (Node 20 Linux) builds web fine.

Closes #537

---

## Review findings disposition

`/review` (high-effort, 7-angle) run on #554. One independent finder pass over the refactor (behaviour-preservation, circular-import, signature change, rename).

**No defects found.** Verified: all four preview builders emit byte-identical `ImportDelta`s (the generator's `keyOf` is the same function the old inline loop used; first-occurrence-wins dedupe preserved); the `import type` makes the new `buildImportPreview → classifyAndCount` runtime edge acyclic; the `(row, kind) → (row, kind, key)` `applyWrite` signature is backward-compatible (extra positional arg harmless); the `.spec.ts → .test.ts` rename loses nothing and runs 4 previously-dead tests for the first time. `core` (210) + `api` (394) suites green.
