### PR TITLE
[chore] Add no-direct-prisma-transaction to eslint-rules test script

### DIFF
--- a/tools/eslint-rules/package.json
+++ b/tools/eslint-rules/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "test": "node --test no-uncovered-error-fallback.test.js require-fetch-cache.test.js no-raw-fetch-outside-api-client.test.js",
+    "test": "node --test no-uncovered-error-fallback.test.js require-fetch-cache.test.js no-raw-fetch-outside-api-client.test.js no-direct-prisma-transaction.test.js",
     "lint": "echo \"(no lint for eslint-rules workspace)\" && exit 0"
   },
   "dependencies": {},


### PR DESCRIPTION
## Summary

- Adds `no-direct-prisma-transaction.test.js` to the `node --test` command in `tools/eslint-rules/package.json`
- PR #529 introduced both the rule and its test file but omitted the test file from the test script — the rule's RuleTester tests have never run as part of `npm test` since June 12
- PR #530 later added an additional allowlist case to the test file without catching the omission

## Root cause

```
// before (tools/eslint-rules/package.json)
"test": "node --test no-uncovered-error-fallback.test.js require-fetch-cache.test.js no-raw-fetch-outside-api-client.test.js"

// after
"test": "node --test no-uncovered-error-fallback.test.js require-fetch-cache.test.js no-raw-fetch-outside-api-client.test.js no-direct-prisma-transaction.test.js"
```

## Testing

```
npm test -w @lifting-logbook/eslint-rules
```

Tests: 14 passed, 0 skipped, 0 failed (was 13 before — `no-direct-prisma-transaction` is the new 14th)

## Suppression / test-integrity checks

```
git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|...)' → (empty)
git diff origin/main -- . | grep -E '(it\.skip|xit\(|...)' → (empty)
```

Both clean.

## Coverage

No new behavior — the test file already existed and covers the rule completely (5 valid cases, 1 invalid case). This PR only makes those tests run.

## Review findings disposition

| Finding | Disposition |
|---|---|
| [documentation] README missing `no-direct-prisma-transaction` entry | fixed in `707f063` (landed on main directly; rebased into this branch at `a5b6039`) |

Closes #621