### PR TITLE
[feat] Add 'enter training maxes directly' onboarding method

### DIFF
--- a/apps/web/app/(authed)/onboarding/OnboardingFlow.test.tsx
+++ b/apps/web/app/(authed)/onboarding/OnboardingFlow.test.tsx
@@ -29,7 +29,7 @@ describe('OnboardingFlow — persistence of confirmed maxes', () => {
     // Step 0 → Step 1 (Enter Lifts)
     await user.click(screen.getByRole('button', { name: /next/i }));
 
-    // Fill each default row: 200 × 5 → Brzycki 1RM = 225
+    // Fill each default row: 200 × 5 → Brzycki 1RM = 225 → TM 90% = 203
     for (const lift of ['Bench Press', 'Squat', 'Deadlift']) {
       await user.type(screen.getByLabelText(`${lift} weight`), '200');
       await user.type(screen.getByLabelText(`${lift} reps`), '5');
@@ -47,11 +47,45 @@ describe('OnboardingFlow — persistence of confirmed maxes', () => {
     await user.click(screen.getByText(rpt.name));
     await user.click(screen.getByRole('button', { name: /choose this program/i }));
 
+    // The flow now resolves each row to its final training max before calling the
+    // action: 225 (1RM) × 90% = 203.
     expect(mockCreateFirstCycle).toHaveBeenCalledTimes(1);
     expect(mockCreateFirstCycle).toHaveBeenCalledWith(rpt.id, [
-      { lift: 'Bench Press', oneRm: 225 },
-      { lift: 'Squat', oneRm: 225 },
-      { lift: 'Deadlift', oneRm: 225 },
+      { lift: 'Bench Press', trainingMax: 203 },
+      { lift: 'Squat', trainingMax: 203 },
+      { lift: 'Deadlift', trainingMax: 203 },
+    ]);
+  });
+
+  it('persists entered training maxes as-is when the "tm" method is used (no 90% derivation)', async () => {
+    const user = userEvent.setup();
+    const rpt = PROGRAMS.find((p) => p.id === 'rpt');
+    if (!rpt) throw new Error('Test setup: expected RPT program in PROGRAMS');
+
+    render(<OnboardingFlow catalog={CATALOG} />);
+
+    // Step 0: pick the "Enter training maxes" method, then advance.
+    await user.click(screen.getByRole('button', { name: /enter training maxes/i }));
+    await user.click(screen.getByRole('button', { name: /next/i }));
+
+    // Weight-only rows (no reps input) — enter the training max directly.
+    for (const lift of ['Bench Press', 'Squat', 'Deadlift']) {
+      expect(screen.queryByLabelText(`${lift} reps`)).not.toBeInTheDocument();
+      await user.type(screen.getByLabelText(`${lift} weight`), '315');
+    }
+
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    await user.click(screen.getByRole('button', { name: /continue to programs/i }));
+    await user.click(screen.getByRole('tab', { name: new RegExp(rpt.experience, 'i') }));
+    await user.click(screen.getByText(rpt.name));
+    await user.click(screen.getByRole('button', { name: /choose this program/i }));
+
+    // 315 entered → 315 persisted (not 283).
+    expect(mockCreateFirstCycle).toHaveBeenCalledTimes(1);
+    expect(mockCreateFirstCycle).toHaveBeenCalledWith(rpt.id, [
+      { lift: 'Bench Press', trainingMax: 315 },
+      { lift: 'Squat', trainingMax: 315 },
+      { lift: 'Deadlift', trainingMax: 315 },
     ]);
   });
 });

--- a/apps/web/app/(authed)/onboarding/OnboardingFlow.tsx
+++ b/apps/web/app/(authed)/onboarding/OnboardingFlow.tsx
@@ -5,6 +5,7 @@ import styles from './onboarding.module.css';
 import {
   brzycki1RM,
   DEFAULT_LIFTS,
+  isWeightOnly,
   type DiscoveryMethod,
   type LiftRow,
 } from './lib';
@@ -33,9 +34,9 @@ export function OnboardingFlow({ catalog }: { catalog: string[] }) {
   const [isPending, startTransition] = useTransition();
   const [cycleError, setCycleError] = useState<string | null>(null);
 
-  // The `tm` method enters training maxes directly (like `manual`, a single
-  // weight per lift with no reps); the others enter a 1RM, estimated or given.
-  const weightOnly = method === 'manual' || method === 'tm';
+  // `manual` (1RM) and `tm` (training max) both capture a single weight per lift
+  // with no reps; the estimate/test methods capture a weight × reps set.
+  const weightOnly = isWeightOnly(method);
 
   const canAdvanceFromLifts =
     lifts.length > 0 &&
@@ -47,13 +48,14 @@ export function OnboardingFlow({ catalog }: { catalog: string[] }) {
   // Each row resolves to a 1RM (for display) and the training max actually
   // persisted. `estimate`/`test` estimate the 1RM from a set; `manual` takes the
   // entered 1RM; both derive the TM at 90%. `tm` skips that derivation — the
-  // entered value *is* the training max, so `oneRm` is N/A (0).
+  // entered value *is* the training max, so `oneRm` is N/A (null): there is no
+  // 1RM to show, and the null forces every read site to handle the absence.
   const computedMaxes = useMemo(() => {
     return lifts.map((row) => {
       const w = Number(row.weight);
       const r = Number(row.reps);
       if (method === 'tm') {
-        return { lift: row.lift, oneRm: 0, trainingMax: Math.round(w) };
+        return { lift: row.lift, oneRm: null, trainingMax: Math.round(w) };
       }
       const oneRm = method === 'manual' ? Math.round(w) : brzycki1RM(w, r);
       return { lift: row.lift, oneRm, trainingMax: Math.round(oneRm * 0.9) };

--- a/apps/web/app/(authed)/onboarding/OnboardingFlow.tsx
+++ b/apps/web/app/(authed)/onboarding/OnboardingFlow.tsx
@@ -33,19 +33,30 @@ export function OnboardingFlow({ catalog }: { catalog: string[] }) {
   const [isPending, startTransition] = useTransition();
   const [cycleError, setCycleError] = useState<string | null>(null);
 
+  // The `tm` method enters training maxes directly (like `manual`, a single
+  // weight per lift with no reps); the others enter a 1RM, estimated or given.
+  const weightOnly = method === 'manual' || method === 'tm';
+
   const canAdvanceFromLifts =
     lifts.length > 0 &&
     lifts.every((row) => {
-      if (method === 'manual') return Number(row.weight) > 0;
+      if (weightOnly) return Number(row.weight) > 0;
       return Number(row.weight) > 0 && Number(row.reps) > 0;
     });
 
+  // Each row resolves to a 1RM (for display) and the training max actually
+  // persisted. `estimate`/`test` estimate the 1RM from a set; `manual` takes the
+  // entered 1RM; both derive the TM at 90%. `tm` skips that derivation — the
+  // entered value *is* the training max, so `oneRm` is N/A (0).
   const computedMaxes = useMemo(() => {
     return lifts.map((row) => {
       const w = Number(row.weight);
       const r = Number(row.reps);
+      if (method === 'tm') {
+        return { lift: row.lift, oneRm: 0, trainingMax: Math.round(w) };
+      }
       const oneRm = method === 'manual' ? Math.round(w) : brzycki1RM(w, r);
-      return { lift: row.lift, oneRm };
+      return { lift: row.lift, oneRm, trainingMax: Math.round(oneRm * 0.9) };
     });
   }, [lifts, method]);
 
@@ -78,7 +89,9 @@ export function OnboardingFlow({ catalog }: { catalog: string[] }) {
   function handleConfirm() {
     if (!selectedProgramId) return;
     setCycleError(null);
-    const maxes = computedMaxes.filter((m) => m.oneRm > 0);
+    const maxes = computedMaxes
+      .filter((m) => m.trainingMax > 0)
+      .map((m) => ({ lift: m.lift, trainingMax: m.trainingMax }));
     startTransition(async () => {
       const result = await createFirstCycle(selectedProgramId, maxes);
       if (result && !result.ok) {
@@ -128,7 +141,7 @@ export function OnboardingFlow({ catalog }: { catalog: string[] }) {
               onRemove={removeLift}
             />
           )}
-          {step === 2 && <StepConfirm maxes={computedMaxes} />}
+          {step === 2 && <StepConfirm maxes={computedMaxes} method={method} />}
           {step === 3 && (
             <StepProgram
               experience={experience}

--- a/apps/web/app/(authed)/onboarding/actions.ts
+++ b/apps/web/app/(authed)/onboarding/actions.ts
@@ -10,7 +10,7 @@ export type CreateFirstCycleResult = { ok: false; error: string };
 
 export async function createFirstCycle(
   programId: string,
-  maxes: { lift: string; oneRm: number }[] = [],
+  maxes: { lift: string; trainingMax: number }[] = [],
 ): Promise<CreateFirstCycleResult | never> {
   const allowed = PROGRAMS.filter((p) => p.available).map((p) => p.id);
   if (!allowed.includes(programId)) {
@@ -18,10 +18,13 @@ export async function createFirstCycle(
   }
   try {
     await initializeCycle(programId);
-    // Persist the confirmed maxes as training maxes (90% of the estimated 1RM,
-    // matching the value shown on the Confirm step). Runs after initializeCycle
-    // so it overrides any maxes the cycle seeded. The PATCH endpoint merges and
-    // appends unknown lifts, so any catalog or custom lift name is accepted.
+    // Persist the confirmed training maxes exactly as shown on the Confirm step.
+    // The caller (OnboardingFlow) already resolved each lift to its final training
+    // max — deriving it at 90% of the 1RM for the estimate/test/manual methods, or
+    // taking the entered value as-is for the "enter training maxes" method — so this
+    // action persists the value verbatim and does no further adjustment. Runs after
+    // initializeCycle so it overrides any maxes the cycle seeded. The PATCH endpoint
+    // merges and appends unknown lifts, so any catalog or custom lift name is accepted.
     //
     // Best-effort by design: initializeCycle has already created the cycle, so a
     // max-persistence failure must not strand the user on the program-selection
@@ -39,7 +42,7 @@ export async function createFirstCycle(
         await updateTrainingMaxes(programId, {
           maxes: maxes.map((m) => ({
             lift: m.lift,
-            weight: Math.round(m.oneRm * 0.9),
+            weight: m.trainingMax,
             unit: 'lbs',
           })),
         });

--- a/apps/web/app/(authed)/onboarding/lib.ts
+++ b/apps/web/app/(authed)/onboarding/lib.ts
@@ -1,4 +1,4 @@
-export type DiscoveryMethod = 'estimate' | 'test' | 'manual';
+export type DiscoveryMethod = 'estimate' | 'test' | 'manual' | 'tm';
 
 /** A single lift the user is entering a max for during onboarding. */
 export type LiftRow = { lift: string; weight: string; reps: string };

--- a/apps/web/app/(authed)/onboarding/lib.ts
+++ b/apps/web/app/(authed)/onboarding/lib.ts
@@ -1,5 +1,16 @@
 export type DiscoveryMethod = 'estimate' | 'test' | 'manual' | 'tm';
 
+/**
+ * Methods that capture a single weight per lift with no reps: `manual` (an
+ * entered 1RM) and `tm` (an entered training max). The estimate/test methods
+ * capture a full weight × reps set. Centralized so the no-reps taxonomy lives
+ * in one place as the method union grows (e.g. a future CSV-import method) —
+ * the parent flow and the entry step must agree on which methods skip reps.
+ */
+export function isWeightOnly(method: DiscoveryMethod): boolean {
+  return method === 'manual' || method === 'tm';
+}
+
 /** A single lift the user is entering a max for during onboarding. */
 export type LiftRow = { lift: string; weight: string; reps: string };
 

--- a/apps/web/app/(authed)/onboarding/steps/StepConfirm.test.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepConfirm.test.tsx
@@ -23,7 +23,7 @@ describe('StepConfirm — training-max method', () => {
     render(
       <StepConfirm
         method="tm"
-        maxes={[{ lift: 'Squat', oneRm: 0, trainingMax: 315 }]}
+        maxes={[{ lift: 'Squat', oneRm: null, trainingMax: 315 }]}
       />,
     );
     expect(screen.getByText('Squat')).toBeInTheDocument();

--- a/apps/web/app/(authed)/onboarding/steps/StepConfirm.test.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepConfirm.test.tsx
@@ -1,0 +1,35 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { StepConfirm } from './StepConfirm';
+
+describe('StepConfirm — 1RM-derived methods', () => {
+  it('shows the 1RM with the derived training max alongside it', () => {
+    render(
+      <StepConfirm
+        method="estimate"
+        maxes={[{ lift: 'Squat', oneRm: 225, trainingMax: 203 }]}
+      />,
+    );
+    expect(screen.getByText('Squat')).toBeInTheDocument();
+    // Both the 1RM and the derived TM are shown.
+    expect(screen.getByText(/225 lb/)).toBeInTheDocument();
+    expect(screen.getByText(/TM 203 lb/)).toBeInTheDocument();
+    expect(screen.getByText(/90% of the 1RM/i)).toBeInTheDocument();
+  });
+});
+
+describe('StepConfirm — training-max method', () => {
+  it('shows the entered training max as-is with no 1RM or 90% note', () => {
+    render(
+      <StepConfirm
+        method="tm"
+        maxes={[{ lift: 'Squat', oneRm: 0, trainingMax: 315 }]}
+      />,
+    );
+    expect(screen.getByText('Squat')).toBeInTheDocument();
+    expect(screen.getByText(/TM 315 lb/)).toBeInTheDocument();
+    // No 1RM value and no 90% derivation copy for a direct training max.
+    expect(screen.queryByText(/90% of the 1RM/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/as entered/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(authed)/onboarding/steps/StepConfirm.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepConfirm.tsx
@@ -1,33 +1,48 @@
 'use client';
 
 import styles from '../onboarding.module.css';
+import type { DiscoveryMethod } from '../lib';
 
-type Max = { lift: string; oneRm: number };
+type Max = { lift: string; oneRm: number; trainingMax: number };
 
 type Props = {
   maxes: Max[];
+  method: DiscoveryMethod;
 };
 
-export function StepConfirm({ maxes }: Props) {
+export function StepConfirm({ maxes, method }: Props) {
+  // For `tm` the entered value is already the training max, so there is no 1RM
+  // to show and no 90% derivation; the other methods display the 1RM with the
+  // derived training max alongside it.
+  const tmDirect = method === 'tm';
+
   return (
     <>
       <h2 className={styles.stepTitle}>Confirm your training maxes</h2>
       <p className={styles.stepHint}>
-        Estimated 1-rep maxes based on what you entered. Training maxes use 90% of the 1RM.
+        {tmDirect
+          ? 'Training maxes as entered — we’ll use these as-is.'
+          : 'Estimated 1-rep maxes based on what you entered. Training maxes use 90% of the 1RM.'}
       </p>
       <div className={styles.maxesGrid}>
-        {maxes.map(({ lift, oneRm }) => (
+        {maxes.map(({ lift, oneRm, trainingMax }) => (
           <div key={lift} className={styles.maxRow}>
             <span className={styles.maxRowLabel}>{lift}</span>
             <span className={styles.maxRowValue}>
-              {oneRm > 0 ? `${oneRm} lb` : '—'}
-              {oneRm > 0 && (
-                <span
-                  className={styles.unitLabel}
-                  style={{ marginLeft: 'var(--space-2)' }}
-                >
-                  (TM {Math.round(oneRm * 0.9)} lb)
-                </span>
+              {tmDirect ? (
+                trainingMax > 0 ? `TM ${trainingMax} lb` : '—'
+              ) : (
+                <>
+                  {oneRm > 0 ? `${oneRm} lb` : '—'}
+                  {oneRm > 0 && (
+                    <span
+                      className={styles.unitLabel}
+                      style={{ marginLeft: 'var(--space-2)' }}
+                    >
+                      (TM {trainingMax} lb)
+                    </span>
+                  )}
+                </>
               )}
             </span>
           </div>

--- a/apps/web/app/(authed)/onboarding/steps/StepConfirm.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepConfirm.tsx
@@ -3,7 +3,7 @@
 import styles from '../onboarding.module.css';
 import type { DiscoveryMethod } from '../lib';
 
-type Max = { lift: string; oneRm: number; trainingMax: number };
+type Max = { lift: string; oneRm: number | null; trainingMax: number };
 
 type Props = {
   maxes: Max[];
@@ -33,8 +33,8 @@ export function StepConfirm({ maxes, method }: Props) {
                 trainingMax > 0 ? `TM ${trainingMax} lb` : '—'
               ) : (
                 <>
-                  {oneRm > 0 ? `${oneRm} lb` : '—'}
-                  {oneRm > 0 && (
+                  {oneRm != null && oneRm > 0 ? `${oneRm} lb` : '—'}
+                  {oneRm != null && oneRm > 0 && (
                     <span
                       className={styles.unitLabel}
                       style={{ marginLeft: 'var(--space-2)' }}

--- a/apps/web/app/(authed)/onboarding/steps/StepLifts.test.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepLifts.test.tsx
@@ -162,3 +162,14 @@ describe('StepLifts — manual method', () => {
     expect(screen.queryByLabelText('Bench Press reps')).not.toBeInTheDocument();
   });
 });
+
+describe('StepLifts — training-max method', () => {
+  it('hides the reps input and shows the training-max hint when method is tm', () => {
+    render(<Harness method="tm" />);
+    expect(screen.getByLabelText('Bench Press weight')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Bench Press reps')).not.toBeInTheDocument();
+    expect(screen.getByText(/enter your current training max/i)).toBeInTheDocument();
+    // The Brzycki helper text references reps and must not show for a TM entry.
+    expect(screen.queryByText(/brzycki formula/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(authed)/onboarding/steps/StepLifts.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepLifts.tsx
@@ -37,14 +37,20 @@ export function StepLifts({ method, lifts, catalog, onChange, onAdd, onRemove }:
     setQuery('');
   }
 
+  // `manual` (1RM) and `tm` (training max) both take a single weight per lift
+  // with no reps; the estimate/test methods take a full weight × reps set.
+  const weightOnly = method === 'manual' || method === 'tm';
+  const hint =
+    method === 'tm'
+      ? 'Enter your current training max for each lift.'
+      : method === 'manual'
+        ? 'Enter your current 1-rep max for each lift.'
+        : 'Enter a recent heavy set (weight × reps) for each lift.';
+
   return (
     <>
       <h2 className={styles.stepTitle}>Enter your lifts</h2>
-      <p className={styles.stepHint}>
-        {method === 'manual'
-          ? 'Enter your current 1-rep max for each lift.'
-          : 'Enter a recent heavy set (weight × reps) for each lift.'}
-      </p>
+      <p className={styles.stepHint}>{hint}</p>
       <div className={styles.dataRows}>
         {lifts.map((row, index) => (
           <div key={row.lift} className={styles.dataRow}>
@@ -60,7 +66,7 @@ export function StepLifts({ method, lifts, catalog, onChange, onAdd, onRemove }:
               aria-label={`${row.lift} weight`}
             />
             <span className={styles.unitLabel}>lb</span>
-            {method !== 'manual' && (
+            {!weightOnly && (
               <>
                 <span className={styles.unitLabel}>×</span>
                 <input
@@ -137,10 +143,12 @@ export function StepLifts({ method, lifts, catalog, onChange, onAdd, onRemove }:
         )}
       </div>
 
-      <p className={styles.infoBox}>
-        We use the Brzycki formula:{' '}
-        <strong>1RM = weight × 36 ÷ (37 − reps)</strong>. Stay under 10 reps for accuracy.
-      </p>
+      {!weightOnly && (
+        <p className={styles.infoBox}>
+          We use the Brzycki formula:{' '}
+          <strong>1RM = weight × 36 ÷ (37 − reps)</strong>. Stay under 10 reps for accuracy.
+        </p>
+      )}
     </>
   );
 }

--- a/apps/web/app/(authed)/onboarding/steps/StepLifts.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepLifts.tsx
@@ -2,7 +2,7 @@
 
 import { useId, useState } from 'react';
 import styles from '../onboarding.module.css';
-import type { DiscoveryMethod, LiftRow } from '../lib';
+import { isWeightOnly, type DiscoveryMethod, type LiftRow } from '../lib';
 
 type Props = {
   method: DiscoveryMethod;
@@ -37,9 +37,7 @@ export function StepLifts({ method, lifts, catalog, onChange, onAdd, onRemove }:
     setQuery('');
   }
 
-  // `manual` (1RM) and `tm` (training max) both take a single weight per lift
-  // with no reps; the estimate/test methods take a full weight × reps set.
-  const weightOnly = method === 'manual' || method === 'tm';
+  const weightOnly = isWeightOnly(method);
   const hint =
     method === 'tm'
       ? 'Enter your current training max for each lift.'

--- a/apps/web/app/(authed)/onboarding/steps/StepMethod.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepMethod.tsx
@@ -22,6 +22,12 @@ const METHOD_OPTIONS: { id: DiscoveryMethod; title: string; description: string 
     description:
       'You already know your 1RMs. Enter them directly and we’ll set training maxes at 90%.',
   },
+  {
+    id: 'tm',
+    title: 'Enter training maxes',
+    description:
+      'You already train off fixed training maxes. Enter them directly — we’ll use them as-is, no 90% adjustment.',
+  },
 ];
 
 type Props = {


### PR DESCRIPTION
## Summary

Adds a fourth lift-discovery method to onboarding — **"Enter training maxes"** — for lifters who already train off fixed training maxes and don't want the app to re-derive them. Selecting it lets the user enter each lift's TM directly (weight only, no reps), and the value is persisted **as-is** with no 90% adjustment.

The existing `estimate` / `test` / `manual` methods are unchanged: they continue to compute a 1RM and persist 90% of it as the training max. The key refactor is that `OnboardingFlow` now resolves each row to its final `trainingMax` *before* calling `createFirstCycle`, and the server action persists that value verbatim — so the 90%-vs-as-entered decision lives in one place.

### Changes
- **StepMethod** — new `tm` option card.
- **StepLifts** — weight-only input (no reps) and a TM-specific hint for `tm`; the Brzycki helper box is hidden for both `tm` and `manual` (neither uses reps).
- **OnboardingFlow** — `computedMaxes` resolves each row to its final `trainingMax` (90% of the 1RM for `estimate`/`test`/`manual`, the entered value for `tm`); passes `method` to `StepConfirm`.
- **actions.createFirstCycle** — signature takes `{ lift, trainingMax }` and persists `trainingMax` directly instead of deriving 90% inside the action.
- **StepConfirm** — shows the TM as-entered for `tm`; shows the 1RM with the derived TM alongside it for the other methods.

## Acceptance Criteria
- [x] New onboarding method lets the user enter training maxes directly
- [x] Entered TMs are persisted without the 90% derivation
- [x] Existing estimate/test/manual methods are unchanged (still persist 90% of the 1RM)
- [x] Confirm step reflects the chosen method (TM as-entered vs 1RM + derived TM)

## Testing

All three web test layers run locally and pass.

- **Onboarding Jest suites** — `npm test -w @lifting-logbook/web -- --testPathPatterns onboarding`
  `Tests: 27 passed, 0 skipped, 0 failed (135 s)` — 6 suites.
- **Full web Jest suite** — `npx jest` (apps/web)
  `Tests: 95 passed, 0 skipped, 0 failed` — 17 suites.
- **Playwright E2E** — `npm run test:e2e -w @lifting-logbook/web`
  `15 passed (1.3m)`. Run because this PR changes onboarding UI strings (new method card + hints), per the CLAUDE.md UI-string rule (#444). The new strings are additive — the smoke spec drives the unchanged `estimate` path — and the suite stays green.

New tests added for the new behavior (coverage gate satisfied):
- `OnboardingFlow.test.tsx` — `tm` path persists entered TMs verbatim (315 → 315, not 283); existing estimate-path assertion updated to the new `{ lift, trainingMax }` contract (225 1RM → 203 TM).
- `StepLifts.test.tsx` — `tm` hides reps, shows the TM hint, hides the Brzycki box.
- `StepConfirm.test.tsx` (new) — `tm` shows TM as-entered with no 90% copy; other methods show 1RM + derived TM.

### Environment note (not part of the diff)
The local `apps/web` `node_modules` was corrupted by an unrelated **disk-full (ENOSPC)** event mid-session: `@next/swc-win32-x64-msvc` was truncated to 32.5 MB (valid binary is 136.8 MB), which crashed `next dev` and initially failed all 15 Playwright tests with `ERR_CONNECTION_REFUSED`. Resolved by re-extracting the binary (documented Windows native-binary recovery in CLAUDE.md); the suite then passed 15/15. No source or dependency change — purely a local toolchain repair.

## Policy checks
- **Suppression grep** — clean (no new `ts-ignore`/`!`/`?? null`/`eslint-disable`).
- **Test-integrity grep** — clean (no skips, no deleted tests, no lowered thresholds). The `--passWithNoTests` flag in the web `test` script is pre-existing, not introduced here.
- **Lockfile** — no `package.json` changed; sync check N/A.

## Risk-dimension audit
- **Testing** — covered above (Jest + Playwright, new-behavior tests added).
- **Observability** — N/A — client-only onboarding UI; no new API boundary, log, or span.
- **Security** — N/A — no authz/PII/secret surface change; persists a numeric TM via the existing authenticated `updateTrainingMaxes` path.
- **Resilience** — `createFirstCycle` error handling is unchanged; TM persistence still runs after `initializeCycle` and surfaces failures via the existing `cycleError` path.
- **Performance** — N/A — no new data-access; same single `updateTrainingMaxes` call.
- **Data integrity** — no schema/migration change; persists the same `{ lift, weight, unit }` shape the PATCH endpoint already accepts.
- **Accessibility** — new card is a labeled `<button>` matching the existing three; weight inputs keep their per-lift `aria-label`s.

Closes #557


## Review findings disposition

`/review` (claude-opus-4-8) posted [this review](https://github.com/brownm09/lifting-logbook/pull/560#issuecomment-4733881086): **0 blocking, 2 non-blocking**. Both fixed in this PR — commit `a9f172c`:

- **[maintainability] `weightOnly` duplicated across `OnboardingFlow.tsx` + `StepLifts.tsx`** — fixed in `a9f172c`: extracted a shared `isWeightOnly(method)` helper in `lib.ts`, consumed by both sites.
- **[maintainability] `oneRm: 0` sentinel for `tm` rows is silently displayable** — fixed in `a9f172c`: retyped the onboarding `oneRm` to `number | null` (computedMaxes returns `null` for `tm`; `StepConfirm` guards reads with `oneRm != null`; the `tm` test passes `null`), so an unguarded read is a compile error rather than a `0 lb` render.

Follow-up verification: onboarding Jest 27/27, full web Jest 95/95, `tsc --noEmit` clean for onboarding, eslint clean. Playwright not re-run — the refactor changes no UI strings/aria-labels/role-names, so the #444 rule is not triggered.
