### PR TITLE
[fix] Set activeProgram when completing onboarding so /cycle/N doesn't 404

### DIFF
--- a/apps/web/app/(authed)/onboarding/actions.test.ts
+++ b/apps/web/app/(authed)/onboarding/actions.test.ts
@@ -1,0 +1,72 @@
+jest.mock('@/lib/api', () => ({
+  switchProgram: jest.fn(),
+  updateTrainingMaxes: jest.fn(),
+}));
+
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
+}));
+
+import { switchProgram, updateTrainingMaxes } from '@/lib/api';
+import { createFirstCycle } from './actions';
+
+const mockedSwitchProgram = switchProgram as unknown as jest.Mock;
+const mockedUpdateTrainingMaxes = updateTrainingMaxes as unknown as jest.Mock;
+
+describe('createFirstCycle', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // Regression test for #650: completing onboarding must set activeProgram (via
+  // switchProgram), not just create the cycle — otherwise the dashboard page's
+  // getActiveProgram() lookup resolves to the wrong program and 404s even though
+  // the cycle was created successfully.
+  it('redirects to /cycle/1 using the cycleNum switchProgram returns (genuine first-time setup)', async () => {
+    mockedSwitchProgram.mockResolvedValue({ activeProgram: 'leangains', cycleNum: 1 });
+
+    await expect(createFirstCycle('leangains', [])).rejects.toThrow('REDIRECT:/cycle/1');
+    expect(mockedSwitchProgram).toHaveBeenCalledWith('leangains');
+  });
+
+  // Proves the redirect target is not hardcoded — switchProgram returns the
+  // existing cycleNum when a cycle already exists, and the redirect must follow it.
+  it('redirects to the returned cycleNum, not a hardcoded /cycle/1', async () => {
+    mockedSwitchProgram.mockResolvedValue({ activeProgram: 'leangains', cycleNum: 3 });
+
+    await expect(createFirstCycle('leangains', [])).rejects.toThrow('REDIRECT:/cycle/3');
+  });
+
+  it('persists confirmed training maxes after switchProgram succeeds', async () => {
+    mockedSwitchProgram.mockResolvedValue({ activeProgram: 'leangains', cycleNum: 1 });
+    mockedUpdateTrainingMaxes.mockResolvedValue(undefined);
+
+    await expect(
+      createFirstCycle('leangains', [{ lift: 'Squat', trainingMax: 315 }]),
+    ).rejects.toThrow('REDIRECT:/cycle/1');
+
+    expect(mockedUpdateTrainingMaxes).toHaveBeenCalledWith('leangains', {
+      maxes: [{ lift: 'Squat', weight: 315, unit: 'lbs' }],
+    });
+  });
+
+  it('rejects a program that is not available', async () => {
+    const result = await createFirstCycle('not-a-real-program', []);
+
+    expect(result).toEqual({ ok: false, error: 'That program is not yet available.' });
+    expect(mockedSwitchProgram).not.toHaveBeenCalled();
+  });
+
+  it('returns a generic error and does not redirect when switchProgram fails', async () => {
+    mockedSwitchProgram.mockRejectedValue(new Error('API down'));
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await createFirstCycle('leangains', []);
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Failed to start your program. Please try again.',
+    });
+    errSpy.mockRestore();
+  });
+});

--- a/apps/web/app/(authed)/onboarding/actions.ts
+++ b/apps/web/app/(authed)/onboarding/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { redirect } from 'next/navigation';
-import { initializeCycle, updateTrainingMaxes } from '@/lib/api';
+import { switchProgram, updateTrainingMaxes } from '@/lib/api';
 import { PROGRAMS } from '@/lib/programs';
 
 export type CreateFirstCycleResult = { ok: false; error: string };
@@ -14,8 +14,14 @@ export async function createFirstCycle(
   if (!allowed.includes(programId)) {
     return { ok: false, error: 'That program is not yet available.' };
   }
+  let cycleNum = 1;
   try {
-    await initializeCycle(programId);
+    // switchProgram both ensures a cycle exists for programId (creating one if this is a
+    // genuine first-time setup) AND sets it as the user's activeProgram in one call — the
+    // dashboard page resolves its program via getActiveProgram(), not the URL, so without
+    // this the redirect below would 404 even though the cycle was created successfully
+    // (issue #650).
+    ({ cycleNum } = await switchProgram(programId));
     // Persist the confirmed training maxes exactly as shown on the Confirm step.
     // The caller (OnboardingFlow) already resolved each lift to its final training
     // max — deriving it at 90% of the 1RM for the estimate/test/manual methods, or
@@ -46,7 +52,7 @@ export async function createFirstCycle(
         });
       } catch (maxErr) {
         console.error(
-          `createFirstCycle: cycle initialized for "${programId}" but persisting training maxes failed; continuing to /cycle/1`,
+          `createFirstCycle: cycle initialized for "${programId}" but persisting training maxes failed; continuing to /cycle/${cycleNum}`,
           maxErr,
         );
       }
@@ -60,6 +66,8 @@ export async function createFirstCycle(
   }
   // redirect() throws NEXT_REDIRECT internally. Calling it outside the try block
   // lets Next.js propagate it natively — no need for the internal isRedirectError
-  // guard, which is fragile across major Next.js versions.
-  redirect('/cycle/1');
+  // guard, which is fragile across major Next.js versions. Uses the cycleNum
+  // switchProgram returned rather than a hardcoded 1 — almost always 1 for a genuine
+  // first-time setup, but correct too if a cycle already existed (see switchProgram).
+  redirect(`/cycle/${cycleNum}`);
 }


### PR DESCRIPTION
## Summary

Discovered live in production immediately after #645 (RLS fix) deployed: onboarding's "Start My Program" succeeded (`POST /programs/leangains/cycles/initialize` → 201, confirmed in prod logs) but the redirect to `/cycle/1` 404'd.

**Root cause:** `apps/web/app/(authed)/cycle/[cycleNum]/page.tsx` resolves its program via `getActiveProgram()` (reads `user_settings.activeProgram`, falls back to a default), not from the URL. `createFirstCycle` created the cycle via `initializeCycle(programId)` but never set `activeProgram` — so for any non-default program choice, the dashboard page looked up the wrong (fallback default) program, found no cycle, and called `notFound()`.

This bug was masked by #644 (RLS silently disabled) the whole time — nobody could get far enough through onboarding to reach it until #645 unblocked cycle creation.

## Fix

`SwitchProgramController`/`switchProgram(programId)` already does exactly what's needed here: ensures a cycle exists (creating one via the same `initializeFirstCycle` path if not) **and** sets `activeProgram`, atomically, returning `{ activeProgram, cycleNum }`. Swapped `initializeCycle` for `switchProgram` in `createFirstCycle`, and redirect to `/cycle/${cycleNum}` (the returned value) instead of a hardcoded `/cycle/1` — correct for a genuine first-time setup (always 1) and also correct in the edge case where a cycle already existed.

## Testing

```
npm test
```
Tests: 420 passed (api, unchanged) + web workspace includes 5 new tests in `apps/web/app/(authed)/onboarding/actions.test.ts` covering: redirect using the returned cycleNum (both 1 and a non-1 value, proving the target isn't hardcoded), training-maxes persistence after success, the not-yet-available-program early return, and the generic-error path when `switchProgram` fails. Full monorepo run: 12/12 tasks passed.

Suppression grep, test-integrity grep: both clean. No `package.json` changes.

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)