### PR TITLE
[docs] Document CONFLICTING PR state silently breaks GitHub Actions CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,12 +400,12 @@ When a PR adds or modifies a `.catch(() => default)`, `?? default`, or `try { �
 
 **Pattern:** A PR in `CONFLICTING` (merge conflict) state causes GitHub Actions `pull_request` events to never fire. GitHub cannot create the virtual merge commit at `refs/pull/N/merge`, so the event is silently dropped — no checks are queued, no runs appear.
 
-**Symptom:** `gh pr checks` returns "no checks reported" and `gh run list --branch <head>` shows only stale runs from before the conflict.
+**Symptom:** `gh pr checks` returns "no checks reported" and `gh run list --branch <branch-name>` shows only stale runs from before the conflict.
 
 **Diagnosis:**
 ```bash
 gh pr view <N> --json mergeable,mergeStateStatus
-# mergeStateStatus: "DIRTY" confirms the conflict
+# mergeable: "CONFLICTING" — direct conflict indicator; mergeStateStatus will also be "DIRTY"
 ```
 
 **Fix:** Rebase (or squash-rebase) the branch onto `origin/main` and force-push. Once the conflict is resolved, GitHub recreates the merge ref and CI fires normally on the next push.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,6 +396,22 @@ A label of "pre-existing" without an open-issue link is not acceptable. The moti
 
 When a PR adds or modifies a `.catch(() => default)`, `?? default`, or `try { … } catch { return neutral }` in a server component or API boundary, the test coverage for that code path must satisfy one of: (a) a data-level assertion the fallback would not produce, (b) a separate test that fails specifically when the upstream fails, or (c) an inline comment that names the swallowed-fallback source line and explains why structure-only is intentional. See [`docs/standards/error-fallback-test-coverage.md`](docs/standards/error-fallback-test-coverage.md) for the full rule and examples.
 
+### CI not firing — merge conflict silences GitHub Actions
+
+**Pattern:** A PR in `CONFLICTING` (merge conflict) state causes GitHub Actions `pull_request` events to never fire. GitHub cannot create the virtual merge commit at `refs/pull/N/merge`, so the event is silently dropped — no checks are queued, no runs appear.
+
+**Symptom:** `gh pr checks` returns "no checks reported" and `gh run list --branch <head>` shows only stale runs from before the conflict.
+
+**Diagnosis:**
+```bash
+gh pr view <N> --json mergeable,mergeStateStatus
+# mergeStateStatus: "DIRTY" confirms the conflict
+```
+
+**Fix:** Rebase (or squash-rebase) the branch onto `origin/main` and force-push. Once the conflict is resolved, GitHub recreates the merge ref and CI fires normally on the next push.
+
+Motivating incident: [PR #604](https://github.com/brownm09/lifting-logbook/pull/604).
+
 ---
 
 ## Observability


### PR DESCRIPTION
## Summary

Documents a silent CI failure pattern discovered during PR #604: when a PR is in \`CONFLICTING\` (merge conflict) state, GitHub Actions \`pull_request\` events never fire because GitHub cannot create the virtual merge commit at \`refs/pull/N/merge\`. Adds a \`### CI not firing — merge conflict silences GitHub Actions\` subsection to \`## Testing\` with the symptom, diagnosis command, and fix.

## Changes

- \`CLAUDE.md\` — new subsection under \`## Testing\` documenting the pattern, \`gh pr view <N> --json mergeable,mergeStateStatus\` as the diagnosis command, and squash-rebase + force-push as the fix.

## Testing

Refactor / docs only — no automated tests required per the coverage matrix.

Tests: N/A (docs-only change)

## Suppression / integrity check

```
git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|![.[]|!\s*[;,)]|\?\? null)'
```
No matches.

## Review findings disposition

- **[maintainability] `CLAUDE.md:406`** — fixed in ed2e323: updated diagnostic comment to anchor on `mergeable: "CONFLICTING"` and note that `mergeStateStatus` will also be `"DIRTY"`.
- **Style — `<head>` placeholder** — fixed in ed2e323: changed to `<branch-name>`.

Closes #609