### PR TITLE
[feat] Embed Smart Import (training-maxes CSV) in onboarding

### DIFF
--- a/apps/web/app/(authed)/onboarding/OnboardingFlow.test.tsx
+++ b/apps/web/app/(authed)/onboarding/OnboardingFlow.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { OnboardingFlow } from './OnboardingFlow';
 import { PROGRAMS } from '@/lib/programs';
@@ -86,6 +86,47 @@ describe('OnboardingFlow — persistence of confirmed maxes', () => {
       { lift: 'Bench Press', trainingMax: 315 },
       { lift: 'Squat', trainingMax: 315 },
       { lift: 'Deadlift', trainingMax: 315 },
+    ]);
+  });
+
+  it('persists imported training maxes as-is when the "import" method is used (no 90% derivation)', async () => {
+    const user = userEvent.setup();
+    const rpt = PROGRAMS.find((p) => p.id === 'rpt');
+    if (!rpt) throw new Error('Test setup: expected RPT program in PROGRAMS');
+
+    render(<OnboardingFlow catalog={CATALOG} />);
+
+    // Step 0: pick "Import from a file", then advance to the import step.
+    await user.click(screen.getByRole('button', { name: /import from a file/i }));
+    await user.click(screen.getByRole('button', { name: /next/i }));
+
+    // Upload a training-maxes CSV — Squat has history, so the latest (315) wins.
+    const csv = [
+      'Date Updated,Lift,Weight',
+      '2026-01-01,Squat,300',
+      '2026-02-01,Squat,315',
+      '2026-01-01,Bench Press,225',
+    ].join('\n');
+    await user.upload(
+      screen.getByLabelText(/training-maxes csv/i),
+      new File([csv], 'maxes.csv', { type: 'text/csv' }),
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/loaded 2 training maxes/i)).toBeInTheDocument(),
+    );
+
+    // Step 1 → Step 2 (Confirm) → Step 3 (Programs)
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    await user.click(screen.getByRole('button', { name: /continue to programs/i }));
+    await user.click(screen.getByRole('tab', { name: new RegExp(rpt.experience, 'i') }));
+    await user.click(screen.getByText(rpt.name));
+    await user.click(screen.getByRole('button', { name: /choose this program/i }));
+
+    // Imported TMs persist verbatim (latest per lift), no 90% derivation.
+    expect(mockCreateFirstCycle).toHaveBeenCalledTimes(1);
+    expect(mockCreateFirstCycle).toHaveBeenCalledWith(rpt.id, [
+      { lift: 'Squat', trainingMax: 315 },
+      { lift: 'Bench Press', trainingMax: 225 },
     ]);
   });
 });

--- a/apps/web/app/(authed)/onboarding/OnboardingFlow.tsx
+++ b/apps/web/app/(authed)/onboarding/OnboardingFlow.tsx
@@ -6,12 +6,14 @@ import {
   brzycki1RM,
   DEFAULT_LIFTS,
   isWeightOnly,
+  valuesAreTrainingMax,
   type DiscoveryMethod,
   type LiftRow,
 } from './lib';
 import type { Experience } from '@/lib/programs';
 import { StepMethod } from './steps/StepMethod';
 import { StepLifts } from './steps/StepLifts';
+import { StepImport } from './steps/StepImport';
 import { StepConfirm } from './steps/StepConfirm';
 import { StepProgram } from './steps/StepProgram';
 import { createFirstCycle } from './actions';
