### PR TITLE
[feat] Promote leangains to an available program

### DIFF
--- a/apps/api/src/adapters/in-memory/fixtures.ts
+++ b/apps/api/src/adapters/in-memory/fixtures.ts
@@ -13,6 +13,7 @@ import {
  */
 
 export const SEED_PROGRAM = '5-3-1';
+export const SEED_LEANGAINS = 'leangains';
 
 export const seedCycleDashboard = (): CycleDashboard => ({
   program: SEED_PROGRAM,
@@ -65,6 +66,24 @@ export const seedLiftRecords = (): LiftRecord[] => [
     reps: 5,
     notes: 'AMRAP',
   },
+];
+
+export const seedLeangainsSpec = (): LiftingProgramSpec[] => [
+  // Day A — offset 0 (Mon: Chest / Back)
+  { week: 1, offset: 0, lift: 'Bench Press',       order: 1, sets: 3, reps: 6,  amrap: true,  increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+  { week: 1, offset: 0, lift: 'Weighted Pull-ups', order: 2, sets: 3, reps: 6,  amrap: true,  increment: 2.5, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+  { week: 1, offset: 0, lift: 'Incline DB Press',  order: 3, sets: 3, reps: 8,  amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
+  { week: 1, offset: 0, lift: 'Cable Row',         order: 4, sets: 3, reps: 10, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
+  // Day B — offset 2 (Wed: Legs)
+  { week: 1, offset: 2, lift: 'Squat',             order: 1, sets: 3, reps: 6,  amrap: true,  increment: 10,  warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+  { week: 1, offset: 2, lift: 'Romanian Deadlift', order: 2, sets: 3, reps: 8,  amrap: false, increment: 10,  warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
+  { week: 1, offset: 2, lift: 'Leg Curl',          order: 3, sets: 3, reps: 10, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'isolation' },
+  { week: 1, offset: 2, lift: 'Calf Raises',       order: 4, sets: 4, reps: 12, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'isolation' },
+  // Day C — offset 4 (Fri: Shoulders / Arms)
+  { week: 1, offset: 4, lift: 'Overhead Press',    order: 1, sets: 3, reps: 6,  amrap: true,  increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+  { week: 1, offset: 4, lift: 'Deadlift',          order: 2, sets: 1, reps: 5,  amrap: false, increment: 10,  warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
+  { week: 1, offset: 4, lift: 'Lateral Raises',    order: 3, sets: 4, reps: 12, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'isolation' },
+  { week: 1, offset: 4, lift: 'Dips',              order: 4, sets: 3, reps: 8,  amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
 ];
 
 export const seedProgramSpec = (): LiftingProgramSpec[] => [

--- a/apps/api/src/adapters/in-memory/lifting-program-spec.adapter.ts
+++ b/apps/api/src/adapters/in-memory/lifting-program-spec.adapter.ts
@@ -9,7 +9,7 @@ import {
   ILiftingProgramSpecRepository,
   SaveProgramSpecResult,
 } from '../../ports/ILiftingProgramSpecRepository';
-import { SEED_PROGRAM, seedProgramSpec } from './fixtures';
+import { SEED_PROGRAM, seedProgramSpec, SEED_LEANGAINS, seedLeangainsSpec } from './fixtures';
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -20,7 +20,10 @@ export class InMemoryLiftingProgramSpecRepository
 
   constructor(_preSeed = false) {
     // Program specs are global (not per-user), so always seed them.
-    this.specByProgram = new Map([[SEED_PROGRAM, seedProgramSpec()]]);
+    this.specByProgram = new Map([
+      [SEED_PROGRAM, seedProgramSpec()],
+      [SEED_LEANGAINS, seedLeangainsSpec()],
+    ]);
   }
 
   async getProgramSpec(program: string): Promise<LiftingProgramSpec[]> {

--- a/apps/api/src/adapters/prisma/hybrid-program-spec.repository.spec.ts
+++ b/apps/api/src/adapters/prisma/hybrid-program-spec.repository.spec.ts
@@ -59,6 +59,16 @@ describe('HybridLiftingProgramSpecRepository', () => {
     expect(prisma.customProgramSpec.findMany).not.toHaveBeenCalled();
   });
 
+  it('resolves leangains spec from the in-memory adapter', async () => {
+    const prisma = makePrisma();
+    const repo = new HybridLiftingProgramSpecRepository(prisma, 'user-1');
+
+    const leangainsSpec = await repo.getProgramSpec('leangains');
+
+    expect(leangainsSpec.length).toBeGreaterThan(0);
+    expect(prisma.customProgramSpec.findMany).not.toHaveBeenCalled();
+  });
+
   it('scopes custom-program lookups to the requesting user (isolation guard)', async () => {
     const prisma = makePrisma();
     const repo = new HybridLiftingProgramSpecRepository(prisma, 'user-1');

--- a/apps/web/app/(authed)/onboarding/steps/StepProgram.test.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepProgram.test.tsx
@@ -206,36 +206,31 @@ describe('StepProgram — availability toggle', () => {
   });
 });
 
-describe('StepProgram — catalog empty state', () => {
-  it('shows a toggle-aware empty state in the full catalog when a goal hides every available program', async () => {
+describe('StepProgram — leangains availability', () => {
+  it('shows leangains without enabling the coming-soon toggle', async () => {
     const user = userEvent.setup();
+    // Leangains is intermediate; default Harness experience is intermediate.
+    render(<Harness />);
 
-    // A goal that no available preset satisfies (RPT is the only available preset
-    // today: strength/muscle-gain). Derived from data + guarded so a future change
-    // that makes every goal available fails loudly here instead of silently passing.
+    // Leangains visible in the default tier view without touching the toggle.
+    expect(screen.getByText('Leangains (Berkhan)')).toBeInTheDocument();
+
+    // Also visible in the full catalog.
+    await user.click(screen.getByRole('button', { name: /view full catalog/i }));
+    expect(screen.getByText('Leangains (Berkhan)')).toBeInTheDocument();
+  });
+});
+
+describe('StepProgram — goal coverage guard', () => {
+  it('every goal has at least one available program', () => {
+    // Guard: if a new goal is added to the Goal type without a matching available program,
+    // this test fails loudly. Update the available set or this assertion when goals expand.
     const availableGoals = new Set(
       PROGRAMS.filter((p) => p.available).flatMap((p) => p.goals),
     );
-    const candidates: { goal: Goal; label: RegExp }[] = [
-      { goal: 'fat-loss', label: /fat loss/i },
-      { goal: 'body-composition', label: /body composition/i },
-    ];
-    const emptying = candidates.find((c) => !availableGoals.has(c.goal));
-    if (!emptying) {
-      throw new Error(
-        'Test setup: expected a goal with no available preset (catalog empty-state path is otherwise unreachable — update this test if the available set changed)',
-      );
+    const ALL_GOALS: Goal[] = ['strength', 'muscle-gain', 'fat-loss', 'body-composition'];
+    for (const g of ALL_GOALS) {
+      expect(availableGoals.has(g)).toBe(true);
     }
-
-    render(<Harness />);
-
-    // Open the full catalog (spans every experience tier), then filter to the
-    // emptying goal so every tier is empty under the default availability filter.
-    await user.click(screen.getByRole('button', { name: /view full catalog/i }));
-    await user.click(screen.getByRole('button', { name: emptying.label }));
-
-    // The catalog explains the empty result and points at the reveal toggle, rather
-    // than showing nothing but a "Back" button on blank space.
-    expect(screen.getByText(/turn on .*show coming soon.* to preview/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/app/(authed)/programs/BrowseTab.test.tsx
+++ b/apps/web/app/(authed)/programs/BrowseTab.test.tsx
@@ -44,6 +44,22 @@ describe('BrowseTab — availability toggle', () => {
   });
 });
 
+describe('BrowseTab — empty state', () => {
+  it('shows the toggle-aware hint when an experience filter hides all available programs', async () => {
+    const user = userEvent.setup();
+    // Both available programs (RPT, Leangains) are 'intermediate'. Clicking 'Beginner'
+    // leaves zero available programs visible; unavailable beginner programs (Starting
+    // Strength, StrongLifts) exist, so hiddenUnavailableCount > 0 and the hint renders.
+    render(<BrowseTab activeProgram={null} workoutSchedule={null} />);
+
+    await user.click(screen.getByRole('button', { name: /^beginner$/i }));
+
+    expect(
+      screen.getByText(/turn on.*show coming soon.*to preview/i),
+    ).toBeInTheDocument();
+  });
+});
+
 describe('BrowseTab — leangains availability', () => {
   it('shows leangains without enabling the coming-soon toggle', () => {
     render(<BrowseTab activeProgram={null} workoutSchedule={null} />);

--- a/apps/web/app/(authed)/programs/BrowseTab.test.tsx
+++ b/apps/web/app/(authed)/programs/BrowseTab.test.tsx
@@ -3,24 +3,6 @@ import userEvent from '@testing-library/user-event';
 import BrowseTab from './BrowseTab';
 import { PROGRAMS, type Goal } from '@/lib/programs';
 
-/** A goal that no *available* preset satisfies, so selecting it empties the default
- *  (availability-filtered) view. Derived from data + guarded so a future change that
- *  makes every goal available fails loudly here instead of silently passing. */
-function findEmptyingGoal(): { goal: Goal; label: RegExp } {
-  const availableGoals = new Set(PROGRAMS.filter((p) => p.available).flatMap((p) => p.goals));
-  const candidates: { goal: Goal; label: RegExp }[] = [
-    { goal: 'fat-loss', label: /fat loss/i },
-    { goal: 'body-composition', label: /body composition/i },
-  ];
-  const emptying = candidates.find((c) => !availableGoals.has(c.goal));
-  if (!emptying) {
-    throw new Error(
-      'Test setup: expected ≥1 goal with no available preset (the empty-tier-view path is unreachable otherwise — update this test if the available set changed)',
-    );
-  }
-  return emptying;
-}
-
 // BrowseTab statically imports SwitchProgramDialog, which transitively pulls in
 // the server-only `./actions` module (switchProgram). The dialog only renders
 // after a "Choose This Program" click and is not under test here, so stub it to
@@ -62,25 +44,21 @@ describe('BrowseTab — availability toggle', () => {
   });
 });
 
-describe('BrowseTab — empty state', () => {
-  it('shows a toggle-aware empty state when the active goal hides every available program', async () => {
-    const user = userEvent.setup();
-    const emptying = findEmptyingGoal();
-
+describe('BrowseTab — leangains availability', () => {
+  it('shows leangains without enabling the coming-soon toggle', () => {
     render(<BrowseTab activeProgram={null} workoutSchedule={null} />);
+    expect(screen.getByText('Leangains (Berkhan)')).toBeInTheDocument();
+  });
+});
 
-    // Default "All Levels" view (the tier-grouped render) shows only available
-    // presets; selecting a goal none of them satisfy empties every tier.
-    await user.click(screen.getByRole('button', { name: emptying.label }));
-
-    // The empty tier view explains itself and points at the reveal toggle, rather
-    // than rendering a blank area below the filters.
-    expect(screen.getByText(/turn on .*show coming soon.* to preview/i)).toBeInTheDocument();
-
-    // Revealing unavailable presets clears the hint (matching coming-soon presets appear).
-    await user.click(screen.getByRole('button', { name: /show coming soon/i }));
-    expect(
-      screen.queryByText(/turn on .*show coming soon.* to preview/i),
-    ).not.toBeInTheDocument();
+describe('BrowseTab — goal coverage guard', () => {
+  it('every goal has at least one available program', () => {
+    // Guard: if a new goal is added to the Goal type without a matching available program,
+    // this test fails loudly. Update the available set or this assertion when goals expand.
+    const availableGoals = new Set(PROGRAMS.filter((p) => p.available).flatMap((p) => p.goals));
+    const ALL_GOALS: Goal[] = ['strength', 'muscle-gain', 'fat-loss', 'body-composition'];
+    for (const g of ALL_GOALS) {
+      expect(availableGoals.has(g)).toBe(true);
+    }
   });
 });

--- a/apps/web/app/(authed)/programs/ProgramEditor.tsx
+++ b/apps/web/app/(authed)/programs/ProgramEditor.tsx
@@ -57,8 +57,16 @@ function buildSpecsFromTemplate(templateId: string, lifts: string[]): CustomProg
     templateId === SEED_LEANGAINS ? seedLeangainsSpec() :
     null;
   if (seeded) {
+    // Single-week repeating templates (maxWeek === 1) define one week's structure that
+    // repeats unchanged. Expand to all three editor weeks so weeks 2 and 3 don't fall
+    // through to DEFAULT_ROW when the user clones the template.
+    const maxWeek = Math.max(...seeded.map((s) => s.week));
+    const expanded =
+      maxWeek === 1
+        ? [1, 2, 3].flatMap((w) => seeded.map((s) => ({ ...s, week: w })))
+        : seeded;
     const seededLifts = new Set(lifts);
-    const filtered = seeded.filter((s) => seededLifts.has(s.lift));
+    const filtered = expanded.filter((s) => seededLifts.has(s.lift));
     if (filtered.length > 0) return filtered.map((s) => ({ ...s, amrap: Boolean(s.amrap) }));
   }
   return buildDefaultSpecs(lifts);

--- a/apps/web/app/(authed)/programs/ProgramEditor.tsx
+++ b/apps/web/app/(authed)/programs/ProgramEditor.tsx
@@ -5,7 +5,7 @@ import { LIFT_CATALOG } from '@lifting-logbook/core';
 import { useRouter } from 'next/navigation';
 import type { CustomProgramResponse, CustomProgramSpecRow } from '@lifting-logbook/types';
 import { createCustomProgram, updateCustomProgram, switchProgram } from './actions';
-import { seedProgramSpec, SEED_PROGRAM } from '@/lib/programs';
+import { seedProgramSpec, SEED_PROGRAM, seedLeangainsSpec, SEED_LEANGAINS } from '@/lib/programs';
 import styles from './programs.module.css';
 
 type Mode = 'new' | 'clone' | 'edit';
@@ -52,8 +52,11 @@ function buildDefaultSpecs(lifts: string[]): CustomProgramSpecRow[] {
 }
 
 function buildSpecsFromTemplate(templateId: string, lifts: string[]): CustomProgramSpecRow[] {
-  if (templateId === SEED_PROGRAM) {
-    const seeded = seedProgramSpec();
+  const seeded =
+    templateId === SEED_PROGRAM ? seedProgramSpec() :
+    templateId === SEED_LEANGAINS ? seedLeangainsSpec() :
+    null;
+  if (seeded) {
     const seededLifts = new Set(lifts);
     const filtered = seeded.filter((s) => seededLifts.has(s.lift));
     if (filtered.length > 0) return filtered.map((s) => ({ ...s, amrap: Boolean(s.amrap) }));

--- a/apps/web/e2e/scheduling.spec.ts
+++ b/apps/web/e2e/scheduling.spec.ts
@@ -73,8 +73,8 @@ test('selecting a program with schedule set shows schedule-info step', async ({ 
 
   await page.goto('/programs');
 
-  // Open the switch dialog
-  await page.getByRole('button', { name: 'Choose This Program' }).click();
+  // Open the switch dialog (multiple programs available; pick the first)
+  await page.getByRole('button', { name: 'Choose This Program' }).first().click();
   await expect(page.getByRole('dialog')).toBeVisible();
 
   // Confirm switch
@@ -94,7 +94,7 @@ test('selecting a program without schedule skips the schedule-info step', async 
   // Default reset has workoutSchedule: null
   await page.goto('/programs');
 
-  await page.getByRole('button', { name: 'Choose This Program' }).click();
+  await page.getByRole('button', { name: 'Choose This Program' }).first().click();
   await expect(page.getByRole('dialog')).toBeVisible();
 
   await page.getByRole('button', { name: 'Confirm Switch' }).click();

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -150,9 +150,8 @@ test('programs page catalog loads and switch dialog can be opened', async ({ pag
 
   await expect(page.getByRole('heading', { name: 'Programs' })).toBeVisible();
 
-  // RPT is the only available program. "Choose This Program" is always visible in the
-  // collapsed card actions row — no need to expand "View Details" first.
-  await page.getByRole('button', { name: 'Choose This Program' }).click();
+  // Multiple programs are available; click the first card's action button.
+  await page.getByRole('button', { name: 'Choose This Program' }).first().click();
   await expect(page.getByRole('dialog')).toBeVisible();
   await expect(page.getByRole('button', { name: 'Confirm Switch' })).toBeVisible();
 

--- a/apps/web/lib/__tests__/programs.seedLeangains.test.ts
+++ b/apps/web/lib/__tests__/programs.seedLeangains.test.ts
@@ -1,0 +1,46 @@
+import { seedLeangainsSpec, SEED_LEANGAINS } from '../programs';
+
+describe('seedLeangainsSpec', () => {
+  const rows = seedLeangainsSpec();
+
+  it('returns 12 rows (4 lifts × 3 days)', () => {
+    expect(rows).toHaveLength(12);
+  });
+
+  it('all rows have week=1 (single-week repeating template)', () => {
+    for (const r of rows) {
+      expect(r.week).toBe(1);
+    }
+  });
+
+  it('covers exactly offsets 0, 2, 4 (Mon/Wed/Fri)', () => {
+    const offsets = new Set(rows.map((r) => r.offset));
+    expect([...offsets].sort((a, b) => a - b)).toEqual([0, 2, 4]);
+  });
+
+  it('satisfies all DTO bounds', () => {
+    for (const r of rows) {
+      expect([1, 2, 3]).toContain(r.week);
+      expect(r.offset).toBeGreaterThanOrEqual(0);
+      expect(r.increment).toBeGreaterThan(0);
+      expect(r.order).toBeGreaterThanOrEqual(1);
+      expect(r.sets).toBeGreaterThanOrEqual(1);
+      expect(r.sets).toBeLessThanOrEqual(20);
+      expect(r.reps).toBeGreaterThanOrEqual(1);
+      expect(r.reps).toBeLessThanOrEqual(20);
+      expect(r.wtDecrementPct).toBeGreaterThanOrEqual(0);
+      expect(r.wtDecrementPct).toBeLessThanOrEqual(1);
+      // 1 − (sets−1)·wtDecrementPct ≥ 0
+      expect(1 - (r.sets - 1) * r.wtDecrementPct).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('has unique (week, offset, lift, order) natural keys', () => {
+    const keys = rows.map((r) => `${r.week}:${r.offset}:${r.lift}:${r.order}`);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('SEED_LEANGAINS matches the leangains program id', () => {
+    expect(SEED_LEANGAINS).toBe('leangains');
+  });
+});

--- a/apps/web/lib/programs.ts
+++ b/apps/web/lib/programs.ts
@@ -28,6 +28,7 @@ export type Program = {
 };
 
 export const SEED_PROGRAM = '5-3-1';
+export const SEED_LEANGAINS = 'leangains';
 
 export type SeedSpec = {
   week: number; offset: number; lift: string; increment: number; order: number;
@@ -49,6 +50,26 @@ export function seedProgramSpec(): SeedSpec[] {
     { week: 3, offset: 0, lift: 'Bench Press',    increment: 5,  order: 2, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
     { week: 3, offset: 3, lift: 'Deadlift',       increment: 10, order: 1, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
     { week: 3, offset: 3, lift: 'Overhead Press', increment: 5,  order: 2, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+  ];
+}
+
+export function seedLeangainsSpec(): SeedSpec[] {
+  return [
+    // Day A — offset 0 (Mon: Chest / Back)
+    { week: 1, offset: 0, lift: 'Bench Press',       order: 1, sets: 3, reps: 6,  amrap: true,  increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 1, offset: 0, lift: 'Weighted Pull-ups', order: 2, sets: 3, reps: 6,  amrap: true,  increment: 2.5, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 1, offset: 0, lift: 'Incline DB Press',  order: 3, sets: 3, reps: 8,  amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
+    { week: 1, offset: 0, lift: 'Cable Row',         order: 4, sets: 3, reps: 10, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
+    // Day B — offset 2 (Wed: Legs)
+    { week: 1, offset: 2, lift: 'Squat',             order: 1, sets: 3, reps: 6,  amrap: true,  increment: 10,  warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 1, offset: 2, lift: 'Romanian Deadlift', order: 2, sets: 3, reps: 8,  amrap: false, increment: 10,  warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
+    { week: 1, offset: 2, lift: 'Leg Curl',          order: 3, sets: 3, reps: 10, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'isolation' },
+    { week: 1, offset: 2, lift: 'Calf Raises',       order: 4, sets: 4, reps: 12, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'isolation' },
+    // Day C — offset 4 (Fri: Shoulders / Arms)
+    { week: 1, offset: 4, lift: 'Overhead Press',    order: 1, sets: 3, reps: 6,  amrap: true,  increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 1, offset: 4, lift: 'Deadlift',          order: 2, sets: 1, reps: 5,  amrap: false, increment: 10,  warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
+    { week: 1, offset: 4, lift: 'Lateral Raises',    order: 3, sets: 4, reps: 12, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'isolation' },
+    { week: 1, offset: 4, lift: 'Dips',              order: 4, sets: 3, reps: 8,  amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
   ];
 }
 
@@ -283,7 +304,7 @@ export const PROGRAMS: Program[] = [
       { day: 'Wednesday (Legs)', lifts: ['Squat RPT', 'Romanian Deadlift 3×8', 'Leg Curl 3×10', 'Calf Raises 4×12'] },
       { day: 'Friday (Shoulders/Arms)', lifts: ['Overhead Press RPT', 'Deadlift 1×5', 'Lateral Raises 4×12', 'Dips 3×8'] },
     ],
-    available: false,
+    available: true,
   },
   {
     id: 'conjugate',


### PR DESCRIPTION
## Summary

Closes #581

- **`apps/web/lib/programs.ts`**: set `leangains` to `available: true`; add `SEED_LEANGAINS = 'leangains'` constant and `seedLeangainsSpec()` returning a 12-row DTO-valid spec (week=1, offsets 0/2/4 for Mon/Wed/Fri; RPT compounds at 10% decrement + fixed-weight accessories)
- **`apps/web/app/(authed)/programs/ProgramEditor.tsx`**: extend `buildSpecsFromTemplate` to handle `SEED_LEANGAINS` with the same filter logic used for `SEED_PROGRAM`
- **`apps/api/src/adapters/in-memory/fixtures.ts`** + **`lifting-program-spec.adapter.ts`**: add `seedLeangainsSpec()` and seed leangains in the in-memory adapter so `initializeCycle('leangains')` works in tests

## Test changes

- `apps/web/lib/__tests__/programs.seedLeangains.test.ts` (new): verifies 12 rows, DTO bounds, unique natural keys
- `BrowseTab.test.tsx` and `StepProgram.test.tsx`: both had a guard (`findEmptyingGoal` / inline) that found a goal with no available preset. With leangains covering all 4 goals (`strength`, `muscle-gain`, `fat-loss`, `body-composition`), that path is unreachable — replaced with an `assertAllGoalsCovered` check and leangains-visibility assertions. Both guard comments anticipated this: *"update this test if the available set changed"*

## Acceptance criteria

- [x] `leangains` visible and selectable in Browse and onboarding without "Show coming soon" toggle
- [x] `createFirstCycle('leangains')` accepted (dynamic allow-list reads `available` programs)
- [x] `ProgramEditor` clone mode works from leangains base template
- [x] `initializeCycle('leangains')` has a spec in the in-memory adapter
- [x] `seedLeangainsSpec()` spec rows all DTO-valid

## Testing

```
npm test -w @lifting-logbook/web   # 120 passed, 0 skipped, 0 failed
npm test -w @lifting-logbook/api   # 395 passed, 0 skipped, 0 failed
npm run build                      # 6 tasks successful
```

Tests: 515 passed, 0 skipped, 0 failed

Suppression grep: clean (no new `ts-ignore`, `eslint-disable`, `?? null`, or `!` suppressions)  
Test-integrity grep: clean (no new skip markers, deleted test files, or lowered thresholds)

## Note on PR2 dependency

The plan identified a dependency on PR2 (`PRESET_BASE_SPECS.leangains`). T2 doesn't actually need an import from `packages/core` — the Leangains compounds are inlined in `seedLeangainsSpec()` consistent with what PR2 will define. No cross-package import added.

## Review findings disposition

Findings from [code review comment](https://github.com/brownm09/lifting-logbook/pull/582#issuecomment-4782832131):

| # | Finding | Disposition |
|---|---------|-------------|
| 1 | Clone leangains fills weeks 2+3 with DEFAULT_ROW | Fixed in `3ca788e` — `buildSpecsFromTemplate` now expands single-week specs (maxWeek===1) to all three editor weeks |
| 2 | BrowseTab empty-state hint path untested | Fixed in `3ca788e` — added `describe('BrowseTab — empty state')` test asserting hint text appears on Beginner filter |
| 3 | No API test for `getProgramSpec('leangains')` | Fixed in `3ca788e` — added assertion in `hybrid-program-spec.repository.spec.ts` |
| 4 | `seedLeangainsSpec` duplicated in programs.ts and fixtures.ts | Filed [#583](https://github.com/brownm09/lifting-logbook/issues/583) — consolidate into packages/core; out of scope for this PR |
| 5 | `buildSpecsFromTemplate` ternary chain needs manual extension per new program | Filed [#584](https://github.com/brownm09/lifting-logbook/issues/584) — replace with dispatch map; out of scope for this PR |