### PR TITLE
[fix] RlsInterceptor should fail loudly, not silently no-op, when RLS context can't be established

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Architecture follows hexagonal / Ports & Adapters. `packages/core` has zero infr
 
 All new issues must be added to the **Lifting Logbook** project and assigned an epic before work begins.
 
-**Important:** All `gh project item-list` queries in this file use `--limit 300` to avoid truncation. The project has 267+ items (default limit is 30). If the project grows beyond 300 items, increase this limit accordingly.
+**Important:** All `gh project item-list` queries in this file use `--limit 500` to avoid truncation. The project has 327+ items (default limit is 30). If the project grows beyond 500 items, increase this limit accordingly.
 
 **Project IDs (needed for CLI commands):**
 - Project number: `2`, owner: `brownm09`
@@ -161,7 +161,7 @@ If `--format json` is not supported by the installed `gh` version, fall back to 
 3. Move the issue to **In Progress** on the project board:
    ```bash
    TMPFILE="C:/Users/brown/.claude/scratch/tmp_item_<N>.json"
-   gh project item-list 2 --owner brownm09 --limit 300 --format json > "$TMPFILE"
+   gh project item-list 2 --owner brownm09 --limit 500 --format json > "$TMPFILE"
    ITEM_ID=$(node -e "
      const d=JSON.parse(require('fs').readFileSync('$TMPFILE','utf8'));
      const item=d.items.find(i=>i.content&&i.content.number===<N>);
@@ -180,7 +180,7 @@ If `--format json` is not supported by the installed `gh` version, fall back to 
 9. Move the issue to **Done** on the project board:
    ```bash
    TMPFILE="C:/Users/brown/.claude/scratch/tmp_item_<N>.json"
-   gh project item-list 2 --owner brownm09 --limit 300 --format json > "$TMPFILE"
+   gh project item-list 2 --owner brownm09 --limit 500 --format json > "$TMPFILE"
    ITEM_ID=$(node -e "
      const d=JSON.parse(require('fs').readFileSync('$TMPFILE','utf8'));
      const item=d.items.find(i=>i.content&&i.content.number===<N>);

--- a/apps/api/src/adapters/prisma/rls.interceptor.spec.ts
+++ b/apps/api/src/adapters/prisma/rls.interceptor.spec.ts
@@ -1,0 +1,86 @@
+import { CallHandler, ExecutionContext, InternalServerErrorException } from '@nestjs/common';
+import { ModuleRef, Reflector } from '@nestjs/core';
+import { ClsService } from 'nestjs-cls';
+import { lastValueFrom, of } from 'rxjs';
+import { RlsInterceptor } from './rls.interceptor';
+import { PrismaService } from './prisma.service';
+
+function makeCls(): ClsService {
+  const store = new Map<string, unknown>();
+  return {
+    get: jest.fn((key: string) => store.get(key)),
+    set: jest.fn((key: string, value: unknown) => store.set(key, value)),
+  } as unknown as ClsService;
+}
+
+function makeReflector(): Reflector {
+  return { getAllAndOverride: jest.fn(() => undefined) } as unknown as Reflector;
+}
+
+function makeModuleRef(resolved: PrismaService | null): ModuleRef {
+  return { get: jest.fn(() => resolved) } as unknown as ModuleRef;
+}
+
+// A real reflection target is required by Reflector.getAllAndOverride, but none of the tests below
+// reach that call — the interceptor resolves (throw or no-op) before request/handler data is read.
+const dummyHandler = function handler() {};
+class DummyController {}
+
+function makeContext(type: 'http' | 'rpc'): ExecutionContext {
+  return {
+    getType: () => type,
+    switchToHttp: () => {
+      throw new Error('switchToHttp should not be called before the Prisma/DATABASE_URL guard resolves');
+    },
+    getHandler: () => dummyHandler,
+    getClass: () => DummyController,
+  } as unknown as ExecutionContext;
+}
+
+const passthroughHandler: CallHandler = { handle: () => of('handled') };
+
+// Stubs the private isDatabaseUrlConfigured() seam directly rather than mutating process.env —
+// jest.env.setup.js wraps process.env in a Proxy that discards writes to DATABASE_URL outside the
+// Testcontainers sentinel, so this is the only way to unit-test the branch without Docker.
+function stubDatabaseUrlConfigured(interceptor: RlsInterceptor, value: boolean): void {
+  jest
+    .spyOn(interceptor as unknown as { isDatabaseUrlConfigured(): boolean }, 'isDatabaseUrlConfigured')
+    .mockReturnValue(value);
+}
+
+describe('RlsInterceptor', () => {
+  describe('when PrismaService cannot be resolved and a real DB is expected (DATABASE_URL configured)', () => {
+    it('throws InternalServerErrorException instead of silently no-oping (issue #649)', () => {
+      const interceptor = new RlsInterceptor(makeCls(), makeReflector(), makeModuleRef(null));
+      stubDatabaseUrlConfigured(interceptor, true);
+
+      expect(() => interceptor.intercept(makeContext('http'), passthroughHandler)).toThrow(
+        InternalServerErrorException,
+      );
+    });
+  });
+
+  describe('when PrismaService cannot be resolved and no DB is configured (in-memory/SystemDb mode)', () => {
+    it('no-ops and runs the request on next.handle() without throwing', async () => {
+      const interceptor = new RlsInterceptor(makeCls(), makeReflector(), makeModuleRef(null));
+      stubDatabaseUrlConfigured(interceptor, false);
+
+      const result = await lastValueFrom(
+        interceptor.intercept(makeContext('http'), passthroughHandler),
+      );
+      expect(result).toBe('handled');
+    });
+  });
+
+  describe('non-HTTP context', () => {
+    it('no-ops regardless of Prisma/DATABASE_URL state — RLS is HTTP-only today (issue #511)', async () => {
+      const interceptor = new RlsInterceptor(makeCls(), makeReflector(), makeModuleRef(null));
+      stubDatabaseUrlConfigured(interceptor, true);
+
+      const result = await lastValueFrom(
+        interceptor.intercept(makeContext('rpc'), passthroughHandler),
+      );
+      expect(result).toBe('handled');
+    });
+  });
+});

--- a/apps/api/src/adapters/prisma/rls.interceptor.spec.ts
+++ b/apps/api/src/adapters/prisma/rls.interceptor.spec.ts
@@ -58,6 +58,21 @@ describe('RlsInterceptor', () => {
         InternalServerErrorException,
       );
     });
