### PR TITLE
[fix] Bot-guard the 'Staging skipped' arm of staging.yml comment matcher

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -835,9 +835,16 @@ jobs:
               issue_number: context.issue.number,
               per_page: 100,
             });
+            // Bot-guard BOTH arms. Without the parentheses, JS operator precedence
+            // makes this `(Bot && integration-tests) || skipped`, so any comment —
+            // including a human's — whose body contains "Staging skipped" would match
+            // and be overwritten by the status updater. The skipped-state sticky
+            // comment body is `⚪ **Staging skipped** …` (no "integration tests"
+            // substring), so that arm is required to find it — it just needs to be
+            // scoped to bot-authored comments. (#564)
             const existing = comments.find(c =>
-              c.user.type === 'Bot' && c.body.includes('Staging integration tests') ||
-              c.body.includes('Staging skipped')
+              c.user.type === 'Bot' &&
+              (c.body.includes('Staging integration tests') || c.body.includes('Staging skipped'))
             );
             if (existing) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -843,7 +843,7 @@ jobs:
             // substring), so that arm is required to find it — it just needs to be
             // scoped to bot-authored comments. (#564)
             const existing = comments.find(c =>
-              c.user.type === 'Bot' &&
+              c.user.type === 'Bot' && c.body &&
               (c.body.includes('Staging integration tests') || c.body.includes('Staging skipped'))
             );
             if (existing) {


### PR DESCRIPTION
## Summary

`staging.yml`'s **Post staging result comment** step (`report-status` job) matched its existing sticky comment with:

```js
const existing = comments.find(c =>
  c.user.type === 'Bot' && c.body.includes('Staging integration tests') ||
  c.body.includes('Staging skipped')
);
```

By JavaScript operator precedence this is `(a && b) || c` — the `'Staging skipped'` arm is **not** bot-guarded, so *any* comment (including a human's) whose body contains the literal string `Staging skipped` would match and be overwritten by the status updater on the next run.

The `'Staging skipped'` arm is itself necessary: when staging is skipped the sticky comment body is `⚪ **Staging skipped** — …` and contains no `Staging integration tests` substring, so the matcher needs it to find that comment. The bug was only the missing bot guard / parentheses.

This was surfaced in the `/review` of #563 (issue #559, which paginated this same lookup) and filed as #564, deliberately split out to keep #563 scoped to pagination. #563's change widened the latent exposure — the matcher now scans **every** comment via `github.paginate` rather than only the first 30, so a stray human comment containing "Staging skipped" anywhere on a long PR became reachable.

## Changes

- `.github/workflows/staging.yml` — parenthesize so **both** arms of the matcher are bot-scoped: `c.user.type === 'Bot' && (c.body.includes('Staging integration tests') || c.body.includes('Staging skipped'))`. Added an explanatory comment. (`+9/-2`, matcher-and-comment only; no change to the comment body, the upsert branches, or the pagination.)

## Acceptance criteria

- [x] The "Staging skipped" arm only matches bot-authored comments.
- [x] A human comment containing the string "Staging skipped" is not overwritten by the status updater.
- [x] The skipped-state sticky comment (`⚪ **Staging skipped**`) is still found and updated in place (its body is bot-authored and contains "Staging skipped").

## Testing

`npm test` from the repo root — full suite green (Docker up, so the DB E2E suite ran):

```
@lifting-logbook/api-client: Tests: 22 passed, 22 total
@lifting-logbook/core:       Tests: 210 passed, 210 total
@lifting-logbook/web:        Tests: 95 passed, 95 total
@lifting-logbook/api:        Tests: 394 passed, 394 total
Tasks: 12 successful, 12 total (turbo)
```

`Tests: 721 passed, 0 skipped, 0 failed` across all workspaces; all 12 turbo `test` tasks succeeded. This change touches only a `.github/` workflow YAML — no application code — so the suite is unaffected by construction; it was run per the test-before-PR gate.

**actionlint** (`rhysd/actionlint` via Docker) on `staging.yml` reports the same two findings as on `main`, **both pre-existing and unrelated** — lines 148 (`SC2129`) and 199 (`head.ref` untrusted-input). Neither is in the edited section (~line 838).

## Verification notes

- **Suppression / test-integrity greps** vs `origin/main`: both clean.
- **Lockfile:** no `package.json` touched — no lockfile impact.
- **Behavior preservation:** the change only narrows *which* comments the `'Staging skipped'` arm can match (bot-only). The status-comment body, the bot-authored sticky comment, and the pagination introduced in #563 are unchanged.

## Review findings disposition

`/review` of this PR (`claude-opus-4-8`): **0 blocking, 1 non-blocking.** Posted as a [PR comment](https://github.com/brownm09/lifting-logbook/pull/565#issuecomment-4744517452); `reviewed-by-claude` label applied. The reviewer verified the fix against all six body strings the `report-status` step emits — every one is bot-authored and contains a matched substring, so the sticky comment is still found in every state.

- **[reliability] non-blocking — missing `c.body &&` guard / inconsistency with `prod-plan-pr.yml`:** **Fixed in `8a24c44`.** Added the same `c.body &&` truthiness guard the sibling `prod-plan-pr.yml` already uses, so both workflows share the identical defensive matcher shape (`c.user.type === 'Bot' && c.body && (…)`) and a future copy-paste can't reintroduce an unguarded `c.body.includes`.
- **Style note** (the added explanatory comment): accurate and useful — no action.

Closes #564

