### PR TITLE
[fix] Checkout target draft branch before pull in journal 'Subsequent sessions'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -482,7 +482,7 @@ Slug is determined at day end when the overall theme is clear.
 4. `git add`, `git commit -m "draft: YYYY-MM-DD session 1"`, `git push -u origin draft/YYYY-MM-DD`
 
 **Subsequent sessions:**
-1. `git -C <engineering-journal-path> pull origin draft/YYYY-MM-DD`
+1. `git -C <engineering-journal-path> checkout draft/YYYY-MM-DD && git -C <engineering-journal-path> pull`
 2. Get the file's line count (`wc -l`), then `Read` with offset to retrieve only the last
    `<!-- next-session-context -->` block — do not read the full draft
 3. Append the new `<!-- session: <slug> -->` block and `<!-- next-session-context -->` paragraph


### PR DESCRIPTION
## Summary

Fixes a silent wrong-branch-pull bug in the Engineering Journal **Subsequent sessions** workflow. `git pull origin draft/YYYY-MM-DD` from a different local branch merges the named remote into whatever is currently checked out — not the target. This contaminated `draft/2026-06-29` with 26 06-30 stub/manifest files during a 2026-06-30 session.

The fix replaces step 1 with an explicit `checkout` followed by a bare `pull`:

```bash
# Before (broken):
git -C <path> pull origin draft/YYYY-MM-DD

# After (correct):
git -C <path> checkout draft/YYYY-MM-DD && git -C <path> pull
```

## Testing

Documentation-only change — no runnable tests. Manual verification: confirmed the old form merges into the wrong branch; the new form switches HEAD first.

Tests: N/A — docs only (CLAUDE.md only changed)

## Suppression / test-integrity checks

```
git diff origin/main -- . | grep -E '(ts-ignore|ts-expect-error|eslint-disable|![.[]|!\s*[;,)]|\?\? null)'
```
No output — no suppressions introduced.

```
git diff origin/main -- . | grep -E '(it\.skip|xit\(|xdescribe\(|test\.skip|describe\.skip|\.todo\(|pending\(|passWithNoTests|--bail|testPathIgnorePatterns)'
```
No output — no test integrity violations.

## Risk dimensions
- **Testing:** N/A — CLAUDE.md only
- **Observability:** N/A
- **Security:** N/A
- **Resilience:** New form fails fast if branch doesn't exist; old form silently contaminated the wrong draft
- **Performance:** N/A
- **Data integrity:** Prevents wrong-day stub contamination

## Review findings disposition

- **[correctness]** `~/.claude/CLAUDE.md:489` — Global Subsequent sessions step 1 not updated: Filed [dev-env#444](https://github.com/brownm09/dev-env/issues/444)

Closes #629
