### PR TITLE
[feat] Hide unavailable programs by default with a reveal toggle

### DIFF
--- a/apps/web/app/(authed)/onboarding/onboarding.module.css
+++ b/apps/web/app/(authed)/onboarding/onboarding.module.css
@@ -322,6 +322,11 @@
   color: var(--color-on-accent);
 }
 
+.availabilityToggleRow {
+  display: flex;
+  margin-bottom: var(--space-3);
+}
+
 .programList {
   display: flex;
   flex-direction: column;

--- a/apps/web/app/(authed)/onboarding/steps/StepProgram.test.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepProgram.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import { StepProgram } from './StepProgram';
-import { PROGRAMS, type Experience } from '@/lib/programs';
+import { PROGRAMS, type Experience, type Goal } from '@/lib/programs';
 
 /** Wrapper that wires up controlled selectedProgramId state so clicking
  *  a program card actually switches to the detail view. */
@@ -203,5 +203,39 @@ describe('StepProgram — availability toggle', () => {
     expect(screen.getByText(rpt.name)).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /show coming soon/i }));
     expect(screen.getByText(rpt.name)).toBeInTheDocument();
+  });
+});
+
+describe('StepProgram — catalog empty state', () => {
+  it('shows a toggle-aware empty state in the full catalog when a goal hides every available program', async () => {
+    const user = userEvent.setup();
+
+    // A goal that no available preset satisfies (RPT is the only available preset
+    // today: strength/muscle-gain). Derived from data + guarded so a future change
+    // that makes every goal available fails loudly here instead of silently passing.
+    const availableGoals = new Set(
+      PROGRAMS.filter((p) => p.available).flatMap((p) => p.goals),
+    );
+    const candidates: { goal: Goal; label: RegExp }[] = [
+      { goal: 'fat-loss', label: /fat loss/i },
+      { goal: 'body-composition', label: /body composition/i },
+    ];
+    const emptying = candidates.find((c) => !availableGoals.has(c.goal));
+    if (!emptying) {
+      throw new Error(
+        'Test setup: expected a goal with no available preset (catalog empty-state path is otherwise unreachable — update this test if the available set changed)',
+      );
+    }
+
+    render(<Harness />);
+
+    // Open the full catalog (spans every experience tier), then filter to the
+    // emptying goal so every tier is empty under the default availability filter.
+    await user.click(screen.getByRole('button', { name: /view full catalog/i }));
+    await user.click(screen.getByRole('button', { name: emptying.label }));
+
+    // The catalog explains the empty result and points at the reveal toggle, rather
+    // than showing nothing but a "Back" button on blank space.
+    expect(screen.getByText(/turn on .*show coming soon.* to preview/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/app/(authed)/onboarding/steps/StepProgram.test.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepProgram.test.tsx
@@ -34,6 +34,10 @@ describe('StepProgram — goal filter', () => {
     const user = userEvent.setup();
     render(<Harness />);
 
+    // Unavailable presets are hidden by default; reveal them so this test
+    // exercises goal-filtering across the full intermediate set.
+    await user.click(screen.getByRole('button', { name: /show coming soon/i }));
+
     // Before filtering: all intermediate programs should be visible
     const intermediatePrograms = PROGRAMS.filter((p) => p.experience === 'intermediate');
     for (const p of intermediatePrograms) {
@@ -77,6 +81,9 @@ describe('StepProgram — coming soon overlay', () => {
     }
 
     render(<Harness />);
+
+    // Unavailable presets are hidden by default; reveal them to open this one's detail.
+    await user.click(screen.getByRole('button', { name: /show coming soon/i }));
 
     // Click on the unavailable program to enter detail view
     await user.click(screen.getByText(unavailableProgram.name));
@@ -159,5 +166,42 @@ describe('StepProgram — confirm wiring', () => {
     const confirmBtn = screen.getByRole('button', { name: /starting/i });
     expect(confirmBtn).toBeDisabled();
     expect(confirmBtn).toHaveTextContent('Starting…');
+  });
+});
+
+describe('StepProgram — availability toggle', () => {
+  it('hides unavailable programs by default and reveals them via the toggle', async () => {
+    const user = userEvent.setup();
+    const unavailable = PROGRAMS.find(
+      (p) => p.experience === 'intermediate' && !p.available,
+    );
+    if (!unavailable) {
+      throw new Error('Test setup: expected ≥1 unavailable intermediate program in PROGRAMS');
+    }
+
+    render(<Harness />);
+
+    // Hidden by default (the availability filter defaults on).
+    expect(screen.queryByText(unavailable.name)).not.toBeInTheDocument();
+
+    const toggle = screen.getByRole('button', { name: /show coming soon/i });
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    // Revealing the toggle surfaces the unavailable program.
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText(unavailable.name)).toBeInTheDocument();
+  });
+
+  it('keeps the available RPT program visible regardless of toggle state', async () => {
+    const user = userEvent.setup();
+    const rpt = PROGRAMS.find((p) => p.id === 'rpt');
+    if (!rpt) throw new Error('Test setup: expected RPT program in PROGRAMS');
+
+    render(<Harness experience={rpt.experience} />);
+
+    expect(screen.getByText(rpt.name)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /show coming soon/i }));
+    expect(screen.getByText(rpt.name)).toBeInTheDocument();
   });
 });

--- a/apps/web/app/(authed)/onboarding/steps/StepProgram.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepProgram.tsx
@@ -96,6 +96,18 @@ export function StepProgram({
     [experience, goalFilter, showUnavailable],
   );
 
+  // Catalog-view variant of the count above: it spans every experience tier, so
+  // it must not be scoped to the current `experience` (unlike the list view).
+  const catalogHiddenUnavailableCount = useMemo(
+    () =>
+      showUnavailable
+        ? 0
+        : PROGRAMS.filter(
+            (p) => !p.available && (goalFilter === 'all' || p.goals.includes(goalFilter)),
+          ).length,
+    [goalFilter, showUnavailable],
+  );
+
   function handleSelectProgram(id: string) {
     onSelectProgram(id);
     setView('detail');
@@ -293,22 +305,30 @@ export function StepProgram({
 
         {availabilityToggle}
 
-        {EXPERIENCE_LEVELS.map((tier) => {
-          const tierPrograms = catalogByTier[tier];
-          if (tierPrograms.length === 0) return null;
-          return (
-            <div key={tier}>
-              <p className={styles.catalogTierLabel}>
-                {tier.charAt(0).toUpperCase() + tier.slice(1)}
-              </p>
-              <div className={styles.programList}>
-                {tierPrograms.map((p) =>
-                  programListItem(p, () => handleSelectProgram(p.id)),
-                )}
+        {EXPERIENCE_LEVELS.every((tier) => catalogByTier[tier].length === 0) ? (
+          <p className={`${styles.stepHint} ${styles.emptyState}`}>
+            {catalogHiddenUnavailableCount > 0
+              ? `No available programs match this filter. Turn on “Show coming soon” to preview ${catalogHiddenUnavailableCount} in development.`
+              : 'No programs match this filter.'}
+          </p>
+        ) : (
+          EXPERIENCE_LEVELS.map((tier) => {
+            const tierPrograms = catalogByTier[tier];
+            if (tierPrograms.length === 0) return null;
+            return (
+              <div key={tier}>
+                <p className={styles.catalogTierLabel}>
+                  {tier.charAt(0).toUpperCase() + tier.slice(1)}
+                </p>
+                <div className={styles.programList}>
+                  {tierPrograms.map((p) =>
+                    programListItem(p, () => handleSelectProgram(p.id)),
+                  )}
+                </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })
+        )}
 
         <button
           type="button"

--- a/apps/web/app/(authed)/onboarding/steps/StepProgram.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepProgram.tsx
@@ -49,27 +49,51 @@ export function StepProgram({
 }: Props) {
   const [view, setView] = useState<View>('list');
   const [goalFilter, setGoalFilter] = useState<'all' | Goal>('all');
+  // Unavailable ("coming soon") presets are hidden by default; this toggle reveals
+  // them. Revealed presets stay non-selectable — see the detail view's availability
+  // gate (Choose This Program is disabled when !isAvailable).
+  const [showUnavailable, setShowUnavailable] = useState(false);
 
   const selectedProgram: Program | null =
     PROGRAMS.find((p) => p.id === selectedProgramId) ?? null;
 
-  function filterByGoal(programs: Program[]): Program[] {
-    if (goalFilter === 'all') return programs;
-    return programs.filter((p) => p.goals.includes(goalFilter));
+  function applyFilters(programs: Program[]): Program[] {
+    return programs.filter((p) => {
+      if (!showUnavailable && !p.available) return false;
+      if (goalFilter !== 'all' && !p.goals.includes(goalFilter)) return false;
+      return true;
+    });
   }
 
   const visiblePrograms = useMemo(
-    () => filterByGoal(PROGRAMS.filter((p) => p.experience === experience)),
-    [experience, goalFilter],
+    () => applyFilters(PROGRAMS.filter((p) => p.experience === experience)),
+    [experience, goalFilter, showUnavailable],
   );
 
   const catalogByTier = useMemo(
     () => ({
-      beginner: filterByGoal(PROGRAMS.filter((p) => p.experience === 'beginner')),
-      intermediate: filterByGoal(PROGRAMS.filter((p) => p.experience === 'intermediate')),
-      advanced: filterByGoal(PROGRAMS.filter((p) => p.experience === 'advanced')),
+      beginner: applyFilters(PROGRAMS.filter((p) => p.experience === 'beginner')),
+      intermediate: applyFilters(PROGRAMS.filter((p) => p.experience === 'intermediate')),
+      advanced: applyFilters(PROGRAMS.filter((p) => p.experience === 'advanced')),
     }),
-    [goalFilter],
+    [goalFilter, showUnavailable],
+  );
+
+  // When the default-on availability filter hides every match for the current
+  // experience/goal, the empty state points at the toggle instead of implying no
+  // program exists (the onboarding default tier is 'beginner', whose presets are
+  // all unavailable today).
+  const hiddenUnavailableCount = useMemo(
+    () =>
+      showUnavailable
+        ? 0
+        : PROGRAMS.filter(
+            (p) =>
+              p.experience === experience &&
+              !p.available &&
+              (goalFilter === 'all' || p.goals.includes(goalFilter)),
+          ).length,
+    [experience, goalFilter, showUnavailable],
   );
 
   function handleSelectProgram(id: string) {
@@ -113,6 +137,22 @@ export function StepProgram({
           </button>
         );
       })}
+    </div>
+  );
+
+  // --- Availability toggle (shared between list and catalog views) ---
+  const availabilityToggle = (
+    <div className={styles.availabilityToggleRow}>
+      <button
+        type="button"
+        className={[styles.filterChip, showUnavailable ? styles.filterChipActive : '']
+          .filter(Boolean)
+          .join(' ')}
+        aria-pressed={showUnavailable}
+        onClick={() => setShowUnavailable((v) => !v)}
+      >
+        Show coming soon
+      </button>
     </div>
   );
 
@@ -251,6 +291,8 @@ export function StepProgram({
 
         {goalFilterBar}
 
+        {availabilityToggle}
+
         {EXPERIENCE_LEVELS.map((tier) => {
           const tierPrograms = catalogByTier[tier];
           if (tierPrograms.length === 0) return null;
@@ -318,6 +360,9 @@ export function StepProgram({
       {/* Goal filter */}
       {goalFilterBar}
 
+      {/* Availability toggle */}
+      {availabilityToggle}
+
       {/* Program list */}
       <div className={styles.programList}>
         {visiblePrograms.length > 0 ? (
@@ -326,7 +371,9 @@ export function StepProgram({
           )
         ) : (
           <p className={`${styles.stepHint} ${styles.emptyState}`}>
-            No programs match this filter.
+            {hiddenUnavailableCount > 0
+              ? `No available programs match this filter. Turn on “Show coming soon” to preview ${hiddenUnavailableCount} in development.`
+              : 'No programs match this filter.'}
           </p>
         )}
       </div>

--- a/apps/web/app/(authed)/programs/BrowseTab.test.tsx
+++ b/apps/web/app/(authed)/programs/BrowseTab.test.tsx
@@ -1,7 +1,25 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import BrowseTab from './BrowseTab';
-import { PROGRAMS } from '@/lib/programs';
+import { PROGRAMS, type Goal } from '@/lib/programs';
+
+/** A goal that no *available* preset satisfies, so selecting it empties the default
+ *  (availability-filtered) view. Derived from data + guarded so a future change that
+ *  makes every goal available fails loudly here instead of silently passing. */
+function findEmptyingGoal(): { goal: Goal; label: RegExp } {
+  const availableGoals = new Set(PROGRAMS.filter((p) => p.available).flatMap((p) => p.goals));
+  const candidates: { goal: Goal; label: RegExp }[] = [
+    { goal: 'fat-loss', label: /fat loss/i },
+    { goal: 'body-composition', label: /body composition/i },
+  ];
+  const emptying = candidates.find((c) => !availableGoals.has(c.goal));
+  if (!emptying) {
+    throw new Error(
+      'Test setup: expected ≥1 goal with no available preset (the empty-tier-view path is unreachable otherwise — update this test if the available set changed)',
+    );
+  }
+  return emptying;
+}
 
 // BrowseTab statically imports SwitchProgramDialog, which transitively pulls in
 // the server-only `./actions` module (switchProgram). The dialog only renders
@@ -41,5 +59,28 @@ describe('BrowseTab — availability toggle', () => {
     expect(screen.getByText(available.name)).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: /show coming soon/i }));
     expect(screen.getByText(available.name)).toBeInTheDocument();
+  });
+});
+
+describe('BrowseTab — empty state', () => {
+  it('shows a toggle-aware empty state when the active goal hides every available program', async () => {
+    const user = userEvent.setup();
+    const emptying = findEmptyingGoal();
+
+    render(<BrowseTab activeProgram={null} workoutSchedule={null} />);
+
+    // Default "All Levels" view (the tier-grouped render) shows only available
+    // presets; selecting a goal none of them satisfy empties every tier.
+    await user.click(screen.getByRole('button', { name: emptying.label }));
+
+    // The empty tier view explains itself and points at the reveal toggle, rather
+    // than rendering a blank area below the filters.
+    expect(screen.getByText(/turn on .*show coming soon.* to preview/i)).toBeInTheDocument();
+
+    // Revealing unavailable presets clears the hint (matching coming-soon presets appear).
+    await user.click(screen.getByRole('button', { name: /show coming soon/i }));
+    expect(
+      screen.queryByText(/turn on .*show coming soon.* to preview/i),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/app/(authed)/programs/BrowseTab.test.tsx
+++ b/apps/web/app/(authed)/programs/BrowseTab.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BrowseTab from './BrowseTab';
+import { PROGRAMS } from '@/lib/programs';
+
+// BrowseTab statically imports SwitchProgramDialog, which transitively pulls in
+// the server-only `./actions` module (switchProgram). The dialog only renders
+// after a "Choose This Program" click and is not under test here, so stub it to
+// keep this a pure client render of the filter/availability UI.
+jest.mock('./SwitchProgramDialog', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+describe('BrowseTab — availability toggle', () => {
+  it('hides unavailable programs by default and reveals them via the toggle', async () => {
+    const user = userEvent.setup();
+    const unavailable = PROGRAMS.find((p) => !p.available);
+    if (!unavailable) throw new Error('Test setup: expected ≥1 unavailable program in PROGRAMS');
+
+    render(<BrowseTab activeProgram={null} workoutSchedule={null} />);
+
+    // Hidden by default (the availability filter defaults on).
+    expect(screen.queryByText(unavailable.name)).not.toBeInTheDocument();
+
+    const toggle = screen.getByRole('button', { name: /show coming soon/i });
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText(unavailable.name)).toBeInTheDocument();
+  });
+
+  it('keeps available programs visible regardless of toggle state', async () => {
+    const user = userEvent.setup();
+    const available = PROGRAMS.find((p) => p.available);
+    if (!available) throw new Error('Test setup: expected ≥1 available program in PROGRAMS');
+
+    render(<BrowseTab activeProgram={null} workoutSchedule={null} />);
+
+    expect(screen.getByText(available.name)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /show coming soon/i }));
+    expect(screen.getByText(available.name)).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(authed)/programs/BrowseTab.tsx
+++ b/apps/web/app/(authed)/programs/BrowseTab.tsx
@@ -39,16 +39,21 @@ type Props = {
 export default function BrowseTab({ activeProgram, workoutSchedule }: Props) {
   const [experienceFilter, setExperienceFilter] = useState<Experience | 'all'>('all');
   const [goalFilter, setGoalFilter] = useState<'all' | Goal>('all');
+  // Unavailable ("coming soon") presets are hidden by default; this toggle reveals
+  // them. Revealed presets remain non-selectable — see renderProgram's availability
+  // gate (Choose This Program only renders when p.available).
+  const [showUnavailable, setShowUnavailable] = useState(false);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [switchTarget, setSwitchTarget] = useState<Program | null>(null);
 
   const filteredPrograms = useMemo(() => {
     return PROGRAMS.filter((p) => {
+      if (!showUnavailable && !p.available) return false;
       if (experienceFilter !== 'all' && p.experience !== experienceFilter) return false;
       if (goalFilter !== 'all' && !p.goals.includes(goalFilter)) return false;
       return true;
     });
-  }, [experienceFilter, goalFilter]);
+  }, [experienceFilter, goalFilter, showUnavailable]);
 
   const grouped = useMemo(() => {
     const tiers: Record<Experience, Program[]> = { beginner: [], intermediate: [], advanced: [] };
@@ -180,6 +185,18 @@ export default function BrowseTab({ activeProgram, workoutSchedule }: Props) {
             {label}
           </button>
         ))}
+      </div>
+
+      {/* Availability toggle */}
+      <div className={styles.filterRow}>
+        <button
+          type="button"
+          className={`${styles.chip} ${showUnavailable ? styles.chipActive : ''}`}
+          aria-pressed={showUnavailable}
+          onClick={() => setShowUnavailable((v) => !v)}
+        >
+          Show coming soon
+        </button>
       </div>
 
       {/* Program list */}

--- a/apps/web/app/(authed)/programs/BrowseTab.tsx
+++ b/apps/web/app/(authed)/programs/BrowseTab.tsx
@@ -61,6 +61,24 @@ export default function BrowseTab({ activeProgram, workoutSchedule }: Props) {
     return tiers;
   }, [filteredPrograms]);
 
+  // Programs hidden purely by the default-on availability filter — i.e. would match
+  // the current experience/goal selection if revealed. Drives the empty-state hint so
+  // a user whose filter matches only "coming soon" presets is pointed at the toggle
+  // rather than left staring at a blank list (RPT is the only available preset today,
+  // so any goal it lacks empties the default tier view).
+  const hiddenUnavailableCount = useMemo(
+    () =>
+      showUnavailable
+        ? 0
+        : PROGRAMS.filter(
+            (p) =>
+              !p.available &&
+              (experienceFilter === 'all' || p.experience === experienceFilter) &&
+              (goalFilter === 'all' || p.goals.includes(goalFilter)),
+          ).length,
+    [experienceFilter, goalFilter, showUnavailable],
+  );
+
   const showTiers = experienceFilter === 'all';
 
   function toggleDetail(id: string) {
@@ -150,6 +168,17 @@ export default function BrowseTab({ activeProgram, workoutSchedule }: Props) {
     );
   }
 
+  // Shared by both the tier-grouped and flat-list renders so an empty result set
+  // always explains itself (and points at the "Show coming soon" toggle when the
+  // availability filter is what hid every match).
+  const emptyState = (
+    <p className={styles.emptyState}>
+      {hiddenUnavailableCount > 0
+        ? `No available programs match this filter. Turn on “Show coming soon” to preview ${hiddenUnavailableCount} in development.`
+        : 'No programs match this filter.'}
+    </p>
+  );
+
   return (
     <>
       {/* Experience filter */}
@@ -201,25 +230,27 @@ export default function BrowseTab({ activeProgram, workoutSchedule }: Props) {
 
       {/* Program list */}
       {showTiers ? (
-        EXPERIENCE_LEVELS.map((tier) => {
-          const programs = grouped[tier];
-          if (programs.length === 0) return null;
-          return (
-            <div key={tier}>
-              <p className={styles.catalogTierLabel}>
-                {tier.charAt(0).toUpperCase() + tier.slice(1)}
-              </p>
-              <div className={styles.programList}>
-                {programs.map(renderProgram)}
+        filteredPrograms.length > 0 ? (
+          EXPERIENCE_LEVELS.map((tier) => {
+            const programs = grouped[tier];
+            if (programs.length === 0) return null;
+            return (
+              <div key={tier}>
+                <p className={styles.catalogTierLabel}>
+                  {tier.charAt(0).toUpperCase() + tier.slice(1)}
+                </p>
+                <div className={styles.programList}>
+                  {programs.map(renderProgram)}
+                </div>
               </div>
-            </div>
-          );
-        })
+            );
+          })
+        ) : (
+          emptyState
+        )
       ) : (
         <div className={styles.programList}>
-          {filteredPrograms.length > 0
-            ? filteredPrograms.map(renderProgram)
-            : <p className={styles.emptyState}>No programs match this filter.</p>}
+          {filteredPrograms.length > 0 ? filteredPrograms.map(renderProgram) : emptyState}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
Program selection now hides unavailable ("coming soon") presets **by default** in both surfaces that list programs — the onboarding program step (`StepProgram`) and the `/programs` Browse tab (`BrowseTab`) — with a **"Show coming soon"** toggle (`aria-pressed`) to reveal them. Revealed presets remain non-selectable (the existing availability gate is unchanged). When the default-on filter hides every match, the onboarding empty state points the user at the toggle rather than implying no program exists (the default `beginner` tier has no available presets today).

First slice of the larger program-import feature set (importing preset / custom-based-on-preset / fully-custom-from-CSV programs).

## Acceptance criteria
- [x] Onboarding `StepProgram`: unavailable presets hidden by default; toggle reveals them.
- [x] `/programs` Browse tab: unavailable presets hidden by default; same toggle reveals them.
- [x] Available presets (RPT) always visible regardless of toggle state.
- [x] Revealed unavailable presets remain non-selectable.
- [x] Toggle is accessible (`aria-pressed`) and covered by tests.

## Testing
- `npm test -w @lifting-logbook/web` — **Tests: 103 passed, 0 skipped, 0 failed (22.6s)** across 19 suites. Adds 2 new `BrowseTab` tests + 2 new `StepProgram` availability-toggle tests.
- `npm run test:e2e -w @lifting-logbook/web` (Playwright) — **15 passed (53s)**. Run because this changes UI roles/labels (project rule / #444): the specs interact only with RPT (still visible) and the new "Show coming soon" button has a non-colliding name.
- `npm run build` — 6/6 successful.
- Suppression + test-integrity greps (added lines only): **clean**. No `package.json`/lockfile changes.

### Note on changed tests
Two existing `StepProgram` tests assumed unavailable presets were visible by default; they now click **"Show coming soon"** first. This reflects the new default-hidden behavior — no skips, deletions, or threshold changes (test-integrity preserved).

### Coverage
New behavior (default-hide + reveal toggle) is covered by 4 new tests across both surfaces.

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review findings disposition

Self-review posted via `/review` (see PR comment). Findings: **0 blocking, 1 non-blocking** — all addressed in-PR per ADR-028.

- **[reliability] Tier-grouped views had no empty state** — `BrowseTab`'s default "All Levels" render and `StepProgram`'s full catalog mapped over experience tiers and skipped empty ones with no overall fallback. With unavailable presets now hidden by default and RPT the only available preset (goals `strength`/`muscle-gain`), selecting a goal RPT lacks (e.g. Fat Loss) emptied every tier and rendered a blank area with no message — while the sibling flat-list views already showed a toggle-aware empty state. **Fixed in 2dbf874**: both tier views now render the same toggle-aware empty state (shared `emptyState` element in `BrowseTab`; catalog-scoped `catalogHiddenUnavailableCount` in `StepProgram`). Covered by 2 new data-driven tests guarded so they fail loudly if a future change makes every goal available.

### Updated testing (post-fix)
- `npm test -w @lifting-logbook/web` — **Tests: 105 passed, 0 skipped, 0 failed** (19 suites; +2 empty-state tests).
- `npm run build` — 6/6 successful.
- `npm run test:e2e -w @lifting-logbook/web` (Playwright) — **15 passed**.
- Suppression + test-integrity greps (added lines): clean. No `package.json`/lockfile changes.
