### PR TITLE
[fix] Resolve PrismaService lazily in RlsInterceptor to fix silently-disabled RLS

### DIFF
--- a/apps/api/jest.env.setup.js
+++ b/apps/api/jest.env.setup.js
@@ -49,13 +49,34 @@ process.env = new Proxy(originalEnv, {
     // Allow the DB E2E spec to restore DATABASE_URL from the Testcontainers
     // sentinel set by jest.global-setup.js. This is the single legitimate
     // write path for DATABASE_URL during a test run.
-    if (
-      String(key) === 'DATABASE_URL' &&
-      value &&
-      value === target.LIFTING_TC_DATABASE_URL
-    ) {
-      target[key] = value;
-      return true;
+    if (String(key) === 'DATABASE_URL' && value) {
+      const sentinel = target.LIFTING_TC_DATABASE_URL;
+      if (value === sentinel) {
+        target[key] = value;
+        return true;
+      }
+      // Also allow the lifting_app-role variant of the sentinel (same host/port/database,
+      // different credentials) — needed by full-app-boot RLS tests that must connect as the
+      // restricted runtime role rather than the Testcontainers owner, so PrismaService's
+      // env("DATABASE_URL") read resolves to a real, RLS-enforcing connection. Scoped to the
+      // sentinel's own host/pathname so this cannot be used to smuggle an arbitrary DB URL in.
+      // See rls.db.e2e.spec.ts's "RLS request wiring (interceptor + factory, full app)" block.
+      if (sentinel) {
+        try {
+          const candidate = new URL(value);
+          const base = new URL(sentinel);
+          if (
+            candidate.host === base.host &&
+            candidate.pathname === base.pathname &&
+            candidate.username === 'lifting_app'
+          ) {
+            target[key] = value;
+            return true;
+          }
+        } catch {
+          // Not a valid URL — fall through and discard below.
+        }
+      }
     }
     if (BLOCK.includes(String(key))) {
       return true; // discard — blocked keys are frozen at ''

--- a/apps/api/jest.env.setup.js
+++ b/apps/api/jest.env.setup.js
@@ -47,8 +47,9 @@ const originalEnv = process.env;
 process.env = new Proxy(originalEnv, {
   set(target, key, value) {
     // Allow the DB E2E spec to restore DATABASE_URL from the Testcontainers
-    // sentinel set by jest.global-setup.js. This is the single legitimate
-    // write path for DATABASE_URL during a test run.
+    // sentinel set by jest.global-setup.js, or from its lifting_app-role variant
+    // (see below) — these are the only legitimate write paths for DATABASE_URL
+    // during a test run.
     if (String(key) === 'DATABASE_URL' && value) {
       const sentinel = target.LIFTING_TC_DATABASE_URL;
       if (value === sentinel) {

--- a/apps/api/src/adapters/prisma/rls.db.e2e.spec.ts
+++ b/apps/api/src/adapters/prisma/rls.db.e2e.spec.ts
@@ -12,11 +12,13 @@
 // rows). Enforcement assertions use the lifting_app client.
 import 'reflect-metadata';
 import { ExecutionContext, CallHandler } from '@nestjs/common';
-import { Reflector } from '@nestjs/core';
+import { NestFactory, Reflector } from '@nestjs/core';
 import { Test } from '@nestjs/testing';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import { PrismaClient } from '@prisma/client';
 import { ClsModule, ClsService } from 'nestjs-cls';
 import { lastValueFrom, from } from 'rxjs';
+import { AppModule } from '../../app.module';
 import { PrismaService } from './prisma.service';
 import { PrismaRepositoryFactory } from './prisma-repository-factory';
 import { RlsInterceptor } from './rls.interceptor';
@@ -279,7 +281,10 @@ describeOrSkip('RLS request wiring (interceptor + factory)', () => {
     prisma = moduleRef.get(PrismaService);
     await prisma.$connect();
     factory = new PrismaRepositoryFactory(prisma, cls);
-    interceptor = new RlsInterceptor(cls, moduleRef.get(Reflector), prisma);
+    // RlsInterceptor resolves PrismaService lazily via ModuleRef (see rls.interceptor.ts) rather
+    // than constructor injection, so the test module itself — which implements ModuleRef and
+    // already has PrismaService registered above — stands in for the real one.
+    interceptor = new RlsInterceptor(cls, moduleRef.get(Reflector), moduleRef);
   });
 
   afterAll(async () => {
@@ -340,5 +345,99 @@ describeOrSkip('RLS request wiring (interceptor + factory)', () => {
 
     // After the request scope ends, it falls back to the base client again.
     expect(prisma.clientForRequest()).toBe(prisma);
+  });
+});
+
+// Proves the FULL request path — real AppModule, real AuthGuard, real RlsInterceptor, real
+// PrismaRepositoryFactory — against the actual restricted lifting_app role. Neither block above
+// covers this exact combination: the enforcement block above calls raw Prisma directly (no
+// interceptor/factory/guard involved), and the wiring block above connects as the OWNER
+// (superuser bypasses policy enforcement, so it can prove the GUC is *set* but not that a real
+// write actually clears the policy). That gap is exactly what let issue #644 ship silently:
+// RlsInterceptor's constructor-injected `@Optional() PrismaService` was permanently null (Nest
+// instantiates APP_INTERCEPTOR-bound providers before this module's PrismaService factory is
+// guaranteed to have run), so no request ever set app.current_user_id — reads on genuinely
+// existing data silently returned "not found" (fail-closed), and every first-time INSERT was
+// rejected with a 42501 row-level security violation. Every other DB E2E suite in this repo
+// connects as the bootstrap superuser and could not have caught this.
+describeOrSkip('RLS request wiring (interceptor + factory, full app boot)', () => {
+  let app: NestFastifyApplication;
+  let owner: PrismaClient;
+
+  function appRoleUrl(): string {
+    const u = new URL(OWNER_URL);
+    u.username = APP_ROLE;
+    u.password = APP_ROLE_PASSWORD;
+    return u.toString();
+  }
+
+  beforeAll(async () => {
+    owner = new PrismaClient({ datasources: { db: { url: OWNER_URL } } });
+    // Idempotent — harmless if the "Row-Level Security (e2e, lifting_app role)" block above
+    // already set this password; this block must not depend on describe-block execution order.
+    await owner.$executeRawUnsafe(
+      `ALTER ROLE "${APP_ROLE}" WITH LOGIN PASSWORD '${APP_ROLE_PASSWORD}'`,
+    );
+
+    // Allowed by jest.env.setup.js's Proxy: same host/pathname as the LIFTING_TC_DATABASE_URL
+    // sentinel, lifting_app user — so PrismaService's env("DATABASE_URL") read resolves to a
+    // real, RLS-enforcing connection instead of the owner/superuser one.
+    process.env.DATABASE_URL = appRoleUrl();
+
+    app = await NestFactory.create<NestFastifyApplication>(AppModule, new FastifyAdapter(), {
+      logger: false,
+    });
+    await app.init();
+  }, DB_E2E_HOOK_TIMEOUT_MS);
+
+  afterAll(async () => {
+    await app?.close().catch(() => undefined);
+    await owner?.$disconnect().catch(() => undefined);
+  }, DB_E2E_HOOK_TIMEOUT_MS);
+
+  const inject = (opts: {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+    payload?: string;
+  }) => app.getHttpAdapter().getInstance().inject(opts);
+
+  it('creates a first-time row for a brand-new user (regression test for #644)', async () => {
+    const userId = `rls-e2e-fullapp-init-${Date.now()}`;
+    const res = await inject({
+      method: 'POST',
+      url: '/programs/leangains/cycles/initialize',
+      headers: { authorization: `Bearer ${userId}`, 'content-type': 'application/json' },
+      payload: '{}',
+    });
+
+    expect(res.statusCode).toBe(201);
+    await owner.cycleDashboard.deleteMany({ where: { userId } });
+  });
+
+  it('reads back data that genuinely exists instead of failing closed (regression test for #644)', async () => {
+    const userId = `rls-e2e-fullapp-read-${Date.now()}`;
+    await owner.cycleDashboard.create({
+      data: {
+        userId,
+        program: 'leangains',
+        cycleUnit: 'week',
+        cycleNum: 1,
+        cycleDate: new Date(),
+        sheetName: 'leangains_Cycle_1_seed',
+        cycleStartWeekday: 'Friday',
+        programType: 'leangains',
+      },
+    });
+
+    const res = await inject({
+      method: 'GET',
+      url: '/programs/leangains/cycles/current',
+      headers: { authorization: `Bearer ${userId}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).program).toBe('leangains');
+    await owner.cycleDashboard.deleteMany({ where: { userId } });
   });
 });

--- a/apps/api/src/adapters/prisma/rls.db.e2e.spec.ts
+++ b/apps/api/src/adapters/prisma/rls.db.e2e.spec.ts
@@ -364,13 +364,6 @@ describeOrSkip('RLS request wiring (interceptor + factory, full app boot)', () =
   let app: NestFastifyApplication;
   let owner: PrismaClient;
 
-  function appRoleUrl(): string {
-    const u = new URL(OWNER_URL);
-    u.username = APP_ROLE;
-    u.password = APP_ROLE_PASSWORD;
-    return u.toString();
-  }
-
   beforeAll(async () => {
     owner = new PrismaClient({ datasources: { db: { url: OWNER_URL } } });
     // Idempotent — harmless if the "Row-Level Security (e2e, lifting_app role)" block above
@@ -382,7 +375,7 @@ describeOrSkip('RLS request wiring (interceptor + factory, full app boot)', () =
     // Allowed by jest.env.setup.js's Proxy: same host/pathname as the LIFTING_TC_DATABASE_URL
     // sentinel, lifting_app user — so PrismaService's env("DATABASE_URL") read resolves to a
     // real, RLS-enforcing connection instead of the owner/superuser one.
-    process.env.DATABASE_URL = appRoleUrl();
+    process.env.DATABASE_URL = appRoleUrl(OWNER_URL);
 
     app = await NestFactory.create<NestFastifyApplication>(AppModule, new FastifyAdapter(), {
       logger: false,

--- a/apps/api/src/adapters/prisma/rls.interceptor.ts
+++ b/apps/api/src/adapters/prisma/rls.interceptor.ts
@@ -3,9 +3,8 @@ import {
   ExecutionContext,
   Injectable,
   NestInterceptor,
-  Optional,
 } from '@nestjs/common';
-import { Reflector } from '@nestjs/core';
+import { ModuleRef, Reflector } from '@nestjs/core';
 import { ClsService } from 'nestjs-cls';
 import { SpanStatusCode, trace } from '@opentelemetry/api';
 import { Observable, defaultIfEmpty, from, lastValueFrom } from 'rxjs';
@@ -31,6 +30,14 @@ import {
  * No-ops when there is no Prisma client (in-memory / SystemDb factories) or no authenticated user
  * (public routes such as /health and /readyz). Those run on the base client with no GUC — which is
  * fail-closed for any userId-scoped table (zero rows) and harmless for the table-less probes.
+ *
+ * PrismaService is resolved lazily via ModuleRef on every request rather than constructor-injected.
+ * RlsInterceptor is bound via APP_INTERCEPTOR, which Nest instantiates as part of its early
+ * global-enhancer setup — before PrismaService's useFactory provider (declared in the same module)
+ * is guaranteed to have run. A constructor-injected `@Optional() PrismaService` captured that
+ * premature `null` permanently (RlsInterceptor is a singleton), silently disabling the RLS
+ * transaction — and therefore the `app.current_user_id` GUC — for the lifetime of the process. See
+ * issue #644.
  */
 @Injectable()
 export class RlsInterceptor implements NestInterceptor {
@@ -39,11 +46,11 @@ export class RlsInterceptor implements NestInterceptor {
   constructor(
     private readonly cls: ClsService,
     private readonly reflector: Reflector,
-    @Optional() private readonly prisma: PrismaService | null = null,
+    private readonly moduleRef: ModuleRef,
   ) {}
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
-    const prisma = this.prisma;
+    const prisma = this.moduleRef.get(PrismaService, { strict: false });
     // Only the HTTP path is RLS-wired today; `apps/api` exposes no GraphQL resolvers
     // (no GraphQLModule). If GraphQL resolvers touching userId tables are ever added, this guard
     // must be broadened to the 'graphql' context type — otherwise those queries skip the GUC and

--- a/apps/api/src/adapters/prisma/rls.interceptor.ts
+++ b/apps/api/src/adapters/prisma/rls.interceptor.ts
@@ -38,10 +38,16 @@ import {
  * premature `null` permanently (RlsInterceptor is a singleton), silently disabling the RLS
  * transaction — and therefore the `app.current_user_id` GUC — for the lifetime of the process. See
  * issue #644.
+ *
+ * The resolution is cached after the first non-null lookup: PrismaService, once resolved, is a
+ * singleton that cannot become unavailable again for the process's lifetime, so paying for a
+ * `strict: false` module-graph search on every request — including unauthenticated /health and
+ * /readyz probe traffic — would be pure repeated overhead.
  */
 @Injectable()
 export class RlsInterceptor implements NestInterceptor {
   private readonly tracer = trace.getTracer('rls-interceptor');
+  private cachedPrisma: PrismaService | null = null;
 
   constructor(
     private readonly cls: ClsService,
@@ -50,7 +56,10 @@ export class RlsInterceptor implements NestInterceptor {
   ) {}
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
-    const prisma = this.moduleRef.get(PrismaService, { strict: false });
+    const prisma = this.cachedPrisma ?? this.moduleRef.get(PrismaService, { strict: false });
+    if (prisma) {
+      this.cachedPrisma = prisma;
+    }
     // Only the HTTP path is RLS-wired today; `apps/api` exposes no GraphQL resolvers
     // (no GraphQLModule). If GraphQL resolvers touching userId tables are ever added, this guard
     // must be broadened to the 'graphql' context type — otherwise those queries skip the GUC and

--- a/docs/adr/ADR-010-multi-tenancy-data-isolation.md
+++ b/docs/adr/ADR-010-multi-tenancy-data-isolation.md
@@ -6,6 +6,8 @@
 **Review outcome:** Pass
 **Implementation status (2026-06-11):** Implemented — isolation is now **two-layer**. Application-level `user_id` scoping remains in every repository, and the Postgres **RLS defense-in-depth layer is now live**: migration `20260611000000_enable_rls` enables + forces RLS and creates per-user `CREATE POLICY` rules on all 14 user-data tables, and a per-request NestJS interceptor sets `app.current_user_id` (via `set_config`) inside a transaction that every repository query runs through. The gap was surfaced by the 2026-06-08 architecture review ([#464](https://github.com/brownm09/lifting-logbook/issues/464)) and closed in [#511](https://github.com/brownm09/lifting-logbook/issues/511). See the **Implementation** section below for the mechanism and the superuser/role requirement.
 
+**Correction (2026-07-02):** The RLS layer described above was **not actually live** from 2026-06-11 until [#645](https://github.com/brownm09/lifting-logbook/pull/645) merged. `rls.interceptor.ts` constructor-injected `PrismaService` as an `@Optional()` dependency; because it is bound globally via `APP_INTERCEPTOR`, NestJS instantiated it before `PrismaService`'s factory provider (declared in the same module) was guaranteed to have run, so the injection silently resolved to `null` and stayed `null` for the interceptor's lifetime. The `app.current_user_id` GUC was therefore never set on any request. Application-level `user_id` scoping (the first layer) was unaffected the entire time, so this was a missing second layer, not a cross-tenant data leak — see [#644](https://github.com/brownm09/lifting-logbook/issues/644) for the full incident writeup. The **Verification** bullet below, which claimed the existing test suite "proves... the interceptor wires the GUC end to end," was also inaccurate: that suite connects as the bootstrap superuser, which bypasses RLS by Postgres design, so it could not have caught this. #645 fixes the interceptor (resolves `PrismaService` lazily via `ModuleRef` instead of at construction) and adds test coverage that boots the real app under the restricted `lifting_app` role — the combination the original verification was missing.
+
 ---
 
 ## Context
@@ -78,8 +80,13 @@ Implemented in [#511](https://github.com/brownm09/lifting-logbook/issues/511) (2
   deployment-coupled follow-up.
 - **Verification** — `apps/api/src/adapters/prisma/rls.db.e2e.spec.ts` connects *as* `lifting_app`
   and proves unscoped-read isolation, fail-closed-on-unset-GUC, `WITH CHECK` rejection, the
-  `custom_program_spec` FK policy, that the test role is genuinely non-superuser/non-`BYPASSRLS`,
-  and that the interceptor wires the GUC end to end.
+  `custom_program_spec` FK policy, and that the test role is genuinely non-superuser/non-`BYPASSRLS`.
+  Its "RLS request wiring (interceptor + factory, full app boot)" block (added in
+  [#645](https://github.com/brownm09/lifting-logbook/pull/645)) additionally boots the real
+  `AppModule` under the restricted role and proves the interceptor wires the GUC end to end for a
+  genuine request — the combination the original verification (raw Prisma calls, or a manually
+  constructed interceptor bypassing Nest's real DI resolution) did not cover, and the gap that let
+  the interceptor sit inert for three weeks (see the 2026-07-02 correction above).
 - **Per-operation user context (`@SkipRlsTransaction()`)** — `cycle-plan` calls an LLM between DB
   reads. Holding one request-level transaction across the model call would pin a DB connection for
   its full duration, so that handler opts out via `@SkipRlsTransaction()`


### PR DESCRIPTION
## Summary

"Start My Program" was failing for every first-time user in production. Root cause is much broader than onboarding: `RlsInterceptor` has silently never set the Postgres RLS `app.current_user_id` session variable for **any** request since the RLS migration (#511) landed on 2026-06-11.

**Root cause:** `RlsInterceptor` is bound globally via `{ provide: APP_INTERCEPTOR, useClass: RlsInterceptor }`. NestJS instantiates `APP_INTERCEPTOR`-bound providers as part of its early global-enhancer setup — before `PrismaService`'s `useFactory` provider (declared in the *same* module) is guaranteed to have run. The interceptor's constructor-injected `@Optional() PrismaService` silently resolved to `null` at that moment, and because the interceptor is a singleton, that `null` was captured **permanently** (confirmed empirically: `app.get(PrismaService)` returns a real instance moments later, but the interceptor's own copy never updates).

**Impact**, confirmed via production log analysis + a from-scratch reproduction against the real compiled app and the actual restricted `lifting_app` role:
- Every first-time INSERT into a userId-scoped table failed with a `42501` row-level-security violation (`WITH CHECK` evaluates against a `NULL` GUC) — this is what broke `POST /programs/:program/cycles/initialize`, and equally affects any other first-write endpoint (verified with `PATCH /users/me/settings` too).
- Every read silently returned "not found," even for genuinely existing rows — Postgres's fail-closed RLS behavior can't distinguish "GUC unset" from "no matching rows."
- **Not a cross-tenant data leak**: every repository query still carries the original, first-layer `where: { userId }` application-level filter that predates RLS. RLS was a second defense-in-depth layer that has been inert; there's no evidence any request ever saw another user's data.

**Why no test caught this:** every existing DB E2E suite either connects as the Postgres bootstrap superuser (bypasses RLS by definition) or manually constructs `RlsInterceptor`/`PrismaRepositoryFactory` directly, bypassing NestJS's real DI instantiation order — exactly where this bug lives.

## Changes

- `apps/api/src/adapters/prisma/rls.interceptor.ts` — resolve `PrismaService` lazily via `ModuleRef.get(PrismaService, { strict: false })` inside `intercept()` on every request, instead of capturing it once via constructor injection. Immune to instantiation-order timing since `ModuleRef` is always available and the lookup always reflects current DI container state. Caches the resolved instance after the first non-null lookup so steady-state requests pay no repeated module-graph search.
- `apps/api/src/adapters/prisma/rls.db.e2e.spec.ts` — updated the existing "RLS request wiring" test's manual `RlsInterceptor` construction to pass the testing module (which implements `ModuleRef`) instead of a raw `PrismaService`, matching the new constructor signature. Added a new "RLS request wiring (interceptor + factory, full app boot)" describe block that boots the real `AppModule` via Fastify `.inject()` against the real restricted `lifting_app` role — proving a first-time INSERT now succeeds and a genuinely-existing row is read back correctly. Manually verified both new tests fail against the pre-fix code (500) and pass against the fix (201/200).
- `apps/api/jest.env.setup.js` — extended the `DATABASE_URL` write-guard Proxy to also allow the `lifting_app`-role variant of the Testcontainers sentinel URL through (scoped to the same host/pathname, so it can't smuggle an arbitrary DB URL in), needed so the new full-app-boot test can make `PrismaService`'s `env("DATABASE_URL")` read resolve to the restricted role.
- `docs/adr/ADR-010-multi-tenancy-data-isolation.md` — added a dated correction recording that the RLS layer was not actually live from 2026-06-11 until this PR, and rewrote the Verification bullet, which previously claimed (inaccurately) that the existing test suite proved the interceptor wired the GUC end to end.

`RlsContextService` (used by `@SkipRlsTransaction()` handlers like cycle-plan) has the same `@Optional() PrismaService` constructor pattern but is **not** affected — it's a regular provider (not `APP_*`-bound), so it follows normal DI dependency-before-dependent resolution. Verified via diagnostic instrumentation during investigation: it consistently receives a non-null `PrismaService`.

## Testing

```
npm test
```
Tests: 420 passed, 0 skipped, 0 failed (api) — up from 418, +2 new regression tests. All other workspaces green (web 147, core, types, api-client, eslint-rules, mobile). Full monorepo run: 12/12 tasks passed. Re-verified after the review-fix commit — still 420/420 + all workspaces green.

Suppression grep, test-integrity grep: both clean. No `package.json` changes, no lockfile drift risk.

## Review findings disposition

| Finding | Category | Disposition |
|---|---|---|
| ADR-010 asserted the RLS layer was live and verified end-to-end when it was inert for 3 weeks | blocking [documentation] | Fixed in `1f33b23` — added a dated correction and rewrote the Verification bullet |
| `moduleRef.get()` ran on every request (incl. health probes) with no caching | non-blocking [performance] | Fixed in `1f33b23` — cached after first non-null resolution |
| Locally-defined `appRoleUrl()` shadowed the existing module-level helper | non-blocking [maintainability] | Fixed in `1f33b23` — removed, now calls the existing helper |
| Stale "single legitimate write path" comment in `jest.env.setup.js` | non-blocking [maintainability] | Fixed in `1f33b23` — comment updated to reflect both paths |
| `RlsContextService` "unaffected" claim rests on manual diagnostic, not an automated test | non-blocking [maintainability] | Filed and linked — [#646 comment](https://github.com/brownm09/lifting-logbook/issues/646#issuecomment-4872233906), folded into that issue's test-default work rather than new infra here |

Closes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)
