### PR TITLE
[fix] Preserve training-max decimal precision in Import, onboarding, and history

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,6 +330,7 @@ rationale, examples, and enforcement notes. Existing standards:
 |---|---|---|
 | [`docs/standards/fetch-cache-semantics.md`](docs/standards/fetch-cache-semantics.md) | `apps/web` Server Components | All `fetch()` calls must specify `{ cache: 'no-store' }` or `{ next: { revalidate: N } }` explicitly |
 | [`docs/standards/error-fallback-test-coverage.md`](docs/standards/error-fallback-test-coverage.md) | all packages and apps | Error-swallowing fallbacks (`.catch(() => default)`, `?? default`, try/catch returning neutral) require a data-level assertion, a paired success-path test, or a documented structure-only comment |
+| [`docs/standards/training-max-precision.md`](docs/standards/training-max-precision.md) | all packages and apps | Directly-known training-max weights are never rounded; formula-derived estimates floor to the nearest plate increment; computed per-workout weights round to the nearest *loadable* plate combination |
 
 When implementing `apps/web`, read the relevant standards before writing any `fetch()` calls.
 

--- a/apps/api/src/programs/cycle-generation.service.spec.ts
+++ b/apps/api/src/programs/cycle-generation.service.spec.ts
@@ -10,7 +10,7 @@ import {
 import { ICycleScheduledWorkoutRepository } from '../ports/ICycleScheduledWorkoutRepository';
 import { IUserSettingsRepository } from '../ports/IUserSettingsRepository';
 import { ProgramNotFoundError } from '../ports/errors';
-import { CycleGenerationService } from './cycle-generation.service';
+import { buildHistoryEntries, CycleGenerationService } from './cycle-generation.service';
 
 const PROGRAM = '5-3-1';
 
@@ -388,5 +388,36 @@ describe('CycleGenerationService', () => {
         ]),
       );
     });
+  });
+});
+
+describe('buildHistoryEntries', () => {
+  const asOf = (weight: number) => ({
+    lift: 'Squat',
+    weight,
+    dateUpdated: new Date('2026-04-18T00:00:00.000Z'),
+  });
+  const date = new Date('2026-04-20T00:00:00.000Z');
+
+  it('records a real sub-0.1lb change that a 1-decimal-place comparison would have missed', () => {
+    // 316.25 -> 316.30 is a genuine 0.05lb change; both round to 316.3 at 1
+    // decimal place, which would have silently dropped this from history.
+    const entries = buildHistoryEntries([asOf(316.25)], [asOf(316.3)], date, 'program');
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ lift: 'Squat', weight: 316.3 });
+  });
+
+  it('does not record an unchanged weight', () => {
+    const entries = buildHistoryEntries([asOf(316.25)], [asOf(316.25)], date, 'program');
+
+    expect(entries).toHaveLength(0);
+  });
+
+  it('records a lift with no prior entry', () => {
+    const entries = buildHistoryEntries([], [asOf(316.25)], date, 'test');
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ lift: 'Squat', weight: 316.25, source: 'test' });
   });
 });

--- a/apps/api/src/programs/cycle-generation.service.ts
+++ b/apps/api/src/programs/cycle-generation.service.ts
@@ -93,19 +93,20 @@ async function saveScheduledDates(
   }
 }
 
