### PR TITLE
[fix] Return null on 409 from initializeCycle — redirect stuck users

### DIFF
--- a/apps/web/app/(authed)/onboarding/page.test.tsx
+++ b/apps/web/app/(authed)/onboarding/page.test.tsx
@@ -4,10 +4,17 @@ import { LIFT_NAMES } from '@lifting-logbook/types';
 
 jest.mock('@/lib/api', () => ({
   fetchLiftCatalog: jest.fn(),
+  fetchCycleDashboard: jest.fn(),
 }));
 
 jest.mock('@/lib/active-program', () => ({
   getActiveProgram: jest.fn().mockResolvedValue('5-3-1'),
+}));
+
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
 }));
 
 // Stub the client flow so the test isolates the page's catalog-fetch fallback.
@@ -18,14 +25,35 @@ jest.mock('./OnboardingFlow', () => ({
   ),
 }));
 
-import { fetchLiftCatalog } from '@/lib/api';
+import { fetchLiftCatalog, fetchCycleDashboard } from '@/lib/api';
 import OnboardingPage from './page';
 import { DEFAULT_LIFTS } from './lib';
 
 const mockedFetch = fetchLiftCatalog as unknown as jest.Mock;
+const mockedFetchDashboard = fetchCycleDashboard as unknown as jest.Mock;
+
+describe('OnboardingPage — existing-cycle guard', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('redirects to /cycle/1 when a cycle already exists', async () => {
+    mockedFetchDashboard.mockResolvedValue({ cycleNum: 1, program: '5-3-1' });
+
+    await expect(OnboardingPage()).rejects.toThrow('REDIRECT:/cycle/1');
+  });
+
+  it('redirects to /cycle/3 matching the existing cycleNum', async () => {
+    mockedFetchDashboard.mockResolvedValue({ cycleNum: 3, program: '5-3-1' });
+
+    await expect(OnboardingPage()).rejects.toThrow('REDIRECT:/cycle/3');
+  });
+});
 
 describe('OnboardingPage — catalog fetch fallback', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // No existing cycle — proceed to render the onboarding flow.
+    mockedFetchDashboard.mockResolvedValue(null);
+  });
 
   it('passes the fetched catalog to the flow on success', async () => {
     const fetched = ['Squat', 'Bench Press', 'My Custom Lift'];
@@ -72,5 +100,16 @@ describe('OnboardingPage — catalog fetch fallback', () => {
       expect.any(Error),
     );
     errSpy.mockRestore();
+  });
+
+  it('still renders the flow when the dashboard check itself throws (API unavailable)', async () => {
+    mockedFetchDashboard.mockRejectedValue(new Error('API down'));
+    const fetched = ['Squat'];
+    mockedFetch.mockResolvedValue(fetched);
+
+    const element = (await OnboardingPage()) as ReactElement;
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain('onboarding-flow');
   });
 });

--- a/apps/web/app/(authed)/onboarding/page.tsx
+++ b/apps/web/app/(authed)/onboarding/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
+import { redirect } from "next/navigation";
 import { LIFT_NAMES } from "@lifting-logbook/types";
-import { fetchLiftCatalog } from "@/lib/api";
+import { fetchCycleDashboard, fetchLiftCatalog } from "@/lib/api";
 import { getActiveProgram } from "@/lib/active-program";
 import { OnboardingFlow } from "./OnboardingFlow";
 