@@ -47,14 +49,15 @@ export function OnboardingFlow({ catalog }: { catalog: string[] }) {
 
   // Each row resolves to a 1RM (for display) and the training max actually
   // persisted. `estimate`/`test` estimate the 1RM from a set; `manual` takes the
-  // entered 1RM; both derive the TM at 90%. `tm` skips that derivation — the
-  // entered value *is* the training max, so `oneRm` is N/A (null): there is no
-  // 1RM to show, and the null forces every read site to handle the absence.
+  // entered 1RM; all three derive the TM at 90%. `tm`/`import` skip that
+  // derivation — the entered/imported value *is* the training max, so `oneRm` is
+  // N/A (null): there is no 1RM to show, and the null forces every read site to
+  // handle the absence.
   const computedMaxes = useMemo(() => {
     return lifts.map((row) => {
       const w = Number(row.weight);
       const r = Number(row.reps);
-      if (method === 'tm') {
+      if (valuesAreTrainingMax(method)) {
         return { lift: row.lift, oneRm: null, trainingMax: Math.round(w) };
       }
       const oneRm = method === 'manual' ? Math.round(w) : brzycki1RM(w, r);
@@ -78,6 +81,13 @@ export function OnboardingFlow({ catalog }: { catalog: string[] }) {
 
   function removeLift(index: number) {
     setLifts((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  // The `import` method pre-fills the lift rows from a training-maxes CSV
+  // (one row per lift, weight = the training max, no reps). Replacing `lifts`
+  // enables the advance gate (every weight > 0) so the user continues to Confirm.
+  function handleImported(rows: LiftRow[]) {
+    setLifts(rows);
   }
 
   function goNext() {
@@ -133,16 +143,19 @@ export function OnboardingFlow({ catalog }: { catalog: string[] }) {
 
         <section className={styles.body}>
           {step === 0 && <StepMethod method={method} onSelect={setMethod} />}
-          {step === 1 && (
-            <StepLifts
-              method={method}
-              lifts={lifts}
-              catalog={catalog}
-              onChange={updateLift}
-              onAdd={addLift}
-              onRemove={removeLift}
-            />
-          )}
+          {step === 1 &&
+            (method === 'import' ? (
+              <StepImport onImported={handleImported} />
+            ) : (
+              <StepLifts
+                method={method}
+                lifts={lifts}
+                catalog={catalog}
+                onChange={updateLift}
+                onAdd={addLift}
+                onRemove={removeLift}
+              />
+            ))}
           {step === 2 && <StepConfirm maxes={computedMaxes} method={method} />}
           {step === 3 && (
             <StepProgram

--- a/apps/web/app/(authed)/onboarding/lib.ts
+++ b/apps/web/app/(authed)/onboarding/lib.ts
@@ -1,14 +1,27 @@
-export type DiscoveryMethod = 'estimate' | 'test' | 'manual' | 'tm';
+export type DiscoveryMethod = 'estimate' | 'test' | 'manual' | 'tm' | 'import';
 
 /**
  * Methods that capture a single weight per lift with no reps: `manual` (an
- * entered 1RM) and `tm` (an entered training max). The estimate/test methods
- * capture a full weight × reps set. Centralized so the no-reps taxonomy lives
- * in one place as the method union grows (e.g. a future CSV-import method) —
- * the parent flow and the entry step must agree on which methods skip reps.
+ * entered 1RM), `tm` (an entered training max), and `import` (training maxes
+ * loaded from a CSV). The estimate/test methods capture a full weight × reps
+ * set. Centralized so the no-reps taxonomy lives in one place — the parent flow
+ * (advance gate) and the entry steps must agree on which methods skip reps.
+ * `import` never renders StepLifts, but the advance gate still uses this to
+ * require only a weight per row once the file has pre-filled them.
  */
 export function isWeightOnly(method: DiscoveryMethod): boolean {
-  return method === 'manual' || method === 'tm';
+  return method === 'manual' || method === 'tm' || method === 'import';
+}
+
+/**
+ * Methods whose entered/imported weight *is* the training max and is persisted
+ * as-is, with no 90%-of-1RM derivation: `tm` (typed directly) and `import`
+ * (loaded from a training-maxes CSV). `estimate`/`test`/`manual` instead yield
+ * a 1RM from which the training max is derived at 90%. Distinct from
+ * {@link isWeightOnly}: `manual` is weight-only but is a 1RM, not a training max.
+ */
+export function valuesAreTrainingMax(method: DiscoveryMethod): boolean {
+  return method === 'tm' || method === 'import';
 }
 
 /** A single lift the user is entering a max for during onboarding. */

--- a/apps/web/app/(authed)/onboarding/onboarding.module.css
+++ b/apps/web/app/(authed)/onboarding/onboarding.module.css
@@ -90,6 +90,14 @@
   color: var(--color-text);
 }
 
+/* Error variant of .infoBox — applied alongside it so a failure reads as an
+   error at a glance, not just by its text (the success summary uses .infoBox
+   alone). role="alert" handles assistive tech; this is the visual cue. */
+.infoBoxError {
+  border-left-color: var(--color-error, #dc2626);
+  color: var(--color-error-text);
+}
+
 .optionList {
   display: flex;
   flex-direction: column;

--- a/apps/web/app/(authed)/onboarding/steps/StepConfirm.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepConfirm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import styles from '../onboarding.module.css';
-import type { DiscoveryMethod } from '../lib';
+import { valuesAreTrainingMax, type DiscoveryMethod } from '../lib';
 
 type Max = { lift: string; oneRm: number | null; trainingMax: number };
 
@@ -11,10 +11,10 @@ type Props = {
 };
 
 export function StepConfirm({ maxes, method }: Props) {
-  // For `tm` the entered value is already the training max, so there is no 1RM
+  // For `tm`/`import` the value is already the training max, so there is no 1RM
   // to show and no 90% derivation; the other methods display the 1RM with the
   // derived training max alongside it.
-  const tmDirect = method === 'tm';
+  const tmDirect = valuesAreTrainingMax(method);
 
   return (
     <>

--- a/apps/web/app/(authed)/onboarding/steps/StepImport.test.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepImport.test.tsx
@@ -1,0 +1,71 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StepImport } from './StepImport';
+
+function csvFile(content: string, name = 'maxes.csv') {
+  return new File([content], name, { type: 'text/csv' });
+}
+
+describe('StepImport', () => {
+  it('parses a training-maxes CSV and pre-fills the latest training max per lift', async () => {
+    const user = userEvent.setup();
+    const onImported = jest.fn();
+    render(<StepImport onImported={onImported} />);
+
+    const csv = [
+      'Date Updated,Lift,Weight',
+      '2026-01-01,Squat,300',
+      '2026-02-01,Squat,315', // newer date for Squat → this one wins
+      '2026-01-01,Bench Press,225',
+    ].join('\n');
+
+    await user.upload(screen.getByLabelText(/training-maxes csv/i), csvFile(csv));
+
+    await waitFor(() => expect(onImported).toHaveBeenCalledTimes(1));
+    // One row per lift, latest TM, no reps; persisted later as the training max.
+    expect(onImported).toHaveBeenCalledWith([
+      { lift: 'Squat', weight: '315', reps: '' },
+      { lift: 'Bench Press', weight: '225', reps: '' },
+    ]);
+    expect(screen.getByText(/loaded 2 training maxes/i)).toBeInTheDocument();
+  });
+
+  it('redirects to the full import tool when the file is not training maxes', async () => {
+    const user = userEvent.setup();
+    const onImported = jest.fn();
+    render(<StepImport onImported={onImported} />);
+
+    // Lift-history shaped: Reps/Set columns (anti-signals for training maxes) and
+    // no "Date Updated" distinctive marker.
+    const csv = [
+      'Date,Lift,Weight,Reps,Set',
+      '2026-01-01,Squat,300,5,1',
+      '2026-01-08,Bench Press,225,5,1',
+    ].join('\n');
+
+    await user.upload(screen.getByLabelText(/training-maxes csv/i), csvFile(csv));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(onImported).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent(/import tool/i);
+  });
+
+  it('shows a file-level error when a training-maxes file has an unreadable row', async () => {
+    const user = userEvent.setup();
+    const onImported = jest.fn();
+    render(<StepImport onImported={onImported} />);
+
+    const csv = [
+      'Date Updated,Lift,Weight',
+      '2026-01-01,Squat,315',
+      '2026-01-01,Bench Press,notanumber', // non-numeric weight → parse throws
+    ].join('\n');
+
+    await user.upload(screen.getByLabelText(/training-maxes csv/i), csvFile(csv));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(onImported).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent(/couldn.t read every row/i);
+  });
+});

--- a/apps/web/app/(authed)/onboarding/steps/StepImport.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepImport.tsx
@@ -79,9 +79,18 @@ export function StepImport({ onImported }: Props) {
   async function handleFile(e: React.ChangeEvent<HTMLInputElement>) {
     setError(null);
     setSummary(null);
-    const file = e.target.files?.[0];
+    const input = e.currentTarget;
+    const file = input.files?.[0];
     if (!file) return;
+    // Clear the input's value so re-selecting the *same* file (e.g. the user
+    // fixed a malformed export on disk and picked it again) still fires
+    // onChange. `file` is already captured above, so this is safe.
+    input.value = '';
 
+    // On any failure below we leave a prior successful import staged: the error
+    // is shown but `onImported` is not re-called, so OnboardingFlow keeps the
+    // last good rows and Next stays enabled. This is intentional — a fat-finger
+    // re-upload after a good import should not discard the valid data.
     if (file.size > MAX_IMPORT_BYTES) {
       setError('That file is larger than 5 MB. Export a smaller training-maxes file and try again.');
       return;
@@ -164,7 +173,11 @@ export function StepImport({ onImported }: Props) {
         />
       </div>
       {error && (
-        <p id={`${inputId}-error`} role="alert" className={styles.infoBox}>
+        <p
+          id={`${inputId}-error`}
+          role="alert"
+          className={`${styles.infoBox} ${styles.infoBoxError}`}
+        >
           {error}
         </p>
       )}

--- a/apps/web/app/(authed)/onboarding/steps/StepImport.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepImport.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { useId, useState } from 'react';
+import {
+  parseCsvText,
+  classifyImport,
+  parseTrainingMaxes,
+  type TrainingMax,
+} from '@lifting-logbook/core';
+import type { ImportClassification } from '@lifting-logbook/types';
+import styles from '../onboarding.module.css';
+import type { LiftRow } from '../lib';
+
+// Mirrors the API import guards (apps/api/src/programs/import-file.util.ts:
+// MAX_IMPORT_ROWS = 5_000; Fastify multipart caps the request body at 5 MB).
+// Those constants are API-side only and the web app cannot import from apps/api,
+// so the same limits are re-stated here for the client-side parse.
+const MAX_IMPORT_ROWS = 5_000;
+const MAX_IMPORT_BYTES = 5 * 1024 * 1024;
+
+// Friendly labels for the "this isn't a training-maxes file" redirect, keyed by
+// the other ImportKind values classifyImport can return.
+const KIND_LABEL: Record<string, string> = {
+  'lift-records': 'lift history',
+  'strength-goals': 'strength goals',
+  'program-spec': 'a program definition',
+};
+
+type Props = {
+  /** Called with one row per lift (latest training max) once a file parses. */
+  onImported: (rows: LiftRow[]) => void;
+};
+
+// Read a File as text via FileReader rather than `File.text()`: the latter is
+// unimplemented in the jsdom version used by the component tests, whereas
+// FileReader is supported in both jsdom and every target browser.
+function readFileText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result ?? ''));
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read file'));
+    reader.readAsText(file);
+  });
+}
+
+// Accept a file as training maxes when it classifies as such outright, or when
+// training-maxes is a close-call runner-up (the user clearly uploaded TMs and
+// another kind only edged it out). Anything else routes to the full /import tool.
+function looksLikeTrainingMaxes(c: ImportClassification): boolean {
+  if (c.type === 'training-maxes') return true;
+  return c.alternatives.some((a) => a.type === 'training-maxes' && a.closeCall);
+}
+
+// A training-maxes export can carry history — several dated rows per lift. For
+// onboarding we want each lift's *current* training max, so keep the row with
+// the most recent dateUpdated per lift and drop non-positive weights.
+function latestPerLift(maxes: TrainingMax[]): LiftRow[] {
+  const byLift = new Map<string, { weight: number; dateUpdated: Date }>();
+  for (const m of maxes) {
+    const lift = String(m.lift).trim();
+    if (!lift || !(m.weight > 0)) continue;
+    const prev = byLift.get(lift);
+    if (!prev || m.dateUpdated.getTime() > prev.dateUpdated.getTime()) {
+      byLift.set(lift, { weight: m.weight, dateUpdated: m.dateUpdated });
+    }
+  }
+  return Array.from(byLift.entries()).map(([lift, { weight }]) => ({
+    lift,
+    weight: String(Math.round(weight)),
+    reps: '',
+  }));
+}
+
+export function StepImport({ onImported }: Props) {
+  const inputId = useId();
+  const [error, setError] = useState<string | null>(null);
+  const [summary, setSummary] = useState<string | null>(null);
+
+  async function handleFile(e: React.ChangeEvent<HTMLInputElement>) {
+    setError(null);
+    setSummary(null);
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (file.size > MAX_IMPORT_BYTES) {
+      setError('That file is larger than 5 MB. Export a smaller training-maxes file and try again.');
+      return;
+    }
+
+    let table;
+    try {
+      const text = await readFileText(file);
+      table = parseCsvText(text);
+    } catch {
+      setError('We couldn’t read that file. Make sure it’s a CSV exported from a spreadsheet.');
+      return;
+    }
+
+    if (table.length < 2) {
+      setError('That file has no data rows. Expected a header row plus one row per lift.');
+      return;
+    }
+    if (table.length - 1 > MAX_IMPORT_ROWS) {
+      setError(`That file has more than ${MAX_IMPORT_ROWS.toLocaleString()} rows. Trim it and try again.`);
+      return;
+    }
+
+    const classification = classifyImport(table);
+    if (!looksLikeTrainingMaxes(classification)) {
+      const label =
+        (classification.type && KIND_LABEL[classification.type]) ??
+        'something other than training maxes';
+      setError(
+        `This looks like ${label}. Finish setup, then use the full Import tool to bring it in.`,
+      );
+      return;
+    }
+
+    let maxes: TrainingMax[];
+    try {
+      maxes = parseTrainingMaxes(table);
+    } catch {
+      // parseTrainingMaxes is all-or-nothing: a single malformed row (bad date,
+      // non-numeric weight, empty lift) rejects the whole file. Granular per-row
+      // repair lives in the full /import wizard; onboarding surfaces a clear
+      // file-level error and lets the user fix the export.
+      setError(
+        'We found training-max columns but couldn’t read every row. Check that each row has a date, a lift name, and a numeric weight.',
+      );
+      return;
+    }
+
+    const rows = latestPerLift(maxes);
+    if (rows.length === 0) {
+      setError('No training maxes were found in that file.');
+      return;
+    }
+
+    onImported(rows);
+    setSummary(
+      `Loaded ${rows.length} training max${rows.length === 1 ? '' : 'es'} from ${file.name}. Review them on the next step.`,
+    );
+  }
+
+  return (
+    <>
+      <h2 className={styles.stepTitle}>Import your training maxes</h2>
+      <p className={styles.stepHint}>
+        Upload a training-maxes CSV (exported from a spreadsheet or another app) and we’ll fill
+        these in for you — no reps needed, we’ll use the values as-is.
+      </p>
+      <div className={styles.dataRows}>
+        <label htmlFor={inputId} className={styles.dataRowLabel}>
+          Training-maxes CSV
+        </label>
+        <input
+          id={inputId}
+          type="file"
+          accept=".csv,text/csv"
+          onChange={handleFile}
+          aria-describedby={
+            error ? `${inputId}-error` : summary ? `${inputId}-summary` : undefined
+          }
+        />
+      </div>
+      {error && (
+        <p id={`${inputId}-error`} role="alert" className={styles.infoBox}>
+          {error}
+        </p>
+      )}
+      {summary && (
+        <p id={`${inputId}-summary`} className={styles.infoBox}>
+          {summary}
+        </p>
+      )}
+    </>
+  );
+}

--- a/apps/web/app/(authed)/onboarding/steps/StepMethod.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepMethod.tsx
@@ -28,6 +28,12 @@ const METHOD_OPTIONS: { id: DiscoveryMethod; title: string; description: string 
     description:
       'You already train off fixed training maxes. Enter them directly — we’ll use them as-is, no 90% adjustment.',
   },
+  {
+    id: 'import',
+    title: 'Import from a file',
+    description:
+      'Upload a training-maxes CSV (exported from a spreadsheet or another app) and we’ll fill these in for you.',
+  },
 ];
 
 type Props = {


### PR DESCRIPTION
## Summary

Adds a fifth onboarding lift-discovery method — **"Import from a file"** — for lifters who already keep their training maxes in a spreadsheet. The user uploads a training-maxes CSV; it is parsed, classified, and validated **entirely client-side** (no `apps/api` call, no commit) and pre-fills the onboarding maxes. Because imported values *are* training maxes, they persist **as-is** via the `{ lift, trainingMax }` contract landed in #557 — no 90% derivation.

This is the second half of the onboarding lift-discovery work; #557 (PR #560) was the foundation (the verbatim `{ lift, trainingMax }` persistence contract this PR reuses).

### Changes
- **`lib.ts`** — `DiscoveryMethod` gains `'import'`; `isWeightOnly` covers it (the advance gate requires only a weight per row once the file pre-fills them); new `valuesAreTrainingMax(method)` (`tm`|`import`) centralizes the persist-as-is-vs-derive-90% decision. Distinct from `isWeightOnly`: `manual` is weight-only but is a 1RM, not a training max.
- **`StepMethod`** — new "Import from a file" card.
- **`StepImport`** (new) — `FileReader` → `parseCsvText` → `classifyImport` gate → `parseTrainingMaxes`. Keeps the **latest training max per lift** (a TM export can carry dated history), enforces **5 MB / 5,000-row** caps mirroring the API import guards, and surfaces: a load summary, a friendly redirect when the file classifies as something else (lift history / strength goals / a program), and a clear file-level error when a row can't be read.
- **`OnboardingFlow`** — renders `StepImport` at step 1 for the `import` method; `computedMaxes` keys on `valuesAreTrainingMax`.
- **`StepConfirm`** — `tmDirect` → `valuesAreTrainingMax`, so imported TMs render as-entered (no 1RM, no 90% note).

### Key implementation decisions
- **Client-side parsing is real, verified.** `csv-parse/sync` (used by `parseCsvText`) ships a browser-safe ESM build (polyfills `global`, no `node:stream`/`fs`), and `@lifting-logbook/core` is infra-free. The production `next build` compiles the `/onboarding` route with these imports in a **client** component — confirming the parser bundles for the browser. This is the web app's first client-side use of the core import utils (the standalone `/import` wizard parses server-side).
- **Read via `FileReader`, not `File.text()`** — the jsdom version used by the component tests does not implement `File.text()`; `FileReader.readAsText` works in both jsdom and every target browser.
- **Lift names pre-fill from `parseTrainingMaxes`' raw (display) names**, not `validateTrainingMaxImport`'s slug-resolved output (`'Squat' → 'back-squat'`). The existing onboarding `tm`/`manual` path persists **display** names (`'Squat'`), so raw names keep imported maxes consistent with the contract the cycle reads back.
- **`parseTrainingMaxes` is all-or-nothing** (it throws on the first malformed row), so onboarding surfaces a single clear file-level error and defers granular per-row repair to the full `/import` wizard. The AC below is worded to match this (file-level error), not per-row.

## Acceptance criteria
- [x] Onboarding offers an "Import from a file" method.
- [x] Uploading a training-maxes CSV pre-fills the onboarding maxes client-side (no `apps/api` call, no commit).
- [x] Imported training maxes persist as-is (no 90% derivation) via the #557 `{ lift, trainingMax }` contract.
- [x] A misclassified file shows a friendly redirect to the full Import tool instead of importing garbage.
- [x] Malformed files surface a clear, actionable **file-level** error; file-size and row-count caps enforced. *(Per-row partial-error UX is intentionally deferred to the `/import` wizard — see decisions above.)*
- [x] Tests: `StepImport` unit/component coverage + an `OnboardingFlow` import-path integration test asserting imported TMs reach `createFirstCycle` unchanged.

## Out of scope
- Manual column-mapping and Undo (Smart Import Phase 2/3 — #483 / #484).
- Lift-history / program-spec import during onboarding (remains the post-setup `/import` wizard).

## Testing

All web test layers run locally and pass.

- **Onboarding Jest** — `npx jest --testPathPatterns onboarding`
  `Tests: 31 passed, 0 skipped, 0 failed` — 7 suites (was 27/6; +4 tests, +1 suite).
- **Full web Jest** — `npx jest`
  `Tests: 99 passed, 0 skipped, 0 failed` — 18 suites.
- **Production build** — `npm run build`
  `Tasks: 6 successful, 6 total`. The `/onboarding` route compiles with the client-side core import; **this is the gate that proves `csv-parse` bundles for the browser.**
- **Playwright E2E** — `npm run test:e2e -w @lifting-logbook/web`
  `15 passed (48.6s)`. Run because this PR changes onboarding UI strings (new method card + the file-input label), per the CLAUDE.md UI-string rule (#444). The new strings are additive; the smoke spec drives the unchanged `estimate` path.
  *Note:* a first run failed 14/15 purely because `npm run build` immediately prior had invalidated the dev `.next` cache, so `next dev` cold-recompiled and the first navigations timed out; the warm re-run passed 15/15. No code involvement.

New tests added for the new behavior (coverage gate satisfied):
- `StepImport.test.tsx` (new) — parses a training-maxes CSV and keeps the latest TM per lift; redirects a lift-history file; surfaces a file-level error on an unreadable row.
- `OnboardingFlow.test.tsx` — `import`-method path asserts imported TMs reach `createFirstCycle` verbatim (Squat 315 / Bench Press 225, no 90%).

Frontend interactive-feature coverage: per the CLAUDE.md coverage table, a dedicated Playwright test for the import flow is deferred until #259 (Playwright onboarding harness) lands; the component + integration Jest coverage above exercises the full parse → pre-fill → persist path in the meantime.

## Policy checks
- **Suppression grep** — clean.
- **Test-integrity grep** — clean (no skips, deleted tests, or lowered thresholds).
- **Lockfile** — no `package.json` changed (`csv-parse` arrives transitively via `@lifting-logbook/core`); sync check N/A.

## Risk-dimension audit
- **Testing** — covered above (component + integration Jest, production build, Playwright).
- **Observability** — N/A — client-only parse; no new API boundary, log, or span.
- **Security** — the user's file is parsed **in the browser and never sent anywhere**; 5 MB + 5,000-row caps bound the work; no `eval`; persistence still flows through the existing authenticated `updateTrainingMaxes` path.
- **Resilience** — parse/classify/validation failures are caught and surfaced (wrong type → redirect, malformed → file-level error), never crashing the step.
- **Performance** — single file read + pure parse, row-capped; `csv-parse` adds to the `/onboarding` client bundle only (route is dynamic, lazy-loaded).
- **Data integrity** — latest-per-lift dedup prevents duplicate rows; same `{ lift, weight, unit }` PATCH shape; no schema/migration.
- **Accessibility** — labeled file input (`<label htmlFor>`), `role="alert"` on errors with `aria-describedby`, and the method card is a labeled `<button>` matching the existing four.

Closes #561


## Review findings disposition

`/review` (claude-opus-4-8) run on this PR — 0 blocking, 1 non-blocking + 1 question + 1 style note. All resolved in `a273348`:

- **[reliability] File input won't re-fire on re-selecting the same file** — fixed in `a273348`: `handleFile` now clears `input.value` after capturing the file, so re-picking a fixed export at the same path re-triggers `onChange`.
- **[question] Stale rows staged when an upload fails after a prior success** — resolved in `a273348`: retain-last-good is intentional (a fat-finger re-upload shouldn't discard valid data); documented with a comment in `StepImport.handleFile`.
- **[style] Error and success messages looked visually identical** — fixed in `a273348`: added `.infoBoxError` (red left-border + error text colour) applied alongside `.infoBox` on the `role="alert"` error.

Re-verified after the fixes: onboarding Jest **31 passed, 0 skipped, 0 failed** (7 suites); onboarding typecheck clean; lint clean (turbo 7/7); suppression + test-integrity greps clean; no `package.json` change. No new UI strings/aria-labels/role-names were introduced by the fixes, so the #444 Playwright trigger does not re-apply — the prior 15/15 run stands.
