### PR TITLE
[feat] Inline editable list on training-maxes import preview

### DIFF
--- a/apps/web/app/(authed)/import/ImportWizard.test.tsx
+++ b/apps/web/app/(authed)/import/ImportWizard.test.tsx
@@ -4,6 +4,16 @@ import type { CustomProgramSummaryResponse, ImportPreviewResponse } from '@lifti
 import { ImportWizard } from './ImportWizard';
 import { commitImport, previewImport } from '@/lib/client-api';
 
+// File.text() is not implemented in jsdom; use FileReader instead.
+function readFileText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result ?? ''));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(file);
+  });
+}
+
 jest.mock('@/lib/client-api', () => ({
   previewImport: jest.fn(),
   commitImport: jest.fn(),
@@ -67,14 +77,88 @@ describe('ImportWizard', () => {
     await user.click(screen.getByRole('button', { name: 'Next' })); // Map → Review
     await user.click(screen.getByRole('button', { name: 'Next' })); // Review → Preview
 
-    // Preview step shows the create/update/skip counts.
+    // Preview step shows the create/update/skip counts and the editable list.
     expect(screen.getByText('Preview changes')).toBeInTheDocument();
     expect(screen.getByText('2')).toBeInTheDocument();
+    // Editable list is shown for training-maxes (from previewBody.deltas).
+    expect(screen.getByLabelText('Weight for squat')).toBeInTheDocument();
+    expect(screen.getByLabelText('Weight for bench')).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Commit import' }));
 
     await waitFor(() => expect(screen.getByText('Import complete')).toBeInTheDocument());
-    expect(mockCommit).toHaveBeenCalledWith('prog-1', file, 'training-maxes');
+    // Commit receives a rebuilt File (not the original), since the user may have
+    // edited maxes; verify it is still a File for training-maxes destination.
+    expect(mockCommit).toHaveBeenCalledWith('prog-1', expect.any(File), 'training-maxes');
+  });
+
+  it('training-maxes: edited weight is reflected in the commit payload', async () => {
+    const user = userEvent.setup();
+    mockPreview.mockResolvedValue(TM_PREVIEW);
+    mockCommit.mockResolvedValue({
+      ok: true,
+      data: { destination: 'training-maxes', created: 2, updated: 1, skipped: 0 },
+    });
+
+    render(<ImportWizard programs={PROGRAMS} />);
+
+    const file = new File(['Date Updated,Lift,Weight\n1/1/2026,Squat,300'], 'tm.csv', {
+      type: 'text/csv',
+    });
+    await user.upload(screen.getByLabelText('CSV file'), file);
+    await user.click(screen.getByRole('button', { name: 'Analyze' }));
+    await waitFor(() => expect(screen.getByText('Training Maxes')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: 'Next' })); // Classify → Map
+    await user.click(screen.getByRole('button', { name: 'Next' })); // Map → Review
+    await user.click(screen.getByRole('button', { name: 'Next' })); // Review → Preview
+
+    // Edit the squat weight from '300' to '325'.
+    const weightInput = screen.getByLabelText('Weight for squat');
+    await user.clear(weightInput);
+    await user.type(weightInput, '325');
+
+    await user.click(screen.getByRole('button', { name: 'Commit import' }));
+    await waitFor(() => expect(mockCommit).toHaveBeenCalledTimes(1));
+
+    const [, commitFile] = mockCommit.mock.calls[0] as [string, File, string];
+    const text = await readFileText(commitFile);
+    expect(text).toContain('squat');
+    expect(text).toContain('325');
+    expect(text).not.toContain(',300');
+  });
+
+  it('training-maxes: removed row is excluded from the commit payload', async () => {
+    const user = userEvent.setup();
+    mockPreview.mockResolvedValue(TM_PREVIEW);
+    mockCommit.mockResolvedValue({
+      ok: true,
+      data: { destination: 'training-maxes', created: 1, updated: 0, skipped: 0 },
+    });
+
+    render(<ImportWizard programs={PROGRAMS} />);
+
+    const file = new File(['Date Updated,Lift,Weight\n1/1/2026,Squat,300'], 'tm.csv', {
+      type: 'text/csv',
+    });
+    await user.upload(screen.getByLabelText('CSV file'), file);
+    await user.click(screen.getByRole('button', { name: 'Analyze' }));
+    await waitFor(() => expect(screen.getByText('Training Maxes')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: 'Next' })); // Classify → Map
+    await user.click(screen.getByRole('button', { name: 'Next' })); // Map → Review
+    await user.click(screen.getByRole('button', { name: 'Next' })); // Review → Preview
+
+    // Remove the bench row.
+    await user.click(screen.getByRole('button', { name: 'Remove bench' }));
+
+    await user.click(screen.getByRole('button', { name: 'Commit import' }));
+    await waitFor(() => expect(mockCommit).toHaveBeenCalledTimes(1));
+
+    const [, commitFile] = mockCommit.mock.calls[0] as [string, File, string];
+    const text = await readFileText(commitFile);
+    expect(text).toContain('squat');
+    expect(text).not.toContain('bench');
   });
 
   it('shows a manual destination picker when classification is low-confidence', async () => {

--- a/apps/web/app/(authed)/import/ImportWizard.test.tsx
+++ b/apps/web/app/(authed)/import/ImportWizard.test.tsx
@@ -161,6 +161,70 @@ describe('ImportWizard', () => {
     expect(text).not.toContain('bench');
   });
 
+  it('training-maxes: Back then Next preserves edits rather than resetting from preview', async () => {
+    const user = userEvent.setup();
+    mockPreview.mockResolvedValue(TM_PREVIEW);
+    mockCommit.mockResolvedValue({
+      ok: true,
+      data: { destination: 'training-maxes', created: 2, updated: 1, skipped: 0 },
+    });
+
+    render(<ImportWizard programs={PROGRAMS} />);
+
+    const file = new File(['Date Updated,Lift,Weight\n1/1/2026,Squat,300'], 'tm.csv', {
+      type: 'text/csv',
+    });
+    await user.upload(screen.getByLabelText('CSV file'), file);
+    await user.click(screen.getByRole('button', { name: 'Analyze' }));
+    await waitFor(() => expect(screen.getByText('Training Maxes')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: 'Next' })); // Classify → Map
+    await user.click(screen.getByRole('button', { name: 'Next' })); // Map → Review
+    await user.click(screen.getByRole('button', { name: 'Next' })); // Review → Preview (initializes editedMaxes)
+
+    // Edit squat weight on step 5.
+    const weightInput = screen.getByLabelText('Weight for squat');
+    await user.clear(weightInput);
+    await user.type(weightInput, '350');
+
+    // Navigate back to step 4, then forward again — edits must survive.
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+
+    // The weight should still be '350', not reset to the original '300'.
+    expect(screen.getByLabelText('Weight for squat')).toHaveValue(350);
+  });
+
+  it('training-maxes: commit is disabled when a weight field is cleared', async () => {
+    const user = userEvent.setup();
+    mockPreview.mockResolvedValue(TM_PREVIEW);
+    mockCommit.mockResolvedValue({
+      ok: true,
+      data: { destination: 'training-maxes', created: 2, updated: 1, skipped: 0 },
+    });
+
+    render(<ImportWizard programs={PROGRAMS} />);
+
+    const file = new File(['Date Updated,Lift,Weight\n1/1/2026,Squat,300'], 'tm.csv', {
+      type: 'text/csv',
+    });
+    await user.upload(screen.getByLabelText('CSV file'), file);
+    await user.click(screen.getByRole('button', { name: 'Analyze' }));
+    await waitFor(() => expect(screen.getByText('Training Maxes')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: 'Next' })); // Classify → Map
+    await user.click(screen.getByRole('button', { name: 'Next' })); // Map → Review
+    await user.click(screen.getByRole('button', { name: 'Next' })); // Review → Preview
+
+    // Clear one weight field — commit must become disabled.
+    const weightInput = screen.getByLabelText('Weight for squat');
+    await user.clear(weightInput);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Commit import' })).toBeDisabled();
+    });
+  });
+
   it('shows a manual destination picker when classification is low-confidence', async () => {
     const user = userEvent.setup();
     mockPreview.mockResolvedValue({

--- a/apps/web/app/(authed)/import/ImportWizard.tsx
+++ b/apps/web/app/(authed)/import/ImportWizard.tsx
@@ -12,6 +12,16 @@ import type {
 import { commitImport, previewImport } from '@/lib/client-api';
 import styles from './import.module.css';
 
+type EditableMax = { lift: string; weight: string };
+
+function buildTrainingMaxesCsv(rows: EditableMax[]): string {
+  const today = new Date().toISOString().slice(0, 10);
+  const lines = rows
+    .filter((r) => Number(r.weight) > 0)
+    .map((r) => `${today},"${r.lift.replace(/"/g, '""')}",${Math.round(Number(r.weight))}`);
+  return ['Date Updated,Lift,Weight', ...lines].join('\n');
+}
+
 const STEP_LABELS = [
   'Source',
   'Analyzing',
@@ -53,6 +63,9 @@ export function ImportWizard({ programs }: { programs: CustomProgramSummaryRespo
   const [commitErrors, setCommitErrors] = useState<ImportError[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  // For training-maxes: user-editable rows populated from previewBody.deltas when
+  // entering the Preview step. Null for all other destination kinds.
+  const [editedMaxes, setEditedMaxes] = useState<EditableMax[] | null>(null);
 
   const destination = preview?.destination ?? null;
   const previewBody = preview?.preview ?? null;
@@ -89,8 +102,17 @@ export function ImportWizard({ programs }: { programs: CustomProgramSummaryRespo
     if (!programId || !file || !destination) return;
     setCommitErrors(null);
     setBusy(true);
+
+    // For training-maxes, rebuild a minimal CSV from the edited rows so the
+    // commit reflects any weight corrections or row removals the user made.
+    let commitFile = file;
+    if (destination === 'training-maxes' && editedMaxes !== null) {
+      const csv = buildTrainingMaxesCsv(editedMaxes);
+      commitFile = new File([csv], file.name, { type: 'text/csv' });
+    }
+
     try {
-      const result = await commitImport(programId, file, destination);
+      const result = await commitImport(programId, commitFile, destination);
       if (result.ok) {
         setCommitResult(result.data);
         setStep(6);
@@ -115,6 +137,7 @@ export function ImportWizard({ programs }: { programs: CustomProgramSummaryRespo
     setCommitResult(null);
     setCommitErrors(null);
     setError(null);
+    setEditedMaxes(null);
   }
 
   return (
@@ -314,29 +337,73 @@ export function ImportWizard({ programs }: { programs: CustomProgramSummaryRespo
                   <span className={styles.countLabel}>Skip</span>
                 </div>
               </div>
-              <ul className={styles.deltaList}>
-                {previewBody.deltas.slice(0, 200).map((d) => (
-                  <li
-                    key={d.key}
-                    className={`${styles.deltaRow} ${
-                      d.kind === 'create'
-                        ? styles.deltaKindCreate
-                        : d.kind === 'update'
-                          ? styles.deltaKindUpdate
-                          : styles.deltaKindSkip
-                    }`}
-                  >
-                    <span className={styles.deltaLabel}>{d.label}</span>
-                    <span className={styles.deltaChange}>
-                      {d.kind === 'update'
-                        ? `${d.before} → ${d.after}`
-                        : d.kind === 'create'
-                          ? d.after
-                          : 'unchanged'}
-                    </span>
-                  </li>
-                ))}
-              </ul>
+              {destination === 'training-maxes' && editedMaxes !== null ? (
+                <>
+                  <p className={styles.stepHint}>
+                    Edit weights or remove rows before committing.
+                  </p>
+                  <ul className={styles.maxEditList} aria-label="Training maxes to import">
+                    {editedMaxes.map((row, i) => (
+                      <li key={row.lift} className={styles.maxEditRow}>
+                        <span className={styles.maxEditLift}>{row.lift}</span>
+                        <input
+                          type="number"
+                          className={styles.maxEditWeight}
+                          value={row.weight}
+                          min={1}
+                          aria-label={`Weight for ${row.lift}`}
+                          onChange={(e) =>
+                            setEditedMaxes((prev) =>
+                              prev
+                                ? prev.map((r, j) =>
+                                    j === i ? { ...r, weight: e.target.value } : r,
+                                  )
+                                : prev,
+                            )
+                          }
+                        />
+                        <span className={styles.stepHint}>lbs</span>
+                        <button
+                          type="button"
+                          className={styles.maxEditRemove}
+                          onClick={() =>
+                            setEditedMaxes((prev) =>
+                              prev ? prev.filter((_, j) => j !== i) : prev,
+                            )
+                          }
+                          aria-label={`Remove ${row.lift}`}
+                        >
+                          ×
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              ) : (
+                <ul className={styles.deltaList}>
+                  {previewBody.deltas.slice(0, 200).map((d) => (
+                    <li
+                      key={d.key}
+                      className={`${styles.deltaRow} ${
+                        d.kind === 'create'
+                          ? styles.deltaKindCreate
+                          : d.kind === 'update'
+                            ? styles.deltaKindUpdate
+                            : styles.deltaKindSkip
+                      }`}
+                    >
+                      <span className={styles.deltaLabel}>{d.label}</span>
+                      <span className={styles.deltaChange}>
+                        {d.kind === 'update'
+                          ? `${d.before} → ${d.after}`
+                          : d.kind === 'create'
+                            ? d.after
+                            : 'unchanged'}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
               {commitErrors && (
                 <div className={styles.errorBox}>
                   <strong>Commit failed:</strong>
@@ -402,7 +469,16 @@ export function ImportWizard({ programs }: { programs: CustomProgramSummaryRespo
             <button
               type="button"
               className={styles.btnPrimary}
-              onClick={() => setStep(5)}
+              onClick={() => {
+                if (destination === 'training-maxes' && previewBody) {
+                  setEditedMaxes(
+                    previewBody.deltas
+                      .filter((d) => d.kind === 'create' || d.kind === 'update')
+                      .map((d) => ({ lift: d.label, weight: d.after ?? '' })),
+                  );
+                }
+                setStep(5);
+              }}
               disabled={!previewBody}
             >
               Next
@@ -414,7 +490,13 @@ export function ImportWizard({ programs }: { programs: CustomProgramSummaryRespo
               type="button"
               className={styles.btnSuccess}
               onClick={handleCommit}
-              disabled={busy || !previewBody}
+              disabled={
+                busy ||
+                !previewBody ||
+                (destination === 'training-maxes' &&
+                  editedMaxes !== null &&
+                  editedMaxes.length === 0)
+              }
             >
               {busy ? 'Importing…' : 'Commit import'}
             </button>

--- a/apps/web/app/(authed)/import/ImportWizard.tsx
+++ b/apps/web/app/(authed)/import/ImportWizard.tsx
@@ -470,7 +470,8 @@ export function ImportWizard({ programs }: { programs: CustomProgramSummaryRespo
               type="button"
               className={styles.btnPrimary}
               onClick={() => {
-                if (destination === 'training-maxes' && previewBody) {
+                // Only initialize when null — re-entering step 5 via Back preserves edits.
+                if (destination === 'training-maxes' && previewBody && editedMaxes === null) {
                   setEditedMaxes(
                     previewBody.deltas
                       .filter((d) => d.kind === 'create' || d.kind === 'update')
@@ -495,7 +496,8 @@ export function ImportWizard({ programs }: { programs: CustomProgramSummaryRespo
                 !previewBody ||
                 (destination === 'training-maxes' &&
                   editedMaxes !== null &&
-                  editedMaxes.length === 0)
+                  (editedMaxes.length === 0 ||
+                    editedMaxes.some((r) => !r.weight || Number(r.weight) <= 0)))
               }
             >
               {busy ? 'Importing…' : 'Commit import'}

--- a/apps/web/app/(authed)/import/import.module.css
+++ b/apps/web/app/(authed)/import/import.module.css
@@ -308,6 +308,81 @@
   opacity: 0.7;
 }
 
+/* ── Editable training-maxes list (Preview step) ───────────── */
+
+.maxEditList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.maxEditRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-surface);
+  border-left: 3px solid var(--color-accent);
+  border-radius: var(--radius-sm);
+}
+
+.maxEditLift {
+  flex: 1;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.maxEditWeight {
+  width: 72px;
+  min-height: 36px;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  text-align: center;
+  background: var(--color-bg);
+  color: var(--color-text);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.maxEditWeight:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-glow);
+}
+
+.maxEditRemove {
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-base);
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.maxEditRemove:hover {
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+}
+
 /* ── Errors / done ─────────────────────────────────────────── */
 
 .errorBox {

--- a/apps/web/app/(authed)/onboarding/onboarding.module.css
+++ b/apps/web/app/(authed)/onboarding/onboarding.module.css
@@ -186,6 +186,20 @@
   color: var(--color-text-muted);
 }
 
+/* ── Editable imported-maxes list ──────────────────────────── */
+
+/* Lift name spans available width inside a .dataRow, pushing inputs right. */
+.maxEditLiftName {
+  flex: 1;
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ── Add-a-lift picker (Enter Lifts step) ──────────────────── */
 
 .removeLiftBtn {

--- a/apps/web/app/(authed)/onboarding/steps/StepImport.test.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepImport.test.tsx
@@ -8,7 +8,7 @@ function csvFile(content: string, name = 'maxes.csv') {
 }
 
 describe('StepImport', () => {
-  it('parses a training-maxes CSV and pre-fills the latest training max per lift', async () => {
+  it('parses a training-maxes CSV, shows editable list, and calls onImported', async () => {
     const user = userEvent.setup();
     const onImported = jest.fn();
     render(<StepImport onImported={onImported} />);
@@ -23,12 +23,64 @@ describe('StepImport', () => {
     await user.upload(screen.getByLabelText(/training-maxes csv/i), csvFile(csv));
 
     await waitFor(() => expect(onImported).toHaveBeenCalledTimes(1));
-    // One row per lift, latest TM, no reps; persisted later as the training max.
+    // One row per lift, latest TM, no reps.
     expect(onImported).toHaveBeenCalledWith([
       { lift: 'Squat', weight: '315', reps: '' },
       { lift: 'Bench Press', weight: '225', reps: '' },
     ]);
     expect(screen.getByText(/loaded 2 training maxes/i)).toBeInTheDocument();
+    // Editable list is rendered.
+    expect(screen.getByLabelText('Weight for Squat')).toBeInTheDocument();
+    expect(screen.getByLabelText('Weight for Bench Press')).toBeInTheDocument();
+  });
+
+  it('reflects an edited weight in the onImported payload', async () => {
+    const user = userEvent.setup();
+    const onImported = jest.fn();
+    render(<StepImport onImported={onImported} />);
+
+    const csv = [
+      'Date Updated,Lift,Weight',
+      '2026-01-01,Squat,300',
+      '2026-01-01,Bench Press,225',
+    ].join('\n');
+
+    await user.upload(screen.getByLabelText(/training-maxes csv/i), csvFile(csv));
+    await waitFor(() => expect(onImported).toHaveBeenCalledTimes(1));
+
+    const weightInput = screen.getByLabelText('Weight for Squat');
+    await user.clear(weightInput);
+    await user.type(weightInput, '320');
+
+    // Each keystroke fires onChange, so onImported is called multiple times; the
+    // last call reflects the fully-typed value.
+    await waitFor(() => {
+      const lastCall = onImported.mock.calls.at(-1)![0] as { lift: string; weight: string }[];
+      expect(lastCall.find(r => r.lift === 'Squat')?.weight).toBe('320');
+    });
+  });
+
+  it('excludes a removed row from the onImported payload', async () => {
+    const user = userEvent.setup();
+    const onImported = jest.fn();
+    render(<StepImport onImported={onImported} />);
+
+    const csv = [
+      'Date Updated,Lift,Weight',
+      '2026-01-01,Squat,300',
+      '2026-01-01,Bench Press,225',
+    ].join('\n');
+
+    await user.upload(screen.getByLabelText(/training-maxes csv/i), csvFile(csv));
+    await waitFor(() => expect(onImported).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole('button', { name: 'Remove Bench Press' }));
+
+    await waitFor(() => {
+      const lastCall = onImported.mock.calls.at(-1)![0] as { lift: string }[];
+      expect(lastCall).toHaveLength(1);
+      expect(lastCall[0]?.lift).toBe('Squat');
+    });
   });
 
   it('redirects to the full import tool when the file is not training maxes', async () => {

--- a/apps/web/app/(authed)/onboarding/steps/StepImport.test.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepImport.test.tsx
@@ -55,8 +55,9 @@ describe('StepImport', () => {
     // Each keystroke fires onChange, so onImported is called multiple times; the
     // last call reflects the fully-typed value.
     await waitFor(() => {
-      const lastCall = onImported.mock.calls.at(-1)![0] as { lift: string; weight: string }[];
-      expect(lastCall.find(r => r.lift === 'Squat')?.weight).toBe('320');
+      expect(onImported).toHaveBeenLastCalledWith(
+        expect.arrayContaining([expect.objectContaining({ lift: 'Squat', weight: '320' })]),
+      );
     });
   });
 
@@ -77,9 +78,9 @@ describe('StepImport', () => {
     await user.click(screen.getByRole('button', { name: 'Remove Bench Press' }));
 
     await waitFor(() => {
-      const lastCall = onImported.mock.calls.at(-1)![0] as { lift: string }[];
-      expect(lastCall).toHaveLength(1);
-      expect(lastCall[0]?.lift).toBe('Squat');
+      expect(onImported).toHaveBeenLastCalledWith([
+        expect.objectContaining({ lift: 'Squat' }),
+      ]);
     });
   });
 

--- a/apps/web/app/(authed)/onboarding/steps/StepImport.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepImport.tsx
@@ -76,6 +76,9 @@ export function StepImport({ onImported }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [fileName, setFileName] = useState<string | null>(null);
   const [rows, setRows] = useState<LiftRow[] | null>(null);
+  // Always-current ref so event handlers never capture a stale rows snapshot.
+  const rowsRef = useRef<LiftRow[] | null>(null);
+  rowsRef.current = rows;
   // Stable counter so each uploaded file resets keyed inputs (avoids stale values).
   const uploadGen = useRef(0);
 
@@ -150,13 +153,15 @@ export function StepImport({ onImported }: Props) {
   }
 
   function updateWeight(index: number, weight: string) {
-    if (!rows) return;
-    applyRows(rows.map((r, i) => (i === index ? { ...r, weight } : r)));
+    const current = rowsRef.current;
+    if (!current) return;
+    applyRows(current.map((r, i) => (i === index ? { ...r, weight } : r)));
   }
 
   function removeRow(index: number) {
-    if (!rows) return;
-    applyRows(rows.filter((_, i) => i !== index));
+    const current = rowsRef.current;
+    if (!current) return;
+    applyRows(current.filter((_, i) => i !== index));
   }
 
   const summaryId = `${inputId}-summary`;

--- a/apps/web/app/(authed)/onboarding/steps/StepImport.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepImport.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useId, useState } from 'react';
+import { useId, useRef, useState } from 'react';
 import {
   parseCsvText,
   classifyImport,
@@ -74,23 +74,26 @@ function latestPerLift(maxes: TrainingMax[]): LiftRow[] {
 export function StepImport({ onImported }: Props) {
   const inputId = useId();
   const [error, setError] = useState<string | null>(null);
-  const [summary, setSummary] = useState<string | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [rows, setRows] = useState<LiftRow[] | null>(null);
+  // Stable counter so each uploaded file resets keyed inputs (avoids stale values).
+  const uploadGen = useRef(0);
+
+  function applyRows(next: LiftRow[]) {
+    setRows(next);
+    onImported(next);
+  }
 
   async function handleFile(e: React.ChangeEvent<HTMLInputElement>) {
     setError(null);
-    setSummary(null);
     const input = e.currentTarget;
     const file = input.files?.[0];
     if (!file) return;
-    // Clear the input's value so re-selecting the *same* file (e.g. the user
-    // fixed a malformed export on disk and picked it again) still fires
-    // onChange. `file` is already captured above, so this is safe.
+    // Clear so re-selecting the same file still fires onChange.
     input.value = '';
 
-    // On any failure below we leave a prior successful import staged: the error
-    // is shown but `onImported` is not re-called, so OnboardingFlow keeps the
-    // last good rows and Next stays enabled. This is intentional — a fat-finger
-    // re-upload after a good import should not discard the valid data.
+    // On any failure we leave a prior successful import staged so the advance
+    // gate stays open and the user can fix their export without losing progress.
     if (file.size > MAX_IMPORT_BYTES) {
       setError('That file is larger than 5 MB. Export a smaller training-maxes file and try again.');
       return;
@@ -101,7 +104,7 @@ export function StepImport({ onImported }: Props) {
       const text = await readFileText(file);
       table = parseCsvText(text);
     } catch {
-      setError('We couldn’t read that file. Make sure it’s a CSV exported from a spreadsheet.');
+      setError("We couldn't read that file. Make sure it's a CSV exported from a spreadsheet.");
       return;
     }
 
@@ -129,34 +132,41 @@ export function StepImport({ onImported }: Props) {
     try {
       maxes = parseTrainingMaxes(table);
     } catch {
-      // parseTrainingMaxes is all-or-nothing: a single malformed row (bad date,
-      // non-numeric weight, empty lift) rejects the whole file. Granular per-row
-      // repair lives in the full /import wizard; onboarding surfaces a clear
-      // file-level error and lets the user fix the export.
       setError(
-        'We found training-max columns but couldn’t read every row. Check that each row has a date, a lift name, and a numeric weight.',
+        "We found training-max columns but couldn't read every row. Check that each row has a date, a lift name, and a numeric weight.",
       );
       return;
     }
 
-    const rows = latestPerLift(maxes);
-    if (rows.length === 0) {
+    const parsed = latestPerLift(maxes);
+    if (parsed.length === 0) {
       setError('No training maxes were found in that file.');
       return;
     }
 
-    onImported(rows);
-    setSummary(
-      `Loaded ${rows.length} training max${rows.length === 1 ? '' : 'es'} from ${file.name}. Review them on the next step.`,
-    );
+    uploadGen.current += 1;
+    setFileName(file.name);
+    applyRows(parsed);
   }
+
+  function updateWeight(index: number, weight: string) {
+    if (!rows) return;
+    applyRows(rows.map((r, i) => (i === index ? { ...r, weight } : r)));
+  }
+
+  function removeRow(index: number) {
+    if (!rows) return;
+    applyRows(rows.filter((_, i) => i !== index));
+  }
+
+  const summaryId = `${inputId}-summary`;
 
   return (
     <>
       <h2 className={styles.stepTitle}>Import your training maxes</h2>
       <p className={styles.stepHint}>
-        Upload a training-maxes CSV (exported from a spreadsheet or another app) and we’ll fill
-        these in for you — no reps needed, we’ll use the values as-is.
+        Upload a training-maxes CSV (exported from a spreadsheet or another app) and we&apos;ll
+        fill these in for you &mdash; no reps needed, we&apos;ll use the values as-is.
       </p>
       <div className={styles.dataRows}>
         <label htmlFor={inputId} className={styles.dataRowLabel}>
@@ -167,9 +177,7 @@ export function StepImport({ onImported }: Props) {
           type="file"
           accept=".csv,text/csv"
           onChange={handleFile}
-          aria-describedby={
-            error ? `${inputId}-error` : summary ? `${inputId}-summary` : undefined
-          }
+          aria-describedby={error ? `${inputId}-error` : fileName ? summaryId : undefined}
         />
       </div>
       {error && (
@@ -181,10 +189,37 @@ export function StepImport({ onImported }: Props) {
           {error}
         </p>
       )}
-      {summary && (
-        <p id={`${inputId}-summary`} className={styles.infoBox}>
-          {summary}
-        </p>
+      {fileName && rows !== null && (
+        <>
+          <p id={summaryId} className={styles.infoBox}>
+            Loaded {rows.length} training max{rows.length === 1 ? '' : 'es'} from {fileName}.
+            Edit or remove any rows before continuing.
+          </p>
+          <div className={styles.dataRows} aria-label="Imported training maxes">
+            {rows.map((row, i) => (
+              <div key={`${uploadGen.current}-${row.lift}`} className={styles.dataRow}>
+                <span className={styles.maxEditLiftName}>{row.lift}</span>
+                <input
+                  type="number"
+                  className={styles.numberInput}
+                  value={row.weight}
+                  min={1}
+                  aria-label={`Weight for ${row.lift}`}
+                  onChange={(e) => updateWeight(i, e.target.value)}
+                />
+                <span className={styles.unitLabel}>lbs</span>
+                <button
+                  type="button"
+                  className={styles.removeLiftBtn}
+                  onClick={() => removeRow(i)}
+                  aria-label={`Remove ${row.lift}`}
+                >
+                  &times;
+                </button>
+              </div>
+            ))}
+          </div>
+        </>
       )}
     </>
   );


### PR DESCRIPTION
## Summary

Closes #577

Renders an inline editable list (lift, weight, remove) on the training-maxes import
preview in two surfaces, so the user can correct or remove rows **before**
`updateTrainingMaxes`/`computedMaxes` is called:

- **`StepImport` (onboarding):** after a CSV parses, an editable table appears inline.
  Each weight edit or row removal calls `onImported` live, keeping the OnboardingFlow
  advance gate in sync. A new upload resets the list.
- **`ImportWizard` (`/import`):** at the Preview step, when `destination === 'training-maxes'`,
  the static delta list is replaced with the same editable list (populated from
  `previewBody.deltas`). `Commit import` rebuilds a minimal training-maxes CSV from the
  edited rows, so corrections and removals are reflected in the committed payload.

No API change. No Prisma migration.

## Changes

| File | Change |
|------|--------|
| `StepImport.tsx` | Added editable list (weight input + remove button per row) shown after parse; `rowsRef` for stale-closure safety |
| `ImportWizard.tsx` | Added `editedMaxes` state; editable list at step 5 for training-maxes; `handleCommit` rebuilds file from edited rows |
| `import.module.css` | Added `.maxEditList/.maxEditRow/.maxEditLift/.maxEditWeight/.maxEditRemove` |
| `onboarding.module.css` | Added `.maxEditLiftName` (flex-grow lift label inside `.dataRow`) |
| `StepImport.test.tsx` | +3 tests: editable list rendered, weight edit reflected, removed row excluded |
| `ImportWizard.test.tsx` | Updated existing test; +4 tests: weight edit, row removal, Back/Next edit preservation, empty-weight commit disabled |

## Testing

`npm test -w @lifting-logbook/web` — Tests: **111 passed, 0 skipped, 0 failed**

`npm run build -w @lifting-logbook/web` — build clean, no TypeScript errors.

Suppression grep: clean (no `+` lines with `!` or `?? null`).
Test-integrity grep: clean.

## Review findings disposition

Findings from `/review` run after initial push. All addressed in `34b19e4`.

| Finding | Severity | Disposition |
|---------|----------|-------------|
| Back→Next on Preview step unconditionally reinitializes `editedMaxes`, discarding user edits | Bug | **Fixed** — added `editedMaxes === null` guard to step-4 Next handler |
| Cleared weight field (`''`) passes `Number('')===0` filter, silently dropping the row from CSV with button still enabled | Bug | **Fixed** — Commit disabled when any row has empty or zero weight |
| `updateWeight`/`removeRow` in `StepImport` capture stale `rows` closure (narrow race under rapid concurrent events) | Plausible | **Fixed** — added `rowsRef` (assigned `rows` each render); handlers read `rowsRef.current` |
| `!` assertions on `.at(-1)` in `StepImport.test.tsx` violate CLAUDE.md suppression policy | Policy | **Fixed** — replaced with `toHaveBeenLastCalledWith` |
| Create/update/skip count pills show stale server values after user removes rows from editable list | UX | **Filed** [#579](https://github.com/brownm09/lifting-logbook/issues/579) — display-only inconsistency, commit payload always correct |