+
+    it('keeps the client-facing message generic and carries the diagnostic detail in `cause`', () => {
+      const interceptor = new RlsInterceptor(makeCls(), makeReflector(), makeModuleRef(null));
+      stubDatabaseUrlConfigured(interceptor, true);
+
+      try {
+        interceptor.intercept(makeContext('http'), passthroughHandler);
+        throw new Error('expected intercept() to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(InternalServerErrorException);
+        const exception = err as InternalServerErrorException;
+        expect(exception.message).not.toMatch(/DATABASE_URL/);
+        expect((exception.cause as Error)?.message).toMatch(/DATABASE_URL/);
+      }
+    });
   });
 
   describe('when PrismaService cannot be resolved and no DB is configured (in-memory/SystemDb mode)', () => {

--- a/apps/api/src/adapters/prisma/rls.interceptor.ts
+++ b/apps/api/src/adapters/prisma/rls.interceptor.ts
@@ -37,7 +37,10 @@ import {
  * plumbing (issue #644), not a legitimate no-DB environment — silently falling through here
  * produces "empty reads / rejected writes" symptoms indistinguishable from "this user has no data
  * yet," which is why #644 went undiagnosed for weeks. This throws InternalServerErrorException
- * instead of no-op'ing in that case (issue #649).
+ * instead of no-op'ing in that case (issue #649) — deliberately including unauthenticated routes
+ * like /health and /readyz, since a deployment with broken RLS plumbing should fail its readiness
+ * probe and stop receiving traffic rather than report healthy while every real endpoint silently
+ * drops RLS.
  *
  * PrismaService is resolved lazily via ModuleRef on every request rather than constructor-injected.
  * RlsInterceptor is bound via APP_INTERCEPTOR, which Nest instantiates as part of its early
@@ -80,11 +83,16 @@ export class RlsInterceptor implements NestInterceptor {
         // A real Postgres connection is configured but the Prisma client still couldn't be
         // resolved from the module graph — the broken-plumbing case from issue #644, not the
         // legitimate in-memory/SystemDb no-op. Fail loudly rather than silently running this
-        // request with no RLS GUC set (issue #649).
-        throw new InternalServerErrorException(
-          'RlsInterceptor could not resolve PrismaService even though DATABASE_URL is configured; ' +
-            'RLS context cannot be established for this request.',
-        );
+        // request with no RLS GUC set (issue #649). The client-facing message stays generic —
+        // the diagnostic detail (which env signal was involved) lives in `cause` instead, so it
+        // reaches server-side logs/traces (via the existing Pino/OTel auto-instrumentation) without
+        // also being echoed back in the HTTP response body, since no global filter in main.ts
+        // redacts InternalServerErrorException messages before they reach the client.
+        throw new InternalServerErrorException('RLS context could not be established for this request.', {
+          cause: new Error(
+            'RlsInterceptor could not resolve PrismaService even though DATABASE_URL is configured.',
+          ),
+        });
       }
       return next.handle();
     }

--- a/apps/api/src/adapters/prisma/rls.interceptor.ts
+++ b/apps/api/src/adapters/prisma/rls.interceptor.ts
@@ -2,6 +2,7 @@ import {
   CallHandler,
   ExecutionContext,
   Injectable,
+  InternalServerErrorException,
   NestInterceptor,
 } from '@nestjs/common';
 import { ModuleRef, Reflector } from '@nestjs/core';
@@ -27,9 +28,16 @@ import {
  * PrismaRepositoryFactory routes every repository query through it. The GUC is transaction-local,
  * which is why all of a request's DB work shares a single transaction.
  *
- * No-ops when there is no Prisma client (in-memory / SystemDb factories) or no authenticated user
- * (public routes such as /health and /readyz). Those run on the base client with no GUC — which is
- * fail-closed for any userId-scoped table (zero rows) and harmless for the table-less probes.
+ * No-ops when there is no Prisma client AND no DATABASE_URL configured (in-memory / SystemDb
+ * factories), or when there is no authenticated user (public routes such as /health and /readyz).
+ * Those run on the base client with no GUC — which is fail-closed for any userId-scoped table
+ * (zero rows) and harmless for the table-less probes.
+ *
+ * If DATABASE_URL IS configured but the Prisma client still can't be resolved, that's broken DI
+ * plumbing (issue #644), not a legitimate no-DB environment — silently falling through here
+ * produces "empty reads / rejected writes" symptoms indistinguishable from "this user has no data
+ * yet," which is why #644 went undiagnosed for weeks. This throws InternalServerErrorException
+ * instead of no-op'ing in that case (issue #649).
  *
  * PrismaService is resolved lazily via ModuleRef on every request rather than constructor-injected.
  * RlsInterceptor is bound via APP_INTERCEPTOR, which Nest instantiates as part of its early
@@ -64,7 +72,20 @@ export class RlsInterceptor implements NestInterceptor {
     // (no GraphQLModule). If GraphQL resolvers touching userId tables are ever added, this guard
     // must be broadened to the 'graphql' context type — otherwise those queries skip the GUC and
     // fail closed (zero rows) under lifting_app rather than scoping correctly. See issue #511.
-    if (!prisma || context.getType() !== 'http') {
+    if (context.getType() !== 'http') {
+      return next.handle();
+    }
+    if (!prisma) {
+      if (this.isDatabaseUrlConfigured()) {
+        // A real Postgres connection is configured but the Prisma client still couldn't be
+        // resolved from the module graph — the broken-plumbing case from issue #644, not the
+        // legitimate in-memory/SystemDb no-op. Fail loudly rather than silently running this
+        // request with no RLS GUC set (issue #649).
+        throw new InternalServerErrorException(
+          'RlsInterceptor could not resolve PrismaService even though DATABASE_URL is configured; ' +
+            'RLS context cannot be established for this request.',
+        );
+      }
       return next.handle();
     }
     // routerPath is the Fastify property for the matched route pattern (e.g. /programs/:id).
@@ -103,6 +124,12 @@ export class RlsInterceptor implements NestInterceptor {
 
     const route = request?.routerPath ?? request?.url ?? 'unknown';
     return from(this.cls.run(() => this.runWithRlsContext(prisma, userId, timeoutMs, route, next)));
+  }
+
+  // Split out so unit tests can stub the "DB expected" signal without needing a real DATABASE_URL —
+  // jest.env.setup.js's Proxy discards writes to it outside the Testcontainers sentinel.
+  private isDatabaseUrlConfigured(): boolean {
+    return Boolean(process.env.DATABASE_URL);
   }
 
   private runWithRlsContext(

--- a/docs/adr/ADR-010-multi-tenancy-data-isolation.md
+++ b/docs/adr/ADR-010-multi-tenancy-data-isolation.md
@@ -8,6 +8,8 @@
 
 **Correction (2026-07-02):** The RLS layer described above was **not actually live** from 2026-06-11 until [#645](https://github.com/brownm09/lifting-logbook/pull/645) merged. `rls.interceptor.ts` constructor-injected `PrismaService` as an `@Optional()` dependency; because it is bound globally via `APP_INTERCEPTOR`, NestJS instantiated it before `PrismaService`'s factory provider (declared in the same module) was guaranteed to have run, so the injection silently resolved to `null` and stayed `null` for the interceptor's lifetime. The `app.current_user_id` GUC was therefore never set on any request. Application-level `user_id` scoping (the first layer) was unaffected the entire time, so this was a missing second layer, not a cross-tenant data leak — see [#644](https://github.com/brownm09/lifting-logbook/issues/644) for the full incident writeup. The **Verification** bullet below, which claimed the existing test suite "proves... the interceptor wires the GUC end to end," was also inaccurate: that suite connects as the bootstrap superuser, which bypasses RLS by Postgres design, so it could not have caught this. #645 fixes the interceptor (resolves `PrismaService` lazily via `ModuleRef` instead of at construction) and adds test coverage that boots the real app under the restricted `lifting_app` role — the combination the original verification was missing.
 
+**Follow-up (2026-07-03):** #645 fixed *why* `PrismaService` could resolve to `null`, but the interceptor's fallback guard still treated "null and no DB expected" (legitimate in-memory/SystemDb mode) and "null but a real DB connection is configured" (broken plumbing — the exact #644 failure mode) identically: both silently ran the request with no GUC set. [#649](https://github.com/brownm09/lifting-logbook/issues/649) closed that gap — the interceptor now checks `DATABASE_URL` in addition to the Prisma-client-null check, and throws `InternalServerErrorException` instead of silently proceeding when a real DB connection is expected but the client is unavailable. This makes a future recurrence of the #644 failure mode surface immediately as a 500 rather than as silent fail-closed reads/writes indistinguishable from "no data yet."
+
 ---
 
 ## Context
@@ -69,7 +71,11 @@ Implemented in [#511](https://github.com/brownm09/lifting-logbook/issues/511) (2
   GUC is transaction-local, all of a request's DB work shares one transaction; the two repositories
   that batch writes and the one that runs an interactive transaction use a small helper
   (`prisma-tx.util.ts`) that reuses the request transaction instead of nesting (Prisma's
-  transaction client cannot open a nested transaction).
+  transaction client cannot open a nested transaction). The interceptor no-ops (runs the request on
+  the base client, no GUC) only when `DATABASE_URL` is unset — the legitimate in-memory/SystemDb
+  case. If `DATABASE_URL` **is** set but the Prisma client still can't be resolved, it throws
+  `InternalServerErrorException` instead of silently no-op'ing, so a recurrence of the #644 failure
+  mode (broken DI plumbing masquerading as "no data yet") surfaces immediately ([#649](https://github.com/brownm09/lifting-logbook/issues/649)).
 - **Non-superuser role (required for enforcement)** — RLS is ignored by superusers and `BYPASSRLS`
   roles. The migration creates a `lifting_app` role (`NOSUPERUSER NOBYPASSRLS`); the application
   must connect as it in deployed environments for the policies to bite. Migrations run as the


### PR DESCRIPTION
## Summary

`RlsInterceptor`'s guard treated two different situations identically:

1. **Legitimate no-op**: an in-memory/SystemDb factory environment where there's genuinely no Prisma client and no `DATABASE_URL` configured.
2. **Broken plumbing**: a real Postgres-backed environment where RLS *should* be active but the interceptor couldn't obtain a working Prisma client — exactly what happened in #644.

Case 2 silently degraded to "run the request with no RLS GUC set," which (combined with Postgres's fail-closed RLS design) produces symptoms — empty reads, rejected writes — that are easy to misread as "this user has no data yet" rather than "the security plumbing is broken." That ambiguity is a large part of why #644 took weeks to diagnose.

This PR distinguishes the two cases explicitly: checks `process.env.DATABASE_URL` (the same raw signal `repository-factory.module.ts` and `prisma.service.ts` already use to decide Prisma-backed vs. in-memory mode) in addition to the Prisma-client-null check. When a real DB connection is expected but the client is unavailable, it throws `InternalServerErrorException` naming the failure instead of silently falling through to `next.handle()`. The legitimate in-memory/SystemDb no-op path is unaffected — it's still gated purely on `DATABASE_URL` being unset.

A small private `isDatabaseUrlConfigured()` seam was extracted so the new branch is unit-testable without needing a real `DATABASE_URL` — `jest.env.setup.js` wraps `process.env` in a Proxy that discards writes to `DATABASE_URL` outside the Testcontainers sentinel (by design, to stop tests from accidentally hitting a real DB), so tests stub this method directly rather than fighting that guard.

## Acceptance criteria (from #649)

- [x] The "DB expected but Prisma client unavailable" case throws a clear, loud error instead of silently proceeding
- [x] The legitimate in-memory/SystemDb no-op path is unaffected
- [x] New test covers both branches explicitly

## Testing

```
npm test
```
Tests: 423 passed, 0 skipped, 0 failed (`apps/api`, includes 3 new tests in `rls.interceptor.spec.ts`) + core 280 passed + api-client 25 passed + types/mobile clean (no tests, pre-existing `--passWithNoTests` convention, untouched by this PR).

New coverage — `apps/api/src/adapters/prisma/rls.interceptor.spec.ts` (new file, no unit spec previously existed for this class):
- Throws `InternalServerErrorException` when `DATABASE_URL` is configured but `PrismaService` can't be resolved
- No-ops via `next.handle()` when `DATABASE_URL` is unset and `PrismaService` can't be resolved (in-memory/SystemDb mode)
- Non-HTTP context short-circuits before the throw is ever reached, regardless of `DATABASE_URL`/Prisma state (RLS is HTTP-only today, #511)

Confirmed the throw/no-op assertions fail pre-fix: the pre-fix `intercept()` has no `isDatabaseUrlConfigured` method at all, so `jest.spyOn` on it throws immediately, and the pre-fix guard never throws `InternalServerErrorException` under any input.

The existing `rls.db.e2e.spec.ts` "RLS request wiring" suites (real Testcontainers Postgres, real `AppModule` boot) construct `RlsInterceptor` with a resolvable `PrismaService` in every case, so `prisma` is always truthy there — this change's new branch is never entered by those tests, and they remain unaffected (still passing).

### Pre-existing failure encountered (unrelated, filed separately)

`npm test -w @lifting-logbook/web` fails 18/24 suites locally on this machine with `Cannot find module 'next/server'` etc. Root-caused to `apps/web/node_modules/{next,react-dom,@testing-library/react,@clerk/nextjs}` existing but containing zero files — a local install corruption, confirmed **not** caused by this branch (nothing here touches `apps/web`), **not** present in CI (green on `main` at the exact commit this branch was cut from), and **not** a lockfile-drift issue (`npm install --package-lock-only` + diff is clean). Filed as [#653](https://github.com/brownm09/lifting-logbook/issues/653); not fixed here since a full `node_modules` reset is out of scope for this change and disruptive to run unprompted on the shared canonical checkout.

## Housekeeping (bundled, encountered while working this issue)

Separate commit: bumped the `gh project item-list --limit` in `CLAUDE.md` from 300 to 500 — the project has grown to 327 items, so the old limit was silently truncating queries (encountered while moving #649 to In Progress; the item wasn't found until the limit was raised).


## Review findings disposition

Both non-blocking findings from the [posted review](https://github.com/brownm09/lifting-logbook/pull/654#issuecomment-4878359320) were fixed in this PR, commit [`f1b287f`](https://github.com/brownm09/lifting-logbook/commit/f1b287f):

- **[security]** Client-facing exception message named `DATABASE_URL` and was returned verbatim to API clients — fixed: split into a generic client message plus a detailed `cause` Error (full diagnostic still reaches server-side logs/traces via existing Pino/OTel auto-instrumentation).
- **[documentation]** `/health`/`/readyz` are also covered by the new fail-loud path (intentional — a broken-RLS deployment should fail its readiness probe) but this wasn't stated anywhere — fixed: added a sentence to the class docstring.

New test (`rls.interceptor.spec.ts`) added in the same commit locks in the message/cause split.
