### PR TITLE
[fix] Address post-merge review findings on #652

### DIFF
--- a/apps/api/src/adapters/prisma/rls.db.e2e.spec.ts
+++ b/apps/api/src/adapters/prisma/rls.db.e2e.spec.ts
@@ -433,4 +433,28 @@ describeOrSkip('RLS request wiring (interceptor + factory, full app boot)', () =
     expect(JSON.parse(res.body).program).toBe('leangains');
     await owner.cycleDashboard.deleteMany({ where: { userId } });
   });
+
+  // switchProgram (SwitchProgramController) is a separate DI-wired path from
+  // cycles/initialize above — it builds its repos via `this.prisma.clientForRequest()`
+  // directly rather than solely through PrismaRepositoryFactory. It has an existing
+  // create-new-cycle test in programs.db.e2e.spec.ts, but that suite (like every DB E2E
+  // suite except this file) connects as the bootstrap superuser, which bypasses RLS.
+  // #650 (the onboarding activeProgram fix) made this the primary path onboarding now
+  // depends on, so it needs the same full-app-boot-under-lifting_app coverage cycles/
+  // initialize got in #645 — otherwise this endpoint carries the same class of blind
+  // spot that let #644 ship undetected.
+  it('switchProgram creates a first-time cycle and sets activeProgram under the restricted role', async () => {
+    const userId = `rls-e2e-fullapp-switch-${Date.now()}`;
+    const res = await inject({
+      method: 'POST',
+      url: '/programs/leangains/switch',
+      headers: { authorization: `Bearer ${userId}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ activeProgram: 'leangains', cycleNum: 1 });
+
+    await owner.cycleDashboard.deleteMany({ where: { userId } });
+    await owner.userSettings.deleteMany({ where: { userId } });
+  });
 });

--- a/apps/web/app/(authed)/onboarding/actions.ts
+++ b/apps/web/app/(authed)/onboarding/actions.ts
@@ -27,10 +27,10 @@ export async function createFirstCycle(
     // max — deriving it at 90% of the 1RM for the estimate/test/manual methods, or
     // taking the entered value as-is for the "enter training maxes" method — so this
     // action persists the value verbatim and does no further adjustment. Runs after
-    // initializeCycle so it overrides any maxes the cycle seeded. The PATCH endpoint
+    // switchProgram so it overrides any maxes the cycle seeded. The PATCH endpoint
     // merges and appends unknown lifts, so any catalog or custom lift name is accepted.
     //
-    // Best-effort by design: initializeCycle has already created the cycle, so a
+    // Best-effort by design: switchProgram has already created (or found) the cycle, so a
     // max-persistence failure must not strand the user on the program-selection
     // step with a cycle that exists but is unreachable from this flow. Training
     // maxes are editable later in settings, so we log and proceed to the cycle

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -71,7 +71,6 @@ async function getAuthHeaders(): Promise<Record<string, string>> {
 export const {
   fetchCycleDashboard,
   createCycle,
-  initializeCycle,
   fetchProgramSpec,
   fetchTrainingMaxes,
   fetchTrainingMaxHistory,


### PR DESCRIPTION
## Summary

The user asked me to review PR #652 after I'd already merged it without doing so first — a real process miss (I'd treated "CI passed" as equivalent to "reviewed," which it isn't). This PR fixes what that review turned up.

## Findings and fixes

1. **Stale comments** — `actions.ts` had two comments still naming `initializeCycle` after #652 replaced it with `switchProgram`.
2. **Dead re-export** — `apps/web/lib/api.ts` re-exports "the subset [of api-client functions] used" per its own header comment, but `initializeCycle` had zero remaining callers in `apps/web` once `actions.ts` stopped using it. Removed the re-export (the underlying `packages/api-client` function and the API's `POST /cycles/initialize` endpoint are untouched — both still have other legitimate uses, including the DB E2E regression test #645 added).
3. **Real test-coverage gap** — `switchProgram` (`SwitchProgramController`) is now onboarding's primary cycle-creation path per #650, but had never been tested under the actual restricted `lifting_app` role. Its only existing coverage (`programs.db.e2e.spec.ts`) connects as the bootstrap superuser, which bypasses RLS — the exact class of blind spot that let #644 ship undetected for 3+ weeks. Added a full-app-boot test for it alongside the existing `cycles/initialize` coverage in `rls.db.e2e.spec.ts`, proving `switchProgram` genuinely creates a cycle and sets `activeProgram` under real RLS enforcement.

No behavior change to #645 or #652's actual fixes.

## Testing

```
npm test
```
Tests: 12/12 in `rls.db.e2e.spec.ts` (was 11, +1 new), 420 api overall, 152 web. Full monorepo run: 12/12 tasks passed.

Suppression grep, test-integrity grep: both clean. No `package.json` changes.

Related: #644, #650, #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)