### PR TITLE
[infra] Add timeout-minutes to all deploy/CI workflow jobs (6h no-timeout hang class)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
   lint-and-test:
     name: Lint & Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v5
@@ -71,6 +72,7 @@ jobs:
   db-integration:
     name: DB Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     services:
       postgres:
@@ -116,6 +118,7 @@ jobs:
   e2e:
     name: Playwright E2E
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: lint-and-test
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,7 @@ jobs:
   preflight:
     name: Preflight
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       staging_enabled: ${{ steps.check.outputs.staging_enabled }}
       ar_repo: ${{ steps.check.outputs.ar_repo }}
@@ -81,6 +82,7 @@ jobs:
   terraform-staging:
     name: Terraform (staging)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [preflight]
     if: needs.preflight.outputs.staging_enabled == 'true'
     permissions:
@@ -150,6 +152,7 @@ jobs:
   build-images:
     name: Build & Push Images
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: [preflight, terraform-staging]
     # Run when preflight succeeds and terraform-staging either succeeded or was skipped.
     if: |
@@ -335,6 +338,7 @@ jobs:
   deploy-staging:
     name: Deploy (staging)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [preflight, terraform-staging, build-images]
     if: needs.preflight.outputs.staging_enabled == 'true' && needs.build-images.result == 'success'
     permissions:
@@ -593,6 +597,7 @@ jobs:
   smoke-test:
     name: Smoke Test (staging)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [preflight, deploy-staging, terraform-staging]
     if: needs.preflight.outputs.staging_enabled == 'true' && needs.deploy-staging.result == 'success'
 
@@ -681,6 +686,7 @@ jobs:
   plan-production:
     name: Plan (production)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [preflight, build-images]
     # Mirror deploy-production's readiness: run whenever build-images succeeded,
     # in both staging-enabled and production-only modes (always() tolerates the
@@ -808,6 +814,10 @@ jobs:
   deploy-production:
     name: Deploy (production)
     runs-on: ubuntu-latest
+    # timeout-minutes bounds only execution time after the job starts running;
+    # time spent waiting at the `environment: production` approval gate is
+    # "waiting" status and does NOT count against it (#566).
+    timeout-minutes: 30
     # plan-production is a needs (not just an upstream job) so the production
     # approval gate does not prompt until the read-only prod plan summary exists
     # in the run — the approver always sees the blast radius before clicking

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -817,7 +817,12 @@ jobs:
     # timeout-minutes bounds only execution time after the job starts running;
     # time spent waiting at the `environment: production` approval gate is
     # "waiting" status and does NOT count against it (#566).
-    timeout-minutes: 30
+    # Higher than deploy-staging's 30: this job does strictly more (secret
+    # validation + `terraform apply` on top of the same migrate + 3× Helm
+    # upgrade + Cloud Run) and, being human-gated and infrequent, has no
+    # measured runtime to back a tighter bound — so it gets build-images-level
+    # headroom to avoid a false-trip mid-prod-deploy, the costliest failure mode.
+    timeout-minutes: 45
     # plan-production is a needs (not just an upstream job) so the production
     # approval gate does not prompt until the read-only prod plan summary exists
     # in the run — the approver always sees the blast radius before clicking

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -45,6 +45,7 @@ jobs:
   preflight:
     name: Preflight
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
       ar_repo: ${{ steps.check.outputs.ar_repo }}
@@ -91,6 +92,7 @@ jobs:
   terraform-staging:
     name: Terraform (staging)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [preflight]
     if: needs.preflight.outputs.should_run == 'true'
     permissions:
@@ -159,6 +161,7 @@ jobs:
   build-images:
     name: Build & Push Images
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     needs: [preflight, terraform-staging]
     if: |
       needs.preflight.outputs.should_run == 'true' &&
@@ -303,6 +306,7 @@ jobs:
   deploy-api:
     name: Deploy API (staging)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [preflight, terraform-staging, build-images]
     if: |
       needs.preflight.outputs.should_run == 'true' &&
@@ -516,6 +520,7 @@ jobs:
   deploy-web:
     name: Deploy web (staging)
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     needs: [preflight, terraform-staging, build-images]
     if: |
       needs.preflight.outputs.should_run == 'true' &&
@@ -643,6 +648,7 @@ jobs:
   staging-integration-tests:
     name: Staging Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     needs: [preflight, terraform-staging, deploy-api, deploy-web]
     # Only skip when staging is not configured at all (no GCP credentials).
     # When staging IS configured, always() ensures the job runs even when a
@@ -779,6 +785,7 @@ jobs:
   report-status:
     name: Report Staging Status
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [preflight, terraform-staging, deploy-api, deploy-web, staging-integration-tests]
     if: always()
     permissions:

--- a/docs/runbooks/staging-ci-flakiness.md
+++ b/docs/runbooks/staging-ci-flakiness.md
@@ -84,6 +84,30 @@ The pipeline now self-heals the transient classes; manual action is the exceptio
 4. If AR 504s become frequent/sustained (not transient), check Artifact Registry status and the
    repo's region health; consider raising the retry attempt limit as a stopgap.
 
