### PR TITLE
[fix] Gate win32 Jest maxWorkers cap on Node major version

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,4 +1,6 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
+const nodeMajor = Number(process.versions.node.split('.')[0]);
+
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
@@ -7,20 +9,29 @@ module.exports = {
     '^.+\\.tsx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.json' }],
   },
   transformIgnorePatterns: ['/node_modules/'],
-  // Node 24 (Windows) workers exhaust heap when several CSV-fixture-heavy
-  // packages/core suites run in parallel. Restarting idle workers above 512MB
-  // RSS and capping parallelism at 50% of CPU clears the OOMs locally. Scoped
-  // to win32 so Node 20 Linux CI keeps Jest's default parallelism (cpus - 1)
-  // and never pays the worker-restart cost. See #419 and CLAUDE.md's Node 24
-  // caveat for the codified workaround.
+  // Two independent win32-only mitigations, gated differently (#656):
   //
-  // testTimeout is also raised on win32: under a full-suite `turbo run test`,
-  // several jest processes (web/core/types/api-client) run concurrently and
-  // oversubscribe the CPU, so a slow-but-healthy suite (e.g. the web CSV/onboarding
-  // suites) can intermittently blow past Jest's 5s default and report an
-  // isolation-only "1 failed" (#567). 15s of headroom absorbs the contention;
-  // Linux CI keeps the 5s default so a genuinely slow test there still fails fast.
+  // 1. testTimeout (ALL win32 Nodes) — under a full-suite `turbo run test`, several
+  //    jest processes (web/core/types/api-client) run concurrently and oversubscribe
+  //    the CPU, so a slow-but-healthy suite can intermittently blow past Jest's 5s
+  //    default and report an isolation-only "1 failed" (#567). 15s of headroom absorbs
+  //    the contention. This is CPU-oversubscription-driven, not Node-version-specific,
+  //    so it applies on every win32 Node. Linux CI keeps the 5s default so a genuinely
+  //    slow test there still fails fast.
+  //
+  // 2. workerIdleMemoryLimit + maxWorkers (Node >= 24 only) — Node 24 (Windows) workers
+  //    exhausted heap when several CSV-fixture-heavy packages/core suites ran in parallel
+  //    (#419); restarting idle workers above 512MB RSS and capping parallelism at 50% of
+  //    CPU cleared the OOMs. Transpile-only ts-jest (#651) cut per-worker memory, so
+  //    Node 20/22 no longer hit that OOM and can keep Jest's default parallelism
+  //    (cpus - 1) without paying the worker-restart cost. Gated to nodeMajor >= 24 to
+  //    restore full-CPU parallelism on supported Nodes; validated on Node 20 that lifting
+  //    the cap does not reintroduce the #567 flakes (the testTimeout above still guards
+  //    them). Linux CI is unaffected either way (not win32).
   ...(process.platform === 'win32'
-    ? { workerIdleMemoryLimit: '512MB', maxWorkers: '50%', testTimeout: 15000 }
+    ? {
+        testTimeout: 15000,
+        ...(nodeMajor >= 24 ? { workerIdleMemoryLimit: '512MB', maxWorkers: '50%' } : {}),
+      }
     : {}),
 };


### PR DESCRIPTION
Part 2 of #656 (deferred from #651 / PR #655).

## Summary
The win32 Jest config unconditionally applied `{ workerIdleMemoryLimit: '512MB', maxWorkers: '50%', testTimeout: 15000 }`. The `maxWorkers`/`workerIdleMemoryLimit` cap was added for the Node-24 per-worker heap OOM (#419). Transpile-only ts-jest (#651) cut per-worker memory, so Node 20/22 no longer hit that OOM — the cap needlessly halves local parallelism on supported Nodes.

This gates the OOM mitigation on Node major version:
- `testTimeout: 15000` stays on **all** win32 — it guards the #567 parallel-load timeout flake, which is CPU-oversubscription-driven and independent of Node version.
- `{ workerIdleMemoryLimit: '512MB', maxWorkers: '50%' }` applies **only when `nodeMajor >= 24`**, restoring full-CPU parallelism (`cpus - 1`) on Node 20/22 win32.

Linux CI (not win32) is unaffected either way.

## Gating logic — verified
`node -e` over the exact expression:

| platform / Node | resolved win32 settings |
|---|---|
| win32 / node20 (this box) | `{ testTimeout: 15000 }` — cap lifted ✅ |
| win32 / node22 | `{ testTimeout: 15000 }` — cap lifted |
| win32 / node24 | `{ testTimeout: 15000, workerIdleMemoryLimit, maxWorkers }` — cap kept |
| win32 / node26 | `{ testTimeout: 15000, workerIdleMemoryLimit, maxWorkers }` — cap kept |
| linux / node24 | `{}` — no win32 settings |

Confirmed the actual `require('./jest.config.base.js')` on this Node 20.11.1 win32 box resolves to `testTimeout: 15000` only (no `maxWorkers`, no `workerIdleMemoryLimit`).

## Caution addressed — #567 double-duty
`maxWorkers: '50%'` also reduced CPU oversubscription that drives the #567 parallel-load flakes, so lifting it on Node 20 needed validation. **Ran the full `npm test` (all workspaces, incl. apps/api DB-E2E via Docker) 5 times on win32 Node 20 with the cap lifted** — full-CPU parallelism, tests uncached so each run executed fresh:

| Run | Result | core | web | api | api-client |
|---|---|---|---|---|---|
| 1 | `Tasks: 12 successful, 12 total` (exit 0) | 280 | 152 | 424 | 25 |
| 2 | `Tasks: 12 successful, 12 total` (exit 0) | 280 | 152 | 424 | 25 |
| 3 | `Tasks: 12 successful, 12 total` (exit 0) | 280 | 152 | 424 | 25 |
| 4 | `Tasks: 12 successful, 12 total` (exit 0) | 280 | 152 | 424 | 25 |
| 5 | `Tasks: 12 successful, 12 total` (exit 0) | 280 | 152 | 424 | 25 |

**5/5 runs green** — every run all workspaces passed, 0 failed, 0 skipped.

No #567-class isolation failures returned; the retained `testTimeout: 15000` absorbs the contention directly (the per-test timeout, not worker count, is the direct guard against the #567 symptom).

## Testing
Full `npm test` run 5× (above). Per run: core 280, web 152, api 424 (incl DB-E2E via Docker), api-client 25; types/mobile passWithNoTests; eslint-rules 14 — 0 failed, 0 skipped.

### Suppression / test-integrity greps
- Suppression grep: clean (no `ts-ignore`/`ts-expect-error`/`eslint-disable`/non-null/`?? null` added).
- Integrity grep: clean — no skip markers, deleted tests, lowered thresholds, or bypass flags. `testTimeout` unchanged (15000, win32); the diff only gates two win32 worker settings on Node version. No `package.json` change → lockfile unaffected.

## Coverage
Test-infra config only — no runtime behavior. Coverage is the gating-matrix verification + multi-run flake validation above.

Closes #660. Refs #656, #651, #419, #567.

## Review findings disposition
`/review` (claude-opus-4-8) surfaced **0 blocking, 0 non-blocking** findings — nothing to fix or file. Review: https://github.com/brownm09/lifting-logbook/pull/664
