### PR TITLE
[infra] Surface the prod Terraform plan on PRs touching infra/terraform/** (Layer B, #542)

### DIFF
--- a/.github/workflows/prod-plan-pr.yml
+++ b/.github/workflows/prod-plan-pr.yml
@@ -1,0 +1,199 @@
+name: Prod Plan (PR)
+
+# Layer B of the #542 defense-in-depth fix ("a routine merge can silently execute
+# a prod Terraform cutover behind a context-free approval"). Layer A (#544) surfaces
+# the production `terraform plan` in the deploy.yml run *before the approval gate*;
+# this workflow surfaces it one step earlier — on the PR itself, *before merge* — so
+# a reviewer sees the prod blast radius at review time, not just at the gate. A
+# prod-affecting Terraform diff can otherwise sit dormant in `main` and ride in on an
+# unrelated merge (the #517/#533/#540 incident). Read-only and advisory: it never
+# applies anything and never blocks merge.
+#
+# Security: this is the deferred tradeoff from #542 — prod *read* creds load on PR
+# runs. Four mitigations bound it:
+#   1. Least-privilege read-only plan SA (#545): viewer + secretmanager.secretAccessor
+#      + storage.objectViewer — no write/apply/setIamPolicy. The write-capable
+#      GCP_PROD_SERVICE_ACCOUNT is never referenced here.
+#   2. `pull_request` (not `pull_request_target`) + the same-repo `if:` guard below —
+#      fork PRs get no secrets and the job is skipped outright.
+#   3. `paths:` filter — prod creds load ONLY when infra/terraform/** actually changes.
+#   4. `-lock=false` — the plan SA has no state-bucket write, so the identity stays
+#      strictly read-only.
+# Residual risk: a same-repo PR author could craft a malicious Terraform external data
+# source to exfiltrate prod secrets the plan SA can read during refresh — accepted for a
+# single-owner, required-review repo; the identical exposure already exists in
+# deploy.yml's plan-production on `main`.
+#
+# Advisory, never a required check: because the trigger is paths-filtered this check
+# does not run on non-infra PRs, so it must NOT be added to
+# .github/expected-required-checks.json (a path-filtered required check would block
+# every non-infra PR).
+#
+# Required GitHub repository secrets (already set; shared with deploy.yml plan-production):
+#   GCP_PROD_WORKLOAD_IDENTITY_PROVIDER
+#   GCP_PROD_PLAN_SERVICE_ACCOUNT   (#545 — read-only)
+#   TF_STATE_BUCKET
+#   GCP_BILLING_ACCOUNT
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'infra/terraform/**'
+
+# Cancel superseded plans for the same PR.
+concurrency:
+  group: prod-plan-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  TF_DIR: infra/terraform
+
+jobs:
+  plan-production-pr:
+    name: Plan (production)
+    runs-on: ubuntu-latest
+    # Same-repo guard: fork PRs never get prod creds (belt-and-suspenders on top of
+    # `pull_request` already withholding secrets from forks). Mirrors staging.yml.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write   # to post/update the plan comment
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Authenticate to GCP (production, read-only)
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_PROD_WORKLOAD_IDENTITY_PROVIDER }}
+          # Least-privilege read-only identity (#545) — see the security note in the
+          # workflow header. Never the write-capable GCP_PROD_SERVICE_ACCOUNT.
+          service_account: ${{ secrets.GCP_PROD_PLAN_SERVICE_ACCOUNT }}
+
+      - name: Terraform setup + init (production)
+        uses: ./.github/actions/tf-init   # #546 composite — init parity with plan-production
+        with:
+          workspace: production
+          state-bucket: ${{ secrets.TF_STATE_BUCKET }}
+
+      - name: Note setup/init failure for the PR comment
+        if: failure()
+        # If tf-init fails the plan step below is skipped, but the PR must still get an
+        # advisory comment (never a silently-absent one) — write its body here. tf-init
+        # still exits 1, so the job ends red; that is advisory only (not a required check).
+        run: |
+          {
+            echo "<!-- prod-plan-pr -->"
+            echo "## Production Terraform plan (read-only — review before merging)"
+            echo ""
+            echo ":warning: \`terraform setup/init (production)\` failed — no blast-radius summary is available for this PR."
+            echo "This is **advisory** and does **not** block merge. Inspect the \"Terraform setup + init (production)\" step log. Do not treat the absence of a diff as proof there are no prod changes — the gated \`plan-production\` job in the Deploy run (Layer A, #544) is the backstop before \`terraform apply\`."
+          } > "$RUNNER_TEMP/prod-plan-comment.md"
+
+      - name: Terraform plan (production)
+        working-directory: ${{ env.TF_DIR }}
+        # Read-only plan against the production workspace — identical command to
+        # deploy.yml's plan-production (#544). Bounded retry absorbs transient GCP 5xx
+        # during refresh. The add/change/destroy summary + resource addresses are written
+        # to a markdown file the next step posts as a PR comment. Never echoes a secret;
+        # -input=false avoids any prompt hang. -lock=false: the read-only plan SA (#545)
+        # cannot write the .tflock — safe here, a PR plan has no concurrent prod-state writer.
+        run: |
+          PLAN_OUT="$RUNNER_TEMP/prod-plan.txt"
+          COMMENT="$RUNNER_TEMP/prod-plan-comment.md"
+          PLANNED=0
+          for attempt in 1 2; do
+            if terraform plan -no-color -input=false -lock=false \
+                 -var-file=terraform.tfvars.production \
+                 -var="billing_account=${{ secrets.GCP_BILLING_ACCOUNT }}" \
+                 > "$PLAN_OUT" 2>&1; then
+              PLANNED=1
+              break
+            fi
+            if [ "${attempt}" -lt 2 ]; then
+              echo "Terraform plan attempt ${attempt} failed; retrying in 20s..."
+              sleep 20
+            fi
+          done
+
+          {
+            echo "<!-- prod-plan-pr -->"
+            echo "## Production Terraform plan (read-only — review before merging)"
+            echo ""
+          } > "$COMMENT"
+
+          if [ "$PLANNED" -ne 1 ]; then
+            {
+              echo ":warning: \`terraform plan (production)\` failed on both attempts — no blast-radius summary is available for this PR."
+              echo "This is **advisory** and does **not** block merge. Inspect the \"Terraform plan (production)\" step log. Do not treat the absence of a diff as proof there are no prod changes — the gated \`plan-production\` job in the Deploy run (Layer A, #544) is the backstop before \`terraform apply\`."
+            } >> "$COMMENT"
+            # Surface the tail for quick triage, then stop WITHOUT failing the job
+            # (advisory by design — the comment is still posted by the next step).
+            echo "::warning title=Prod plan unavailable::terraform plan (production) failed; this is advisory and does not block the PR."
+            tail -n 30 "$PLAN_OUT" || true
+            exit 0
+          fi
+
+          # `Plan: N to add, N to change, N to destroy.` — present only when the plan is
+          # non-empty; "No changes" otherwise.
+          SUMMARY_LINE=$(grep -E '^Plan: [0-9]+ to add' "$PLAN_OUT" | tail -n 1 || true)
+          {
+            if [ -n "$SUMMARY_LINE" ]; then
+              echo ":rotating_light: **${SUMMARY_LINE}**"
+              echo ""
+              echo "This PR's prod Terraform plan is **non-empty** — merging it makes these changes part of \`main\`, and approving the next \`production\` gate will \`terraform apply\` them to prod. A prod-affecting diff can ride in on an unrelated merge (the #542 / #517 incident). **Confirm every address below is intended before merging.**"
+              echo ""
+              echo "<details><summary>Resource addresses</summary>"
+              echo ""
+              echo '```'
+              grep -E '^  # ' "$PLAN_OUT" || echo "(plan reported changes but no resource-address lines were parsed — read the full step log)"
+              echo '```'
+              echo ""
+              echo "</details>"
+            else
+              echo ":white_check_mark: **No changes.** This PR does not change production Terraform state; merging applies no prod infra changes."
+            fi
+          } >> "$COMMENT"
+
+      - name: Post/update the prod plan PR comment
+        if: always()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const MARKER = '<!-- prod-plan-pr -->';
+            const commentPath = `${process.env.RUNNER_TEMP}/prod-plan-comment.md`;
+            let body;
+            try {
+              body = fs.readFileSync(commentPath, 'utf8');
+            } catch {
+              // No comment file means the job died before any plan/init step ran
+              // (e.g. checkout or GCP auth failed). Post a generic advisory so the PR
+              // is never left with a stale or missing prod-plan comment.
+              body = `${MARKER}\n## Production Terraform plan (read-only — review before merging)\n\n:warning: The prod-plan job failed before producing output. This is **advisory** and does **not** block merge — inspect the [workflow run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`;
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(MARKER));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/prod-plan-pr.yml
+++ b/.github/workflows/prod-plan-pr.yml
@@ -176,10 +176,15 @@ jobs:
               body = `${MARKER}\n## Production Terraform plan (read-only — review before merging)\n\n:warning: The prod-plan job failed before producing output. This is **advisory** and does **not** block merge — inspect the [workflow run](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`;
             }
 
-            const { data: comments } = await github.rest.issues.listComments({
+            // Paginate: listComments returns only the first 30 by default, so on a
+            // chatty PR (>30 comments) the sticky prod-plan comment could fall off
+            // page 1 and we'd stack a duplicate on every re-push instead of updating
+            // in place. github.paginate walks every page.
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
+              per_page: 100,
             });
             const existing = comments.find(c => c.body && c.body.includes(MARKER));
             if (existing) {

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -372,6 +372,20 @@ while `deploy-production` was skipped. If `plan-production` shows resources you 
 if it fails transiently the deploy is not blocked, but no summary is available — review the
 apply output during the gated deploy instead.)
 
+**See the prod plan one step earlier — on the PR (Layer B).** The
+[`prod-plan-pr.yml`](../.github/workflows/prod-plan-pr.yml) workflow runs the same read-only
+`terraform plan (production)` on every PR that touches `infra/terraform/**` and posts the
+`add/change/destroy` summary + resource addresses as a sticky PR comment, so the prod blast radius
+is visible at **review/merge time**, not just at the approval gate. It authenticates as the
+least-privilege read-only plan service account (`GCP_PROD_PLAN_SERVICE_ACCOUNT`, see
+[Step 5](#step-5--add-github-repository-secrets-and-variables) / [#545](https://github.com/brownm09/lifting-logbook/issues/545))
+— `terraform plan -lock=false`, never an apply — and only loads prod creds on same-repo PRs that
+change `infra/terraform/**` (`pull_request`, not `pull_request_target`; fork PRs are skipped). It is
+**advisory** — a non-empty plan does not block merge and is not a required check — but a reviewer who
+sees an unexpected prod resource address in the comment should **not merge** until they understand
+why. This is Layer B of [#542](https://github.com/brownm09/lifting-logbook/issues/542); `plan-production`
+above is the Layer A backstop at the gate.
+
 Once approved, `deploy-production` self-guards at two boundaries (issue
 [#490](https://github.com/brownm09/lifting-logbook/issues/490)):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2600,11 +2600,11 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.7.1.tgz",
-      "integrity": "sha512-2CeOUZJQ0aKZ51fdaoCEh8ffOC7KD5w9Q8HZXw0AnEWuxFiplyyhwDo/ixFWYueQULWOehjzRNR89YEQTwuY0w==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.8.0.tgz",
+      "integrity": "sha512-uZLyJNsRYnc8Ccx7IK/ZpUajRmb69khgwab3c24THK/oIyFs78wFlZ3rAKuC5K+BroggDOSUBwceXYJPUTCLLQ==",
       "dependencies": {
-        "@clerk/shared": "^4.18.0",
+        "@clerk/shared": "^4.19.0",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -2613,9 +2613,9 @@
       }
     },
     "node_modules/@clerk/backend/node_modules/@clerk/shared": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.18.0.tgz",
-      "integrity": "sha512-WHqnq1dUUjBFrrnptQEpRpoP3H2Pag00E2MP6+aHfJICNjqSSZU3NecOpcKeizYr77hFG38jqV9jcIyB5UpmBQ==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.19.0.tgz",
+      "integrity": "sha512-27tZG3/PAuuOQAKFpKGzFlio2FC/t/0TcSRl6UNlYap85BJRPnnYdo3PaVunNbKYKOpaFwJlwgcD2cKB7l/qWw==",
       "dependencies": {
         "@tanstack/query-core": "^5.100.6",
         "dequal": "2.0.3",


### PR DESCRIPTION
## Summary

Layer B of the #542 defense-in-depth fix ("a routine merge can silently execute a prod Terraform cutover behind a context-free approval"). **Layer A** (#544) surfaces the production `terraform plan` in the Deploy run **before the approval gate**; this PR surfaces it one step earlier — **on the PR itself, before merge** — so a reviewer sees the prod blast radius at review time, not just at the gate.

A new, narrowly-scoped workflow `.github/workflows/prod-plan-pr.yml`:

- Triggers on `pull_request` filtered to `paths: [infra/terraform/**]` — prod read creds load **only** when infra actually changes.
- Same-repo `if:` guard + `pull_request` (not `pull_request_target`) — fork PRs are skipped and get no secrets.
- Authenticates as the **least-privilege read-only plan SA** (`GCP_PROD_PLAN_SERVICE_ACCOUNT`, #545 — viewer + secretmanager.secretAccessor + storage.objectViewer, no write/apply), reuses the `tf-init` composite (#546), and runs deploy.yml's exact `-lock=false` plan command.
- Posts/updates a sticky PR comment (marker `<!-- prod-plan-pr -->`) with `Plan: N to add/change/destroy` + resource addresses, "no changes", or an advisory note on plan failure.
- **Advisory** — never blocks merge, never a required check (not added to `expected-required-checks.json`; a path-filtered required check would block every non-infra PR).

No new secrets, no new service account, no Terraform changes.

## Security note (the deferred #542 tradeoff)

Prod **read** creds now load on PR runs. Bounded by four mitigations: (1) least-privilege read-only SA; (2) same-repo guard + non-`pull_request_target`; (3) `paths:` filter; (4) `-lock=false` keeps the SA write-free. **Residual risk:** a same-repo PR author could craft a malicious Terraform external data source to exfiltrate prod secrets the plan SA can read during refresh — accepted for a single-owner, required-review repo; the identical exposure already exists in `plan-production` on `main`. Documented in the workflow header.

## Acceptance criteria

- [x] A PR touching a prod-affecting Terraform resource gets its prod plan diff posted as a PR comment before merge.
- [x] Prod read creds scoped to the read-only plan SA, loaded only on same-repo infra PRs.
- [x] Documented in `docs/deploy.md`, referencing the #542/#517 incident.

## Testing

`Tests: 647 passed, 70 skipped, 0 failed` across all workspaces (core 210, api 324, web 91, api-client 22; types/mobile have no tests).

- This change is **CI-config + docs only** (one new workflow YAML + 14 doc lines) — zero application/DB code, so per the project coverage table it is "Refactor / docs only — None required."
- The 70 skipped are the API DB-E2E suites, skipped via `LIFTING_SKIP_DB_E2E=1` — valid because the diff touches no DB code (no `apps/api/prisma/`, no repository changes). Cites #394.
- Initial `npm test` from the worktree hit `Error: spawn UNKNOWN` in jest-worker init (the documented Windows worktree native-spawn limitation); re-running each workspace with `--runInBand` produced the green results above.
- **Workflow validated** with `actionlint` (clean, exit 0 — includes shellcheck on the embedded bash) + YAML/JS parse checks, re-run clean after the pagination fix. The live end-to-end (a real `infra/terraform/**` PR exercising the prod-plan comment) runs on the next infra PR, since this PR touches only `.github/` and `docs/` and so does not self-trigger.

Suppression grep, test-integrity grep: both clean.

**Lockfile note (upstream in-range `@clerk` float).** Updating this branch with `main` (required before merge) re-ran CI's lockfile-sync check against the current registry, which had published `@clerk/backend` 3.8.0 and `@clerk/shared` 4.19.0 — both in range of the committed `^3.x` / `^4.x` carets — while the committed lockfile still pinned 3.7.1 / 4.18.0, so `npm ci` failed `EUSAGE` and the sync gate blocked the merge. **No `package.json` dependency was changed by this branch**; this is the documented upstream in-range float response (regenerate + commit; `npm ci` verified exit 0 locally on Node 20.11.1). The lockfile delta is `@clerk`-only, 7 insertions / 7 deletions (commit `70da7f9`).

## Review findings disposition

`/review` (claude-opus-4-8) — **0 blocking, 1 non-blocking**. Full review: https://github.com/brownm09/lifting-logbook/pull/558#issuecomment-4733089140

- **[reliability] Sticky-comment lookup not paginated** (`prod-plan-pr.yml` post step) — **fixed in 1b4cd2a**. `listComments` returned only the first 30 comments, so on a >30-comment PR the sticky prod-plan comment could fall off page 1 and a duplicate would be posted per re-push. Switched to `github.paginate(github.rest.issues.listComments, { ..., per_page: 100 })`. actionlint re-run clean.
- **[style] Auth-stage failure misattributed as "setup/init failed"** — **left as-is, intentional parity**. The wording is identical to deploy.yml's `plan-production` note step; diverging here would break the Layer A/Layer B mirror. Advisory intent (no summary; check logs) is preserved. Not a tracked finding.
- **[style] Outputs-only TF change reported as "No changes"** — **left as-is, intentional parity** with `plan-production`'s identical `^Plan:` parsing. Divergence from Layer A would be worse than the edge case.
- **Out-of-scope (filed):** the same latent `listComments` pagination bug exists in `staging.yml` — filed as #559 to keep this PR narrowly scoped.

Closes #556