@@ -10,6 +11,16 @@ export const metadata: Metadata = {
 };
 
 export default async function OnboardingPage() {
+  const program = await getActiveProgram();
+
+  // Skip onboarding if a cycle already exists — send the user directly to their
+  // current cycle view. This handles users who land on /onboarding with an existing
+  // cycle (e.g. via the "Get Started" link, a browser back, or after the pre-#594
+  // redirect-swallow bug left them stuck here).
+  // fallback-covered-by: apps/web/app/(authed)/onboarding/page.test.tsx
+  const existingDashboard = await fetchCycleDashboard(program).catch(() => null);
+  if (existingDashboard) redirect(`/cycle/${existingDashboard.cycleNum}`);
+
   // The catalog (built-in + the user's custom lifts) powers the add-a-lift
   // picker on the "Enter Lifts" step. getLifts keys off the authenticated user
   // and ignores the :program param, so the active-program default is safe even
@@ -27,7 +38,6 @@ export default async function OnboardingPage() {
   // distinct from the pre-selected defaults.
   let catalog: string[];
   try {
-    const program = await getActiveProgram();
     catalog = await fetchLiftCatalog(program);
   } catch (e) {
     console.error(

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -31,7 +31,10 @@ test('no active cycle redirects to onboarding', async ({ page, request }) => {
 // 3. Onboarding flow → lands on cycle dashboard
 // ---------------------------------------------------------------------------
 
-test('onboarding: enter lifts → confirm → choose program → lands on cycle', async ({ page }) => {
+test('onboarding: enter lifts → confirm → choose program → lands on cycle', async ({ page, request }) => {
+  // The onboarding guard redirects to /cycle/<N> when a cycle already exists,
+  // so this test must start from a no-cycle state.
+  await request.get(`${MOCK_API}/__reset?noCurrentCycle=true`);
   await page.goto('/onboarding');
   await expect(page.getByRole('heading', { name: 'Get Started' })).toBeVisible();
 

--- a/packages/api-client/src/index.test.ts
+++ b/packages/api-client/src/index.test.ts
@@ -154,6 +154,32 @@ describe('createApiClient', () => {
     });
   });
 
+  describe('conflict-tolerant POSTs (initializeCycle)', () => {
+    it('returns null on 409 Conflict instead of throwing', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ message: 'A cycle for "rpt" already exists.' }), { status: 409 }),
+      );
+      const client = makeClient();
+      await expect(client.initializeCycle('rpt')).resolves.toBeNull();
+    });
+
+    it('returns the parsed dashboard on 200', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ program: 'rpt', cycleNum: 1 }), { status: 200 }),
+      );
+      const client = makeClient();
+      await expect(client.initializeCycle('rpt')).resolves.toMatchObject({ program: 'rpt', cycleNum: 1 });
+    });
+
+    it('throws on a non-409 error', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ message: 'server exploded' }), { status: 500 }),
+      );
+      const client = makeClient();
+      await expect(client.initializeCycle('rpt')).rejects.toThrow('server exploded');
+    });
+  });
+
   describe('importLiftRecords', () => {
     const file = new File(['a,b\n1,2'], 'records.csv', { type: 'text/csv' });
 

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -136,6 +136,17 @@ export function createApiClient(config: ApiClientConfig) {
     return (await res.json()) as T;
   }
 
+  // Like request but returns null on 409 Conflict instead of throwing.
+  // Use for POST operations that are idempotent by intent — where a conflict
+  // means the resource already exists in the desired state.
+  async function requestOrConflict<T>(path: string, init?: FetchInit): Promise<T | null> {
+    const res = await rawFetch(path, init);
+    if (res.status === 409) return null;
+    if (res.status === 204) return undefined as T;
+    if (!res.ok) throw new Error(await extractErrorMessage(res, path));
+    return (await res.json()) as T;
+  }
+
   // Void request that treats 404 as success — for idempotent deletes, where an
   // already-absent resource is the desired end state.
   async function requestVoidIdempotent(path: string, init?: FetchInit): Promise<void> {
@@ -158,11 +169,13 @@ export function createApiClient(config: ApiClientConfig) {
         cache: 'no-store',
       });
     },
+    // Returns null when a cycle already exists (409) — the caller should treat
+    // null as "already initialized" and redirect rather than error.
     initializeCycle(
       programId: string,
       options: { cycleDate?: string } = {},
-    ): Promise<CycleDashboardResponse> {
-      return request(`/programs/${enc(programId)}/cycles/initialize`, {
+    ): Promise<CycleDashboardResponse | null> {
+      return requestOrConflict(`/programs/${enc(programId)}/cycles/initialize`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify(options),


### PR DESCRIPTION
Closes #597 (part of #592)

## Summary

After PR #594 fixed the redirect-swallow bug, users whose cycle was silently created by that bug still see "Failed to start your program. Please try again." on every subsequent attempt. The cycle IS there — `initializeCycle` returns 409 ConflictException because the cycle already exists, but the `createFirstCycle` catch block treats all errors identically.

**Fix 1 (api-client):** Add `requestOrConflict<T>` helper — mirrors `requestNullable` (returns null on 404) but for 409 Conflict. `initializeCycle` now uses it. In `createFirstCycle`, null flows past the catch block and reaches `redirect('/cycle/1')` naturally — no change to the Server Action needed.

**Fix 2 (OnboardingPage guard):** Users with an existing cycle who land on `/onboarding` (via "Get Started" link, browser back, or pre-#594 stuck state) now get redirected to `/cycle/<N>` immediately at page load, before the wizard renders.

**Not the cause:** Having zero or few training maxes does not cause this error. The `updateTrainingMaxes` call is in an inner try-catch that doesn't re-throw.

## Files changed

- `packages/api-client/src/index.ts` — add `requestOrConflict<T>`, change `initializeCycle` return type to `CycleDashboardResponse | null`
- `packages/api-client/src/index.test.ts` — 3 new tests for the conflict-tolerant path (409→null, 200→parsed, 500→throw)
- `apps/web/app/(authed)/onboarding/page.tsx` — early-exit guard: `fetchCycleDashboard(program).catch(() => null)` at page load; redirect to `/cycle/<N>` if non-null
- `apps/web/app/(authed)/onboarding/page.test.tsx` — 3 new tests for the guard (cycleNum: 1, cycleNum: 3, API-unavailable fallthrough)

## Testing

```
npm test -w @lifting-logbook/api-client -w @lifting-logbook/web
```

Tests: 148 passed, 0 skipped, 0 failed (api-client: 25 (+3), web: 123 (+3))

Suppression grep: clean
Test integrity grep: clean

## Suppression check
None added.

## Review findings disposition

| Finding | Disposition |
|---|---|
| Stale test count in PR body (non-blocking) | Fixed — updated Testing section to 148 passed (web: 123) |
