### PR TITLE
[chore] Fix stale Epic option IDs in local .claude/hook-config.json

### DIFF
--- a/.claude/hook-config.json
+++ b/.claude/hook-config.json
@@ -5,12 +5,16 @@
   "project_node_id": "PVT_kwHOAjEKvM4BTuEF",
   "epic_field_id": "PVTSSF_lAHOAjEKvM4BTuEFzhA7GEs",
   "epic_options": {
-    "Monorepo Scaffolding":         "974b67c1",
-    "Package & App Scaffolding":    "26d27ab2",
-    "Port Interfaces":              "9196ffd9",
-    "Shared Types":                 "42bf8843",
-    "CI/CD Foundation":             "23133b3a",
-    "Architecture & Documentation": "656e470c"
+    "Monorepo Scaffolding":         "9dcd9556",
+    "Package & App Scaffolding":    "ae06cfdd",
+    "Port Interfaces":              "cc1ae008",
+    "Shared Types":                 "a6b59698",
+    "CI/CD Foundation":             "fc0df03b",
+    "Architecture & Documentation": "f7202bcd",
+    "Observability":                "d3c68018",
+    "API Implementation":           "50a1da76",
+    "Client Applications":          "31d3931e",
+    "Operations":                   "0c3f26d2"
   },
   "milestones": [
     "v0.1 — Foundation",


### PR DESCRIPTION
## Summary
- `.claude/hook-config.json`'s `epic_options` map (read by `~/.claude/scripts/post-tool-use.py`, the auto-add-to-project hook) contained 6 stale Epic IDs matching none of the live GitHub Projects GraphQL state, and was missing 4 known epics entirely (Observability, API Implementation, Client Applications, Operations).
- Corrected the map to the verified live 10-entry set, confirmed via direct `gh api graphql` query against the project's `Epic` field.
- The live project board itself was never corrupted — only this cached, but actually git-tracked, file had drifted (see issue for full root cause: it was missed by the 2026-05-08 Epic-field-mutation recovery, since that procedure updates `CLAUDE.md`'s table but has no step for this file).

## Testing
Ran `npm test` from repo root per `## Testing`.
Tests: 406 passed, 0 skipped, 0 failed (33.058s, api workspace) — all 12 turbo test tasks across every workspace succeeded. This change touches only a GitHub-tooling JSON config file with no relation to any workspace's code path; the run establishes a clean baseline and confirms no regression.

Closes #638