### PR TITLE
[test] Add Playwright E2E for MAP_COLUMNS column override flow

### DIFF
--- a/apps/web/e2e/import.spec.ts
+++ b/apps/web/e2e/import.spec.ts
@@ -36,3 +36,43 @@ test('import wizard: Source → Classify → Preview → Done', async ({ page })
   // Done step.
   await expect(page.getByText('Import complete')).toBeVisible();
 });
+
+test('import wizard MAP_COLUMNS: fuzzy-matched columns shown; override unmapped column enables Next', async ({ page, request }) => {
+  // Override the default reset to enable the non-standard-columns scenario.
+  await request.get(`${MOCK_API}/__reset?withCustomProgram=true&withNonStandardColumns=true`);
+
+  await page.goto('/import');
+
+  // Source step: upload a CSV with non-standard headers (Date, Exercise, Max Weight).
+  await expect(page.getByRole('heading', { name: 'Import a file' })).toBeVisible();
+  await page.getByLabel('CSV file').setInputFiles({
+    name: 'nonstandard.csv',
+    mimeType: 'text/csv',
+    buffer: Buffer.from('Date,Exercise,Max Weight\n1/1/2026,Squat,300'),
+  });
+  await page.getByRole('button', { name: 'Analyze' }).click();
+
+  // Classify step: mock classifies as Training Maxes.
+  await expect(page.getByText('Training Maxes')).toBeVisible();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
+
+  // MAP_COLUMNS step: mapping table is shown with the fuzzy-matched source columns.
+  await expect(page.getByRole('heading', { name: 'Map columns' })).toBeVisible();
+  await expect(page.getByRole('table', { name: 'Column mappings' })).toBeVisible();
+
+  // "Exercise" is unmapped (required, confidence 0) — alert visible, Next disabled.
+  await expect(page.getByText('Some required fields are not yet mapped')).toBeVisible();
+  const nextButton = page.getByRole('button', { name: 'Next', exact: true });
+  await expect(nextButton).toBeDisabled();
+
+  // Override the Exercise column → Lift.
+  await page.getByLabel('Map column Exercise').selectOption({ label: 'Lift' });
+
+  // Alert should disappear and Next should become enabled.
+  await expect(page.getByText('Some required fields are not yet mapped')).not.toBeVisible();
+  await expect(nextButton).toBeEnabled();
+
+  // Clicking Next advances to the Review step.
+  await nextButton.click();
+  await expect(page.getByRole('heading', { name: 'Review' })).toBeVisible();
+});

--- a/apps/web/e2e/mock-api.mjs
+++ b/apps/web/e2e/mock-api.mjs
@@ -104,6 +104,9 @@ function createInitialState() {
     // Empty by default so the /programs page test still sees RPT as the only
     // program; the import test opts in via /__reset?withCustomProgram=true.
     customPrograms: [],
+    // When true, the import preview response includes columnMappings with one
+    // required field unmapped, to exercise the MAP_COLUMNS override flow.
+    nonStandardColumns: false,
   };
 }
 
