### PR TITLE
[fix] Replace stale count pills with live summary when editing training-maxes

### DIFF
--- a/apps/web/app/(authed)/import/ImportWizard.test.tsx
+++ b/apps/web/app/(authed)/import/ImportWizard.test.tsx
@@ -77,9 +77,9 @@ describe('ImportWizard', () => {
     await user.click(screen.getByRole('button', { name: 'Next' })); // Map → Review
     await user.click(screen.getByRole('button', { name: 'Next' })); // Review → Preview
 
-    // Preview step shows the create/update/skip counts and the editable list.
+    // Preview step shows the live summary (not stale pills) and the editable list.
     expect(screen.getByText('Preview changes')).toBeInTheDocument();
-    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('2 maxes will be imported.')).toBeInTheDocument();
     // Editable list is shown for training-maxes (from previewBody.deltas).
     expect(screen.getByLabelText('Weight for squat')).toBeInTheDocument();
     expect(screen.getByLabelText('Weight for bench')).toBeInTheDocument();

--- a/apps/web/app/(authed)/import/ImportWizard.test.tsx
+++ b/apps/web/app/(authed)/import/ImportWizard.test.tsx
@@ -149,8 +149,9 @@ describe('ImportWizard', () => {
     await user.click(screen.getByRole('button', { name: 'Next' })); // Map → Review
     await user.click(screen.getByRole('button', { name: 'Next' })); // Review → Preview
 
-    // Remove the bench row.
+    // Remove the bench row — live count must decrement immediately.
     await user.click(screen.getByRole('button', { name: 'Remove bench' }));
+    expect(screen.getByText('1 max will be imported.')).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Commit import' }));
     await waitFor(() => expect(mockCommit).toHaveBeenCalledTimes(1));

--- a/apps/web/app/(authed)/import/ImportWizard.tsx
+++ b/apps/web/app/(authed)/import/ImportWizard.tsx
@@ -323,20 +323,26 @@ export function ImportWizard({ programs }: { programs: CustomProgramSummaryRespo
           {step === 5 && previewBody && (
             <>
               <h2 className={styles.stepTitle}>Preview changes</h2>
-              <div className={styles.countRow}>
-                <div className={styles.countPill}>
-                  <span className={styles.countValue}>{previewBody.creates}</span>
-                  <span className={styles.countLabel}>Create</span>
+              {destination === 'training-maxes' && editedMaxes !== null ? (
+                <p className={styles.infoBox}>
+                  {editedMaxes.length} max{editedMaxes.length !== 1 ? 'es' : ''} will be imported.
+                </p>
+              ) : (
+                <div className={styles.countRow}>
+                  <div className={styles.countPill}>
+                    <span className={styles.countValue}>{previewBody.creates}</span>
+                    <span className={styles.countLabel}>Create</span>
+                  </div>
+                  <div className={styles.countPill}>
+                    <span className={styles.countValue}>{previewBody.updates}</span>
+                    <span className={styles.countLabel}>Update</span>
+                  </div>
+                  <div className={styles.countPill}>
+                    <span className={styles.countValue}>{previewBody.skips}</span>
+                    <span className={styles.countLabel}>Skip</span>
+                  </div>
                 </div>
-                <div className={styles.countPill}>
-                  <span className={styles.countValue}>{previewBody.updates}</span>
-                  <span className={styles.countLabel}>Update</span>
-                </div>
-                <div className={styles.countPill}>
-                  <span className={styles.countValue}>{previewBody.skips}</span>
-                  <span className={styles.countLabel}>Skip</span>
-                </div>
-              </div>
+              )}
               {destination === 'training-maxes' && editedMaxes !== null ? (
                 <>
                   <p className={styles.stepHint}>

--- a/apps/web/e2e/import.spec.ts
+++ b/apps/web/e2e/import.spec.ts
@@ -27,9 +27,9 @@ test('import wizard: Source → Classify → Preview → Done', async ({ page })
   await page.getByRole('button', { name: 'Next', exact: true }).click(); // → Review
   await page.getByRole('button', { name: 'Next', exact: true }).click(); // → Preview
 
-  // Preview step: create/update/skip counts and the commit action.
+  // Preview step: live summary (training-maxes editable list) and the commit action.
   await expect(page.getByRole('heading', { name: 'Preview changes' })).toBeVisible();
-  await expect(page.getByText('Create', { exact: true })).toBeVisible();
+  await expect(page.getByText('2 maxes will be imported.')).toBeVisible();
 
   await page.getByRole('button', { name: 'Commit import' }).click();
 


### PR DESCRIPTION
## Summary

When a user removed rows from the editable training-maxes import list (introduced in #578), the Creates/Updates/Skips count pills above the list kept showing server-computed values. E.g. "Creates: 3" would persist after the user removed 2 of 3 rows.

- When `editedMaxes` is active (training-maxes destination), the three stale pills are replaced with a live **"N maxes will be imported."** summary driven by `editedMaxes.length`.
- For all other destination kinds (no editable list), the pills are unchanged.

## Changes

- [`apps/web/app/(authed)/import/ImportWizard.tsx`](apps/web/app/(authed)/import/ImportWizard.tsx) — conditional render: live summary when `editedMaxes !== null`, pills otherwise
- [`apps/web/app/(authed)/import/ImportWizard.test.tsx`](apps/web/app/(authed)/import/ImportWizard.test.tsx) — update unit test assertion from `getByText('2')` (the stale pill value) to `getByText('2 maxes will be imported.')`
- [`apps/web/e2e/import.spec.ts`](apps/web/e2e/import.spec.ts) — update E2E assertion from `getByText('Create')` to the new summary text

## Testing

Full suite: `npm test`

Tests: 505 passed, 0 skipped, 0 failed (1m 20s)

Coverage: behaviour change is fully covered by the updated unit test (live summary visible on entering step 5) and E2E test (import wizard smoke spec walks through step 5).

Suppression grep: clean
Test-integrity grep: clean
Deleted test files: none

## Review findings disposition

- **[maintainability]** Missing count-decrement assertion in `removed row` test — fixed in daf102f (added `expect(screen.getByText('1 max will be imported.'))` after Remove click; also covers singular form)

Closes #579