### PR TITLE
[feat] Add PRESET_BASE_SPECS and program inference functions to packages/core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './catalog';
 export * from './constants';
 export * from './models';
+export * from './presets';
 export * from './services';
 export * from './utils';

--- a/packages/core/src/presets/index.test.ts
+++ b/packages/core/src/presets/index.test.ts
@@ -127,11 +127,15 @@ describe('inferProgramFromLiftRecords', () => {
     expect(inferProgramFromLiftRecords([...LIFTS_531, 'Barbell Row'])).toBe('5-3-1');
   });
 
+  it("returns 'leangains' when history covers all leangains lifts", () => {
+    expect(inferProgramFromLiftRecords(LIFTS_LEANGAINS)).toBe('leangains');
+  });
+
   it('returns null when history matches no preset', () => {
     expect(inferProgramFromLiftRecords(['Squat', 'Bench Press'])).toBeNull();
   });
 
-  it('returns null when history is empty even with a known lift', () => {
+  it('returns null for a single-lift history that matches no preset', () => {
     expect(inferProgramFromLiftRecords(['Squat'])).toBeNull();
   });
 });

--- a/packages/core/src/presets/index.test.ts
+++ b/packages/core/src/presets/index.test.ts
@@ -1,0 +1,137 @@
+import {
+  PRESET_BASE_SPECS,
+  parseProgramSpecFlexible,
+  detectPresetSuperset,
+  inferProgramFromLiftRecords,
+} from '.';
+
+const LIFTS_531 = ['Squat', 'Bench Press', 'Deadlift', 'Overhead Press'];
+const LIFTS_LEANGAINS = [
+  'Bench Press', 'Weighted Pull-ups', 'Incline DB Press', 'Cable Row',
+  'Squat', 'Romanian Deadlift', 'Leg Curl', 'Calf Raises',
+  'Overhead Press', 'Deadlift', 'Lateral Raises', 'Dips',
+];
+
+describe('PRESET_BASE_SPECS', () => {
+  it('exposes 5-3-1 and leangains entries', () => {
+    expect(Object.keys(PRESET_BASE_SPECS)).toContain('5-3-1');
+    expect(Object.keys(PRESET_BASE_SPECS)).toContain('leangains');
+  });
+
+  it('5-3-1 covers the four main lifts across 3 weeks', () => {
+    const spec = PRESET_BASE_SPECS['5-3-1'];
+    expect(spec).toBeDefined();
+    if (!spec) return;
+    const lifts = [...new Set(spec.map((r) => r.lift))].sort();
+    expect(lifts).toEqual([...LIFTS_531].sort());
+    const weeks = [...new Set(spec.map((r) => r.week))].sort();
+    expect(weeks).toEqual([1, 2, 3]);
+  });
+
+  it('leangains covers three workout days (offsets 0, 2, 4)', () => {
+    const spec = PRESET_BASE_SPECS['leangains'];
+    expect(spec).toBeDefined();
+    if (!spec) return;
+    const offsets = [...new Set(spec.map((r) => r.offset))].sort((a, b) => a - b);
+    expect(offsets).toEqual([0, 2, 4]);
+  });
+});
+
+describe('parseProgramSpecFlexible', () => {
+  const validRow = {
+    week: 1, offset: 0, lift: 'Squat', increment: 5, order: 1,
+    sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6',
+    wtDecrementPct: 0.1, activation: 'compound',
+  };
+
+  it('returns null for an empty array', () => {
+    expect(parseProgramSpecFlexible([])).toBeNull();
+  });
+
+  it('returns the typed array for valid rows', () => {
+    const rows = PRESET_BASE_SPECS['5-3-1'];
+    expect(rows).toBeDefined();
+    if (!rows) return;
+    expect(parseProgramSpecFlexible(rows)).toEqual(rows);
+  });
+
+  it('accepts amrap as a string', () => {
+    expect(parseProgramSpecFlexible([{ ...validRow, amrap: 'true' }])).not.toBeNull();
+  });
+
+  it('returns null when a required field is missing', () => {
+    const { lift: _omit, ...noLift } = validRow;
+    expect(parseProgramSpecFlexible([noLift])).toBeNull();
+  });
+
+  it('returns null when a field has the wrong type', () => {
+    expect(parseProgramSpecFlexible([{ ...validRow, week: '1' }])).toBeNull();
+  });
+
+  it('returns null if any row is invalid (fails fast)', () => {
+    const rows = [validRow, { ...validRow, sets: 'three' }];
+    expect(parseProgramSpecFlexible(rows)).toBeNull();
+  });
+
+  it('returns null for a null item in the array', () => {
+    expect(parseProgramSpecFlexible([null])).toBeNull();
+  });
+
+  it('returns null for a primitive item in the array', () => {
+    expect(parseProgramSpecFlexible(['string'])).toBeNull();
+  });
+});
+
+describe('detectPresetSuperset', () => {
+  it('returns true when liftHistory contains all 5-3-1 lifts', () => {
+    expect(detectPresetSuperset(LIFTS_531, '5-3-1')).toBe(true);
+  });
+
+  it('returns true when liftHistory is a strict superset of 5-3-1 lifts', () => {
+    expect(detectPresetSuperset([...LIFTS_531, 'Barbell Row', 'Chin-up'], '5-3-1')).toBe(true);
+  });
+
+  it('returns false when a required 5-3-1 lift is missing', () => {
+    const withoutOhp = LIFTS_531.filter((l) => l !== 'Overhead Press');
+    expect(detectPresetSuperset(withoutOhp, '5-3-1')).toBe(false);
+  });
+
+  it('returns false for an unknown presetId', () => {
+    expect(detectPresetSuperset(LIFTS_531, 'unknown-program')).toBe(false);
+  });
+
+  it('returns false for an empty liftHistory when the preset has lifts', () => {
+    expect(detectPresetSuperset([], '5-3-1')).toBe(false);
+  });
+
+  it('returns true when liftHistory covers all leangains lifts', () => {
+    expect(detectPresetSuperset(LIFTS_LEANGAINS, 'leangains')).toBe(true);
+  });
+
+  it('returns false for leangains when a unique lift is missing', () => {
+    const withoutPullups = LIFTS_LEANGAINS.filter((l) => l !== 'Weighted Pull-ups');
+    expect(detectPresetSuperset(withoutPullups, 'leangains')).toBe(false);
+  });
+});
+
+describe('inferProgramFromLiftRecords', () => {
+  it('returns null for an empty liftHistory', () => {
+    expect(inferProgramFromLiftRecords([])).toBeNull();
+  });
+
+  it("returns '5-3-1' when history covers exactly those lifts", () => {
+    expect(inferProgramFromLiftRecords(LIFTS_531)).toBe('5-3-1');
+  });
+
+  it("returns '5-3-1' for a strict superset of those lifts", () => {
+    expect(inferProgramFromLiftRecords([...LIFTS_531, 'Barbell Row'])).toBe('5-3-1');
+  });
+
+  it('returns null when history matches no preset', () => {
+    expect(inferProgramFromLiftRecords(['Squat', 'Bench Press'])).toBeNull();
+  });
+
+  it('returns null when history is empty even with a known lift', () => {
+    expect(inferProgramFromLiftRecords(['Squat'])).toBeNull();
+  });
+});

