### PR TITLE
[fix] Default DB E2E suites to the restricted lifting_app role

### DIFF
--- a/apps/api/jest.env.setup.js
+++ b/apps/api/jest.env.setup.js
@@ -46,38 +46,20 @@ process.env.OTEL_SDK_AUTOSTART = 'false';
 const originalEnv = process.env;
 process.env = new Proxy(originalEnv, {
   set(target, key, value) {
-    // Allow the DB E2E spec to restore DATABASE_URL from the Testcontainers
-    // sentinel set by jest.global-setup.js, or from its lifting_app-role variant
-    // (see below) — these are the only legitimate write paths for DATABASE_URL
-    // during a test run.
-    if (String(key) === 'DATABASE_URL' && value) {
-      const sentinel = target.LIFTING_TC_DATABASE_URL;
-      if (value === sentinel) {
-        target[key] = value;
-        return true;
-      }
-      // Also allow the lifting_app-role variant of the sentinel (same host/port/database,
-      // different credentials) — needed by full-app-boot RLS tests that must connect as the
-      // restricted runtime role rather than the Testcontainers owner, so PrismaService's
-      // env("DATABASE_URL") read resolves to a real, RLS-enforcing connection. Scoped to the
-      // sentinel's own host/pathname so this cannot be used to smuggle an arbitrary DB URL in.
-      // See rls.db.e2e.spec.ts's "RLS request wiring (interceptor + factory, full app)" block.
-      if (sentinel) {
-        try {
-          const candidate = new URL(value);
-          const base = new URL(sentinel);
-          if (
-            candidate.host === base.host &&
-            candidate.pathname === base.pathname &&
-            candidate.username === 'lifting_app'
-          ) {
-            target[key] = value;
-            return true;
-          }
-        } catch {
-          // Not a valid URL — fall through and discard below.
-        }
-      }
+    // Allow the DB E2E spec to restore DATABASE_URL from either sentinel
+    // jest.global-setup.js sets (issue #646): LIFTING_TC_DATABASE_URL (the
+    // restricted lifting_app role — the default) or LIFTING_TC_OWNER_DATABASE_URL
+    // (the superuser/owner opt-in). Both are exact, fixed strings by the time any
+    // worker's setupFiles script runs — global-setup sets them once in the parent
+    // process before workers fork — so an exact match against either is sufficient;
+    // no derived third URL is a legitimate write.
+    if (
+      String(key) === 'DATABASE_URL' &&
+      value &&
+      (value === target.LIFTING_TC_DATABASE_URL || value === target.LIFTING_TC_OWNER_DATABASE_URL)
+    ) {
+      target[key] = value;
+      return true;
     }
     if (BLOCK.includes(String(key))) {
       return true; // discard — blocked keys are frozen at ''

--- a/apps/api/jest.global-setup.js
+++ b/apps/api/jest.global-setup.js
@@ -17,11 +17,30 @@
 //      `prisma migrate deploy` failures throw buildMigrationFailedMessage
 //      (schema drift, SQL error, timeout — Docker is fine).
 //
-// In paths 1 and 3 the spec reads LIFTING_TC_DATABASE_URL (not DATABASE_URL)
-// because jest.env.setup.js force-blanks DATABASE_URL in every worker to keep
-// the in-memory e2e suite wiring InMemoryRepositoryFactory. The DB E2E spec
-// restores DATABASE_URL from the sentinel inside its own beforeAll;
-// jest.env.setup.js allows that one specific write through its Proxy.
+// In paths 1 and 3, once the database is confirmed migrated (so the `lifting_app`
+// role from the enable_rls migration exists), this file also provisions that
+// role's login password and exposes TWO connection strings (issue #646):
+//   - LIFTING_TC_DATABASE_URL: the restricted `lifting_app` role. This is the
+//     DEFAULT every DB E2E spec should use — it's the same non-superuser role
+//     the production app runs as, so Row-Level Security is actually enforced.
+//     Postgres superusers bypass RLS entirely regardless of policy correctness,
+//     which is exactly how issue #644 (RlsInterceptor silently never setting the
+//     RLS GUC) went undetected for 3+ weeks — every DB E2E suite ran as superuser.
+//   - LIFTING_TC_OWNER_DATABASE_URL: the bootstrap superuser/owner connection,
+//     kept available as an explicit, named opt-in for suites that genuinely need
+//     to bypass RLS (seeding/cleanup across many synthetic users, or asserting on
+//     RLS metadata itself). Only read this sentinel with a comment explaining why
+//     the suite needs to bypass RLS.
+// buildRoleProvisioningFailedMessage covers failures in that provisioning step —
+// by that point Docker and migrations are both known-good, so the failure is
+// specific to the ALTER ROLE statement itself.
+//
+// In paths 1 and 3 the spec reads LIFTING_TC_DATABASE_URL / LIFTING_TC_OWNER_DATABASE_URL
+// (not DATABASE_URL) because jest.env.setup.js force-blanks DATABASE_URL in every
+// worker to keep the in-memory e2e suite wiring InMemoryRepositoryFactory. The DB
+// E2E spec restores DATABASE_URL from one of the two sentinels inside its own
+// beforeAll; jest.env.setup.js allows exactly those two specific writes through
+// its Proxy.
 
 const path = require('path');
 const { execSync } = require('child_process');
@@ -31,6 +50,12 @@ const { execSync } = require('child_process');
 // latest postgres:16-alpine, capture its digest, and update both call sites.
 const POSTGRES_IMAGE = 'postgres:16-alpine@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229';
 const MIGRATION_TIMEOUT_MS = 120_000;
+
+// The restricted runtime role created (passwordless) by the enable_rls migration.
+// Test-only password — never used outside an ephemeral Testcontainers instance or
+// CI's throwaway service container.
+const APP_ROLE = 'lifting_app';
+const APP_ROLE_PASSWORD = 'lifting_app';
 
 // Keep recovery copy in sync with docs/testing/e2e-coverage.md ("Running locally
 // when Docker is unavailable") and the CLAUDE.md Testing prerequisites bullet.
@@ -72,6 +97,51 @@ function buildMigrationFailedMessage(underlying) {
   ].join('\n');
 }
 
+// Distinct from the two messages above: by the time this fires, Docker is
+// reachable AND migrations have already succeeded (this only runs after a
+// successful CI passthrough or a successful local migrate-deploy), so the
+// failure is specific to provisioning the lifting_app role's login password.
+function buildRoleProvisioningFailedMessage(underlying) {
+  return [
+    "[jest.global-setup] Failed to provision the `lifting_app` role's login password.",
+    '',
+    'Docker is reachable and migrations succeeded — the failure is specific to this step.',
+    '',
+    'Likely causes:',
+    '  1. The enable_rls migration (20260611000000_enable_rls) has not actually run,',
+    '     so the `lifting_app` role does not exist yet — check the migration history.',
+    '  2. The owner/superuser connection used here lacks privilege to ALTER ROLE —',
+    '     should not happen against the bootstrap superuser Testcontainers/CI creates.',
+    '  3. A network or auth issue reaching the database specific to this connection.',
+    '',
+    `Underlying error: ${underlying && underlying.message ? underlying.message : String(underlying)}`,
+  ].join('\n');
+}
+
+// Clones ownerUrl with the lifting_app role's credentials substituted in — same
+// host/port/database, only the role differs.
+function appRoleUrl(ownerUrl) {
+  const u = new URL(ownerUrl);
+  u.username = APP_ROLE;
+  u.password = APP_ROLE_PASSWORD;
+  return u.toString();
+}
+
+// Sets a known login password on the lifting_app role (created passwordless by the
+// enable_rls migration) using the owner/superuser connection, which alone has
+// privilege to ALTER ROLE. Idempotent — safe to call on every run.
+async function provisionAppRolePassword(ownerUrl) {
+  const { PrismaClient } = require('@prisma/client');
+  const owner = new PrismaClient({ datasources: { db: { url: ownerUrl } } });
+  try {
+    await owner.$executeRawUnsafe(
+      `ALTER ROLE "${APP_ROLE}" WITH LOGIN PASSWORD '${APP_ROLE_PASSWORD}'`,
+    );
+  } finally {
+    await owner.$disconnect().catch(() => {});
+  }
+}
+
 // Truthy variants the opt-out accepts. Anything else that is set-but-not-listed
 // triggers a near-miss warning so a typoed value doesn't silently fall through
 // to the hard-fail path.
@@ -79,11 +149,20 @@ const SKIP_DB_E2E_TRUTHY = new Set(['1', 'true', 'yes']);
 
 module.exports = async function globalSetup() {
   if (process.env.DATABASE_URL) {
-    process.env.LIFTING_TC_DATABASE_URL = process.env.DATABASE_URL;
+    const ownerUrl = process.env.DATABASE_URL;
+    try {
+      await provisionAppRolePassword(ownerUrl);
+    } catch (err) {
+      throw new Error(buildRoleProvisioningFailedMessage(err));
+    }
+    process.env.LIFTING_TC_OWNER_DATABASE_URL = ownerUrl;
+    process.env.LIFTING_TC_DATABASE_URL = appRoleUrl(ownerUrl);
     // Clear DATABASE_URL so worker setupFiles' BLOCK list takes effect uniformly.
-    // The spec restores it from LIFTING_TC_DATABASE_URL in beforeAll.
+    // The spec restores it from one of the two sentinels above in beforeAll.
     delete process.env.DATABASE_URL;
-    console.log('[jest.global-setup] CI passthrough — using pre-set DATABASE_URL.');
+    console.log(
+      '[jest.global-setup] CI passthrough — provisioned lifting_app; it is now the default DB E2E connection.',
+    );
     return;
   }
 
@@ -146,6 +225,19 @@ module.exports = async function globalSetup() {
     throw new Error(buildMigrationFailedMessage(err));
   }
 
-  process.env.LIFTING_TC_DATABASE_URL = url;
-  console.log('[jest.global-setup] Postgres testcontainer ready.');
+  try {
+    await provisionAppRolePassword(url);
+  } catch (err) {
+    // Mirror the migrate-failure branch above: stop the container and clear its
+    // handle BEFORE throwing, so a role-provisioning failure can't leak it.
+    await container.stop().catch(() => {});
+    globalThis.__LL_PG_CONTAINER__ = undefined;
+    throw new Error(buildRoleProvisioningFailedMessage(err));
+  }
+
+  process.env.LIFTING_TC_OWNER_DATABASE_URL = url;
+  process.env.LIFTING_TC_DATABASE_URL = appRoleUrl(url);
+  console.log(
+    '[jest.global-setup] Postgres testcontainer ready — lifting_app is the default DB E2E connection.',
+  );
 };

--- a/apps/api/jest.global-setup.js
+++ b/apps/api/jest.global-setup.js
@@ -103,7 +103,7 @@ function buildMigrationFailedMessage(underlying) {
 // failure is specific to provisioning the lifting_app role's login password.
 function buildRoleProvisioningFailedMessage(underlying) {
   return [
-    "[jest.global-setup] Failed to provision the `lifting_app` role's login password.",
+    '[jest.global-setup] Failed to provision the `lifting_app` role\'s login password.',
     '',
     'Docker is reachable and migrations succeeded — the failure is specific to this step.',
     '',
@@ -127,6 +127,23 @@ function appRoleUrl(ownerUrl) {
   return u.toString();
 }
 
+// Bounds the ALTER ROLE call the same way MIGRATION_TIMEOUT_MS bounds the migrate-deploy
+// step above: without this, a connectivity loss in the (narrow) window between a successful
+// migration and this step would hang globalSetup indefinitely instead of failing fast with
+// buildRoleProvisioningFailedMessage. Does not abort the underlying query directly (Prisma has
+// no query-cancellation API) — the subsequent $disconnect() in provisionAppRolePassword's
+// `finally` forces the connection closed, which is sufficient to unblock the process.
+const ROLE_PROVISIONING_TIMEOUT_MS = 15_000;
+
+function withTimeout(promise, ms, label) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms),
+    ),
+  ]);
+}
+
 // Sets a known login password on the lifting_app role (created passwordless by the
 // enable_rls migration) using the owner/superuser connection, which alone has
 // privilege to ALTER ROLE. Idempotent — safe to call on every run.
@@ -134,8 +151,12 @@ async function provisionAppRolePassword(ownerUrl) {
   const { PrismaClient } = require('@prisma/client');
   const owner = new PrismaClient({ datasources: { db: { url: ownerUrl } } });
   try {
-    await owner.$executeRawUnsafe(
-      `ALTER ROLE "${APP_ROLE}" WITH LOGIN PASSWORD '${APP_ROLE_PASSWORD}'`,
+    await withTimeout(
+      owner.$executeRawUnsafe(
+        `ALTER ROLE "${APP_ROLE}" WITH LOGIN PASSWORD '${APP_ROLE_PASSWORD}'`,
+      ),
+      ROLE_PROVISIONING_TIMEOUT_MS,
+      'lifting_app role provisioning',
     );
   } finally {
     await owner.$disconnect().catch(() => {});

--- a/apps/api/src/adapters/prisma/rls.db.e2e.spec.ts
+++ b/apps/api/src/adapters/prisma/rls.db.e2e.spec.ts
@@ -1,12 +1,13 @@
 // Real-Postgres E2E suite for Row-Level Security (issue #511).
 //
 // Postgres is provisioned by jest.global-setup.js (Testcontainers locally; CI passthrough),
-// which exposes the OWNER connection string via LIFTING_TC_DATABASE_URL. The enable_rls migration
-// has already created the non-superuser `lifting_app` role (without a password). This suite:
-//   1. sets a known password on lifting_app using the owner connection, then
-//   2. connects a second Prisma client AS lifting_app to prove the policies actually constrain a
-//      non-superuser caller — the existing DB-E2E suites connect as the bootstrap superuser, which
-//      bypasses RLS, so they could never catch a missing/broken policy.
+// which also provisions the `lifting_app` role's login password and exposes both connection
+// strings directly (issue #646): LIFTING_TC_DATABASE_URL (the restricted lifting_app role — the
+// default every DB E2E suite now uses) and LIFTING_TC_OWNER_DATABASE_URL (the superuser/owner
+// opt-in). This suite:
+//   1. connects a second Prisma client AS lifting_app to prove the policies actually constrain a
+//      non-superuser caller — the enforcement tests below assert the policies themselves hold,
+//      which merely connecting as the (now-default) restricted role elsewhere cannot substitute for.
 //
 // Seeding and cleanup use the owner client (superuser → bypasses RLS, so it can write any user's
 // rows). Enforcement assertions use the lifting_app client.
@@ -25,35 +26,26 @@ import { RlsInterceptor } from './rls.interceptor';
 import { RLS_TX_CLIENT } from './rls-context';
 import { runBatch } from './prisma-tx.util';
 
-const TC_DATABASE_URL = process.env.LIFTING_TC_DATABASE_URL;
-const describeOrSkip = TC_DATABASE_URL ? describe : describe.skip;
-// Guaranteed-string form for use inside the guarded describe blocks (they only run when
-// TC_DATABASE_URL is set, so the '' fallback is never exercised — it just avoids a non-null
+const APP_ROLE_URL = process.env.LIFTING_TC_DATABASE_URL;
+const OWNER_TC_URL = process.env.LIFTING_TC_OWNER_DATABASE_URL;
+const describeOrSkip = APP_ROLE_URL && OWNER_TC_URL ? describe : describe.skip;
+// Guaranteed-string forms for use inside the guarded describe blocks (they only run when
+// both sentinels are set, so the '' fallback is never exercised — it just avoids a non-null
 // assertion and keeps Prisma's `url: string` type satisfied).
-const OWNER_URL = TC_DATABASE_URL ?? '';
+const OWNER_URL = OWNER_TC_URL ?? '';
+const APP_DB_URL = APP_ROLE_URL ?? '';
 
-// The beforeAll below connects an owner PrismaClient, runs ALTER ROLE, and seeds
-// fixtures. In isolation it finishes in ~2s, but under a full-suite Windows
-// `turbo run test` it contends with the CSV-fixture-heavy web/core suites and
-// intermittently blows past Jest's 5s default hook timeout (an isolation-only
-// flake — apps/api/jest.config.js does not extend the win32-capped base config).
-// 30s gives ample headroom over the contended case while still failing fast on a
+// The beforeAll below connects an owner PrismaClient and seeds fixtures. In isolation it
+// finishes in ~2s, but under a full-suite Windows `turbo run test` it contends with the
+// CSV-fixture-heavy web/core suites and intermittently blows past Jest's 5s default hook
+// timeout (an isolation-only flake — apps/api/jest.config.js does not extend the win32-capped
+// base config). 30s gives ample headroom over the contended case while still failing fast on a
 // genuine hang (Testcontainers readiness is already bounded in jest.global-setup.js). See #567.
 const DB_E2E_HOOK_TIMEOUT_MS = 30_000;
-
-const APP_ROLE = 'lifting_app';
-const APP_ROLE_PASSWORD = 'lifting_app';
 
 const USER_ALICE = 'rls-e2e-alice';
 const USER_BOB = 'rls-e2e-bob';
 const PROGRAM = 'rls-e2e-program';
-
-function appRoleUrl(ownerUrl: string): string {
-  const u = new URL(ownerUrl);
-  u.username = APP_ROLE;
-  u.password = APP_ROLE_PASSWORD;
-  return u.toString();
-}
 
 /** Runs `body` inside a transaction with app.current_user_id set to `userId` (or unset if null). */
 async function asUser<T>(
@@ -82,13 +74,9 @@ describeOrSkip('Row-Level Security (e2e, lifting_app role)', () => {
   beforeAll(async () => {
     owner = new PrismaClient({ datasources: { db: { url: OWNER_URL } } });
 
-    // The migration created lifting_app without a password; give it one so the app-role client can
-    // connect. Owner is a superuser here, so ALTER ROLE is permitted. (Password is test-only.)
-    await owner.$executeRawUnsafe(
-      `ALTER ROLE "${APP_ROLE}" WITH LOGIN PASSWORD '${APP_ROLE_PASSWORD}'`,
-    );
-
-    appDb = new PrismaClient({ datasources: { db: { url: appRoleUrl(OWNER_URL) } } });
+    // jest.global-setup.js already provisioned lifting_app's login password (issue #646),
+    // so the app-role client can connect directly against the sentinel it exposed.
+    appDb = new PrismaClient({ datasources: { db: { url: APP_DB_URL } } });
 
     await cleanup();
 
@@ -264,7 +252,7 @@ describeOrSkip('RLS request wiring (interceptor + factory)', () => {
   let interceptor: RlsInterceptor;
 
   beforeAll(async () => {
-    process.env.DATABASE_URL = OWNER_URL; // allowed by jest.env.setup.js Proxy (== sentinel value)
+    process.env.DATABASE_URL = OWNER_URL; // allowed by jest.env.setup.js Proxy (== LIFTING_TC_OWNER_DATABASE_URL sentinel)
     const moduleRef = await Test.createTestingModule({
       imports: [ClsModule.forRoot({ global: true })],
       providers: [
@@ -366,16 +354,12 @@ describeOrSkip('RLS request wiring (interceptor + factory, full app boot)', () =
 
   beforeAll(async () => {
     owner = new PrismaClient({ datasources: { db: { url: OWNER_URL } } });
-    // Idempotent — harmless if the "Row-Level Security (e2e, lifting_app role)" block above
-    // already set this password; this block must not depend on describe-block execution order.
-    await owner.$executeRawUnsafe(
-      `ALTER ROLE "${APP_ROLE}" WITH LOGIN PASSWORD '${APP_ROLE_PASSWORD}'`,
-    );
 
-    // Allowed by jest.env.setup.js's Proxy: same host/pathname as the LIFTING_TC_DATABASE_URL
-    // sentinel, lifting_app user — so PrismaService's env("DATABASE_URL") read resolves to a
-    // real, RLS-enforcing connection instead of the owner/superuser one.
-    process.env.DATABASE_URL = appRoleUrl(OWNER_URL);
+    // jest.global-setup.js already provisioned lifting_app's login password (issue #646).
+    // This matches the LIFTING_TC_DATABASE_URL sentinel exactly, so jest.env.setup.js's Proxy
+    // allows the write — PrismaService's env("DATABASE_URL") read resolves to a real,
+    // RLS-enforcing connection instead of the owner/superuser one.
+    process.env.DATABASE_URL = APP_DB_URL;
 
     app = await NestFactory.create<NestFastifyApplication>(AppModule, new FastifyAdapter(), {
       logger: false,

--- a/apps/api/src/programs/programs.db.e2e.spec.ts
+++ b/apps/api/src/programs/programs.db.e2e.spec.ts
@@ -2,11 +2,21 @@
 //   - Local: an ephemeral container via @testcontainers/postgresql (Docker required).
 //   - CI:    passthrough of the DATABASE_URL already exported by the
 //            db-integration job's postgres service container.
-// globalSetup exposes the connection string via LIFTING_TC_DATABASE_URL; this
-// spec restores DATABASE_URL from that sentinel below, before AppModule is
-// instantiated. (jest.env.setup.js force-blanks DATABASE_URL in every worker so
-// the in-memory e2e suite keeps wiring InMemoryRepositoryFactory; its Proxy
-// allows this one specific restoration.)
+// globalSetup provisions the `lifting_app` role's login password and exposes two
+// connection strings (issue #646): LIFTING_TC_DATABASE_URL (the restricted lifting_app
+// role) and LIFTING_TC_OWNER_DATABASE_URL (the superuser/owner opt-in). This spec uses
+// both, deliberately for different things:
+//   - `app` (the NestJS instance under test) restores DATABASE_URL from
+//     LIFTING_TC_DATABASE_URL before boot, so every one of this file's HTTP-driven
+//     assertions genuinely exercises the restricted role end to end — real RLS
+//     enforcement on the same path production traffic takes.
+//   - `prisma` (this file's own seeding/cleanup/DB-assertion client) connects via
+//     LIFTING_TC_OWNER_DATABASE_URL explicitly, because this suite acts as a harness
+//     across many synthetic users (Alice, Bob, TEST_USER, ...) rather than as one
+//     authenticated request — exactly the legitimate owner-opt-in case.
+// (jest.env.setup.js force-blanks DATABASE_URL in every worker so the in-memory e2e
+// suite keeps wiring InMemoryRepositoryFactory; its Proxy allows restoring DATABASE_URL
+// from either of the two sentinels above.)
 import 'reflect-metadata';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -68,9 +78,10 @@ async function cleanTestUsers(prisma: PrismaClient): Promise<void> {
 }
 
 const TC_DATABASE_URL = process.env.LIFTING_TC_DATABASE_URL;
+const OWNER_DATABASE_URL = process.env.LIFTING_TC_OWNER_DATABASE_URL;
 // Skip only when globalSetup did not provision a DB (e.g. Docker unavailable
-// and not running in CI). Normal local / CI runs always have it set.
-const describeOrSkip = TC_DATABASE_URL ? describe : describe.skip;
+// and not running in CI). Normal local / CI runs always have both sentinels set.
+const describeOrSkip = TC_DATABASE_URL && OWNER_DATABASE_URL ? describe : describe.skip;
 
 describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
   let app: NestFastifyApplication;
@@ -135,7 +146,12 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
   };
 
   beforeAll(async () => {
-    prisma = new PrismaClient();
+    // Owner/superuser connection, explicit and deliberate (issue #646): this suite seeds
+    // and asserts against many synthetic users as a test harness, not as one authenticated
+    // request, so it bypasses RLS on purpose. `app` below boots against the ambient
+    // DATABASE_URL (the restricted lifting_app role) — that's the connection every one of
+    // this file's HTTP-driven `it()` blocks actually exercises.
+    prisma = new PrismaClient({ datasources: { db: { url: OWNER_DATABASE_URL } } });
 
     // Clean any leftover data from an interrupted previous run before seeding.
     await cleanTestUsers(prisma);

--- a/apps/api/src/programs/programs.db.e2e.spec.ts
+++ b/apps/api/src/programs/programs.db.e2e.spec.ts
@@ -77,11 +77,11 @@ async function cleanTestUsers(prisma: PrismaClient): Promise<void> {
   await prisma.customLift.deleteMany({ where: { userId: { in: users } } });
 }
 
-const TC_DATABASE_URL = process.env.LIFTING_TC_DATABASE_URL;
+const APP_ROLE_URL = process.env.LIFTING_TC_DATABASE_URL;
 const OWNER_DATABASE_URL = process.env.LIFTING_TC_OWNER_DATABASE_URL;
 // Skip only when globalSetup did not provision a DB (e.g. Docker unavailable
 // and not running in CI). Normal local / CI runs always have both sentinels set.
-const describeOrSkip = TC_DATABASE_URL && OWNER_DATABASE_URL ? describe : describe.skip;
+const describeOrSkip = APP_ROLE_URL && OWNER_DATABASE_URL ? describe : describe.skip;
 
 describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
   let app: NestFastifyApplication;
@@ -89,7 +89,7 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
 
   beforeAll(() => {
     // Allowed by jest.env.setup.js Proxy because value === LIFTING_TC_DATABASE_URL.
-    process.env.DATABASE_URL = TC_DATABASE_URL;
+    process.env.DATABASE_URL = APP_ROLE_URL;
   });
 
   const AUTH = { authorization: `Bearer ${TEST_USER}` };

--- a/docs/testing/e2e-coverage.md
+++ b/docs/testing/e2e-coverage.md
@@ -30,7 +30,8 @@ This document maps every critical user flow to its test coverage across the API 
 | File | What it covers |
 |---|---|
 | `apps/api/src/programs/programs.e2e.spec.ts` | Full API surface via in-memory adapters. Runs on every `npm test`. |
-| `apps/api/src/programs/programs.db.e2e.spec.ts` | Full API surface via Prisma adapters. Postgres is auto-provisioned by Jest globalSetup (Testcontainers locally; service container in CI). Runs on every `npm test -w @lifting-logbook/api` when Docker is available. |
+| `apps/api/src/programs/programs.db.e2e.spec.ts` | Full API surface via Prisma adapters. Postgres is auto-provisioned by Jest globalSetup (Testcontainers locally; service container in CI). HTTP requests run through the restricted `lifting_app` role (RLS-enforced) by default; direct DB seeding/cleanup and cross-user fixture setup use the owner/superuser connection via `LIFTING_TC_OWNER_DATABASE_URL`. Runs on every `npm test -w @lifting-logbook/api` when Docker is available. |
+| `apps/api/src/adapters/prisma/rls.db.e2e.spec.ts` | Row-Level Security enforcement and request-wiring tests (issues #511, #644). Connects as `lifting_app` for policy-enforcement assertions and full-app-boot HTTP tests; uses the owner connection only for cross-user seeding/cleanup and RLS-independent metadata checks against `pg_policy`/`pg_roles`. |
 | `apps/api/src/observability/otel.e2e.spec.ts` | OTel + nestjs-pino trace correlation smoke test. |
 
 ## Frontend E2E Tests
@@ -88,6 +89,32 @@ npm run test:db -w @lifting-logbook/api
 # postgres service container), globalSetup uses it directly and skips
 # container startup. Run migrations yourself in this case before invoking jest.
 ```
+
+## DB E2E connection defaults (issue #646)
+
+Every DB E2E suite connects as the restricted **`lifting_app`** role by default — the same
+non-superuser role the production application uses at runtime, with Row-Level Security fully
+enforced (`FORCE ROW LEVEL SECURITY` on every userId-scoped table, per the `enable_rls`
+migration). `jest.global-setup.js` provisions this role's password once and exposes it as
+`LIFTING_TC_DATABASE_URL`.
+
+A distinct, explicit opt-in, **`LIFTING_TC_OWNER_DATABASE_URL`**, exposes the superuser/owner
+connection for suites that genuinely need to bypass RLS: seeding or cleaning up fixtures across
+many synthetic users, or DB-layer assertions on RLS metadata itself that must run
+role-independently.
+
+**Rule of thumb:** if a test's Prisma calls stand in for what an authenticated HTTP request would
+do, use the restricted sentinel — or better, let the app under test boot against the ambient
+`DATABASE_URL`, which is already the restricted role. If a test needs to act as an omniscient
+harness across multiple users' data, use the owner sentinel explicitly via
+`datasources.db.url`. Never construct a Prisma client from ambient env when the intent is to
+bypass RLS — ambient env now resolves to the restricted role by default.
+
+This flips the pre-#646 default, under which every DB E2E suite connected as the superuser
+bootstrap role and structurally could not detect a broken or missing RLS policy. That's exactly
+how issue [#644](https://github.com/brownm09/lifting-logbook/issues/644) shipped and stayed live
+for 3+ weeks: `RlsInterceptor` silently never set the `app.current_user_id` GUC, and no suite
+besides `rls.db.e2e.spec.ts` ran with RLS actually capable of rejecting anything.
 
 ## Running locally when Docker is unavailable
 


### PR DESCRIPTION
## Summary

Every DB E2E suite except `rls.db.e2e.spec.ts` connected to Postgres as the bootstrap **superuser**, which structurally bypasses Row-Level Security regardless of policy correctness. That's exactly how issue #644 (`RlsInterceptor` silently never setting the `app.current_user_id` GUC) shipped and stayed live for 3+ weeks — every test touching a userId-scoped table ran as superuser and got correct-looking results regardless of whether RLS was actually enforced.

This flips the default: `apps/api/jest.global-setup.js` now provisions the restricted `lifting_app` role's login password once and exposes **two** connection strings instead of one:
- `LIFTING_TC_DATABASE_URL` — the restricted `lifting_app` role. **New default.**
- `LIFTING_TC_OWNER_DATABASE_URL` — the superuser/owner connection. **Explicit, named opt-in** for suites that genuinely need to bypass RLS.

## Changes

- **`apps/api/jest.global-setup.js`** — provisions `lifting_app`'s password (in both the CI-passthrough and local-Testcontainers branches) and exposes both sentinels. Added `buildRoleProvisioningFailedMessage()` matching the existing error-message style; a provisioning failure in the local path stops the container and clears its handle before throwing, mirroring the existing migrate-failure branch.
- **`apps/api/jest.env.setup.js`** — simplified the `DATABASE_URL` Proxy carve-out to an exact-match check against the two sentinels (deleted the old URL-parsing/host-pathname/username fallback, no longer needed).
- **`apps/api/src/adapters/prisma/rls.db.e2e.spec.ts`** — consumes both sentinels directly instead of deriving/provisioning the app-role URL itself; removed the now-dead `APP_ROLE`/`APP_ROLE_PASSWORD`/`appRoleUrl()`.
- **`apps/api/src/programs/programs.db.e2e.spec.ts`** — split into an explicit owner connection (seeding/cleanup/DB-assertions across many synthetic users — a deliberate, commented opt-in) and the app's ambient `DATABASE_URL` (now the restricted role by default), so every HTTP-driven assertion in this suite genuinely exercises real RLS enforcement end to end.
- **`docs/testing/e2e-coverage.md`** — documents the new default, the opt-out, and a rule of thumb for choosing between them; added the previously-missing `rls.db.e2e.spec.ts` row to the Test Files table.

Note: the issue body names `custom-lift.e2e.spec.ts` as an example DB suite to audit, but it (and `import.e2e.spec.ts`) are in-memory-only and untouched by this change — only `rls.db.e2e.spec.ts` and `programs.db.e2e.spec.ts` are real Postgres-backed DB E2E suites today.

## Audit result

Ran both DB E2E suites against real Postgres under the new restricted-role default: **72/72 pass unchanged**. This confirms the existing controller/factory RLS wiring (`PrismaService.clientForRequest()`, `PrismaRepositoryFactory.client()`, and the three controllers that build repositories outside the factory) was already correct — no suite needed an undocumented superuser opt-in beyond the two already-commented, deliberate cases (seeding/cleanup in both suites, and `rls.db.e2e.spec.ts`'s own policy-enforcement assertions, which must connect as `lifting_app` to prove the policies actually constrain a non-superuser caller).

## Testing

- `node apps/api/scripts/check-globalsetup-failure-paths.js` — 17/17 passed (none of the 3 mocked failure scenarios reach the new provisioning code path, since they all fail earlier).
- `npm run test:db -w @lifting-logbook/api` (Docker) — 2 suites, 72/72 passed.
- `npm test` (full repo) — 12/12 turbo tasks successful; API 420/420 passed, web 152/152 passed.

Tests: 644 passed, 0 skipped, 0 failed (~1m combined).

No suppressions added. `describe.skip` matches in the pre-PR grep are the pre-existing `describeOrSkip` conditional-skip helper in both spec files — I tightened its condition from a single-sentinel check to requiring both sentinels (defensive; global-setup always sets both together in every non-skip path, so this cannot cause a spurious skip in any real invocation), not a new skip marker.

## Out of scope (filed separately)

While validating this change I found `docker-compose.test.yml` — referenced by both `jest.global-setup.js`'s Docker-unavailable error message and `docs/testing/e2e-coverage.md` — doesn't exist anywhere in the repo (only an unrelated `docker-compose.yml` with a different port/credentials/db-name does). This predates #646 and isn't caused by it; flagged as a follow-up rather than folded into this diff.

## Review findings disposition

Per the [`/review` comment](https://github.com/brownm09/lifting-logbook/pull/658#issuecomment-4878499359), both non-blocking findings were fixed in-PR (commit `8f97922`):

- **[reliability]** `provisionAppRolePassword()` had no timeout on its `ALTER ROLE` call — fixed in `8f97922` (added `ROLE_PROVISIONING_TIMEOUT_MS` via `Promise.race`, matching the existing `MIGRATION_TIMEOUT_MS` pattern).
- **[maintainability]** `programs.db.e2e.spec.ts` kept the name `TC_DATABASE_URL` while `rls.db.e2e.spec.ts` (same PR, same purpose) used `APP_ROLE_URL` — fixed in `8f97922` (renamed to match).
- **[style]** Quote-style inconsistency in `buildRoleProvisioningFailedMessage`'s headline — fixed in `8f97922`.

Re-verified after both fixes: failure-path script 17/17, DB E2E audit 72/72, full suite 12/12 turbo tasks green (same 644 passed / 0 skipped / 0 failed — the fixes changed no test count).

Closes #646
