### PR TITLE
[chore] Fix Prisma migration drift: custom_lift.jointActions DEFAULT not declared in schema.prisma

### DIFF
--- a/apps/api/prisma/migrations/20260702193740_drop_custom_lift_jointactions_default/migration.sql
+++ b/apps/api/prisma/migrations/20260702193740_drop_custom_lift_jointactions_default/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "custom_lift" ALTER COLUMN "jointActions" DROP DEFAULT;


### PR DESCRIPTION
## Summary
- Every `npx prisma migrate dev` run was injecting an unrequested `ALTER TABLE "custom_lift" ALTER COLUMN "jointActions" DROP DEFAULT;` into whatever migration was being generated, regardless of the actual schema change.
- Root cause: migration `20260603120000_add_movement_profile` set `DEFAULT '{}'` at the SQL level when adding the column (Prisma's own behavior when backfilling a required array column on a non-empty table), but `schema.prisma`'s `CustomLift.jointActions` was never annotated with `@default([])` — permanent schema/DB drift that `migrate dev`'s diff engine re-proposed fixing on every run.
- Investigated every write path (`PrismaCustomLiftRepository.create()`/`update()`, the in-memory adapter, `prisma/seed.ts`, every test) — the DB-level default is never relied upon; every path always passes `jointActions` explicitly. So the fix is to generate a real migration dropping the default, not to add `@default([])` to the schema (which would reconcile toward behavior nothing needs).
- No `schema.prisma` edit needed — it already reflects the desired end state. Ran `prisma migrate dev` on its own so it captures *only* this drift as one intentional migration, consuming it.

## Changes
- New migration `apps/api/prisma/migrations/20260702193740_drop_custom_lift_jointactions_default/migration.sql` — contains only `ALTER TABLE "custom_lift" ALTER COLUMN "jointActions" DROP DEFAULT;`.

## Acceptance criteria
- [x] New migration exists containing only the DROP DEFAULT statement
- [x] A subsequent `npx prisma migrate dev` run with no schema changes produces no new migration (proves drift is resolved)
- [x] Full test suite passes, including `programs.db.e2e.spec.ts` and `custom-lift.e2e.spec.ts`

## Testing
Ran `npm test` from repo root per `## Testing`.
Tests: 552 passed, 0 skipped, 0 failed (api 406/406 incl. `programs.db.e2e.spec.ts` + `custom-lift.e2e.spec.ts` via Testcontainers, web 146/146) — 12/12 turbo test tasks.

Direct verification of the fix itself: after generating and applying the migration, re-ran `npx prisma migrate dev` with no schema changes — output: `Already in sync, no schema change or pending migration was found.` This is the concrete proof the recurring-drift bug is resolved.

Closes #637