-function round1dp(w: number): number {
-  return Math.round(w * 10) / 10;
+function round2dp(w: number): number {
+  return Math.round(w * 100) / 100;
 }
 
-function buildHistoryEntries(
+/** Exported for direct unit testing of the change-detection comparison precision. */
+export function buildHistoryEntries(
   prevMaxes: TrainingMax[],
   newMaxes: TrainingMax[],
   date: Date,
   source: 'test' | 'program',
 ): Omit<TrainingMaxHistoryEntry, 'id'>[] {
-  const prevMap = new Map(prevMaxes.map((m) => [m.lift, round1dp(m.weight)]));
+  const prevMap = new Map(prevMaxes.map((m) => [m.lift, round2dp(m.weight)]));
   return newMaxes
-    .filter((m) => prevMap.get(m.lift) !== round1dp(m.weight))
+    .filter((m) => prevMap.get(m.lift) !== round2dp(m.weight))
     .map((m) => ({
       lift: m.lift,
       weight: m.weight,

--- a/apps/web/app/(authed)/import/ImportWizard.test.tsx
+++ b/apps/web/app/(authed)/import/ImportWizard.test.tsx
@@ -135,6 +135,36 @@ describe('ImportWizard', () => {
     expect(text).not.toContain(',300');
   });
 
+  it('training-maxes: a decimal weight in REVIEW is not rounded in the commit payload', async () => {
+    const user = userEvent.setup();
+    mockPreview.mockResolvedValue(TM_PREVIEW);
+    mockCommit.mockResolvedValue({
+      ok: true,
+      data: { destination: 'training-maxes', created: 2, updated: 1, skipped: 0, batchId: 'batch-1' },
+    });
+
+    render(<ImportWizard programs={PROGRAMS} />);
+
+    const file = new File(['Date Updated,Lift,Weight\n1/1/2026,Squat,300'], 'tm.csv', {
+      type: 'text/csv',
+    });
+    await navigateToReview(user, file);
+
+    // Edit the squat weight to a value with 2.5/1.25-increment decimal precision.
+    const weightInput = screen.getByLabelText('Weight for squat');
+    await user.clear(weightInput);
+    await user.type(weightInput, '316.25');
+
+    await user.click(screen.getByRole('button', { name: 'Next' })); // Review → Preview
+    await user.click(screen.getByRole('button', { name: 'Commit import' }));
+    await waitFor(() => expect(mockCommit).toHaveBeenCalledTimes(1));
+
+    const [, commitFile] = mockCommit.mock.calls[0] as [string, File, string];
+    const text = await readFileText(commitFile);
+    expect(text).toContain('316.25');
+    expect(text).not.toContain(',316\n');
+  });
+
   it('training-maxes: removed row in REVIEW is excluded from the commit payload', async () => {
     const user = userEvent.setup();
     mockPreview.mockResolvedValue(TM_PREVIEW);

--- a/apps/web/app/(authed)/import/ImportWizard.tsx
+++ b/apps/web/app/(authed)/import/ImportWizard.tsx
@@ -24,7 +24,7 @@ function buildTrainingMaxesCsv(rows: EditableMax[]): string {
   const today = new Date().toISOString().slice(0, 10);
   const lines = rows
     .filter((r) => Number(r.weight) > 0)
-    .map((r) => `${today},"${r.lift.replace(/"/g, '""')}",${Math.round(Number(r.weight))}`);
+    .map((r) => `${today},"${r.lift.replace(/"/g, '""')}",${Number(r.weight)}`);
   return ['Date Updated,Lift,Weight', ...lines].join('\n');
 }
 
@@ -597,6 +597,7 @@ export function ImportWizard({ programs }: { programs: CustomProgramSummaryRespo
                                 className={styles.maxEditWeight}
                                 value={row.weight}
                                 min={1}
+                                step="0.01"
                                 aria-label={`Weight for ${row.lift}`}
                                 onChange={(e) =>
                                   setReviewMaxes((prev) =>

--- a/apps/web/app/(authed)/onboarding/OnboardingFlow.test.tsx
+++ b/apps/web/app/(authed)/onboarding/OnboardingFlow.test.tsx
@@ -47,7 +47,8 @@ describe('OnboardingFlow — persistence of confirmed maxes', () => {
     // Step 1 (Program): choose RPT → seeds 9 lifts → Step 2 (Enter Lifts)
     await selectRpt(user);
 
-    // Step 2: fill each seeded lift with 200 × 5 → Brzycki 1RM 225 → TM 203
+    // Step 2: fill each seeded lift with 200 × 5 → Brzycki 1RM 225 → TM 202.5
+    // (floored to the nearest 2.5, not rounded — 225 * 0.9 = 202.5 exactly)
     for (const lift of RPT_LIFTS) {
       await user.type(screen.getByLabelText(`${lift} weight`), '200');
       await user.type(screen.getByLabelText(`${lift} reps`), '5');
@@ -62,7 +63,7 @@ describe('OnboardingFlow — persistence of confirmed maxes', () => {
     expect(mockCreateFirstCycle).toHaveBeenCalledTimes(1);
     expect(mockCreateFirstCycle).toHaveBeenCalledWith(
       rpt.id,
-      RPT_LIFTS.map((lift) => ({ lift, trainingMax: 203 })),
+      RPT_LIFTS.map((lift) => ({ lift, trainingMax: 202.5 })),
     );
   });
 
@@ -80,21 +81,25 @@ describe('OnboardingFlow — persistence of confirmed maxes', () => {
     // Step 1 (Program): choose RPT → seeds 9 lifts → Step 2 (Enter Lifts)
     await selectRpt(user);
 
-    // Weight-only rows (no reps input) — enter 315 for each.
+    // Weight-only rows (no reps input) — enter 315 for each, except the first
+    // lift gets a decimal value to prove full precision is preserved (2.5/1.25
+    // plate increments), not just whole numbers.
+    const [decimalLift, ...wholeLifts] = RPT_LIFTS;
+    if (!decimalLift) throw new Error('Test setup: RPT_LIFTS is empty');
     for (const lift of RPT_LIFTS) {
       expect(screen.queryByLabelText(`${lift} reps`)).not.toBeInTheDocument();
-      await user.type(screen.getByLabelText(`${lift} weight`), '315');
+      await user.type(screen.getByLabelText(`${lift} weight`), lift === decimalLift ? '316.25' : '315');
     }
 
     await user.click(screen.getByRole('button', { name: /next/i }));
     await user.click(screen.getByRole('button', { name: /start my program/i }));
 
-    // 315 entered → 315 persisted (not 283 which would be 90% of 315 rounded).
+    // Entered as-is → persisted as-is (not 283 which would be 90% of 315 rounded).
     expect(mockCreateFirstCycle).toHaveBeenCalledTimes(1);
-    expect(mockCreateFirstCycle).toHaveBeenCalledWith(
-      rpt.id,
-      RPT_LIFTS.map((lift) => ({ lift, trainingMax: 315 })),
-    );
+    expect(mockCreateFirstCycle).toHaveBeenCalledWith(rpt.id, [
+      { lift: decimalLift, trainingMax: 316.25 },
+      ...wholeLifts.map((lift) => ({ lift, trainingMax: 315 })),
+    ]);
   });
 
   it('persists imported training maxes as-is when the "import" method is used (not seeded rows)', async () => {
@@ -112,11 +117,12 @@ describe('OnboardingFlow — persistence of confirmed maxes', () => {
     // → Step 2 (Import)
     await selectRpt(user);
 
-    // Step 2: Upload a training-maxes CSV — Squat has history, so the latest (315) wins.
+    // Step 2: Upload a training-maxes CSV — Squat has history, so the latest
+    // (316.25, a 2.5/1.25-increment decimal) wins.
     const csv = [
       'Date Updated,Lift,Weight',
       '2026-01-01,Squat,300',
-      '2026-02-01,Squat,315',
+      '2026-02-01,Squat,316.25',
       '2026-01-01,Bench Press,225',
     ].join('\n');
     await user.upload(
@@ -131,13 +137,44 @@ describe('OnboardingFlow — persistence of confirmed maxes', () => {
     await user.click(screen.getByRole('button', { name: /next/i }));
     await user.click(screen.getByRole('button', { name: /start my program/i }));
 
-    // Imported TMs persist verbatim (latest per lift); the 9 seeded RPT rows are
-    // overwritten by the import, not passed to createFirstCycle.
+    // Imported TMs persist verbatim (latest per lift, full precision); the 9
+    // seeded RPT rows are overwritten by the import, not passed to createFirstCycle.
     expect(mockCreateFirstCycle).toHaveBeenCalledTimes(1);
     expect(mockCreateFirstCycle).toHaveBeenCalledWith(rpt.id, [
-      { lift: 'Squat', trainingMax: 315 },
+      { lift: 'Squat', trainingMax: 316.25 },
       { lift: 'Bench Press', trainingMax: 225 },
     ]);
+  });
+
+  it('floors both the entered 1RM and the 90%-derived training max to the nearest 2.5 when the "manual" method is used', async () => {
+    const user = userEvent.setup();
+    const rpt = PROGRAMS.find((p) => p.id === 'rpt');
+    if (!rpt) throw new Error('Test setup: rpt missing from PROGRAMS catalog');
+
+    render(<OnboardingFlow catalog={CATALOG} />);
+
+    // Step 0: pick "Enter manually" (1RM), then advance.
+    await user.click(screen.getByRole('button', { name: /enter manually/i }));
+    await user.click(screen.getByRole('button', { name: /next/i }));
+
+    // Step 1 (Program): choose RPT → seeds 9 lifts → Step 2 (Enter Lifts)
+    await selectRpt(user);
+
+    // 203 floors to 202.5 (not rounds to 203); 202.5 * 0.9 = 182.25, which
+    // floors to 180.
+    for (const lift of RPT_LIFTS) {
+      expect(screen.queryByLabelText(`${lift} reps`)).not.toBeInTheDocument();
+      await user.type(screen.getByLabelText(`${lift} weight`), '203');
+    }
+
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    await user.click(screen.getByRole('button', { name: /start my program/i }));
+
+    expect(mockCreateFirstCycle).toHaveBeenCalledTimes(1);
+    expect(mockCreateFirstCycle).toHaveBeenCalledWith(
+      rpt.id,
+      RPT_LIFTS.map((lift) => ({ lift, trainingMax: 180 })),
+    );
   });
 });
 

--- a/apps/web/app/(authed)/onboarding/OnboardingFlow.tsx
+++ b/apps/web/app/(authed)/onboarding/OnboardingFlow.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useState, useTransition } from 'react';
 import styles from './onboarding.module.css';
 import {
   brzycki1RM,
+  floorToIncrement,
   getSeedLiftsByProgramId,
   isWeightOnly,
   valuesAreTrainingMax,
@@ -58,10 +59,10 @@ export function OnboardingFlow({ catalog }: { catalog: string[] }) {
       const w = Number(row.weight);
       const r = Number(row.reps);
       if (valuesAreTrainingMax(method)) {
-        return { lift: row.lift, oneRm: null, trainingMax: Math.round(w) };
+        return { lift: row.lift, oneRm: null, trainingMax: w };
       }
-      const oneRm = method === 'manual' ? Math.round(w) : brzycki1RM(w, r);
-      return { lift: row.lift, oneRm, trainingMax: Math.round(oneRm * 0.9) };
+      const oneRm = method === 'manual' ? floorToIncrement(w) : brzycki1RM(w, r);
+      return { lift: row.lift, oneRm, trainingMax: floorToIncrement(oneRm * 0.9) };
     });
   }, [lifts, method]);
 

--- a/apps/web/app/(authed)/onboarding/lib.test.ts
+++ b/apps/web/app/(authed)/onboarding/lib.test.ts
@@ -1,14 +1,35 @@
-import { brzycki1RM, DEFAULT_LIFTS, getSeedLifts } from './lib';
+import { brzycki1RM, DEFAULT_LIFTS, floorToIncrement, getSeedLifts } from './lib';
 
-describe('brzycki1RM', () => {
-  it('returns the weight rounded for a single rep', () => {
-    expect(brzycki1RM(225, 1)).toBe(225);
-    expect(brzycki1RM(225.4, 1)).toBe(225);
+describe('floorToIncrement', () => {
+  it('leaves an exact multiple of the increment unchanged', () => {
+    expect(floorToIncrement(315)).toBe(315);
+    expect(floorToIncrement(317.5)).toBe(317.5);
   });
 
-  it('estimates a higher 1RM for multi-rep sets', () => {
-    // 200 × 5 → 200 × 36 / 32 = 225
+  it('floors down to the nearest lower multiple (default 2.5)', () => {
+    expect(floorToIncrement(316.9)).toBe(315);
+    expect(floorToIncrement(203)).toBe(202.5);
+  });
+
+  it('respects a custom increment', () => {
+    expect(floorToIncrement(23, 5)).toBe(20);
+  });
+});
+
+describe('brzycki1RM', () => {
+  it('floors the weight to the nearest 2.5 for a single rep', () => {
+    expect(brzycki1RM(225, 1)).toBe(225);
+    expect(brzycki1RM(225.4, 1)).toBe(225);
+    // Distinguishes floor-to-2.5 from round-to-nearest: 203 rounds to 203 but
+    // floors to 202.5.
+    expect(brzycki1RM(203, 1)).toBe(202.5);
+  });
+
+  it('estimates a higher 1RM for multi-rep sets, floored to the nearest 2.5', () => {
+    // 200 × 5 → 200 × 36 / 32 = 225 (already an exact multiple of 2.5)
     expect(brzycki1RM(200, 5)).toBe(225);
+    // 210 × 3 → 210 × 36 / 34 = 222.35... rounds to 222 but floors to 220.
+    expect(brzycki1RM(210, 3)).toBe(220);
   });
 
   it('returns 0 for non-positive weight or reps', () => {

--- a/apps/web/app/(authed)/onboarding/lib.test.ts
+++ b/apps/web/app/(authed)/onboarding/lib.test.ts
@@ -14,6 +14,10 @@ describe('floorToIncrement', () => {
   it('respects a custom increment', () => {
     expect(floorToIncrement(23, 5)).toBe(20);
   });
+
+  it('degrades to the unrounded value for a zero increment instead of dividing by zero', () => {
+    expect(floorToIncrement(203, 0)).toBe(203);
+  });
 });
 
 describe('brzycki1RM', () => {

--- a/apps/web/app/(authed)/onboarding/lib.ts
+++ b/apps/web/app/(authed)/onboarding/lib.ts
@@ -64,10 +64,20 @@ export function getSeedLiftsByProgramId(programId: string | null | undefined): L
   return getSeedLifts(PRESET_BASE_SPECS[programId]);
 }
 
+/**
+ * Floors a value down to the nearest lower multiple of `increment` (default
+ * 2.5 lb plates). Used for estimated/derived maxes, which are approximations
+ * by nature — directly-entered or imported maxes are persisted at full
+ * precision instead (see {@link valuesAreTrainingMax}).
+ */
+export function floorToIncrement(value: number, increment = 2.5): number {
+  return Math.floor(value / increment) * increment;
+}
+
 export function brzycki1RM(weight: number, reps: number): number {
   if (reps <= 0 || weight <= 0) return 0;
-  if (reps === 1) return Math.round(weight);
+  if (reps === 1) return floorToIncrement(weight);
   const denom = 37 - reps;
   if (denom <= 0) return 0;
-  return Math.round((weight * 36) / denom);
+  return floorToIncrement((weight * 36) / denom);
 }

--- a/apps/web/app/(authed)/onboarding/lib.ts
+++ b/apps/web/app/(authed)/onboarding/lib.ts
@@ -71,6 +71,9 @@ export function getSeedLiftsByProgramId(programId: string | null | undefined): L
  * precision instead (see {@link valuesAreTrainingMax}).
  */
 export function floorToIncrement(value: number, increment = 2.5): number {
+  // A zero increment would divide by zero and yield NaN — degrade safely to
+  // the unrounded value instead, matching MROUND's guard in packages/core.
+  if (increment === 0) return value;
   return Math.floor(value / increment) * increment;
 }
 

--- a/apps/web/app/(authed)/onboarding/steps/StepImport.test.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepImport.test.tsx
@@ -34,6 +34,27 @@ describe('StepImport', () => {
     expect(screen.getByLabelText('Weight for Bench Press')).toBeInTheDocument();
   });
 
+  it('preserves a decimal weight from the CSV without rounding', async () => {
+    const user = userEvent.setup();
+    const onImported = jest.fn();
+    render(<StepImport onImported={onImported} />);
+
+    const csv = [
+      'Date Updated,Lift,Weight',
+      '2026-01-01,Squat,316.25',
+      '2026-01-01,Bench Press,225',
+    ].join('\n');
+
+    await user.upload(screen.getByLabelText(/training-maxes csv/i), csvFile(csv));
+
+    await waitFor(() => expect(onImported).toHaveBeenCalledTimes(1));
+    expect(onImported).toHaveBeenCalledWith([
+      { lift: 'Squat', weight: '316.25', reps: '' },
+      { lift: 'Bench Press', weight: '225', reps: '' },
+    ]);
+    expect(screen.getByLabelText('Weight for Squat')).toHaveValue(316.25);
+  });
+
   it('reflects an edited weight in the onImported payload', async () => {
     const user = userEvent.setup();
     const onImported = jest.fn();

--- a/apps/web/app/(authed)/onboarding/steps/StepImport.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepImport.tsx
@@ -66,7 +66,7 @@ function latestPerLift(maxes: TrainingMax[]): LiftRow[] {
   }
   return Array.from(byLift.entries()).map(([lift, { weight }]) => ({
     lift,
-    weight: String(Math.round(weight)),
+    weight: String(weight),
     reps: '',
   }));
 }
@@ -230,6 +230,7 @@ export function StepImport({ onImported }: Props) {
                     className={styles.numberInput}
                     value={row.weight}
                     min={1}
+                    step="0.01"
                     aria-label={`Weight for ${row.lift}`}
                     onChange={(e) => updateWeight(i, e.target.value)}
                   />

--- a/apps/web/app/(authed)/onboarding/steps/StepLifts.tsx
+++ b/apps/web/app/(authed)/onboarding/steps/StepLifts.tsx
@@ -57,6 +57,7 @@ export function StepLifts({ method, lifts, catalog, onChange, onAdd, onRemove }:
               type="number"
               inputMode="decimal"
               min="0"
+              step="0.01"
               placeholder="Weight"
               className={styles.numberInput}
               value={row.weight}

--- a/docs/standards/training-max-precision.md
+++ b/docs/standards/training-max-precision.md
@@ -1,0 +1,109 @@
+# Coding Standard: Training-Max Weight Precision
+
+**Applies to:** all packages and apps — anywhere a training-max or 1RM weight value is parsed, persisted, compared, or derived
+**Status:** Active
+**Related issue:** [#633 — Training-max precision loss and configurable workout-rounding increment](https://github.com/brownm09/lifting-logbook/issues/633)
+
+---
+
+## Rule
+
+Training-max weight is a `Float` (`apps/api/prisma/schema.prisma`) because users' plate
+increments (commonly 2.5 and 1.25 lbs) produce values with up to 2 decimal places, e.g.
+`316.25`. Whether a code path may round that value — and how — depends entirely on where
+the value *comes from*:
+
+1. **Directly-known values** — a value the user typed, imported from a file, or that is
+   already stored — **must be persisted, compared, and displayed at full precision**. Do
+   not call `Math.round()`, `toFixed(0)`, or similar on these. If a comparison needs
+   tolerance for floating-point noise from upstream arithmetic, round to **2 decimal
+   places**, never coarser — 1 decimal place is not sufficient (see Why, below).
+2. **Formula-derived estimates** — a 1RM estimated from a weight×reps set (Brzycki
+   formula), or a training max derived from that estimate at a fixed percentage — are
+   approximations by nature, and this repo's convention is to **floor down to the nearest
+   plate increment** (`floorToIncrement()` in `apps/web/app/(authed)/onboarding/lib.ts`,
+   default 2.5 lbs) rather than round to nearest. Floor, not round: a lifter should never
+   be told to load slightly more than their estimate supports.
+3. **Computed per-workout target weights** — a percentage of a training max, generated
+   while planning a specific set (e.g. "70% of your squat TM this week") — must round to
+   the nearest *loadable* plate combination. This is the one case where rounding to a
+   coarser value than the stored training max is not just acceptable but required — you
+   cannot load a bar to a non-plate weight. Use `MROUND()` (`packages/core/src/constants/config.ts`),
+   which rounds to the program spec's configured `increment` field, not a hardcoded value.
+
+When adding a new code path that touches a training-max or 1RM weight, identify which of
+these three categories it falls into before deciding whether — and how — to round.
+
+---
+
+## Why
+
+[PR #636](https://github.com/brownm09/lifting-logbook/pull/636) fixed four places where a
+directly-known value (category 1) was silently rounded to a whole number, contradicting
+that code's own documented "persisted as-is" contract in three of the four cases. Git blame
+traced one of them to [PR #560](https://github.com/brownm09/lifting-logbook/pull/560), which
+introduced the "enter training maxes directly" onboarding method by copy-pasting the
+adjacent estimate-derivation code's rounding pattern (category 2) without reconsidering it
+for a path meant to have none. The contract existed only in a code comment — nowhere a
+future contributor modifying adjacent code would necessarily see it before repeating the
+mistake.
+
+A fourth bug in the same PR was in a category-1 path with a legitimate reason for *some*
+rounding tolerance (absorbing floating-point noise from upstream arithmetic in
+`cycle-generation.service.ts`'s history-change detection) — but the tolerance was coarser
+(1 decimal place) than the precision that actually matters to users, silently dropping real
+sub-0.1lb changes from history. This is why the rule above specifies a floor on how coarse
+a *comparison* tolerance may be, separately from the "no rounding at all" rule for the
+persisted/displayed value itself.
+
+---
+
+## Examples
+
+### Good: full precision through the import pipeline
+
+`apps/web/app/(authed)/import/ImportWizard.tsx`'s `buildTrainingMaxesCsv()` rebuilds a CSV
+from user-edited rows for the commit API — `${Number(r.weight)}`, no rounding.
+
+### Good: floor-to-increment for an estimate
+
+`apps/web/app/(authed)/onboarding/lib.ts`'s `brzycki1RM()` estimates a 1RM from a
+weight×reps set and floors the result: `floorToIncrement((weight * 36) / denom)`.
+
+### Good: increment-aware rounding for a computed workout weight
+
+`packages/core/src/services/workout/calculateLiftWeights.ts` calls
+`MROUND(currLiftTm * pct, currLiftIncrement)` — rounds to the program's configured plate
+increment, not a hardcoded value, and never touches the stored `TrainingMax.weight`.
+
+### Bad: rounding a directly-entered value
+
+```ts
+// apps/web/app/(authed)/onboarding/OnboardingFlow.tsx (pre-#636)
+if (valuesAreTrainingMax(method)) {
+  return { lift: row.lift, oneRm: null, trainingMax: Math.round(w) };
+}
+```
+
+`w` here is a value the user typed directly (`tm` method) or imported from a CSV (`import`
+method) — both categorized by this file's own `valuesAreTrainingMax()` docstring as
+"persisted as-is... no adjustment." Rounding it violates that contract silently.
+
+---
+
+## Enforcement
+
+No automated static check exists for this standard — unlike `fetch-cache-semantics.md` and
+`error-fallback-test-coverage.md`, a lint rule would need to distinguish "this `Math.round()`
+call operates on a training-max-shaped value" from any other numeric rounding in the
+codebase, which isn't reliably inferable from syntax alone. This standard is enforced by
+code review: when a PR touches training-max weight handling, confirm which of the three
+categories above applies and that the rounding behavior (or lack of it) matches.
+
+---
+
+## References
+
+- [Issue #633 — Training-max precision loss and configurable workout-rounding increment](https://github.com/brownm09/lifting-logbook/issues/633) — the audit that produced this standard
+- [PR #636 — Preserve training-max decimal precision in Import, onboarding, and history](https://github.com/brownm09/lifting-logbook/pull/636) — the incident and fix
+- [PR #560 — Add 'enter training maxes directly' onboarding method](https://github.com/brownm09/lifting-logbook/pull/560) — introduced one of the four bugs fixed in #636


### PR DESCRIPTION
## Summary

Training maxes carry up to 2 decimal places of precision (2.5 / 1.25 lb plate
increments, e.g. `316.25`). Four places silently rounded a directly-known
value (typed, imported, or already-persisted) to coarser precision:

1. **`ImportWizard.tsx`** `buildTrainingMaxesCsv()` — rounded to a whole
   number when rebuilding the commit CSV from the REVIEW step's editable
   list, even though REVIEW displayed the precise value correctly.
2. **`StepImport.tsx`** `latestPerLift()` — rounded to a whole number when
   parsing an uploaded training-maxes CSV during onboarding, contradicting
   its own UI copy ("we'll use the values as-is").
3. **`OnboardingFlow.tsx`** `computedMaxes` — the `tm`/`import` onboarding
   methods rounded to a whole number, contradicting `lib.ts`'s documented
   "persisted as-is... no adjustment" contract.
4. **`cycle-generation.service.ts`** `buildHistoryEntries` — compared
   training maxes at 1 decimal place purely to decide whether to write a
   `TrainingMaxHistory` row; a real change like `316.25 → 316.30` both round
   to `316.3` and was silently dropped from history. Renamed `round1dp` →
   `round2dp`. The `weight` field written on a match was already full
   precision — only the change-detection comparison was too coarse.

## Also included: estimate/manual-entry rounding

Per explicit instruction, the `estimate`/`test`/`manual` onboarding methods
(formula-derived or manually-typed 1RM, then derived to a training max at
90%) now floor down to the nearest 2.5 lbs instead of rounding to the
nearest whole number — applied to both the 1RM and the 90%-derived training
max, via a new `floorToIncrement()` helper. These compute an approximation
rather than persist a known value as-is, so coarser, load-relevant precision
is intentional here (unlike the 4 bugs above).

Verified empirically that `Math.floor(value / 2.5) * 2.5` has no
floating-point drift risk across realistic weight ranges — no epsilon guard
needed.

## Out of scope (confirmed, not bugs)

Plate-increment rounding of *computed* per-workout weights (`MROUND`) is
correct/required — you can't load a bar to a non-plate weight. Full audit
inventory in parent issue #633.

## Testing

Ran `npm test -w @lifting-logbook/web` and `npm test -w @lifting-logbook/api`,
plus `npm run build`.

Tests: 145 passed, 0 skipped, 0 failed (web) + 406 passed, 0 skipped, 0 failed
(api).

New/updated coverage:
- `ImportWizard.test.tsx` — decimal weight survives the REVIEW→commit CSV rebuild
- `StepImport.test.tsx` — decimal weight survives CSV parse
- `lib.test.ts` — `floorToIncrement` unit tests + `brzycki1RM` cases that
  distinguish floor-to-2.5 from round-to-nearest
- `OnboardingFlow.test.tsx` — decimal precision proven for `tm`/`import`
  methods (previously only whole-number values were tested, which would have
  passed even with the bug present); new `manual`-method test for
  floor-to-2.5
- `cycle-generation.service.spec.ts` — new `buildHistoryEntries` unit tests
  (exported for direct testing; no existing coverage existed for this
  function). Proves a sub-0.1lb real change is no longer dropped from history.

Suppression grep, test-integrity grep: both clean. `baseline_test_failure_tracking`
is not enabled for this repo.

Closes #634

## Review findings disposition

- **[reliability]** floorToIncrement() zero-increment guard — fixed in `9b3a813`
- **[documentation]** No single doc captured the training-max rounding contract — fixed in `9b3a813` (added docs/standards/training-max-precision.md, indexed in CLAUDE.md)