--- a/packages/core/src/presets/index.ts
+++ b/packages/core/src/presets/index.ts
@@ -1,0 +1,81 @@
+import { LiftingProgramSpec } from '../models/LiftingProgramSpec';
+
+export const PRESET_BASE_SPECS: Record<string, LiftingProgramSpec[]> = {
+  '5-3-1': [
+    // Week 1: 3×5 (65/75/85% TM)
+    { week: 1, offset: 0, lift: 'Squat',         increment: 5,  order: 1, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 1, offset: 0, lift: 'Bench Press',    increment: 5,  order: 2, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 1, offset: 3, lift: 'Deadlift',       increment: 10, order: 1, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 1, offset: 3, lift: 'Overhead Press', increment: 5,  order: 2, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    // Week 2: 3×3 (70/80/90% TM)
+    { week: 2, offset: 0, lift: 'Squat',         increment: 5,  order: 1, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 2, offset: 0, lift: 'Bench Press',    increment: 5,  order: 2, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 2, offset: 3, lift: 'Deadlift',       increment: 10, order: 1, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 2, offset: 3, lift: 'Overhead Press', increment: 5,  order: 2, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    // Week 3: 5/3/1 (75/85/95% TM, last set AMRAP)
+    { week: 3, offset: 0, lift: 'Squat',         increment: 5,  order: 1, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 3, offset: 0, lift: 'Bench Press',    increment: 5,  order: 2, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 3, offset: 3, lift: 'Deadlift',       increment: 10, order: 1, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 3, offset: 3, lift: 'Overhead Press', increment: 5,  order: 2, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+  ],
+  leangains: [
+    // Day A — offset 0 (Mon: Chest / Back)
+    { week: 1, offset: 0, lift: 'Bench Press',       order: 1, sets: 3, reps: 6,  amrap: true,  increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 1, offset: 0, lift: 'Weighted Pull-ups', order: 2, sets: 3, reps: 6,  amrap: true,  increment: 2.5, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 1, offset: 0, lift: 'Incline DB Press',  order: 3, sets: 3, reps: 8,  amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
+    { week: 1, offset: 0, lift: 'Cable Row',         order: 4, sets: 3, reps: 10, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
+    // Day B — offset 2 (Wed: Legs)
+    { week: 1, offset: 2, lift: 'Squat',             order: 1, sets: 3, reps: 6,  amrap: true,  increment: 10,  warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 1, offset: 2, lift: 'Romanian Deadlift', order: 2, sets: 3, reps: 8,  amrap: false, increment: 10,  warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
+    { week: 1, offset: 2, lift: 'Leg Curl',          order: 3, sets: 3, reps: 10, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'isolation' },
+    { week: 1, offset: 2, lift: 'Calf Raises',       order: 4, sets: 4, reps: 12, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'isolation' },
+    // Day C — offset 4 (Fri: Shoulders / Arms)
+    { week: 1, offset: 4, lift: 'Overhead Press',    order: 1, sets: 3, reps: 6,  amrap: true,  increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 1, offset: 4, lift: 'Deadlift',          order: 2, sets: 1, reps: 5,  amrap: false, increment: 10,  warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
+    { week: 1, offset: 4, lift: 'Lateral Raises',    order: 3, sets: 4, reps: 12, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'isolation' },
+    { week: 1, offset: 4, lift: 'Dips',              order: 4, sets: 3, reps: 8,  amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
+  ],
+};
+
+function isLiftingProgramSpec(row: unknown): row is LiftingProgramSpec {
+  if (!row || typeof row !== 'object') return false;
+  const r = row as Record<string, unknown>;
+  return (
+    typeof r['week'] === 'number' &&
+    typeof r['offset'] === 'number' &&
+    typeof r['lift'] === 'string' &&
+    (r['lift'] as string).length > 0 &&
+    typeof r['increment'] === 'number' &&
+    typeof r['order'] === 'number' &&
+    typeof r['sets'] === 'number' &&
+    typeof r['reps'] === 'number' &&
+    (typeof r['amrap'] === 'string' || typeof r['amrap'] === 'boolean') &&
+    typeof r['warmUpPct'] === 'string' &&
+    typeof r['wtDecrementPct'] === 'number' &&
+    typeof r['activation'] === 'string'
+  );
+}
+
+export function parseProgramSpecFlexible(rows: unknown[]): LiftingProgramSpec[] | null {
+  if (!rows.length) return null;
+  const result: LiftingProgramSpec[] = [];
+  for (const row of rows) {
+    if (!isLiftingProgramSpec(row)) return null;
+    result.push(row);
+  }
+  return result;
+}
+
+export function detectPresetSuperset(liftHistory: string[], presetId: string): boolean {
+  const spec = PRESET_BASE_SPECS[presetId];
+  if (!spec) return false;
+  const presetLifts = [...new Set(spec.map((row) => row.lift as string))];
+  return presetLifts.every((lift) => liftHistory.includes(lift));
+}
+
+export function inferProgramFromLiftRecords(liftHistory: string[]): string | null {
+  for (const presetId of Object.keys(PRESET_BASE_SPECS)) {
+    if (detectPresetSuperset(liftHistory, presetId)) return presetId;
+  }
+  return null;
+}

--- a/packages/core/src/presets/index.ts
+++ b/packages/core/src/presets/index.ts
@@ -1,23 +1,8 @@
 import { LiftingProgramSpec } from '../models/LiftingProgramSpec';
 
 export const PRESET_BASE_SPECS: Record<string, LiftingProgramSpec[]> = {
-  '5-3-1': [
-    // Week 1: 3×5 (65/75/85% TM)
-    { week: 1, offset: 0, lift: 'Squat',         increment: 5,  order: 1, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 1, offset: 0, lift: 'Bench Press',    increment: 5,  order: 2, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 1, offset: 3, lift: 'Deadlift',       increment: 10, order: 1, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 1, offset: 3, lift: 'Overhead Press', increment: 5,  order: 2, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    // Week 2: 3×3 (70/80/90% TM)
-    { week: 2, offset: 0, lift: 'Squat',         increment: 5,  order: 1, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 2, offset: 0, lift: 'Bench Press',    increment: 5,  order: 2, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 2, offset: 3, lift: 'Deadlift',       increment: 10, order: 1, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 2, offset: 3, lift: 'Overhead Press', increment: 5,  order: 2, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    // Week 3: 5/3/1 (75/85/95% TM, last set AMRAP)
-    { week: 3, offset: 0, lift: 'Squat',         increment: 5,  order: 1, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 3, offset: 0, lift: 'Bench Press',    increment: 5,  order: 2, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 3, offset: 3, lift: 'Deadlift',       increment: 10, order: 1, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 3, offset: 3, lift: 'Overhead Press', increment: 5,  order: 2, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-  ],
+  // leangains is defined first: it requires 12 unique lifts vs 5-3-1's 4, so inferProgramFromLiftRecords
+  // checks the more-specific preset first and avoids misclassifying leangains users as 5-3-1.
   leangains: [
     // Day A — offset 0 (Mon: Chest / Back)
     { week: 1, offset: 0, lift: 'Bench Press',       order: 1, sets: 3, reps: 6,  amrap: true,  increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
@@ -34,6 +19,23 @@ export const PRESET_BASE_SPECS: Record<string, LiftingProgramSpec[]> = {
     { week: 1, offset: 4, lift: 'Deadlift',          order: 2, sets: 1, reps: 5,  amrap: false, increment: 10,  warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
     { week: 1, offset: 4, lift: 'Lateral Raises',    order: 3, sets: 4, reps: 12, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'isolation' },
     { week: 1, offset: 4, lift: 'Dips',              order: 4, sets: 3, reps: 8,  amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
+  ],
+  '5-3-1': [
+    // Week 1: 3×5 (65/75/85% TM)
+    { week: 1, offset: 0, lift: 'Squat',         increment: 5,  order: 1, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 1, offset: 0, lift: 'Bench Press',    increment: 5,  order: 2, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 1, offset: 3, lift: 'Deadlift',       increment: 10, order: 1, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 1, offset: 3, lift: 'Overhead Press', increment: 5,  order: 2, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    // Week 2: 3×3 (70/80/90% TM)
+    { week: 2, offset: 0, lift: 'Squat',         increment: 5,  order: 1, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 2, offset: 0, lift: 'Bench Press',    increment: 5,  order: 2, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 2, offset: 3, lift: 'Deadlift',       increment: 10, order: 1, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 2, offset: 3, lift: 'Overhead Press', increment: 5,  order: 2, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    // Week 3: 5/3/1 (75/85/95% TM, last set AMRAP)
+    { week: 3, offset: 0, lift: 'Squat',         increment: 5,  order: 1, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 3, offset: 0, lift: 'Bench Press',    increment: 5,  order: 2, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 3, offset: 3, lift: 'Deadlift',       increment: 10, order: 1, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    { week: 3, offset: 3, lift: 'Overhead Press', increment: 5,  order: 2, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
   ],
 };
 


### PR DESCRIPTION
## Summary

- Adds `PRESET_BASE_SPECS` to `@lifting-logbook/core` — a single `Record<string, LiftingProgramSpec[]>` keyed by preset program ID (`'5-3-1'` and `'leangains'`), consolidating the canonical spec data that `seedProgramSpec()` / `seedLeangainsSpec()` in `apps/web` and `apps/api` currently duplicate.
- Adds `parseProgramSpecFlexible(rows: unknown[]): LiftingProgramSpec[] | null` — validates and coerces an arbitrary array into the typed spec shape; returns `null` on failure.
- Adds `detectPresetSuperset(liftHistory: string[], presetId: string): boolean` — returns `true` when the user's lift history is a superset of the lifts required by the given preset.
- Adds `inferProgramFromLiftRecords(liftHistory: string[]): string | null` — iterates `PRESET_BASE_SPECS` and returns the first matching preset ID, or `null`.

Closes #587

Part of a multi-PR sequence. The callers in `apps/web` and `apps/api` that currently duplicate this data will be migrated to delegate to `@lifting-logbook/core` in issue #583.

## Acceptance criteria

- [x] `PRESET_BASE_SPECS` exported from `@lifting-logbook/core` with entries for `'5-3-1'` and `'leangains'`
- [x] `parseProgramSpecFlexible` returns `null` for invalid/empty input and a typed array for valid input
- [x] `detectPresetSuperset` correctly identifies superset relationships between lift history and preset lifts
- [x] `inferProgramFromLiftRecords` returns the correct preset ID or `null`
- [x] Unit tests cover all four exports
- [x] Callers in `apps/web` and `apps/api` are NOT changed (deferred to #583)

## Testing

```
npm test -w @lifting-logbook/core
```

Tests: 234 passed, 0 skipped, 0 failed (33.8s)

New tests: `packages/core/src/presets/index.test.ts` — 24 cases across `PRESET_BASE_SPECS`, `parseProgramSpecFlexible`, `detectPresetSuperset`, and `inferProgramFromLiftRecords` (includes `inferProgramFromLiftRecords(LIFTS_LEANGAINS)` regression test added post-review).

## Risk dimensions

1. **Testing** — 24 new unit tests covering all four exports including edge cases (empty input, missing fields, wrong types, unknown preset ID, strict vs. non-strict superset, leangains regression).
2. **Observability** — N/A — pure domain logic in `packages/core` with no I/O boundaries.
3. **Security** — N/A — no auth, no external input surface; `parseProgramSpecFlexible` validates untrusted input rather than assuming it is safe.
4. **Resilience** — `parseProgramSpecFlexible` returns `null` on any invalid row (fails fast); `detectPresetSuperset` returns `false` for unknown preset IDs; `inferProgramFromLiftRecords` returns `null` when no preset matches.
5. **Performance** — N/A — in-memory operations over small fixed-size arrays.
6. **Data integrity** — N/A — no schema changes, no persistence; `PRESET_BASE_SPECS` is a read-only constant.

## Suppression check

```
git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|![.[]|!\s*[;,)]|\?\? null)'
```
Output: clean (no suppressions).

## Test integrity check

```
git diff origin/main -- . | grep -E '(it\.skip|xit\(|xdescribe\(|test\.skip|describe\.skip|\.todo\(|pending\(|passWithNoTests|--bail|testPathIgnorePatterns)'
```
Output: clean (no integrity violations).

## Review findings disposition

Review posted at https://github.com/brownm09/lifting-logbook/pull/588#issuecomment-4790896330

| Finding | Disposition |
|---|---|
| **[correctness]** `inferProgramFromLiftRecords` could never infer `'leangains'` — `'5-3-1'` was checked first; leangains history always matched it before reaching the leangains check | Fixed in `ce02fab`: reordered `PRESET_BASE_SPECS` keys (leangains first, 12 unique lifts before 5-3-1's 4); added `inferProgramFromLiftRecords(LIFTS_LEANGAINS)` regression test |
| **[maintainability]** case-sensitive lift name comparison in `detectPresetSuperset` undocumented | Filed [#589](https://github.com/brownm09/lifting-logbook/issues/589) — resolve when #583 callers are implemented |
| **[style]** misleading test description (`'returns null when history is empty even with a known lift'`) | Fixed in `ce02fab`: renamed to `'returns null for a single-lift history that matches no preset'` |
