### PR TITLE
[feat] Migrate seedProgramSpec / seedLeangainsSpec to PRESET_BASE_SPECS

### DIFF
--- a/apps/api/src/adapters/in-memory/fixtures.ts
+++ b/apps/api/src/adapters/in-memory/fixtures.ts
@@ -2,6 +2,7 @@ import {
   CycleDashboard,
   LiftRecord,
   LiftingProgramSpec,
+  PRESET_BASE_SPECS,
   TrainingMax,
   Weekday,
 } from '@lifting-logbook/core';
@@ -68,38 +69,6 @@ export const seedLiftRecords = (): LiftRecord[] => [
   },
 ];
 
-export const seedLeangainsSpec = (): LiftingProgramSpec[] => [
-  // Day A — offset 0 (Mon: Chest / Back)
-  { week: 1, offset: 0, lift: 'Bench Press',       order: 1, sets: 3, reps: 6,  amrap: true,  increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-  { week: 1, offset: 0, lift: 'Weighted Pull-ups', order: 2, sets: 3, reps: 6,  amrap: true,  increment: 2.5, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-  { week: 1, offset: 0, lift: 'Incline DB Press',  order: 3, sets: 3, reps: 8,  amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
-  { week: 1, offset: 0, lift: 'Cable Row',         order: 4, sets: 3, reps: 10, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
-  // Day B — offset 2 (Wed: Legs)
-  { week: 1, offset: 2, lift: 'Squat',             order: 1, sets: 3, reps: 6,  amrap: true,  increment: 10,  warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-  { week: 1, offset: 2, lift: 'Romanian Deadlift', order: 2, sets: 3, reps: 8,  amrap: false, increment: 10,  warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
-  { week: 1, offset: 2, lift: 'Leg Curl',          order: 3, sets: 3, reps: 10, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'isolation' },
-  { week: 1, offset: 2, lift: 'Calf Raises',       order: 4, sets: 4, reps: 12, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'isolation' },
-  // Day C — offset 4 (Fri: Shoulders / Arms)
-  { week: 1, offset: 4, lift: 'Overhead Press',    order: 1, sets: 3, reps: 6,  amrap: true,  increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-  { week: 1, offset: 4, lift: 'Deadlift',          order: 2, sets: 1, reps: 5,  amrap: false, increment: 10,  warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
-  { week: 1, offset: 4, lift: 'Lateral Raises',    order: 3, sets: 4, reps: 12, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'isolation' },
-  { week: 1, offset: 4, lift: 'Dips',              order: 4, sets: 3, reps: 8,  amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
-];
+export const seedLeangainsSpec = (): LiftingProgramSpec[] => PRESET_BASE_SPECS['leangains'] ?? [];
 
-export const seedProgramSpec = (): LiftingProgramSpec[] => [
-  // Week 1: 3×5 (65/75/85 % TM)
-  { week: 1, offset: 0, lift: 'Squat',         increment: 5,  order: 1, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-  { week: 1, offset: 0, lift: 'Bench Press',    increment: 5,  order: 2, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-  { week: 1, offset: 3, lift: 'Deadlift',       increment: 10, order: 1, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-  { week: 1, offset: 3, lift: 'Overhead Press', increment: 5,  order: 2, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-  // Week 2: 3×3 (70/80/90 % TM)
-  { week: 2, offset: 0, lift: 'Squat',         increment: 5,  order: 1, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-  { week: 2, offset: 0, lift: 'Bench Press',    increment: 5,  order: 2, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-  { week: 2, offset: 3, lift: 'Deadlift',       increment: 10, order: 1, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-  { week: 2, offset: 3, lift: 'Overhead Press', increment: 5,  order: 2, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-  // Week 3: 5/3/1 (75/85/95 % TM, last set AMRAP)
-  { week: 3, offset: 0, lift: 'Squat',         increment: 5,  order: 1, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-  { week: 3, offset: 0, lift: 'Bench Press',    increment: 5,  order: 2, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-  { week: 3, offset: 3, lift: 'Deadlift',       increment: 10, order: 1, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-  { week: 3, offset: 3, lift: 'Overhead Press', increment: 5,  order: 2, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-];
+export const seedProgramSpec = (): LiftingProgramSpec[] => PRESET_BASE_SPECS['5-3-1'] ?? [];

--- a/apps/api/src/adapters/in-memory/fixtures.ts
+++ b/apps/api/src/adapters/in-memory/fixtures.ts
@@ -69,6 +69,6 @@ export const seedLiftRecords = (): LiftRecord[] => [
   },
 ];
 
-export const seedLeangainsSpec = (): LiftingProgramSpec[] => PRESET_BASE_SPECS['leangains'] ?? [];
+export const seedLeangainsSpec = (): LiftingProgramSpec[] => PRESET_BASE_SPECS['leangains']?.slice() ?? [];
 
-export const seedProgramSpec = (): LiftingProgramSpec[] => PRESET_BASE_SPECS['5-3-1'] ?? [];
+export const seedProgramSpec = (): LiftingProgramSpec[] => PRESET_BASE_SPECS['5-3-1']?.slice() ?? [];

--- a/apps/web/lib/programs.ts
+++ b/apps/web/lib/programs.ts
@@ -1,3 +1,5 @@
+import { LiftingProgramSpec, PRESET_BASE_SPECS } from '@lifting-logbook/core';
+
 export type Experience = 'beginner' | 'intermediate' | 'advanced';
 export type Goal = 'strength' | 'muscle-gain' | 'body-composition' | 'fat-loss';
 export type Purpose =
@@ -30,47 +32,12 @@ export type Program = {
 export const SEED_PROGRAM = '5-3-1';
 export const SEED_LEANGAINS = 'leangains';
 
-export type SeedSpec = {
-  week: number; offset: number; lift: string; increment: number; order: number;
-  sets: number; reps: number; amrap: boolean; warmUpPct: string;
-  wtDecrementPct: number; activation: string;
-};
-
-export function seedProgramSpec(): SeedSpec[] {
-  return [
-    { week: 1, offset: 0, lift: 'Squat',         increment: 5,  order: 1, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 1, offset: 0, lift: 'Bench Press',    increment: 5,  order: 2, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 1, offset: 3, lift: 'Deadlift',       increment: 10, order: 1, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 1, offset: 3, lift: 'Overhead Press', increment: 5,  order: 2, sets: 3, reps: 5, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 2, offset: 0, lift: 'Squat',         increment: 5,  order: 1, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 2, offset: 0, lift: 'Bench Press',    increment: 5,  order: 2, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 2, offset: 3, lift: 'Deadlift',       increment: 10, order: 1, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 2, offset: 3, lift: 'Overhead Press', increment: 5,  order: 2, sets: 3, reps: 3, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 3, offset: 0, lift: 'Squat',         increment: 5,  order: 1, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 3, offset: 0, lift: 'Bench Press',    increment: 5,  order: 2, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 3, offset: 3, lift: 'Deadlift',       increment: 10, order: 1, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 3, offset: 3, lift: 'Overhead Press', increment: 5,  order: 2, sets: 3, reps: 1, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-  ];
+export function seedProgramSpec(): LiftingProgramSpec[] {
+  return PRESET_BASE_SPECS['5-3-1'] ?? [];
 }
 
-export function seedLeangainsSpec(): SeedSpec[] {
-  return [
-    // Day A — offset 0 (Mon: Chest / Back)
-    { week: 1, offset: 0, lift: 'Bench Press',       order: 1, sets: 3, reps: 6,  amrap: true,  increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 1, offset: 0, lift: 'Weighted Pull-ups', order: 2, sets: 3, reps: 6,  amrap: true,  increment: 2.5, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 1, offset: 0, lift: 'Incline DB Press',  order: 3, sets: 3, reps: 8,  amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
-    { week: 1, offset: 0, lift: 'Cable Row',         order: 4, sets: 3, reps: 10, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
-    // Day B — offset 2 (Wed: Legs)
-    { week: 1, offset: 2, lift: 'Squat',             order: 1, sets: 3, reps: 6,  amrap: true,  increment: 10,  warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 1, offset: 2, lift: 'Romanian Deadlift', order: 2, sets: 3, reps: 8,  amrap: false, increment: 10,  warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
-    { week: 1, offset: 2, lift: 'Leg Curl',          order: 3, sets: 3, reps: 10, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'isolation' },
-    { week: 1, offset: 2, lift: 'Calf Raises',       order: 4, sets: 4, reps: 12, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'isolation' },
-    // Day C — offset 4 (Fri: Shoulders / Arms)
-    { week: 1, offset: 4, lift: 'Overhead Press',    order: 1, sets: 3, reps: 6,  amrap: true,  increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
-    { week: 1, offset: 4, lift: 'Deadlift',          order: 2, sets: 1, reps: 5,  amrap: false, increment: 10,  warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
-    { week: 1, offset: 4, lift: 'Lateral Raises',    order: 3, sets: 4, reps: 12, amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'isolation' },
-    { week: 1, offset: 4, lift: 'Dips',              order: 4, sets: 3, reps: 8,  amrap: false, increment: 5,   warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0,   activation: 'compound' },
-  ];
+export function seedLeangainsSpec(): LiftingProgramSpec[] {
+  return PRESET_BASE_SPECS['leangains'] ?? [];
 }
 
 export const PROGRAMS: Program[] = [

--- a/apps/web/lib/programs.ts
+++ b/apps/web/lib/programs.ts
@@ -33,11 +33,11 @@ export const SEED_PROGRAM = '5-3-1';
 export const SEED_LEANGAINS = 'leangains';
 
 export function seedProgramSpec(): LiftingProgramSpec[] {
-  return PRESET_BASE_SPECS['5-3-1'] ?? [];
+  return PRESET_BASE_SPECS['5-3-1']?.slice() ?? [];
 }
 
 export function seedLeangainsSpec(): LiftingProgramSpec[] {
-  return PRESET_BASE_SPECS['leangains'] ?? [];
+  return PRESET_BASE_SPECS['leangains']?.slice() ?? [];
 }
 
 export const PROGRAMS: Program[] = [

--- a/packages/core/src/presets/index.ts
+++ b/packages/core/src/presets/index.ts
@@ -68,6 +68,11 @@ export function parseProgramSpecFlexible(rows: unknown[]): LiftingProgramSpec[] 
   return result;
 }
 
+/**
+ * Returns true if every lift in the named preset appears in liftHistory.
+ * Lift name comparison is case-sensitive: names in liftHistory must match
+ * PRESET_BASE_SPECS casing exactly (e.g. 'Squat', 'Bench Press').
+ */
 export function detectPresetSuperset(liftHistory: string[], presetId: string): boolean {
   const spec = PRESET_BASE_SPECS[presetId];
   if (!spec) return false;


### PR DESCRIPTION
## Summary

- Replaces the hardcoded 5-3-1 and leangains spec literals in `apps/web/lib/programs.ts` and `apps/api/src/adapters/in-memory/fixtures.ts` with `PRESET_BASE_SPECS` lookups imported from `@lifting-logbook/core`
- Removes the `SeedSpec` type from `apps/web` (superseded by `LiftingProgramSpec`)
- Adds JSDoc to `detectPresetSuperset` documenting the case-sensitive lift-name contract

Closes #590. Also closes #589 (documents the case-sensitive contract). Part of #583 (PR3/3).

## Changes

**`packages/core/src/presets/index.ts`**
- Added JSDoc to `detectPresetSuperset` stating lift names must match `PRESET_BASE_SPECS` casing exactly

**`apps/api/src/adapters/in-memory/fixtures.ts`**
- Added `PRESET_BASE_SPECS` to the `@lifting-logbook/core` import
- Replaced `seedLeangainsSpec()` and `seedProgramSpec()` bodies (28 rows of duplicated literals) with one-liners: `PRESET_BASE_SPECS['leangains'] ?? []` and `PRESET_BASE_SPECS['5-3-1'] ?? []`

**`apps/web/lib/programs.ts`**
- Added `import { LiftingProgramSpec, PRESET_BASE_SPECS } from '@lifting-logbook/core'`
- Removed the local `SeedSpec` type (identical to `LiftingProgramSpec` modulo `amrap: boolean` vs `string | boolean`)
- Replaced `seedProgramSpec()` and `seedLeangainsSpec()` bodies with `PRESET_BASE_SPECS` lookups; updated return types to `LiftingProgramSpec[]`

### `?? []` fallback note (not a suppression)
`PRESET_BASE_SPECS` is typed `Record<string, LiftingProgramSpec[]>`, so TypeScript infers the index access as `LiftingProgramSpec[] | undefined`. The `?? []` is purely a type-narrowing artifact — both keys are always defined. The existing adapter and web tests confirm non-empty specs are returned (data-level assertion).

## Testing

```
LIFTING_SKIP_DB_E2E=1 npm test
```

`LIFTING_SKIP_DB_E2E=1` is valid here: no changes under `apps/api/prisma/` or any repository file. (See [#394](https://github.com/brownm09/lifting-logbook/issues/394).)

Tests: 234 + 120 + 395 + 22 = **771 passed, 0 skipped, 0 failed**

| Workspace | Suites | Tests |
|---|---|---|
| `@lifting-logbook/core` | 33 passed | 234 passed |
| `@lifting-logbook/web` | 20 passed | 120 passed |
| `@lifting-logbook/api` | 34 passed | 395 passed |
| `@lifting-logbook/api-client` | 1 passed | 22 passed |

## Risk dimensions

1. **Testing** — Existing `seedLeangainsSpec` test in `apps/web` continues to pass (same 12 rows, same structure). API in-memory adapter tests exercise the spec data path via `InMemoryLiftingProgramSpecRepository`.
2. **Observability** — N/A — fixture / pure data files; no new logging paths.
3. **Security** — N/A — no auth, no user input.
4. **Resilience** — The `?? []` fallback is a type-safety artifact; PRESET_BASE_SPECS always contains both keys. No runtime failure modes introduced.
5. **Performance** — N/A — removes object literals; no new computation.
6. **Data integrity** — N/A — pure TypeScript type change, no schema or migration changes.

## Review findings disposition

| Finding | Disposition |
|---|---|
| [reliability] `seedLeangainsSpec`/`seedProgramSpec` return mutable shared reference | fixed in 49908b0 — added `.slice()` to both callers in `fixtures.ts` and `programs.ts` |
