### PR TITLE
[fix] Regenerate lockfile for @clerk/backend 3.8.1 / @clerk/shared 4.19.1 in-range float

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2600,11 +2600,11 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.8.0.tgz",
-      "integrity": "sha512-uZLyJNsRYnc8Ccx7IK/ZpUajRmb69khgwab3c24THK/oIyFs78wFlZ3rAKuC5K+BroggDOSUBwceXYJPUTCLLQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.8.1.tgz",
+      "integrity": "sha512-Q3ezkBJ7cFc0POEgdfyMnLHzAdPpb8jgTSdqA3Vt39rq/LiwRp4ebS2CHkrnrkews/8cwFhTQ6yNynPcpZFh8Q==",
       "dependencies": {
-        "@clerk/shared": "^4.19.0",
+        "@clerk/shared": "^4.19.1",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -2613,9 +2613,9 @@
       }
     },
     "node_modules/@clerk/backend/node_modules/@clerk/shared": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.19.0.tgz",
-      "integrity": "sha512-27tZG3/PAuuOQAKFpKGzFlio2FC/t/0TcSRl6UNlYap85BJRPnnYdo3PaVunNbKYKOpaFwJlwgcD2cKB7l/qWw==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.19.1.tgz",
+      "integrity": "sha512-0VDUXJ47FRDwPyu61uYTNy7HLMUrDAo7ig8JVqyKWb07ysUw7miXk1MKOsIEQ3Nm0g8lzj13LBv43J7o870GUw==",
       "dependencies": {
         "@tanstack/query-core": "^5.100.6",
         "dequal": "2.0.3",


### PR DESCRIPTION
## Summary

A fresh `npm ci` on `main` fails `EUSAGE` — the committed lockfile is out of sync with the live registry:

```
npm ERR! Invalid: lock file's @clerk/backend@3.8.0 does not satisfy @clerk/backend@3.8.1
npm ERR! Invalid: lock file's @clerk/shared@4.19.0 does not satisfy @clerk/shared@4.19.1
```

This is the recurring **transitive-clerk in-range caret float** (`@clerk/shared` publishes under `@clerk/backend`'s own caret). Both floated upstream since the last `main` merge (`5815138`, #568) with no `package.json` change, leaving the committed lockfile stale so `npm ci` refuses and `node_modules` lands incomplete. Recurring class: #432 / #433 / #501 / #516 / #520 ([ADR-036](docs/adr/036-lockfile-drift-prevention.md) — note: dev-env ADR).

This regenerates `package-lock.json` to the floated versions. **Diff is `package-lock.json` only** — the two `@clerk/*` patch bumps (+ their `resolved`/`integrity` lines).

## Acceptance criteria

- [x] `npm ci` resolves cleanly (`npm ci --dry-run` → `added 1609 packages`; lockfile satisfiable).
- [x] `npm install --package-lock-only --ignore-scripts && git diff --exit-code package-lock.json` is clean (in sync).
- [x] Diff is `package-lock.json` only: `@clerk/backend` 3.8.0→3.8.1, `@clerk/shared` 4.19.0→4.19.1.

## Testing

Lockfile-only change. Verified against the regenerated lockfile:

- `npm ci --dry-run` resolves (`added 1609 packages`), and the pre-PR sync check (`npm install --package-lock-only --ignore-scripts` + `git diff --exit-code`) is clean.
- Full suite on this exact lockfile: `npx turbo run test --force` → **12/12 tasks pass, 0 cached** (api `Test Suites: 34 passed`, `Tests: 394 passed`; web/core/types/api-client green). No app/test code changed by this PR — the suite run confirms the floated clerk patches don't regress anything.

## Risk audit

Dependency/lockfile only. Security: patch-level upstream bumps within existing carets, no new direct deps, no `package.json` change. Resilience: trivially reversible (revert the lockfile). Testing/Observability/Performance/Data-integrity/Accessibility: N/A.

Closes #569
