### PR TITLE
[infra] Paginate the staging-result sticky-comment lookup

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -823,11 +823,17 @@ jobs:
               body = `⚠️ **Staging integration tests did not run** (status: ${testResult})`;
             }
 
-            // Find and update an existing bot comment, or create a new one
-            const { data: comments } = await github.rest.issues.listComments({
+            // Find and update an existing bot comment, or create a new one.
+            // Paginate: listComments returns only the first 30 by default, so on a
+            // chatty PR (>30 comments) the sticky staging-result comment could fall
+            // off page 1 and we'd stack a duplicate on every re-push instead of
+            // updating in place. github.paginate walks every page. Mirrors the fix
+            // in prod-plan-pr.yml (#559).
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
+              per_page: 100,
             });
             const existing = comments.find(c =>
               c.user.type === 'Bot' && c.body.includes('Staging integration tests') ||


### PR DESCRIPTION
## Summary

`staging.yml`'s **Post staging result comment** step (`report-status` job) found its existing sticky comment via `github.rest.issues.listComments({...})` with no pagination. That call returns only the first 30 comments by default, so on a PR with more than 30 comments the staging-result comment can fall off page 1 — the `find` misses it and a **duplicate** comment is posted on each subsequent push instead of updating in place.

This is the same latent bug fixed in the new `prod-plan-pr.yml` during the `/review` of #558, deliberately split into its own issue to keep that PR narrowly scoped.

The fix replaces the unpaginated call with `github.paginate(github.rest.issues.listComments, { ..., per_page: 100 })` and `find`s over the full set — byte-for-byte mirroring the pattern now in `prod-plan-pr.yml`.

## Changes

- `.github/workflows/staging.yml` — paginate the staging-result sticky-comment lookup (`+8/-2`, comment-and-call only; no behavior change to the comment body, the upsert branches, or the `find` predicate).

## Acceptance criteria

- [x] The staging-result comment lookup paginates over all comments.
- [x] A PR with >30 comments updates the single staging-result comment in place rather than stacking duplicates.

## Testing

`npm test` from the repo root — full suite green (Docker was up, so the DB E2E suite ran rather than being skipped):

```
@lifting-logbook/api: Test Suites: 34 passed, 34 total
                      Tests:       394 passed, 394 total
Tasks:    12 successful, 12 total (turbo)
```

`Tests: 394 passed, 0 skipped, 0 failed (35.9s)` for the api workspace; all 12 turbo `test` tasks succeeded across workspaces. This change touches only a `.github/` workflow YAML — no application code — so the suite is unaffected by construction; it was run per the test-before-PR gate.

**actionlint** (`rhysd/actionlint` via Docker) on `staging.yml` reports two findings, **both pre-existing and unrelated** to this change — at lines 148 (`SC2129` redirect-style suggestion) and 199 (`head.ref` untrusted-input expression note). Neither is in the edited section (~line 827); my diff does not introduce or shift them.

## Verification notes

- **Suppression / test-integrity greps** vs `origin/main`: both clean (no `ts-ignore`/`eslint-disable`/`!`-assertion/skip-marker/threshold changes).
- **Lockfile:** no `package.json` touched — no lockfile impact.
- **Live exercise:** the comment-upsert path runs on the next staging PR with an open sticky comment; the pagination only changes behavior past 30 comments, so existing PRs are unaffected.

## Out of scope (noted, not changed)

The `find` predicate uses `a && b || c` (`c.user.type === 'Bot' && c.body.includes('Staging integration tests') || c.body.includes('Staging skipped')`), which by JS precedence is `(a && b) || c` — the "Staging skipped" arm is not bot-guarded. This is a separate latent quirk, independent of pagination, and is left untouched to keep this PR scoped to #559's stated fix. Filed as #564.

## Review findings disposition

`/review` of this PR (`claude-opus-4-8`): **0 blocking, 1 non-blocking.** Posted as a [PR comment](https://github.com/brownm09/lifting-logbook/pull/563#issuecomment-4744287127); `reviewed-by-claude` label applied.

- **[correctness] non-blocking — `find`-predicate precedence quirk (`(a && b) || c`, unguarded "Staging skipped" arm):** **Filed #564** (project #2, CI/CD Foundation). Pre-existing on the unchanged predicate line and a behavior change to *which* comment is treated as sticky — genuinely independent of this PR's pagination fix, so split out rather than folded in (mirroring how #559 was split from #558's review). Exposure is marginally widened by paginating over all comments, hence surfaced here.
- **Style note** (trailing `(#559)` comment reference): accurate as a "tracked by" reference — no action.

Closes #559

