### PR TITLE
[fix] TS2540: Replace direct NODE_ENV assignment with Object.defineProperty in tests

### DIFF
--- a/apps/web/lib/__tests__/public-config.test.tsx
+++ b/apps/web/lib/__tests__/public-config.test.tsx
@@ -46,14 +46,14 @@ describe('readServerPublicConfig', () => {
   // Fail-loud guard: in a deployed runtime a missing/empty PUBLIC_API_URL must throw rather
   // than silently fall back to localhost (which would ship a broken prod image — #395/#458).
   it('throws in a deployed runtime when PUBLIC_API_URL is unset', () => {
-    process.env.NODE_ENV = 'production';
+    Object.defineProperty(process.env, 'NODE_ENV', { value: 'production', configurable: true });
     delete process.env.NEXT_PHASE;
     delete process.env.PUBLIC_API_URL;
     expect(() => readServerPublicConfig()).toThrow(/PUBLIC_API_URL is not set/);
   });
 
   it('throws in a deployed runtime when PUBLIC_API_URL is the empty string', () => {
-    process.env.NODE_ENV = 'production';
+    Object.defineProperty(process.env, 'NODE_ENV', { value: 'production', configurable: true });
     delete process.env.NEXT_PHASE;
     process.env.PUBLIC_API_URL = '';
     expect(() => readServerPublicConfig()).toThrow(/PUBLIC_API_URL is not set/);
@@ -61,7 +61,7 @@ describe('readServerPublicConfig', () => {
 
   it('does NOT throw during `next build` even with PUBLIC_API_URL unset', () => {
     // The keyless build the force-dynamic root layout relies on must never throw here.
-    process.env.NODE_ENV = 'production';
+    Object.defineProperty(process.env, 'NODE_ENV', { value: 'production', configurable: true });
     process.env.NEXT_PHASE = 'phase-production-build';
     delete process.env.PUBLIC_API_URL;
     expect(readServerPublicConfig().apiUrl).toBe(PUBLIC_CONFIG_FALLBACK.apiUrl);


### PR DESCRIPTION
## Summary

TypeScript types `process.env.NODE_ENV` as readonly (`TS2540`). Three tests in `apps/web/lib/__tests__/public-config.test.tsx` (lines 49, 56, 64) assigned to it directly, producing pre-existing type errors.

## Change

Replace:
```ts
process.env.NODE_ENV = 'production';
```
with:
```ts
Object.defineProperty(process.env, 'NODE_ENV', { value: 'production', configurable: true });
```

`configurable: true` allows the property to be redefined by subsequent tests. The existing `afterEach(() => { process.env = { ...ORIGINAL }; })` restores the env object after each test, so no additional teardown is needed.

## Why Object.defineProperty and not a cast

A type cast (`(process.env as any).NODE_ENV = 'production'`) would be a suppression requiring a PR-body justification (per the suppression policy). `Object.defineProperty` is the proper escape hatch — it bypasses the readonly constraint at the runtime level without masking a type error.

## Testing

```
npm test -w @lifting-logbook/web
```

Tests: 139 passed, 0 skipped, 0 failed (102.336 s)

## Risk dimensions

- **Testing** — only touches test code; all 139 web tests pass
- **Observability** — N/A (test-only change)
- **Security** — N/A
- **Resilience** — N/A
- **Performance** — N/A
- **Data integrity** — N/A

Closes #608