### PR TITLE
[chore] Pin the clerk graph to eliminate recurring transitive lockfile float

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,6 +264,15 @@ npm install
 **Symptom if skipped:** `Lint failed. Commit aborted.` or a Node.js `EUNKNOWN` crash on the first
 `git commit`.
 
+**Recovery after a failed `npm ci` (EUSAGE) + `npm install`:** when a lockfile-drift `npm ci`
+fails mid-install and you recover with `npm install`, the worktree-local `node_modules/turbo` can
+be left **missing or incomplete** — the test suite may have kept running via the *global* `turbo`,
+masking the gap. The next `git commit` then fails the `.husky/pre-commit` lint hook with
+`Lint failed. Commit aborted.` **even though `npx turbo run lint` passes standalone** (the hook
+requires the worktree-local `turbo` via `TURBO_BINARY_PATH`, not the global one). The fix is a
+clean **`npm ci`** once the lockfile is back in sync — *not* another `npm install`, which can
+leave the same partial-extract state. Motivating incident: the #570/#571 session (Windows, Node 20).
+
 ---
 
 ## CLI Scripting Checklist

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.92.0",
-    "@clerk/backend": "^3.4.4",
+    "@clerk/backend": "3.8.1",
     "@fastify/multipart": "8.3.1",
     "@lifting-logbook/core": "*",
     "@lifting-logbook/types": "*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,8 +25,8 @@
     "server-only": "^0.0.1"
   },
   "devDependencies": {
-    "@clerk/backend": "^3.4.13",
-    "@clerk/testing": "^2.0.33",
+    "@clerk/backend": "3.8.1",
+    "@clerk/testing": "2.0.33",
     "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
-        "@clerk/backend": "^3.4.4",
+        "@clerk/backend": "3.8.1",
         "@fastify/multipart": "8.3.1",
         "@lifting-logbook/core": "*",
         "@lifting-logbook/types": "*",
@@ -338,8 +338,8 @@
         "server-only": "^0.0.1"
       },
       "devDependencies": {
-        "@clerk/backend": "^3.4.13",
-        "@clerk/testing": "^2.0.33",
+        "@clerk/backend": "3.8.1",
+        "@clerk/testing": "2.0.33",
         "@playwright/test": "^1.60.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "turbo run lint",
     "dev": "turbo run dev"
   },
+  "//clerk-pins": "@clerk/backend and @clerk/testing are exact-pinned (not caret) in apps/api and apps/web to stop the recurring lockfile float (#572; prior floats #432/#433/#501/#516/#520/#570). Each @clerk/backend version raises the floor of its own ^@clerk/shared range, so a direct caret re-resolving backend to a newer patch dragged @clerk/shared up and reddened open PRs; freezing the direct version freezes the whole v4 chain. The @clerk/nextjs@6 v2/v3 sub-tree is intentionally left on a caret — it has never been an incident. Bump these deliberately when upgrading clerk.",
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.9",


### PR DESCRIPTION
## Summary

Two follow-ups from the #570/#571 session, bundled (they stem from the same lockfile-float incident; the second is a one-paragraph doc note).

### 1. Pin the clerk graph to end the recurring lockfile float (`Closes #572`)

`@clerk/backend` and `@clerk/testing` are now **exact-pinned** (not caret) in `apps/api` and `apps/web`, freezing the v4 clerk chain.

**Root cause (verified, not assumed).** The direct `^3.4.x` caret on `@clerk/backend` re-resolves to the newest 3.x patch on every regen. Each `@clerk/backend` version raises the **floor** of its own `^@clerk/shared` range (`backend@3.8.0` → `^4.19.0`, `backend@3.8.1` → `^4.19.1`), so that direct re-resolution dragged `@clerk/shared` up in lockstep and reddened open PRs at the lockfile-sync gate — six times (#432/#433/#501/#516/#520/#570). Exact-pinning the direct dep freezes the floor, so the whole v4 chain is now deterministic.

**Investigation note — overrides were the wrong lever.** The plan originally proposed a scoped `overrides` block to pin `@clerk/shared`. Hands-on testing showed that approach is **inert** under the CI gate's `npm install --package-lock-only` (it preserves in-range locked transitives regardless of the override) and could even *conflict* on a future deliberate `@clerk/backend` bump. The exact direct-dep pin is the actual mechanism; the overrides were dropped. A root `//clerk-pins` note records the rationale and the lockstep-bump procedure.

**Scope (surgical, confirmed with maintainer).** The `@clerk/nextjs@6` v2/v3 sub-tree (its bundled `@clerk/backend@2` → `@clerk/shared@3`) is intentionally left on a caret — it has never been an incident. If it ever floats, pin it then.

**Zero installed-version change.** Pinned to the versions npm already resolved on `main`, so `node_modules` is byte-identical and the `package-lock.json` delta is spec-strings only (no `version`/`resolved`/`integrity` churn). The clerk tree after the change: `@clerk/backend@3.8.1` → `@clerk/shared@4.19.1`; `@clerk/testing@2.0.33` → `@clerk/shared@4.13.1`; nextjs chain unchanged at `@clerk/shared@3.47.6`.

### 2. Document the worktree-turbo recovery gotcha

Adds a note to CLAUDE.md's **Worktree Setup** section: after a failed lockfile-drift `npm ci` (EUSAGE) + `npm install` recovery, the worktree-local `node_modules/turbo` can be left missing (the suite kept running via *global* turbo, masking it), breaking the `.husky/pre-commit` lint hook with `Lint failed. Commit aborted.` even though `npx turbo run lint` passes standalone. Fix: a clean `npm ci` once the lockfile is in sync — not another `npm install`.

## Acceptance criteria

- [x] `@clerk/backend` (both sites), `@clerk/testing` exact-pinned.
- [x] `package-lock.json` regenerated and committed together; delta is clerk-only, spec-only.
- [x] `npm ci` exits 0; `npm install --package-lock-only --ignore-scripts && git diff --exit-code package-lock.json` is **CLEAN (no drift)**.
- [x] Worktree-turbo recovery gotcha documented in CLAUDE.md.

## Testing

`npm test` from the repo root (full suite, Docker up — DB-E2E exercised via Testcontainers):

```
Tests: 725 passed, 0 skipped, 0 failed
(api-client 22, api 394, core 210, web 99; 85 suites; 12/12 turbo tasks; ~2m14s)
```

No new behavior — dependency-spec change with zero resolved-version delta, so the suite behaves identically to `main`. Coverage gate N/A (no testable behavior added). Pre-PR suppression and test-integrity greps: **clean**. Lockfile-sync gate: **clean**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review findings disposition

`/review` (claude-opus-4-8): **0 blocking, 1 non-blocking.**

- **[maintainability] `apps/web/package.json:28` — `@clerk/backend` devDep shadowed by `@clerk/nextjs@6`'s bundled `backend@2`:** **filed [#574](https://github.com/brownm09/lifting-logbook/issues/574).** Pre-existing (identical under the prior `^3.4.13`), not changed by this PR (resolution is byte-identical to `main`). Fixing it changes what `apps/web/e2e/staging.setup.ts` resolves and needs independent verification of the Playwright staging setup — out of scope for this zero-resolution-change pin PR.
