### PR TITLE
[fix] TS2322 in bucketClass — CSS module string | undefined vs string return type

### DIFF
--- a/apps/web/app/(authed)/import/ImportWizard.tsx
+++ b/apps/web/app/(authed)/import/ImportWizard.tsx
@@ -48,10 +48,10 @@ const ALL_KINDS: ImportKind[] = [
 
 function bucketClass(bucket: 'high' | 'medium' | 'low'): string {
   return bucket === 'high'
-    ? styles.bucketHigh
+    ? styles.bucketHigh ?? ''
     : bucket === 'medium'
-      ? styles.bucketMedium
-      : styles.bucketLow;
+      ? styles.bucketMedium ?? ''
+      : styles.bucketLow ?? '';
 }
 
 export function ImportWizard({ programs }: { programs: CustomProgramSummaryResponse[] }) {


### PR DESCRIPTION
## Summary

`bucketClass()` in `apps/web/app/(authed)/import/ImportWizard.tsx` was introduced by PR #578 with a declared return type of `string`. Next.js types CSS module property lookups as `string | undefined`, causing TS2322 in ts-jest diagnostics. Tests still passed at runtime (type-only error), but the diagnostic was noise in every web suite run since #578 landed.

Changing the return type to `string | undefined` would be wrong — the sole call site (line 233) concatenates the result into a className template literal, which would render the literal string `"undefined"` in the DOM for a missing class. Instead, `?? ''` is added to all three branches: the `string` promise is kept, and a missing class (theoretical — all three are defined in `import.module.css`) yields a harmless empty string.

## Acceptance criteria

- [x] `npm test -w @lifting-logbook/web` passes with no TS2322 diagnostic for `ImportWizard.tsx`
- [x] No logic change — all three CSS classes exist and resolve to their expected strings at runtime

## Testing

```
Tests: 120 passed, 120 total
Snapshots: 0 total
Time: 64.205s
```

No skips, no suppressions introduced. Playwright E2E not required (no aria-label, role, or display-string change).

## Suppression check

```
git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|![.[]|!\s*[;,)]|\?\? null)'
```
No matches — `?? ''` is not a suppression.

## Test integrity check

No skip markers, no deleted tests, no coverage-threshold changes.

Closes #585