@@ -175,6 +178,9 @@ const server = createServer(async (req, res) => {
     }
     if (url.searchParams.get('withCustomProgram') === 'true') {
       state.customPrograms = [CUSTOM_PROGRAM];
+    }
+    if (url.searchParams.get('withNonStandardColumns') === 'true') {
+      state.nonStandardColumns = true;
     }
     json(res, { ok: true });
     return;
@@ -361,6 +367,15 @@ const server = createServer(async (req, res) => {
       if (mode === 'commit') {
         json(res, { destination, created: 2, updated: 1, skipped: 0, errors: [] });
       } else {
+        // When nonStandardColumns is set, return fuzzy column mappings with one
+        // required field unmapped so the MAP_COLUMNS override flow can be tested.
+        const columnMappings = state.nonStandardColumns
+          ? [
+              { sourceHeader: 'Date', destinationField: 'dateUpdated', confidence: 0.65, required: true, transformationNote: null },
+              { sourceHeader: 'Exercise', destinationField: '', confidence: 0.0, required: true, transformationNote: null },
+              { sourceHeader: 'Max Weight', destinationField: 'weight', confidence: 0.72, required: true, transformationNote: null },
+            ]
+          : [];
         json(res, {
           classification: {
             type: 'training-maxes',
@@ -370,6 +385,7 @@ const server = createServer(async (req, res) => {
             alternatives: [{ type: 'lift-records', confidence: 0.42, closeCall: false }],
           },
           destination: 'training-maxes',
+          columnMappings,
           preview: {
             creates: 2,
             updates: 1,

--- a/apps/web/e2e/mock-api.mjs
+++ b/apps/web/e2e/mock-api.mjs
@@ -367,15 +367,6 @@ const server = createServer(async (req, res) => {
       if (mode === 'commit') {
         json(res, { destination, created: 2, updated: 1, skipped: 0, errors: [] });
       } else {
-        // When nonStandardColumns is set, return fuzzy column mappings with one
-        // required field unmapped so the MAP_COLUMNS override flow can be tested.
-        const columnMappings = state.nonStandardColumns
-          ? [
-              { sourceHeader: 'Date', destinationField: 'dateUpdated', confidence: 0.65, required: true, transformationNote: null },
-              { sourceHeader: 'Exercise', destinationField: '', confidence: 0.0, required: true, transformationNote: null },
-              { sourceHeader: 'Max Weight', destinationField: 'weight', confidence: 0.72, required: true, transformationNote: null },
-            ]
-          : [];
         json(res, {
           classification: {
             type: 'training-maxes',
@@ -385,7 +376,19 @@ const server = createServer(async (req, res) => {
             alternatives: [{ type: 'lift-records', confidence: 0.42, closeCall: false }],
           },
           destination: 'training-maxes',
-          columnMappings,
+          // When nonStandardColumns is set, include fuzzy column mappings with one
+          // required field unmapped so the MAP_COLUMNS override flow can be tested.
+          // Omitted in the standard case (not empty array) to preserve the mock
+          // contract the existing first import test relies on.
+          ...(state.nonStandardColumns
+            ? {
+                columnMappings: [
+                  { sourceHeader: 'Date', destinationField: 'dateUpdated', confidence: 0.65, required: true, transformationNote: null },
+                  { sourceHeader: 'Exercise', destinationField: '', confidence: 0.0, required: true, transformationNote: null },
+                  { sourceHeader: 'Max Weight', destinationField: 'weight', confidence: 0.72, required: true, transformationNote: null },
+                ],
+              }
+            : {}),
           preview: {
             creates: 2,
             updates: 1,


### PR DESCRIPTION
## Summary

Fulfils the deferred Playwright acceptance criteria from issue #612 / PR #613.

- Adds `withNonStandardColumns` reset variant to `apps/web/e2e/mock-api.mjs`: returns `columnMappings` in the preview response, with the `Exercise` column unmapped (required, confidence 0)
- Adds a new test to `apps/web/e2e/import.spec.ts` that exercises the full MAP_COLUMNS override flow:
  1. Upload a CSV with non-standard headers (`Date`, `Exercise`, `Max Weight`)
  2. Verify the MAP_COLUMNS table is rendered with fuzzy-matched source columns
  3. Assert the unmapped-required alert is visible and Next is disabled
  4. Override the `Exercise` dropdown → `Lift`
  5. Assert the alert disappears and Next becomes enabled
  6. Click Next and land on the Review step

## Testing

```
npm run test:e2e -w @lifting-logbook/web
```

**Tests: 16 passed, 0 skipped, 0 failed (41.7s)** — after cleaning the stale `packages/core/tsconfig.tsbuildinfo` and rebuilding core. All 16 Playwright tests pass, including both import tests.

> **Note:** before this run `@lifting-logbook/core` had a stale `.tsbuildinfo` (no matching dist/ — previously observed behaviour under incremental build). After `rm packages/core/tsconfig.tsbuildinfo && npm run build -w @lifting-logbook/core` all 16 tests passed. The 14 smoke/scheduling failures from the first run were purely the missing build artifact, not related to this PR's changes.

## Suppression check

```
git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|![.[]|!\s*[;,)]|\?\? null)'
```
→ No matches.

## Test integrity check

```
git diff origin/main -- . | grep -E '(it\.skip|xit\(|xdescribe\(|test\.skip|describe\.skip|\.todo\(|pending\(|passWithNoTests|--bail|testPathIgnorePatterns)'
```
→ No matches. No test files deleted, no coverage thresholds changed.

## Coverage gate

New test covers the MAP_COLUMNS override flow end-to-end via Playwright; no new untested runtime behaviour.

## Risk dimensions

1. **Testing** — all 16 Playwright tests pass; new test covers the full acceptance criteria from #612
2. **Observability** — N/A (test/mock-only change)
3. **Security** — N/A (no auth, no secrets, test fixture only)
4. **Resilience** — N/A (tests are additive, no runtime code changed)
5. **Performance** — N/A (mock-api is a test server; one small conditional added)
6. **Data integrity** — N/A (no schema or migration changes)

## Review findings disposition

- **[maintainability] mock-api.mjs** — `columnMappings: []` always present in standard response vs. absent key. Fixed in `50c195a`: changed to conditional spread so the key is omitted for the standard case, preserving the original mock contract.

Closes #614
Part of #483