### PR TITLE
[chore] Speed up web/core tests via transpile-only ts-jest + typecheck gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Generate Prisma client
         run: npx prisma generate --schema=apps/api/prisma/schema.prisma
 
-      - name: Lint & Test
-        run: npx turbo run lint test
+      - name: Lint, Typecheck & Test
+        run: npx turbo run lint typecheck test
 
       - name: Validate analytics taxonomy
         run: node scripts/validate-analytics-taxonomy.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,6 +352,15 @@ Run `npm test` from the repo root to execute the full test suite across all work
 npm test
 ```
 
+Type-checking runs as a separate Turbo task. ts-jest runs **transpile-only** for speed (see
+[#651](https://github.com/brownm09/lifting-logbook/issues/651)), so a dedicated `tsc --noEmit` gate
+owns type-checking for `core` and `web`. It is a **blocking CI gate** (CI runs
+`turbo run lint typecheck test`) — run it before opening a PR:
+
+```bash
+npm run typecheck
+```
+
 **Prerequisites:**
 - Run `npm run build` first if you have touched compiled output (e.g., API controllers, shared types in `packages/types`).
 - The API DB E2E suite (`apps/api/src/programs/programs.db.e2e.spec.ts`) auto-provisions Postgres via Testcontainers in `apps/api/jest.global-setup.js`. Docker Desktop must be running; no `DATABASE_URL` configuration is required locally. In CI, the existing service container provides `DATABASE_URL` and globalSetup uses it directly.

--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -7,13 +7,13 @@ module.exports = {
   setupFilesAfterEnv: [...(base.setupFilesAfterEnv ?? []), '<rootDir>/jest.setup.ts'],
   testMatch: ['**/*.test.ts', '**/*.test.tsx'],
   transform: {
-    // diagnostics.warnOnly: ts-jest emits TS compile errors as warnings rather
-    // than aborting the suite. The @testing-library/jest-dom augmentation on
-    // jest.Matchers (toBeInTheDocument, etc.) fails to resolve under Node10
-    // moduleResolution in this monorepo setup — tracked in #421. Tests that
-    // use those matchers run and pass at runtime (jest.setup.ts loads the lib);
-    // the TS error is only at the type-check layer.
-    '^.+\\.tsx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json', diagnostics: { warnOnly: true } }],
+    // ts-jest runs transpile-only here: tsconfig.spec.json sets isolatedModules, so
+    // each test file is transpiled without type-checking (fast — see issue #651).
+    // This also sidesteps the #421 @testing-library/jest-dom matcher-augmentation
+    // type error (previously softened with diagnostics.warnOnly): transpile-only emits
+    // no type diagnostics from the test run at all. Tests still run and pass at runtime
+    // (jest.setup.ts loads jest-dom).
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
   },
   moduleNameMapper: {
     '\\.module\\.css$': 'identity-obj-proxy',

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "eslint app lib",
     "test": "jest --passWithNoTests",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "test:e2e": "playwright test",
     "test:e2e:ci": "playwright test --reporter=github",
     "test:e2e:staging": "playwright test --config=playwright.config.staging.ts"

--- a/apps/web/tsconfig.spec.json
+++ b/apps/web/tsconfig.spec.json
@@ -2,9 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     // isolatedModules: ts-jest transpiles each test file without type-checking
-    // (transpile-only) for fast runs. See issue #651. (A blocking whole-program
-    // type-check gate for web tests is tracked as follow-up work — web tests were
-    // previously only diagnostics.warnOnly, i.e. non-blocking.)
+    // (transpile-only) for fast runs. See issue #651. Type-checking is instead performed
+    // by the blocking `typecheck` task (tsc --noEmit -p tsconfig.typecheck.json): web tests
+    // were previously only diagnostics.warnOnly (non-blocking); they now have a real
+    // blocking whole-program type-check gate.
     "isolatedModules": true,
     // The root base sets lib: ["ES2020"] only. Test files type-check DOM-typed
     // code (e.g. e.target.value on input change events) under ts-jest, so the

--- a/apps/web/tsconfig.spec.json
+++ b/apps/web/tsconfig.spec.json
@@ -1,6 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    // isolatedModules: ts-jest transpiles each test file without type-checking
+    // (transpile-only) for fast runs. See issue #651. (A blocking whole-program
+    // type-check gate for web tests is tracked as follow-up work — web tests were
+    // previously only diagnostics.warnOnly, i.e. non-blocking.)
+    "isolatedModules": true,
     // The root base sets lib: ["ES2020"] only. Test files type-check DOM-typed
     // code (e.g. e.target.value on input change events) under ts-jest, so the
     // spec config must include the same DOM libs the app builds against

--- a/apps/web/tsconfig.typecheck.json
+++ b/apps/web/tsconfig.typecheck.json
@@ -1,0 +1,13 @@
+{
+  // Whole-program type-check gate for web (app source + component/unit tests), run by the
+  // `typecheck` task as `tsc --noEmit -p tsconfig.typecheck.json`. Extends the app tsconfig
+  // (bundler moduleResolution + the next plugin + next-env.d.ts) so next/*, CSS-module imports,
+  // and the @testing-library/jest-dom matcher augmentation all resolve — unlike tsconfig.spec.json,
+  // which is tuned for ts-jest per-file transpile under Node10 resolution. Playwright e2e specs are
+  // excluded (they type-check against @playwright/test in their own context, not jest). See #651.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": ["node_modules", "e2e"]
+}

--- a/apps/web/tsconfig.typecheck.json
+++ b/apps/web/tsconfig.typecheck.json
@@ -7,7 +7,21 @@
   // excluded (they type-check against @playwright/test in their own context, not jest). See #651.
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    // Resolve workspace packages to their TypeScript SOURCE, mirroring this app's Jest
+    // moduleNameMapper (jest.config.js) exactly — so the type-check sees the same code the
+    // tests run against, and needs no upstream build (the app tsconfig otherwise resolves
+    // @lifting-logbook/* via node_modules -> packages/*/dist, which is absent in a clean CI
+    // checkout because the `typecheck` Turbo task has no build dependency). See #651.
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"],
+      "@src/core": ["../../packages/core/src/index.ts"],
+      "@src/core/*": ["../../packages/core/src/*"],
+      "@lifting-logbook/core": ["../../packages/core/src/index.ts"],
+      "@lifting-logbook/api-client": ["../../packages/api-client/src/index.ts"],
+      "@lifting-logbook/types": ["../../packages/types/src/index.ts"]
+    }
   },
   "exclude": ["node_modules", "e2e"]
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "turbo run build",
     "test": "turbo run test",
+    "typecheck": "turbo run typecheck",
     "lint": "turbo run lint",
     "dev": "turbo run dev"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsc --project tsconfig.json && tsc-alias --project tsconfig.json",
     "lint": "eslint src",
-    "test": "jest"
+    "test": "jest",
+    "typecheck": "tsc --noEmit -p tsconfig.spec.json"
   },
   "dependencies": {
     "@lifting-logbook/types": "*",

--- a/packages/core/tsconfig.spec.json
+++ b/packages/core/tsconfig.spec.json
@@ -1,7 +1,16 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": ".",
+    // isolatedModules: ts-jest transpiles each test file in isolation (transpile-only,
+    // no type-checking) for fast runs. The compensating whole-program type-check is the
+    // `typecheck` task: `tsc --noEmit -p tsconfig.spec.json`. See issue #651.
+    "isolatedModules": true,
+    // rootDir at the repo root + composite:false: this config's `include` pulls
+    // cross-package source in via the @lifting-logbook/types path mapping (which lives
+    // outside packages/core), so a narrower rootDir raises TS6059. noEmit means rootDir
+    // is only an assertion here, never an emit layout.
+    "rootDir": "../../",
+    "composite": false,
     "noEmit": true,
     "paths": {
       "@src/core": ["src/index.ts"],

--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,9 @@
     "lint": {
       "inputs": ["src/**", "app/**", "*.ts", ".eslintrc*", "eslint.config*"]
     },
+    "typecheck": {
+      "cache": false
+    },
     "dev": {
       "dependsOn": ["db:generate"],
       "persistent": true,


### PR DESCRIPTION
## Summary

Separates **type-checking from test execution**. The two slowest Jest workspaces (`core`, `web`) switch their ts-jest transform to **transpile-only** (`isolatedModules`), and a dedicated **blocking `typecheck` Turbo task** (`tsc --noEmit`, tests-inclusive) now owns type-checking. This is faster *and* **coverage-positive**: `web` tests gain a real blocking type-check for the first time (they were previously non-blocking `diagnostics.warnOnly`), while `core`'s existing blocking surface is preserved 1:1.

Closes #651.

## What changed

- **`packages/core/tsconfig.spec.json`** — `isolatedModules: true` (ts-jest → transpile-only) + `rootDir: "../../"` + `composite: false` so the same file is also a clean whole-program `tsc --noEmit` gate (the cross-package `@lifting-logbook/types` source import otherwise trips `TS6059`).
- **`packages/core/package.json`** — new `typecheck` script: `tsc --noEmit -p tsconfig.spec.json`.
- **`apps/web/tsconfig.typecheck.json`** *(new)* — web's type-check gate config: extends the app `tsconfig.json` (bundler resolution + next plugin + `next-env.d.ts`) so `next/*`, CSS-module imports, and the jest-dom matcher augmentation all resolve; excludes Playwright `e2e/`.
- **`apps/web/package.json`** — new `typecheck` script: `tsc --noEmit -p tsconfig.typecheck.json`.
- **`apps/web/tsconfig.spec.json`** — `isolatedModules: true` (ts-jest → transpile-only).
- **`apps/web/jest.config.js`** — dropped `diagnostics: { warnOnly: true }` (moot under transpile-only; type-checking now lives in the `typecheck` task instead of being softened in the test run).
- **`turbo.json`** — new `typecheck` task (`cache: false`; no build dependency — it type-checks source directly via workspace path mappings, so it runs fully in parallel with `test`).
- **`package.json`** (root) — new `typecheck` script: `turbo run typecheck`.
- **`.github/workflows/ci.yml`** — the lint-and-test job now runs `npx turbo run lint typecheck test`.

## Why this is coverage-safe — actually coverage-positive (the hard requirement of #651)

Rule: **any type error that is *blocking* today must remain *blocking* after the change.**

| Workspace | Blocking type-check *before* | *After* |
|---|---|---|
| **core** | ts-jest full type-check (blocking) | **`typecheck` task** (blocking) — preserved 1:1 |
| **web** | `diagnostics.warnOnly` → **non-blocking** | **`typecheck` task (blocking)** — ⬆ coverage-positive |
| api | already transpile-only (`tsconfig.isolatedModules`) | **untouched** |
| api-client | ts-jest full type-check | **untouched** |
| types | (0 tests) | **untouched** |

No blocking surface is removed; `web` gains one. api/api-client/types are untouched, so their surfaces are preserved by construction.

### Empirical proof (reproduced during development, probes then removed)

For **both** `core` and `web`, an injected `TS2322` (`const x: number = 'string'`) in a test:

1. **transpile-only ts-jest**: the suite **passes**, error ignored → surface removed from the test run.
2. **`typecheck` task** (`tsc --noEmit`): **catches exactly that error** (exit 2, naming the probe file); clean code exits 0 → surface present and **blocking in CI**.

The gate is non-vacuous (catches a real injected error) and green on the current tree (0 errors, both workspaces).

## Performance (honest, same-machine, **warm** caches; Node 20 / Windows)

| Workspace | Full-check (warm) | Transpile-only (warm) | Speedup |
|---|---|---|---|
| core (280 tests) | 11.7s | **8.0s** | 1.5× |
| web (147 tests)  | 22.6s | **13.2s** | 1.7× |

Modest warm, larger cold: a **cold** web run (empty ts-jest cache, e.g. CI) was 54.6s vs 13.2s warm, so type-checking is a much larger fraction of cold/CI runs — where this change saves the most. The `typecheck` task (~4–16s/workspace incl. Turbo overhead) runs in parallel with `test` and finishes under the api test tall pole, adding no wall-clock. The headline benefit is the combination: faster runs **and** a new blocking web type-check surface.

## Testing

- `npm test` — **green**. Turbo 12/12 tasks successful (2m22s). Per workspace: core 280, web 147, api 420 (incl. DB-E2E via Testcontainers — Postgres container started & torn down cleanly), api-client 25, types 0.
- `npm run typecheck` (Turbo: core + web) — **green**, 2/2 tasks successful (14.3s).
- `npm test -w @lifting-logbook/core` — 280 passed (8.0s transpile-only).
- `npm test -w @lifting-logbook/web` — 147 passed (13.2s transpile-only).
- Docker was up; the api DB-E2E suite ran via Testcontainers.
- Coverage-safety probes (injected `TS2322` in core and web tests) reproduced as above, then removed.

Tests: 872 passed, 0 skipped, 0 failed (npm test, 2m22s wall-clock)

## Suppression / test-integrity check

Clean — the added-line greps for suppressions and test-integrity violations both returned nothing; the change adds no new `ts-ignore`/`eslint-disable`/`!`-assertion/`?? null` and no skip markers or deleted tests. Dropping web's `diagnostics.warnOnly` **removes** a softening flag (net stricter). (`apps/web`'s pre-existing `test: "jest --passWithNoTests"` is unchanged.)

## Deferred (out of scope to keep the coverage-safety story clean; follow-ups)

- **Turbo test caching for pure packages** — coverage-neutral but carries stale-cache risk; wants its own input-hash correctness validation.
- **Gate the win32 `maxWorkers: '50%'` cap on Node major version** — the cap serves *double duty* (Node-24 OOM #419 **and** Windows parallel-load flakes #567); relaxing it needs multi-run win32 flake validation.

## Review findings disposition

Self-review posted 2026-07-03 (0 blocking, 3 non-blocking):

- **[documentation]** stale "follow-up work" comment in `apps/web/tsconfig.spec.json` (the web gate is actually implemented in this PR) — **fixed in `87243ee`**.
- **[documentation]** `CLAUDE.md` `## Testing` didn't mention the new `npm run typecheck` gate — **fixed in `87243ee`**.
- **[performance]** `turbo.json` `typecheck` `cache: false` leaves caching on the table (deliberate for cross-package source-dep correctness) — **filed [#656](https://github.com/brownm09/lifting-logbook/issues/656)** alongside the other deferred test-speed optimizations.
