### PR TITLE
[fix] Send a JSON body from switchProgram to avoid Fastify empty-body rejection

### DIFF
--- a/packages/api-client/src/index.test.ts
+++ b/packages/api-client/src/index.test.ts
@@ -180,6 +180,35 @@ describe('createApiClient', () => {
     });
   });
 
+  describe('switchProgram', () => {
+    it('sends a JSON body alongside the JSON content-type header (issue #665)', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ activeProgram: 'leangains', cycleNum: 1 }), { status: 200 }),
+      );
+      const client = makeClient();
+      await client.switchProgram('leangains');
+
+      const [url, init] = lastCall();
+      expect(url).toBe('http://api.test/programs/leangains/switch');
+      expect(init.method).toBe('POST');
+      // A Content-Type: application/json header with no body is rejected outright by Fastify's
+      // JSON body parser in production — inject()-based E2E tests don't set Content-Type and so
+      // never caught this. Assert on the constructed request shape directly instead.
+      expect(init.body).toBe('{}');
+    });
+
+    it('resolves with the parsed response', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify({ activeProgram: 'leangains', cycleNum: 3 }), { status: 200 }),
+      );
+      const client = makeClient();
+      await expect(client.switchProgram('leangains')).resolves.toEqual({
+        activeProgram: 'leangains',
+        cycleNum: 3,
+      });
+    });
+  });
+
   describe('importLiftRecords', () => {
     const file = new File(['a,b\n1,2'], 'records.csv', { type: 'text/csv' });
 

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -499,6 +499,7 @@ export function createApiClient(config: ApiClientConfig) {
       return request(`/programs/${enc(programId)}/switch`, {
         method: 'POST',
         headers: JSON_HEADERS,
+        body: JSON.stringify({}),
         cache: 'no-store',
       });
     },


### PR DESCRIPTION
## Summary

Root cause of "Program still fails to start" reported live in production **after** #645, #649, #652, and #657 all shipped — a third, previously-hidden layer in the same incident chain.

`packages/api-client`'s `switchProgram()` set `Content-Type: application/json` but never sent a `body`, unlike every other no-meaningful-payload POST in the file (e.g. `createCycle` sends `body: JSON.stringify({})`). `fetch()` sends the header with nothing to parse, and Fastify's JSON body parser rejects it outright.

Confirmed live via `gcloud logging read` against `lifting-logbook-prod-api`:
```
POST /programs/leangains/switch -> 400
"Body cannot be empty when content-type is set to 'application/json'"
```

This is why onboarding's "Start My Program" (`createFirstCycle` → `switchProgram`, added in #652) still failed end-to-end: #657's RLS regression test calls this endpoint via Fastify's `inject()` directly, which never sets `Content-Type` and so never exercised the real client request shape — same "tested one path, not the real path" gap as #644 and #650, one layer further down.

## Fix

- Add `body: JSON.stringify({})` to `switchProgram`, matching the established convention.
- Add a `packages/api-client` unit test asserting the request body is actually sent (using the existing `mockFetch`/`lastCall()` harness), so a regression here fails at the client-contract layer instead of only surfacing in production logs. Verified the test fails without the fix (`Expected: "{}", Received: undefined`) and passes with it.

## Testing

```
npm test
npm run typecheck
```
Tests: 12/12 turbo tasks passed (425 api, 27 api-client [+2 new], full monorepo). Typecheck clean.

Suppression grep, test-integrity grep: both clean. No `package.json` changes.

Closes #665