### PR TITLE
[chore] Add missing docker-compose.test.yml for DB E2E Docker-unavailable recovery

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,28 @@
+services:
+  # Test-only Postgres for the DB E2E suite's Docker-unavailable recovery path
+  # (apps/api/jest.global-setup.js buildDockerUnavailableMessage, docs/testing/e2e-coverage.md
+  # "Running locally when Docker is unavailable"). Postgres only — no OTel Collector, Tempo,
+  # Loki, or Prometheus — per ADR-021 (docs/adr/ADR-021-no-test-tracing.md).
+  #
+  # Pinned digest — keep in sync with apps/api/jest.global-setup.js POSTGRES_IMAGE and
+  # .github/workflows/ci.yml's db-integration service.
+  db:
+    image: postgres:16-alpine@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229
+    environment:
+      POSTGRES_USER: lifting
+      POSTGRES_PASSWORD: lifting
+      POSTGRES_DB: lifting_test
+    ports:
+      # Host 5433 (not 5432) so this can run alongside the main docker-compose.yml's
+      # Postgres and a locally-installed default-port Postgres without conflict.
+      - "5433:5432"
+    volumes:
+      - postgres_test_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U lifting"]
+      interval: 5s
+      timeout: 5s
+      retries: 6
+
+volumes:
+  postgres_test_data:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,3 +1,11 @@
+# Explicit project name — without it, Compose defaults to the invoking directory's basename
+# ("lifting-logbook" at repo root), which is the same default the root docker-compose.yml
+# resolves to. Both files name their service `db`; without a distinct project name here, running
+# this file alongside an already-running docker-compose.yml stack would make Compose reconcile
+# the shared `db` service to THIS file's spec, recreating a running dev Postgres with a different
+# image/credentials/database.
+name: lifting-logbook-test
+
 services:
   # Test-only Postgres for the DB E2E suite's Docker-unavailable recovery path
   # (apps/api/jest.global-setup.js buildDockerUnavailableMessage, docs/testing/e2e-coverage.md

--- a/docs/testing/e2e-coverage.md
+++ b/docs/testing/e2e-coverage.md
@@ -132,7 +132,7 @@ The three recovery options the error names:
 2. **Use `docker-compose.test.yml`.** Spin up the compose Postgres on 5433 and
    set `DATABASE_URL` so globalSetup takes the CI passthrough branch:
    ```bash
-   docker-compose -f docker-compose.test.yml up -d
+   docker-compose -f docker-compose.test.yml up -d --wait
    DATABASE_URL=postgresql://lifting:lifting@localhost:5433/lifting_test \
      npx prisma migrate deploy --schema=apps/api/prisma/schema.prisma
    DATABASE_URL=postgresql://lifting:lifting@localhost:5433/lifting_test \


### PR DESCRIPTION
## Summary

Adds the missing `docker-compose.test.yml` at the repo root. Three pre-existing references already document this file as recovery option 2 for the DB E2E suite when Testcontainers/Docker is unreachable, but it was never actually committed:

- `apps/api/jest.global-setup.js` (`buildDockerUnavailableMessage`) — names it with port 5433, `lifting`/`lifting`, `lifting_test`.
- `docs/testing/e2e-coverage.md` ("Running locally when Docker is unavailable", option 2) — same values, plus the exact `docker-compose up -d && prisma migrate deploy && npm test` sequence.
- `docs/adr/ADR-021-no-test-tracing.md` (accepted, closes #222) — treats the file as already-existing, load-bearing design: "The test environment (`docker-compose.test.yml`) runs only Postgres — no OTel Collector, Tempo, Loki, or Prometheus."

No doc changes are needed — all three already describe the file correctly. This PR only adds the file itself, matching:

- The pinned `postgres:16-alpine` digest already used by `jest.global-setup.js`'s `POSTGRES_IMAGE` and CI's `db-integration` service.
- `lifting`/`lifting`/`lifting_test` credentials, matching CI exactly.
- Host port `5433` (not CI's 5432) so it doesn't collide with the root `docker-compose.yml`'s Postgres (also 5432) or a locally-installed default-port Postgres.
- Postgres only — no observability services — per ADR-021's explicit scope decision.

Pre-existing gap, not caused by #646/#658 — traced back to ADR-021 (2026-05-10), where the ADR recorded the file's scope decision as already-accepted fact but the file itself apparently never got committed.

## Acceptance Criteria

- [x] `docker-compose.test.yml` exists at the repo root with the values `jest.global-setup.js` and `e2e-coverage.md` already document.
- [x] Postgres-only — no OTel/Tempo/Loki/Prometheus/Grafana services, per ADR-021.
- [x] Verified end-to-end against the actual documented recovery steps (see Testing below).

## Testing

Verified the exact documented recovery procedure end-to-end, not just that the YAML parses:

1. `docker-compose -f docker-compose.test.yml config` — valid.
2. `docker-compose -f docker-compose.test.yml up -d`, waited for the healthcheck to report `healthy`.
3. `DATABASE_URL=postgresql://lifting:lifting@localhost:5433/lifting_test npx prisma migrate deploy --schema=apps/api/prisma/schema.prisma` — all 22 migrations applied cleanly.
4. `DATABASE_URL=postgresql://lifting:lifting@localhost:5433/lifting_test npm run test:db -w @lifting-logbook/api` — **Test Suites: 2 passed, 2 total. Tests: 73 passed, 73 total.**
5. `docker-compose -f docker-compose.test.yml down -v` — clean teardown.
6. Full pre-PR gate: `npx turbo run lint typecheck test` (matches CI's `db-integration`/`lint-and-test` jobs) — **Tasks: 21 successful, 21 total.** `apps/api` ran fresh (Testcontainers path, unrelated to the compose file): **Test Suites: 35 passed, 35 total. Tests: 425 passed, 425 total (76.3s).** Other workspaces (`core`, `web`, `types`, `api-client`, `mobile`) hit valid turbo cache — untouched by this change.

**Tests: 425 passed, 0 skipped, 0 failed (76.3s)** — plus the 73/73 direct DB E2E run against the new compose file itself (item 4 above).

Suppression / test-integrity / coverage-threshold pre-PR greps: all clean (single new YAML file, no code touched). No `package.json` changed, so no lockfile-sync check applies. `baseline_test_failure_tracking` is not enabled for this repo.

Closes #663


## Review findings disposition

`/review` posted: https://github.com/brownm09/lifting-logbook/pull/666#issuecomment-4878891730

- **[correctness, blocking]** `db` service name collided with the root `docker-compose.yml`'s own `db` service under Compose's shared default project-naming (both resolve to "lifting-logbook" at repo root) — fixed in `b55aaf2` by pinning an explicit top-level `name: lifting-logbook-test`.
- **[reliability, non-blocking]** Documented recovery steps didn't leverage the healthcheck, leaving a startup race before `prisma migrate deploy` — fixed in `b55aaf2` by adding `--wait` to the documented `up -d` command.

Re-verified end-to-end after both fixes: `up -d --wait` blocks until healthy, migrate deploy applies cleanly, DB E2E suite 73/73 passed.