+## No-timeout job hang (6-hour default)
+
+A distinct failure class from the transient build/Terraform causes above: a job **wedges with
+no progress** and, lacking a `timeout-minutes`, runs until GitHub's **6-hour default** cancels
+it (or someone force-cancels it manually).
+
+- **Symptom:** a single job (e.g. `Staging Integration Tests`) shows as running for *hours* with
+  the live log stalled on one step — commonly a network-bound step like
+  `npx playwright install --with-deps chromium` (~6.5 min when healthy) or an image pull. The
+  rest of the run is otherwise normal; re-running goes green.
+- **Cause:** a runner-level wedge (a hung apt/network fetch, a stuck process), **not** a code or
+  config failure. The 6h fallback applies to any job with no explicit `timeout-minutes`.
+- **Mitigation (in place):** every job in `staging.yml`, `ci.yml`, and `deploy.yml` now sets an
+  explicit `timeout-minutes` sized to ~2–4× its normal runtime (see [#566](https://github.com/brownm09/lifting-logbook/issues/566)).
+  A wedge now auto-cancels in minutes instead of consuming a 6h slot. If you add a **new** job to
+  any of these workflows, give it a `timeout-minutes` too.
+- **If it recurs anyway:** cancel the run, then `gh run rerun <run-id> --failed`. If the same
+  step wedges repeatedly (not a one-off), investigate that step's network dependency rather than
+  raising the timeout.
+
+**Motivating incident:** 2026-06-18, PR #562 run `27772616067` — the `staging-integration-tests`
+job (then with no `timeout-minutes`) wedged on the Playwright `--with-deps` install and ran 3+
+hours before being force-cancelled.
+
 ## Escalation
 
 - Sustained (non-transient) Artifact Registry failures → GCP support / status page; this is


### PR DESCRIPTION
## Summary

No job in `staging.yml` set `timeout-minutes`, and in `ci.yml` only `observability-smoke` did; `deploy.yml` had the same gap on **every** job. A job with no `timeout-minutes` falls back to GitHub's **6-hour default**. On 2026-06-18, a GitHub-hosted runner wedged on the Playwright `--with-deps` install step in `staging-integration-tests` (PR #562, run `27772616067`) and ran **3+ hours** before being force-cancelled — a job that normally completes in ~10–11 min.

This adds an explicit `timeout-minutes` to **every** job across the three workflows, sized to ~2–4× the normal runtime: generous enough never to trip on a healthy run, far below 6h so a wedge fails fast.

### Timeouts added

| Workflow | Job | timeout-minutes |
|---|---|---|
| staging.yml | preflight / terraform-staging / build-images / deploy-api / deploy-web / **staging-integration-tests** / report-status | 10 / 20 / 40 / 30 / 25 / **25** / 10 |
| ci.yml | lint-and-test / db-integration / e2e | 20 / 20 / 30 |
| ci.yml | observability-smoke | 10 *(pre-existing, unchanged)* |
| deploy.yml | preflight / terraform-staging / build-images / deploy-staging / smoke-test / plan-production / deploy-production | 10 / 20 / 45 / 30 / 15 / 20 / **45** |

`deploy-production`'s timeout is annotated in-file to clarify it bounds only execution time — the `environment: production` approval wait is "waiting" status and does not count against it. It is set to 45 (build-images parity, higher than deploy-staging's 30) because it does strictly more work (secret validation + `terraform apply` on top of the same migrate + 3× Helm upgrade + Cloud Run) and, being human-gated and infrequent, has no measured runtime to back a tighter bound — see the review-findings disposition below.

## Acceptance criteria

- [x] Every job in `staging.yml` has an explicit `timeout-minutes` (7/7).
- [x] Every job in `ci.yml` has an explicit `timeout-minutes` (4/4).
- [x] Every job in `deploy.yml` has an explicit `timeout-minutes` (7/7).
- [x] `docs/runbooks/staging-ci-flakiness.md` documents the no-timeout hang class.

## Testing

This change touches **workflow YAML + one runbook markdown only — zero application/test code**, so no code path under test is affected.

- **YAML validity (substantive check):** all three workflows parse via `js-yaml`, and a programmatic check confirms every job has exactly one `timeout-minutes` (18 total: 7 staging + 4 ci + 7 deploy, with `observability-smoke`'s pre-existing value unchanged).
- **Full suite** (`npm test`, Windows/local): two suites flaked **under Windows parallel load** and both pass deterministically in isolation:
  - `apps/api` `rls.db.e2e.spec.ts` `beforeAll` exceeded the 5000ms hook timeout under contention → **9 passed, 9 total** in isolation (~2.1s).
  - one `apps/web` suite reported `1 failed` in the parallel run → **18 suites, 99 passed, 99 total** in isolation.
  - These are the known Windows local-parallel-contention class; filed as **#567** (the prior #419/#394 are closed). CI (Linux, Node 20) is unaffected. Neither failure is related to this diff.
- **Pre-PR greps** (suppression / test-integrity): clean. **No `package.json` changed**, so lockfile-sync is N/A.

## Risk audit

Resilience is the point of the change (bounds worst-case job runtime; fully reversible). Security / data-integrity / performance / accessibility: N/A — scheduling-bound config only, no app behavior, no secrets, no UI.

## Review findings disposition

- **[reliability] deploy/migrate job timeout headroom (deploy-production weakest-evidence case)** — **fixed in `c192265`**: raised `deploy-production` from 30 → 45 (build-images parity). It does strictly more work than deploy-staging yet sat at the same bound and, being human-gated/infrequent, had no measured runtime backing the tighter value; 45 removes the false-trip risk on the costliest job to interrupt mid-flight while still failing well under the 6h default. The well-measured staging deploy jobs (deploy-api / deploy-staging, both 30) are unchanged.

Closes #566
