### PR TITLE
[refactor] Replace buildSpecsFromTemplate ternary chain with dispatch map

### DIFF
--- a/apps/web/app/(authed)/programs/ProgramEditor.test.ts
+++ b/apps/web/app/(authed)/programs/ProgramEditor.test.ts
@@ -1,90 +1,15 @@
-import { seedProgramSpec, SEED_PROGRAM, seedLeangainsSpec, SEED_LEANGAINS } from '@/lib/programs';
+import { TEMPLATE_BUILDERS, SEED_PROGRAM, SEED_LEANGAINS, seedProgramSpec, seedLeangainsSpec } from '@/lib/programs';
 
-// Mock the seed functions
-jest.mock('@/lib/programs', () => ({
-  ...jest.requireActual('@/lib/programs'),
-  seedProgramSpec: jest.fn(),
-  seedLeangainsSpec: jest.fn(),
-}));
-
-// Extract buildSpecsFromTemplate by importing the module with the mock
-// Since buildSpecsFromTemplate is not exported, we need to import and test it indirectly
-// through the component, or we can test it via the ProgramEditor component's behavior.
-// For now, we'll export these helper functions for testing.
-
-describe('buildSpecsFromTemplate', () => {
-  const mockSeedProgram = [
-    {
-      week: 1,
-      offset: 0,
-      lift: 'Squat',
-      increment: 5,
-      order: 1,
-      sets: 3,
-      reps: 5,
-      amrap: false,
-      warmUpPct: '0.4,0.5,0.6',
-      wtDecrementPct: 0.1,
-      activation: 'compound',
-    },
-    {
-      week: 1,
-      offset: 0,
-      lift: 'Bench Press',
-      increment: 2.5,
-      order: 2,
-      sets: 3,
-      reps: 5,
-      amrap: true,
-      warmUpPct: '0.4,0.5,0.6',
-      wtDecrementPct: 0.1,
-      activation: 'compound',
-    },
-  ] as const;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    (seedProgramSpec as jest.Mock).mockReturnValue(mockSeedProgram);
-    (seedLeangainsSpec as jest.Mock).mockReturnValue([]);
+describe('TEMPLATE_BUILDERS dispatch map', () => {
+  it('maps SEED_PROGRAM key to seedProgramSpec', () => {
+    expect(TEMPLATE_BUILDERS[SEED_PROGRAM]).toBe(seedProgramSpec);
   });
 
-  it('returns result from SEED_PROGRAM builder when templateId matches', () => {
-    (seedProgramSpec as jest.Mock).mockReturnValue(mockSeedProgram);
-
-    // Test through the module by re-importing or creating a standalone version
-    // For now, we'll just verify the mock is set up correctly
-    const result = seedProgramSpec();
-    expect(result).toEqual(mockSeedProgram);
-    expect(seedProgramSpec).toHaveBeenCalled();
+  it('maps SEED_LEANGAINS key to seedLeangainsSpec', () => {
+    expect(TEMPLATE_BUILDERS[SEED_LEANGAINS]).toBe(seedLeangainsSpec);
   });
 
-  it('returns result from SEED_LEANGAINS builder when templateId matches', () => {
-    const leangainsSpecs = [
-      {
-        week: 1,
-        offset: 0,
-        lift: 'Deadlift',
-        increment: 5,
-        order: 1,
-        sets: 3,
-        reps: 5,
-        amrap: false,
-        warmUpPct: '0.4,0.5,0.6',
-        wtDecrementPct: 0.1,
-        activation: 'compound',
-      },
-    ] as const;
-    (seedLeangainsSpec as jest.Mock).mockReturnValue(leangainsSpecs);
-
-    const result = seedLeangainsSpec();
-    expect(result).toEqual(leangainsSpecs);
-    expect(seedLeangainsSpec).toHaveBeenCalled();
-  });
-
-  it('uses dispatch map to look up template builders', () => {
-    // This test verifies the dispatch map pattern is used correctly.
-    // Both SEED_PROGRAM and SEED_LEANGAINS should be in the map.
-    expect(SEED_PROGRAM).toBe('5-3-1');
-    expect(SEED_LEANGAINS).toBe('leangains');
+  it('returns undefined for an unknown template ID', () => {
+    expect(TEMPLATE_BUILDERS['unknown-template']).toBeUndefined();
   });
 });

--- a/apps/web/app/(authed)/programs/ProgramEditor.tsx
+++ b/apps/web/app/(authed)/programs/ProgramEditor.tsx
@@ -2,11 +2,10 @@
 
 import { useState, useTransition } from 'react';
 import { LIFT_CATALOG } from '@lifting-logbook/core';
-import type { LiftingProgramSpec } from '@lifting-logbook/core';
 import { useRouter } from 'next/navigation';
 import type { CustomProgramResponse, CustomProgramSpecRow } from '@lifting-logbook/types';
 import { createCustomProgram, updateCustomProgram, switchProgram } from './actions';
-import { seedProgramSpec, SEED_PROGRAM, seedLeangainsSpec, SEED_LEANGAINS } from '@/lib/programs';
+import { TEMPLATE_BUILDERS } from '@/lib/programs';
 import styles from './programs.module.css';
 
 type Mode = 'new' | 'clone' | 'edit';
@@ -51,11 +50,6 @@ function buildDefaultSpecs(lifts: string[]): CustomProgramSpecRow[] {
   }
   return rows;
 }
-
-const TEMPLATE_BUILDERS: Record<string, () => LiftingProgramSpec[]> = {
-  [SEED_PROGRAM]: seedProgramSpec,
-  [SEED_LEANGAINS]: seedLeangainsSpec,
-};
 
 function buildSpecsFromTemplate(templateId: string, lifts: string[]): CustomProgramSpecRow[] {
   const builder = TEMPLATE_BUILDERS[templateId];

--- a/apps/web/lib/programs.ts
+++ b/apps/web/lib/programs.ts
@@ -40,6 +40,11 @@ export function seedLeangainsSpec(): LiftingProgramSpec[] {
   return PRESET_BASE_SPECS['leangains']?.slice() ?? [];
 }
 
+export const TEMPLATE_BUILDERS: Record<string, () => LiftingProgramSpec[]> = {
+  [SEED_PROGRAM]: seedProgramSpec,
+  [SEED_LEANGAINS]: seedLeangainsSpec,
+};
+
 export const PROGRAMS: Program[] = [
   {
     id: 'starting-strength',


### PR DESCRIPTION
## Summary

Consolidate program template dispatch into a `TEMPLATE_BUILDERS` map, improving maintainability when new program types are added and reducing duplication vs. nested ternaries. Aligns with #489's dispatch consolidation effort across the codebase.

## Changes

- Moved `TEMPLATE_BUILDERS: Record<string, () => LiftingProgramSpec[]>` to `@/lib/programs` for testability
- Replaced ternary chain in `buildSpecsFromTemplate` with map lookup pattern
- Kept all expansion and filtering logic unchanged
- Added dispatch routing tests verifying key→function mapping

## Testing

Tests: 126 passed, 0 skipped, 0 failed

All web tests pass, including `ProgramEditor.test.ts` verifying the `TEMPLATE_BUILDERS` dispatch map integration.

## Related

Aligns with #489 (Smart Import dispatch consolidation) as part of v0.3 refactoring effort.

Closes #584

## Review findings disposition

**[non-blocking/maintainability]** Test file didn't test the dispatch map it claimed to cover — fixed in `f1f3dad`: moved `TEMPLATE_BUILDERS` from `ProgramEditor.tsx` to `@/lib/programs`, rewrote tests to directly verify `TEMPLATE_BUILDERS[SEED_PROGRAM] === seedProgramSpec`, `TEMPLATE_BUILDERS[SEED_LEANGAINS] === seedLeangainsSpec`, and unknown-key → undefined.
