### PR TITLE
[chore] Enable Turbo caching for typecheck + test on pure packages

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "lint": "eslint src",
-    "test": "jest"
+    "test": "jest",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json"
   },
   "dependencies": {
     "@lifting-logbook/types": "*"

--- a/packages/api-client/tsconfig.typecheck.json
+++ b/packages/api-client/tsconfig.typecheck.json
@@ -1,0 +1,23 @@
+{
+  // Whole-program type-check gate for api-client source, run by the `typecheck` task as
+  // `tsc --noEmit -p tsconfig.typecheck.json`. Resolves @lifting-logbook/types to its
+  // TypeScript SOURCE (not node_modules -> dist) so the check needs no upstream build —
+  // this is what makes the Turbo `typecheck` task cacheable via `dependsOn: ["^typecheck"]`
+  // (the task has no build dependency, so packages/types/dist is absent in a clean CI
+  // checkout). Mirrors packages/core/tsconfig.spec.json and apps/web/tsconfig.typecheck.json.
+  // See #656 / #651.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    // rootDir at the repo root + composite:false: the @lifting-logbook/types path mapping
+    // pulls source from outside packages/api-client, so a narrower rootDir raises TS6059.
+    // noEmit means rootDir is only an assertion here, never an emit layout.
+    "composite": false,
+    "rootDir": "../../",
+    "baseUrl": ".",
+    "paths": {
+      "@lifting-logbook/types": ["../types/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "lint": "eslint src",
-    "test": "jest --passWithNoTests"
+    "test": "jest --passWithNoTests",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  // Shared root configs that are not per-package files: a change to the base tsconfig
+  // (extended by every workspace) or the base Jest config (required by every jest.config.js)
+  // must invalidate every dependent typecheck/test cache. See #656.
+  "globalDependencies": ["tsconfig.base.json", "jest.config.base.js"],
   "tasks": {
     "db:generate": {
       "inputs": ["prisma/schema.prisma", "package.json", "../../package-lock.json"],
@@ -10,15 +14,39 @@
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"],
       "inputs": ["src/**", "app/**", "!src/**/*.test.ts", "!src/**/*.spec.ts", "!src/**/__tests__/**", "tsconfig.json", "package.json", "next.config.*"]
     },
+    // Base test task stays uncached: apps/api's suite includes Testcontainers-backed DB E2E
+    // (external state), and apps/web / apps/mobile are left uncached by default. Only the
+    // hermetic pure packages opt into caching via the per-package overrides below. Each
+    // resolves upstream workspace SOURCE (jest moduleNameMapper -> packages/*/src), and the
+    // `build` dependency chains that source into the hash (own build -> ^build -> upstream
+    // build inputs), so an upstream source change invalidates the dependent's test cache. #656
     "test": {
       "dependsOn": ["build"],
       "cache": false
     },
+    "@lifting-logbook/core#test": {
+      "dependsOn": ["build"],
+      "cache": true
+    },
+    "@lifting-logbook/types#test": {
+      "dependsOn": ["build"],
+      "cache": true
+    },
+    "@lifting-logbook/api-client#test": {
+      "dependsOn": ["build"],
+      "cache": true
+    },
     "lint": {
       "inputs": ["src/**", "app/**", "*.ts", ".eslintrc*", "eslint.config*"]
     },
+    // typecheck is build-free by design (#651): each workspace's typecheck tsconfig resolves
+    // workspace deps to SOURCE, not dist. `dependsOn: ["^typecheck"]` chains upstream source
+    // into the hash through the typecheck graph (every workspace whose source is resolved has
+    // its own typecheck task), so an upstream source change invalidates the dependent's cache
+    // without forcing an upstream build. outputs:[] — tsc --noEmit produces no artifacts. #656
     "typecheck": {
-      "cache": false
+      "dependsOn": ["^typecheck"],
+      "outputs": []
     },
     "dev": {
       "dependsOn": ["db:generate"],


### PR DESCRIPTION
Part 1 of #656 (deferred from #651 / PR #655).

## Summary
Makes the `typecheck` and pure-package `test` Turbo tasks cacheable **correctly**. They were `cache: false` because both resolve cross-package **source** — core/web/api-client typecheck resolve workspace `src` via tsconfig `paths`; core/api-client tests resolve `types` src via jest `moduleNameMapper` — which a naive per-workspace input hash would not invalidate (stale cache could hide a cross-package regression).

## Changes
- **typecheck** → `dependsOn: ["^typecheck"]` + `outputs: []`. Chains upstream **source** into each task's hash through the typecheck graph, keeping typecheck **build-free** (per #651's design).
  - Added source-only `typecheck` scripts to `packages/types` (`tsc --noEmit -p tsconfig.json`) and `packages/api-client` (`tsc --noEmit -p tsconfig.typecheck.json`). Each is a strict subset of the package's existing `build` tsc → no new type surface, zero new errors possible.
  - New `packages/api-client/tsconfig.typecheck.json` resolves `@lifting-logbook/types` to **source** (mirrors `core`/`web`). Proven build-free with both `packages/{types,api-client}/dist` removed.
- **test** → per-package `cache: true` overrides for `@lifting-logbook/core#test`, `#types#test`, `#api-client#test` (hermetic pure packages). Base `test` stays `cache: false`, so **apps/api** (Testcontainers DB-E2E), **web**, and **mobile** remain uncached.
- **globalDependencies**: `["tsconfig.base.json", "jest.config.base.js"]` — these shared root configs aren't per-package files, so a change to either now invalidates every dependent typecheck/test cache.

## Validation — input-hash correctness (the stale-cache risk)
turbo 2.9.3; every probe reverted afterward.

| Probe | Expectation | Result |
|---|---|---|
| Warm run ×2 | 2nd run all cache-hit | ✅ FULL TURBO (typecheck 75ms / test 122ms) |
| Touch `types/src` | **all** dependents invalidate | ✅ core+web+api-client+types miss |
| Touch `core/src` | only core+web miss; types+api-client **hit** (precise) | ✅ |
| **Rename exported type in `types/src`** | consumer typecheck **fails**, not a stale pass | ✅ `api-client#typecheck` → `error TS2724 … has no exported member 'BodyWeightResponse'`; turbo exit 1 |
| Touch `types/src` (test) | core#test + api-client#test invalidate | ✅ |
| Touch `jest.config.base.js` / `tsconfig.base.json` (globalDep) | all test / typecheck caches invalidate | ✅ |
| `--dry=json` resolved config | api#test uncached; core/types/api-client#test cached | ✅ |

## Testing
`npm test` (full, incl. apps/api DB-E2E via Docker) + `npm run typecheck`, both green:
- **Tests: 881 passed, 0 skipped, 0 failed** (api 424, core 280, web 152, api-client 25; types/mobile `passWithNoTests`).
- typecheck: 4 tasks successful.

### Suppression / test-integrity greps
- **Suppression grep** — only match is the pre-existing `"!.next/cache/**"` **turbo glob negation** in the `build` task; not a TS suppression.
- **Integrity grep** — only match is `--passWithNoTests` on `packages/types` (genuinely no test files; pre-existing). My diff only appended a trailing comma to that line when adding the `typecheck` script. No new integrity violations.
- **Lockfile** in sync (`package.json` edits were scripts-only). Baseline-failure tracking not enabled for this repo.

## Coverage
Config/tooling only — no new runtime behavior. Coverage is the hash-correctness validation table above.

Closes #659. Refs #656, #651.

## Review findings disposition
`/review` (claude-opus-4-8) surfaced **0 blocking, 0 non-blocking** findings — nothing to fix or file. One non-blocking style note (two coexisting per-package turbo config patterns) needs no action. Review: https://github.com/brownm09/lifting-logbook/pull/661#issuecomment-4878692077
