### PR TITLE
[test] Add staging onboarding write-path test with self-cleaning DELETE endpoint

### DIFF
--- a/apps/api/src/adapters/in-memory/cycle-dashboard.adapter.ts
+++ b/apps/api/src/adapters/in-memory/cycle-dashboard.adapter.ts
@@ -25,4 +25,8 @@ export class InMemoryCycleDashboardRepository
   async saveCycleDashboard(dashboard: CycleDashboard): Promise<void> {
     this.dashboards.set(dashboard.program, dashboard);
   }
+
+  async deleteCycleDashboard(program: string): Promise<void> {
+    this.dashboards.delete(program);
+  }
 }

--- a/apps/api/src/adapters/in-memory/lift-record.adapter.ts
+++ b/apps/api/src/adapters/in-memory/lift-record.adapter.ts
@@ -62,4 +62,8 @@ export class InMemoryLiftRecordRepository implements ILiftRecordRepository {
     this.store.set(program, after);
     return before.length - after.length;
   }
+
+  async deleteAllLiftRecords(program: string): Promise<void> {
+    this.store.delete(program);
+  }
 }

--- a/apps/api/src/adapters/in-memory/training-max-history.adapter.ts
+++ b/apps/api/src/adapters/in-memory/training-max-history.adapter.ts
@@ -42,4 +42,8 @@ export class InMemoryTrainingMaxHistoryRepository implements ITrainingMaxHistory
     this.entriesByProgram.set(program, next);
     return updated;
   }
+
+  async deleteAllHistory(program: string): Promise<void> {
+    this.entriesByProgram.delete(program);
+  }
 }

--- a/apps/api/src/adapters/in-memory/training-max.adapter.ts
+++ b/apps/api/src/adapters/in-memory/training-max.adapter.ts
@@ -55,4 +55,8 @@ export class InMemoryTrainingMaxRepository implements ITrainingMaxRepository {
     const existing = this.maxesByProgram.get(program) ?? [];
     this.maxesByProgram.set(program, existing.filter((m) => !liftSet.has(m.lift)));
   }
+
+  async deleteAllTrainingMaxes(program: string): Promise<void> {
+    this.maxesByProgram.delete(program);
+  }
 }

--- a/apps/api/src/adapters/prisma/cycle-dashboard.repository.ts
+++ b/apps/api/src/adapters/prisma/cycle-dashboard.repository.ts
@@ -48,4 +48,10 @@ export class PrismaCycleDashboardRepository implements ICycleDashboardRepository
       },
     });
   }
+
+  async deleteCycleDashboard(program: string): Promise<void> {
+    await this.prisma.cycleDashboard.deleteMany({
+      where: { userId: this.userId, program },
+    });
+  }
 }

--- a/apps/api/src/adapters/prisma/lift-record.repository.ts
+++ b/apps/api/src/adapters/prisma/lift-record.repository.ts
@@ -121,6 +121,12 @@ export class PrismaLiftRecordRepository implements ILiftRecordRepository {
     });
     return count;
   }
+
+  async deleteAllLiftRecords(program: string): Promise<void> {
+    await this.prisma.liftRecord.deleteMany({
+      where: { userId: this.userId, program },
+    });
+  }
 }
 
 // ID format: ${program}-${cycleNum}-${workoutNum}-${lift}-${setNum}

--- a/apps/api/src/adapters/prisma/rls.db.e2e.spec.ts
+++ b/apps/api/src/adapters/prisma/rls.db.e2e.spec.ts
@@ -441,4 +441,49 @@ describeOrSkip('RLS request wiring (interceptor + factory, full app boot)', () =
     await owner.cycleDashboard.deleteMany({ where: { userId } });
     await owner.userSettings.deleteMany({ where: { userId } });
   });
+
+  // Regression coverage for #647: the new DELETE cycles/current endpoint (added to
+  // support a self-cleaning staging Playwright test) deletes through the same
+  // factory/repos path as every other request. Proves the deleteMany calls are
+  // genuinely RLS-scoped under the restricted lifting_app role — not merely
+  // filtered by an application-level WHERE clause that happens to look correct —
+  // exactly the risk class that let #644 ship silently.
+  it('deletes a cycle scoped to the requesting user only, under real RLS (regression coverage for #647)', async () => {
+    const userId = `rls-e2e-fullapp-delete-${Date.now()}`;
+    const otherUserId = `rls-e2e-fullapp-delete-other-${Date.now()}`;
+
+    const seedDashboard = (uid: string) => ({
+      userId: uid,
+      program: 'leangains',
+      cycleUnit: 'week',
+      cycleNum: 1,
+      cycleDate: new Date(),
+      sheetName: `leangains_Cycle_1_${uid}`,
+      cycleStartWeekday: 'Friday',
+      programType: 'leangains',
+    });
+    await owner.cycleDashboard.create({ data: seedDashboard(userId) });
+    await owner.cycleDashboard.create({ data: seedDashboard(otherUserId) });
+
+    const delRes = await inject({
+      method: 'DELETE',
+      url: '/programs/leangains/cycles/current',
+      headers: { authorization: `Bearer ${userId}` },
+    });
+    expect(delRes.statusCode).toBe(204);
+
+    const mineGone = await owner.cycleDashboard.findFirst({
+      where: { userId, program: 'leangains' },
+    });
+    expect(mineGone).toBeNull();
+
+    // The other user's row must survive — proves the delete was RLS-scoped to the
+    // requesting user, not a bug that deleted every row matching the program.
+    const otherSurvives = await owner.cycleDashboard.findFirst({
+      where: { userId: otherUserId, program: 'leangains' },
+    });
+    expect(otherSurvives).not.toBeNull();
+
+    await owner.cycleDashboard.deleteMany({ where: { userId: { in: [userId, otherUserId] } } });
+  });
 });

--- a/apps/api/src/adapters/prisma/rls.db.e2e.spec.ts
+++ b/apps/api/src/adapters/prisma/rls.db.e2e.spec.ts
@@ -449,41 +449,98 @@ describeOrSkip('RLS request wiring (interceptor + factory, full app boot)', () =
   // filtered by an application-level WHERE clause that happens to look correct —
   // exactly the risk class that let #644 ship silently.
   it('deletes a cycle scoped to the requesting user only, under real RLS (regression coverage for #647)', async () => {
+    // deleteCurrentCycle issues five scoped deletes (CycleDashboard, LiftRecord,
+    // TrainingMax, TrainingMaxHistory, CycleScheduledWorkout). Seeding all five
+    // for both users — not just the dashboard — matters because #644 was a
+    // per-repository DI-wiring failure, not a missing-policy failure: a future
+    // regression where one specific repository fails to route through the
+    // request-scoped RLS transaction would not be caught if this test only ever
+    // exercised an empty table for that repository.
     const userId = `rls-e2e-fullapp-delete-${Date.now()}`;
     const otherUserId = `rls-e2e-fullapp-delete-other-${Date.now()}`;
+    const PROGRAM = 'leangains';
 
-    const seedDashboard = (uid: string) => ({
-      userId: uid,
-      program: 'leangains',
-      cycleUnit: 'week',
-      cycleNum: 1,
-      cycleDate: new Date(),
-      sheetName: `leangains_Cycle_1_${uid}`,
-      cycleStartWeekday: 'Friday',
-      programType: 'leangains',
-    });
-    await owner.cycleDashboard.create({ data: seedDashboard(userId) });
-    await owner.cycleDashboard.create({ data: seedDashboard(otherUserId) });
+    const seedAllTables = async (uid: string) => {
+      await owner.cycleDashboard.create({
+        data: {
+          userId: uid,
+          program: PROGRAM,
+          cycleUnit: 'week',
+          cycleNum: 1,
+          cycleDate: new Date(),
+          sheetName: `leangains_Cycle_1_${uid}`,
+          cycleStartWeekday: 'Friday',
+          programType: PROGRAM,
+        },
+      });
+      await owner.liftRecord.create({
+        data: {
+          userId: uid,
+          program: PROGRAM,
+          cycleNum: 1,
+          workoutNum: 1,
+          date: new Date(),
+          lift: 'Squat',
+          setNum: 1,
+          weight: 135,
+          reps: 5,
+        },
+      });
+      await owner.trainingMax.create({
+        data: { userId: uid, program: PROGRAM, lift: 'Squat', weight: 225, dateUpdated: new Date() },
+      });
+      await owner.trainingMaxHistory.create({
+        data: {
+          userId: uid,
+          program: PROGRAM,
+          lift: 'Squat',
+          weight: 225,
+          reps: 1,
+          date: new Date(),
+          isPR: false,
+          source: 'program',
+          goalMet: false,
+        },
+      });
+      await owner.cycleScheduledWorkout.create({
+        data: { userId: uid, program: PROGRAM, cycleNum: 1, workoutNum: 1, weekNum: 1, scheduledDate: new Date() },
+      });
+    };
+    await seedAllTables(userId);
+    await seedAllTables(otherUserId);
 
     const delRes = await inject({
       method: 'DELETE',
-      url: '/programs/leangains/cycles/current',
+      url: `/programs/${PROGRAM}/cycles/current`,
       headers: { authorization: `Bearer ${userId}` },
     });
     expect(delRes.statusCode).toBe(204);
 
-    const mineGone = await owner.cycleDashboard.findFirst({
-      where: { userId, program: 'leangains' },
-    });
-    expect(mineGone).toBeNull();
+    const findAllFor = (uid: string) =>
+      Promise.all([
+        owner.cycleDashboard.findFirst({ where: { userId: uid, program: PROGRAM } }),
+        owner.liftRecord.findFirst({ where: { userId: uid, program: PROGRAM } }),
+        owner.trainingMax.findFirst({ where: { userId: uid, program: PROGRAM } }),
+        owner.trainingMaxHistory.findFirst({ where: { userId: uid, program: PROGRAM } }),
+        owner.cycleScheduledWorkout.findFirst({ where: { userId: uid, program: PROGRAM } }),
+      ]);
 
-    // The other user's row must survive — proves the delete was RLS-scoped to the
-    // requesting user, not a bug that deleted every row matching the program.
-    const otherSurvives = await owner.cycleDashboard.findFirst({
-      where: { userId: otherUserId, program: 'leangains' },
-    });
-    expect(otherSurvives).not.toBeNull();
+    // The requesting user's rows are gone from every affected table...
+    const mine = await findAllFor(userId);
+    expect(mine).toEqual([null, null, null, null, null]);
 
-    await owner.cycleDashboard.deleteMany({ where: { userId: { in: [userId, otherUserId] } } });
+    // ...but the other user's rows in every table survive — proves each of the
+    // five deletes was RLS-scoped to the requesting user, not a bug that deleted
+    // every row matching the program regardless of owner.
+    const others = await findAllFor(otherUserId);
+    for (const row of others) expect(row).not.toBeNull();
+
+    await Promise.all([
+      owner.cycleDashboard.deleteMany({ where: { userId: { in: [userId, otherUserId] } } }),
+      owner.liftRecord.deleteMany({ where: { userId: { in: [userId, otherUserId] } } }),
+      owner.trainingMax.deleteMany({ where: { userId: { in: [userId, otherUserId] } } }),
+      owner.trainingMaxHistory.deleteMany({ where: { userId: { in: [userId, otherUserId] } } }),
+      owner.cycleScheduledWorkout.deleteMany({ where: { userId: { in: [userId, otherUserId] } } }),
+    ]);
   });
 });

--- a/apps/api/src/adapters/prisma/training-max-history.repository.ts
+++ b/apps/api/src/adapters/prisma/training-max-history.repository.ts
@@ -84,4 +84,10 @@ export class PrismaTrainingMaxHistoryRepository implements ITrainingMaxHistoryRe
       throw e;
     }
   }
+
+  async deleteAllHistory(program: string): Promise<void> {
+    await this.prisma.trainingMaxHistory.deleteMany({
+      where: { userId: this.userId, program },
+    });
+  }
 }

--- a/apps/api/src/adapters/prisma/training-max.repository.ts
+++ b/apps/api/src/adapters/prisma/training-max.repository.ts
@@ -95,4 +95,10 @@ export class PrismaTrainingMaxRepository implements ITrainingMaxRepository {
       where: { userId: this.userId, program, lift: { in: lifts } },
     });
   }
+
+  async deleteAllTrainingMaxes(program: string): Promise<void> {
+    await this.prisma.trainingMax.deleteMany({
+      where: { userId: this.userId, program },
+    });
+  }
 }

--- a/apps/api/src/ports/ICycleDashboardRepository.ts
+++ b/apps/api/src/ports/ICycleDashboardRepository.ts
@@ -4,4 +4,7 @@ export interface ICycleDashboardRepository {
   getCycleDashboard(program: string): Promise<CycleDashboard>;
 
   saveCycleDashboard(dashboard: CycleDashboard): Promise<void>;
+
+  /** Deletes the cycle dashboard row for a program. No-op if none exists. */
+  deleteCycleDashboard(program: string): Promise<void>;
 }

--- a/apps/api/src/ports/ILiftRecordRepository.ts
+++ b/apps/api/src/ports/ILiftRecordRepository.ts
@@ -28,4 +28,7 @@ export interface ILiftRecordRepository {
    * Returns the number of rows deleted.
    */
   deleteLiftRecordsByNaturalKeys(program: string, naturalKeys: string[]): Promise<number>;
+
+  /** Deletes every lift record for a program, across all cycles. No-op if none exist. */
+  deleteAllLiftRecords(program: string): Promise<void>;
 }

--- a/apps/api/src/ports/ITrainingMaxHistoryRepository.ts
+++ b/apps/api/src/ports/ITrainingMaxHistoryRepository.ts
@@ -14,4 +14,7 @@ export interface ITrainingMaxHistoryRepository {
     id: string,
     update: { isPR?: boolean; goalMet?: boolean },
   ): Promise<TrainingMaxHistoryEntry>;
+
+  /** Deletes every training-max-history entry for a program. No-op if none exist. */
+  deleteAllHistory(program: string): Promise<void>;
 }

--- a/apps/api/src/ports/ITrainingMaxRepository.ts
+++ b/apps/api/src/ports/ITrainingMaxRepository.ts
@@ -29,4 +29,7 @@ export interface ITrainingMaxRepository {
 
   /** Deletes training maxes by lift name for undo support. */
   deleteTrainingMaxes(program: string, lifts: string[]): Promise<void>;
+
+  /** Deletes every training max for a program, regardless of lift. No-op if none exist. */
+  deleteAllTrainingMaxes(program: string): Promise<void>;
 }

--- a/apps/api/src/ports/ports.compile-test.ts
+++ b/apps/api/src/ports/ports.compile-test.ts
@@ -105,6 +105,8 @@ const _trainingMaxRepo: ITrainingMaxRepository = {
     Promise.resolve({ created: 0, updated: 0, skipped: 0 }),
   deleteTrainingMaxes: (): Promise<void> =>
     Promise.resolve(),
+  deleteAllTrainingMaxes: (): Promise<void> =>
+    Promise.resolve(),
 };
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/ports/ports.compile-test.ts
+++ b/apps/api/src/ports/ports.compile-test.ts
@@ -45,6 +45,8 @@ const _cycleDashboardRepo: ICycleDashboardRepository = {
     Promise.resolve({} as CycleDashboard),
   saveCycleDashboard: (): Promise<void> =>
     Promise.resolve(),
+  deleteCycleDashboard: (): Promise<void> =>
+    Promise.resolve(),
 };
 
 // ---------------------------------------------------------------------------
@@ -75,6 +77,8 @@ const _liftRecordRepo: ILiftRecordRepository = {
     Promise.resolve(null),
   deleteLiftRecordsByNaturalKeys: (): Promise<number> =>
     Promise.resolve(0),
+  deleteAllLiftRecords: (): Promise<void> =>
+    Promise.resolve(),
 };
 
 // ---------------------------------------------------------------------------
@@ -112,6 +116,7 @@ const _trainingMaxHistoryRepo: ITrainingMaxHistoryRepository = {
   appendHistoryEntries: (): Promise<void> => Promise.resolve(),
   updateHistoryEntry: (): Promise<TrainingMaxHistoryEntry> =>
     Promise.resolve({ id: '', lift: '', weight: 0, reps: 1, date: new Date(), isPR: false, source: 'program', goalMet: false }),
+  deleteAllHistory: (): Promise<void> => Promise.resolve(),
 };
 
 // IWorkoutRepository

--- a/apps/api/src/programs/cycle-dashboard.controller.spec.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.spec.ts
@@ -9,6 +9,7 @@ import { IWorkoutSkipOverrideRepository } from '../ports/IWorkoutSkipOverrideRep
 import { IRepositoryFactory } from '../ports/factory';
 import { REPOSITORY_FACTORY } from '../ports/tokens';
 import { CycleDashboardController } from './cycle-dashboard.controller';
+import { CycleGenerationService } from './cycle-generation.service';
 
 const MOCK_USER = { id: 'test-user', email: 'test@example.com', provider: 'dev' };
 
@@ -51,11 +52,13 @@ describe('CycleDashboardController', () => {
   let overrideRepo: jest.Mocked<IWorkoutDateOverrideRepository>;
   let skipRepo: jest.Mocked<IWorkoutSkipOverrideRepository>;
   let factory: jest.Mocked<IRepositoryFactory>;
+  let cycleGenerationService: jest.Mocked<Pick<CycleGenerationService, 'deleteCurrentCycle'>>;
 
   beforeEach(async () => {
     repo = {
       getCycleDashboard: jest.fn(),
       saveCycleDashboard: jest.fn(),
+      deleteCycleDashboard: jest.fn(),
     };
     specRepo = { getProgramSpec: jest.fn(), saveProgramSpec: jest.fn(), deleteSpecRows: jest.fn() };
     scheduledRepo = {
@@ -89,10 +92,14 @@ describe('CycleDashboardController', () => {
         workoutSkipOverride: skipRepo,
       }),
     };
+    cycleGenerationService = { deleteCurrentCycle: jest.fn().mockResolvedValue(undefined) };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CycleDashboardController],
-      providers: [{ provide: REPOSITORY_FACTORY, useValue: factory }],
+      providers: [
+        { provide: REPOSITORY_FACTORY, useValue: factory },
+        { provide: CycleGenerationService, useValue: cycleGenerationService },
+      ],
     }).compile();
     controller = module.get(CycleDashboardController);
   });
@@ -201,5 +208,15 @@ describe('CycleDashboardController', () => {
     const result = await controller.getCurrentCycle('5-3-1', MOCK_USER);
 
     expect(result.weeks[0]?.completed).toBe(false);
+  });
+
+  it('DELETE /programs/:program/cycles/current calls service.deleteCurrentCycle with repos and program', async () => {
+    await controller.deleteCurrentCycle('5-3-1', MOCK_USER);
+
+    expect(factory.forUser).toHaveBeenCalledWith(MOCK_USER);
+    expect(cycleGenerationService.deleteCurrentCycle).toHaveBeenCalledWith(
+      expect.objectContaining({ cycleDashboard: repo }),
+      '5-3-1',
+    );
   });
 });

--- a/apps/api/src/programs/cycle-dashboard.controller.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Inject, Param } from '@nestjs/common';
+import { Controller, Delete, Get, HttpCode, HttpStatus, Inject, Param } from '@nestjs/common';
 import { CycleDashboardResponse } from '@lifting-logbook/types';
 import { weekTypeForDate } from '@lifting-logbook/core';
 import { CurrentUser } from '../auth/current-user.decorator';
@@ -6,11 +6,13 @@ import { AuthUser } from '../ports/auth';
 import { IRepositoryFactory } from '../ports/factory';
 import { REPOSITORY_FACTORY } from '../ports/tokens';
 import { buildCycleDashboardResponse } from './mappers';
+import { CycleGenerationService } from './cycle-generation.service';
 
 @Controller('programs/:program')
 export class CycleDashboardController {
   constructor(
     @Inject(REPOSITORY_FACTORY) private readonly factory: IRepositoryFactory,
+    private readonly cycleGenerationService: CycleGenerationService,
   ) {}
 
   @Get('cycles/current')
@@ -36,5 +38,15 @@ export class CycleDashboardController {
     const completedWorkoutNums = new Set(liftRecords.map((r) => r.workoutNum));
 
     return buildCycleDashboardResponse(dashboard, currentWeekType, scheduledWorkouts, overrideMap, completedWorkoutNums, skippedNums);
+  }
+
+  @Delete('cycles/current')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteCurrentCycle(
+    @Param('program') program: string,
+    @CurrentUser() user: AuthUser,
+  ): Promise<void> {
+    const repos = await this.factory.forUser(user);
+    await this.cycleGenerationService.deleteCurrentCycle(repos, program);
   }
 }

--- a/apps/api/src/programs/cycle-generation.service.spec.ts
+++ b/apps/api/src/programs/cycle-generation.service.spec.ts
@@ -96,6 +96,7 @@ describe('CycleGenerationService', () => {
       saveTrainingMaxes: jest.fn().mockResolvedValue(undefined),
       importTrainingMaxes: jest.fn(),
       deleteTrainingMaxes: jest.fn().mockResolvedValue(undefined),
+      deleteAllTrainingMaxes: jest.fn().mockResolvedValue(undefined),
     };
     trainingMaxHistoryRepo = {
       getHistory: jest.fn().mockResolvedValue([]),
@@ -356,28 +357,30 @@ describe('CycleGenerationService', () => {
   describe('deleteCurrentCycle', () => {
     it('deletes lift records, training maxes, history, scheduled workouts, and the dashboard', async () => {
       cycleDashboardRepo.getCycleDashboard.mockResolvedValue(stubDashboard());
-      trainingMaxRepo.getTrainingMaxes.mockResolvedValue(stubTrainingMaxes());
 
       await service.deleteCurrentCycle(repos, PROGRAM);
 
       expect(liftRecordRepo.deleteAllLiftRecords).toHaveBeenCalledWith(PROGRAM);
       expect(trainingMaxHistoryRepo.deleteAllHistory).toHaveBeenCalledWith(PROGRAM);
-      expect(trainingMaxRepo.deleteTrainingMaxes).toHaveBeenCalledWith(PROGRAM, ['Squat']);
+      expect(trainingMaxRepo.deleteAllTrainingMaxes).toHaveBeenCalledWith(PROGRAM);
       expect(cycleScheduledWorkoutRepo.saveScheduledWorkouts).toHaveBeenCalledWith(PROGRAM, 1, []);
       expect(cycleDashboardRepo.deleteCycleDashboard).toHaveBeenCalledWith(PROGRAM);
     });
 
-    it('deletes the dashboard after the other deletes complete (ordering)', async () => {
+    it('deletes sequentially, in a fixed order, ending with the dashboard', async () => {
+      // The five deletes share one request-scoped Prisma transaction client, which
+      // serializes queries on a single connection — asserting a real, deterministic
+      // order here (rather than Promise.all's unordered settling) is itself the
+      // regression guard for that constraint.
       const order: string[] = [];
       cycleDashboardRepo.getCycleDashboard.mockResolvedValue(stubDashboard());
-      trainingMaxRepo.getTrainingMaxes.mockResolvedValue(stubTrainingMaxes());
       liftRecordRepo.deleteAllLiftRecords.mockImplementation(async () => {
         order.push('liftRecord');
       });
       trainingMaxHistoryRepo.deleteAllHistory.mockImplementation(async () => {
         order.push('trainingMaxHistory');
       });
-      trainingMaxRepo.deleteTrainingMaxes.mockImplementation(async () => {
+      trainingMaxRepo.deleteAllTrainingMaxes.mockImplementation(async () => {
         order.push('trainingMax');
       });
       cycleScheduledWorkoutRepo.saveScheduledWorkouts.mockImplementation(async () => {
@@ -389,8 +392,13 @@ describe('CycleGenerationService', () => {
 
       await service.deleteCurrentCycle(repos, PROGRAM);
 
-      expect(order[order.length - 1]).toBe('cycleDashboard');
-      expect(order).toHaveLength(5);
+      expect(order).toEqual([
+        'liftRecord',
+        'trainingMaxHistory',
+        'trainingMax',
+        'cycleScheduledWorkout',
+        'cycleDashboard',
+      ]);
     });
 
     it('propagates ProgramNotFoundError when no cycle exists (404 path)', async () => {
@@ -403,12 +411,10 @@ describe('CycleGenerationService', () => {
 
     it('scopes the scheduled-workout clear to the dashboard current cycleNum', async () => {
       cycleDashboardRepo.getCycleDashboard.mockResolvedValue({ ...stubDashboard(), cycleNum: 3 });
-      trainingMaxRepo.getTrainingMaxes.mockResolvedValue([]);
 
       await service.deleteCurrentCycle(repos, PROGRAM);
 
       expect(cycleScheduledWorkoutRepo.saveScheduledWorkouts).toHaveBeenCalledWith(PROGRAM, 3, []);
-      expect(trainingMaxRepo.deleteTrainingMaxes).toHaveBeenCalledWith(PROGRAM, []);
     });
   });
 

--- a/apps/api/src/programs/cycle-generation.service.spec.ts
+++ b/apps/api/src/programs/cycle-generation.service.spec.ts
@@ -84,6 +84,7 @@ describe('CycleGenerationService', () => {
     cycleDashboardRepo = {
       getCycleDashboard: jest.fn(),
       saveCycleDashboard: jest.fn().mockResolvedValue(undefined),
+      deleteCycleDashboard: jest.fn().mockResolvedValue(undefined),
     };
     programSpecRepo = {
       getProgramSpec: jest.fn().mockResolvedValue(stubProgramSpec()),
@@ -94,12 +95,13 @@ describe('CycleGenerationService', () => {
       getTrainingMaxes: jest.fn(),
       saveTrainingMaxes: jest.fn().mockResolvedValue(undefined),
       importTrainingMaxes: jest.fn(),
-      deleteTrainingMaxes: jest.fn(),
+      deleteTrainingMaxes: jest.fn().mockResolvedValue(undefined),
     };
     trainingMaxHistoryRepo = {
       getHistory: jest.fn().mockResolvedValue([]),
       appendHistoryEntries: jest.fn().mockResolvedValue(undefined),
       updateHistoryEntry: jest.fn(),
+      deleteAllHistory: jest.fn().mockResolvedValue(undefined),
     };
     liftRecordRepo = {
       getLiftRecords: jest.fn(),
@@ -107,6 +109,7 @@ describe('CycleGenerationService', () => {
       findExistingRecords: jest.fn(),
       updateLiftRecord: jest.fn(),
       deleteLiftRecordsByNaturalKeys: jest.fn(),
+      deleteAllLiftRecords: jest.fn().mockResolvedValue(undefined),
     };
     userSettingsRepo = {
       getSettings: jest
@@ -347,6 +350,65 @@ describe('CycleGenerationService', () => {
       ).resolves.not.toThrow();
 
       expect(cycleScheduledWorkoutRepo.saveScheduledWorkouts).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteCurrentCycle', () => {
+    it('deletes lift records, training maxes, history, scheduled workouts, and the dashboard', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockResolvedValue(stubDashboard());
+      trainingMaxRepo.getTrainingMaxes.mockResolvedValue(stubTrainingMaxes());
+
+      await service.deleteCurrentCycle(repos, PROGRAM);
+
+      expect(liftRecordRepo.deleteAllLiftRecords).toHaveBeenCalledWith(PROGRAM);
+      expect(trainingMaxHistoryRepo.deleteAllHistory).toHaveBeenCalledWith(PROGRAM);
+      expect(trainingMaxRepo.deleteTrainingMaxes).toHaveBeenCalledWith(PROGRAM, ['Squat']);
+      expect(cycleScheduledWorkoutRepo.saveScheduledWorkouts).toHaveBeenCalledWith(PROGRAM, 1, []);
+      expect(cycleDashboardRepo.deleteCycleDashboard).toHaveBeenCalledWith(PROGRAM);
+    });
+
+    it('deletes the dashboard after the other deletes complete (ordering)', async () => {
+      const order: string[] = [];
+      cycleDashboardRepo.getCycleDashboard.mockResolvedValue(stubDashboard());
+      trainingMaxRepo.getTrainingMaxes.mockResolvedValue(stubTrainingMaxes());
+      liftRecordRepo.deleteAllLiftRecords.mockImplementation(async () => {
+        order.push('liftRecord');
+      });
+      trainingMaxHistoryRepo.deleteAllHistory.mockImplementation(async () => {
+        order.push('trainingMaxHistory');
+      });
+      trainingMaxRepo.deleteTrainingMaxes.mockImplementation(async () => {
+        order.push('trainingMax');
+      });
+      cycleScheduledWorkoutRepo.saveScheduledWorkouts.mockImplementation(async () => {
+        order.push('cycleScheduledWorkout');
+      });
+      cycleDashboardRepo.deleteCycleDashboard.mockImplementation(async () => {
+        order.push('cycleDashboard');
+      });
+
+      await service.deleteCurrentCycle(repos, PROGRAM);
+
+      expect(order[order.length - 1]).toBe('cycleDashboard');
+      expect(order).toHaveLength(5);
+    });
+
+    it('propagates ProgramNotFoundError when no cycle exists (404 path)', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockRejectedValue(new ProgramNotFoundError(PROGRAM));
+
+      await expect(service.deleteCurrentCycle(repos, PROGRAM)).rejects.toThrow(ProgramNotFoundError);
+      expect(cycleDashboardRepo.deleteCycleDashboard).not.toHaveBeenCalled();
+      expect(liftRecordRepo.deleteAllLiftRecords).not.toHaveBeenCalled();
+    });
+
+    it('scopes the scheduled-workout clear to the dashboard current cycleNum', async () => {
+      cycleDashboardRepo.getCycleDashboard.mockResolvedValue({ ...stubDashboard(), cycleNum: 3 });
+      trainingMaxRepo.getTrainingMaxes.mockResolvedValue([]);
+
+      await service.deleteCurrentCycle(repos, PROGRAM);
+
+      expect(cycleScheduledWorkoutRepo.saveScheduledWorkouts).toHaveBeenCalledWith(PROGRAM, 3, []);
+      expect(trainingMaxRepo.deleteTrainingMaxes).toHaveBeenCalledWith(PROGRAM, []);
     });
   });
 

--- a/apps/api/src/programs/cycle-generation.service.ts
+++ b/apps/api/src/programs/cycle-generation.service.ts
@@ -238,6 +238,42 @@ export class CycleGenerationService {
     return { dashboard, programSpec };
   }
 
+  /**
+   * Deletes the current cycle for a program and every row scoped to it: the
+   * CycleDashboard, all LiftRecord rows across every cycle number, all TrainingMax
+   * rows, all TrainingMaxHistory entries, and any CycleScheduledWorkout rows for the
+   * deleted cycle. Deliberately leaves UserSettings.activeProgram untouched — that
+   * field is independent of cycle existence and is used by switchProgram's routing.
+   *
+   * getCycleDashboard(program) is called first for two reasons: it supplies the
+   * cycleNum needed to scope the CycleScheduledWorkout clear, and it throws
+   * ProgramNotFoundError (-> 404) when nothing exists, giving a free "nothing to
+   * delete" response with no new error-handling code — mirrors the guard
+   * initializeFirstCycle uses to detect "no cycle yet".
+   */
+  async deleteCurrentCycle(
+    repos: Pick<
+      CycleRepos,
+      'cycleDashboard' | 'cycleScheduledWorkout' | 'liftRecord' | 'trainingMax' | 'trainingMaxHistory'
+    >,
+    program: string,
+  ): Promise<void> {
+    const dashboard = await repos.cycleDashboard.getCycleDashboard(program);
+    const trainingMaxes = await repos.trainingMax.getTrainingMaxes(program);
+
+    await Promise.all([
+      repos.liftRecord.deleteAllLiftRecords(program),
+      repos.trainingMaxHistory.deleteAllHistory(program),
+      repos.trainingMax.deleteTrainingMaxes(program, trainingMaxes.map((m) => m.lift)),
+      repos.cycleScheduledWorkout.saveScheduledWorkouts(program, dashboard.cycleNum, []),
+    ]);
+
+    // Delete the dashboard last — while it's present, a concurrent GET still
+    // resolves a (possibly slightly stale) cycle rather than racing into a 404
+    // mid-cleanup.
+    await repos.cycleDashboard.deleteCycleDashboard(program);
+  }
+
   async recalculateMaxes(
     repos: CycleRepos,
     program: string,

--- a/apps/api/src/programs/cycle-generation.service.ts
+++ b/apps/api/src/programs/cycle-generation.service.ts
@@ -250,6 +250,15 @@ export class CycleGenerationService {
    * ProgramNotFoundError (-> 404) when nothing exists, giving a free "nothing to
    * delete" response with no new error-handling code — mirrors the guard
    * initializeFirstCycle uses to detect "no cycle yet".
+   *
+   * The five deletes run sequentially, not concurrently: repos.forUser() binds
+   * them all to the single interactive-transaction Prisma client RlsInterceptor
+   * holds for this request, which serializes queries on one connection — a
+   * Promise.all here would not parallelize anything and can throw a "queries
+   * cannot run concurrently" error against the real Prisma adapter (the in-memory
+   * adapter has no such constraint, so this would pass there and fail in
+   * production). Atomicity across all five is already guaranteed by that same
+   * request transaction, independent of the order below.
    */
   async deleteCurrentCycle(
     repos: Pick<
@@ -259,18 +268,11 @@ export class CycleGenerationService {
     program: string,
   ): Promise<void> {
     const dashboard = await repos.cycleDashboard.getCycleDashboard(program);
-    const trainingMaxes = await repos.trainingMax.getTrainingMaxes(program);
 
-    await Promise.all([
-      repos.liftRecord.deleteAllLiftRecords(program),
-      repos.trainingMaxHistory.deleteAllHistory(program),
-      repos.trainingMax.deleteTrainingMaxes(program, trainingMaxes.map((m) => m.lift)),
-      repos.cycleScheduledWorkout.saveScheduledWorkouts(program, dashboard.cycleNum, []),
-    ]);
-
-    // Delete the dashboard last — while it's present, a concurrent GET still
-    // resolves a (possibly slightly stale) cycle rather than racing into a 404
-    // mid-cleanup.
+    await repos.liftRecord.deleteAllLiftRecords(program);
+    await repos.trainingMaxHistory.deleteAllHistory(program);
+    await repos.trainingMax.deleteAllTrainingMaxes(program);
+    await repos.cycleScheduledWorkout.saveScheduledWorkouts(program, dashboard.cycleNum, []);
     await repos.cycleDashboard.deleteCycleDashboard(program);
   }
 

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -1234,4 +1234,104 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
       expect(finalDash.json().weeks[0].completed).toBe(true);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // DELETE cycles/current (issue #647) — a program not touched by SEED_PROGRAM's
+  // order-sensitive write-operations chain, with fresh per-test user tokens, so
+  // this block cannot interfere with (or depend on) state left by earlier blocks.
+  // ---------------------------------------------------------------------------
+
+  describe('DELETE /programs/:program/cycles/current', () => {
+    const FRESH_PROGRAM = 'leangains';
+    const injectRaw = () =>
+      app.getHttpAdapter().getInstance().inject.bind(app.getHttpAdapter().getInstance());
+
+    it('DELETE then re-initialize succeeds (full lifecycle)', async () => {
+      const AS_FRESH = { authorization: 'Bearer user-cycle-delete-fresh' };
+      const inject = injectRaw();
+
+      const initRes = await inject({
+        method: 'POST',
+        url: `/programs/${FRESH_PROGRAM}/cycles/initialize`,
+        headers: { 'content-type': 'application/json', ...AS_FRESH },
+        payload: '{}',
+      });
+      expect(initRes.statusCode).toBe(201);
+
+      const delRes = await inject({
+        method: 'DELETE',
+        url: `/programs/${FRESH_PROGRAM}/cycles/current`,
+        headers: AS_FRESH,
+      });
+      expect(delRes.statusCode).toBe(204);
+
+      const getRes = await inject({
+        method: 'GET',
+        url: `/programs/${FRESH_PROGRAM}/cycles/current`,
+        headers: AS_FRESH,
+      });
+      expect(getRes.statusCode).toBe(404);
+
+      // Re-initialize succeeds again — would 409 (ConflictException) if the
+      // delete had silently failed to remove the dashboard row.
+      const reInitRes = await inject({
+        method: 'POST',
+        url: `/programs/${FRESH_PROGRAM}/cycles/initialize`,
+        headers: { 'content-type': 'application/json', ...AS_FRESH },
+        payload: '{}',
+      });
+      expect(reInitRes.statusCode).toBe(201);
+    });
+
+    it('DELETE with no existing cycle returns 404', async () => {
+      const AS_NEW = { authorization: 'Bearer user-cycle-delete-none' };
+      const res = await injectRaw()({
+        method: 'DELETE',
+        url: `/programs/${FRESH_PROGRAM}/cycles/current`,
+        headers: AS_NEW,
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('isolates cycle deletion between users', async () => {
+      const AS_ALICE = { authorization: 'Bearer user-cycle-delete-alice' };
+      const AS_BOB = { authorization: 'Bearer user-cycle-delete-bob' };
+      const inject = injectRaw();
+
+      await inject({
+        method: 'POST',
+        url: `/programs/${FRESH_PROGRAM}/cycles/initialize`,
+        headers: { 'content-type': 'application/json', ...AS_ALICE },
+        payload: '{}',
+      });
+      await inject({
+        method: 'POST',
+        url: `/programs/${FRESH_PROGRAM}/cycles/initialize`,
+        headers: { 'content-type': 'application/json', ...AS_BOB },
+        payload: '{}',
+      });
+
+      const delRes = await inject({
+        method: 'DELETE',
+        url: `/programs/${FRESH_PROGRAM}/cycles/current`,
+        headers: AS_ALICE,
+      });
+      expect(delRes.statusCode).toBe(204);
+
+      const aliceGet = await inject({
+        method: 'GET',
+        url: `/programs/${FRESH_PROGRAM}/cycles/current`,
+        headers: AS_ALICE,
+      });
+      expect(aliceGet.statusCode).toBe(404);
+
+      const bobGet = await inject({
+        method: 'GET',
+        url: `/programs/${FRESH_PROGRAM}/cycles/current`,
+        headers: AS_BOB,
+      });
+      expect(bobGet.statusCode).toBe(200);
+      expect(bobGet.json().cycleNum).toBe(1);
+    });
+  });
 });

--- a/apps/web/app/api/test-support/reset-cycle/route.ts
+++ b/apps/web/app/api/test-support/reset-cycle/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { deleteCurrentCycle } from '@/lib/api';
+
+// Test-support endpoint for the staging Playwright suite (issue #647). Deletes the
+// requesting user's current cycle (and its dependent rows) so the onboarding write-
+// path test can run repeatedly against the same account without hitting the
+// "cycle already exists" short-circuit in switchProgram
+// (apps/api/src/programs/switch-program.controller.ts).
+//
+// Uses the SAME auth mechanism as the real "Start My Program" flow (lib/api.ts's
+// X-Clerk-Authorization strategy) rather than a special-cased path — see
+// docs/adr/ADR-023-staging-integration-test-design.md's "Alternatives Considered"
+// for why the two more "obvious" shortcuts (server getToken()+forward, client
+// getToken()+direct-fetch) are both already known to be flaky against this
+// specific staging Clerk instance; this route intentionally does not reinvent
+// either.
+//
+// Not linked from any UI; not documented as a public API.
+export async function DELETE(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const program = searchParams.get('program') ?? 'rpt';
+
+  try {
+    await deleteCurrentCycle(program);
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    console.error(`[reset-cycle] failed for program "${program}":`, e);
+    return NextResponse.json({ ok: false, error: String(e) }, { status: 500 });
+  }
+}

--- a/apps/web/app/api/test-support/reset-cycle/route.ts
+++ b/apps/web/app/api/test-support/reset-cycle/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { ApiClientError } from '@lifting-logbook/api-client';
 import { deleteCurrentCycle } from '@/lib/api';
 
 // Test-support endpoint for the staging Playwright suite (issue #647). Deletes the
@@ -15,16 +16,37 @@ import { deleteCurrentCycle } from '@/lib/api';
 // specific staging Clerk instance; this route intentionally does not reinvent
 // either.
 //
-// Not linked from any UI; not documented as a public API.
+// Not linked from any UI; not documented as a public API. It is still a real,
+// destructive, auth-gated-but-not-environment-gated endpoint, so it is
+// deliberately inert wherever CLERK_PUBLISHABLE_KEY is a live (pk_live_) key —
+// per docs/deploy.md, staging uses pk_test_ and production uses pk_live_, and
+// apps/web is built once and promoted to both (ADR-028), so this runtime check
+// is the only way to keep the route staging-only without a new deploy-time env
+// var. "Not linked from any UI" alone is not a control; this is.
 export async function DELETE(request: Request) {
+  if (process.env.CLERK_PUBLISHABLE_KEY?.startsWith('pk_live_')) {
+    return NextResponse.json({ ok: false, error: 'Not found' }, { status: 404 });
+  }
+
   const { searchParams } = new URL(request.url);
-  const program = searchParams.get('program') ?? 'rpt';
+  const program = searchParams.get('program');
+  // Fail fast on misuse rather than silently defaulting to a program the caller
+  // may not have meant — the one caller (staging.spec.ts) always passes this
+  // explicitly, so a missing param means the route was called wrong.
+  if (!program) {
+    return NextResponse.json({ ok: false, error: 'Missing required "program" query param' }, { status: 400 });
+  }
 
   try {
     await deleteCurrentCycle(program);
     return NextResponse.json({ ok: true });
   } catch (e) {
     console.error(`[reset-cycle] failed for program "${program}":`, e);
-    return NextResponse.json({ ok: false, error: String(e) }, { status: 500 });
+    // Relay the upstream status (e.g. 401/403 from an expired/invalid Clerk
+    // session) rather than flattening every failure to 500 — the caller (the
+    // Playwright test's cleanup hooks) and anyone debugging a red staging run
+    // both need to tell "auth is broken" apart from "the delete itself failed".
+    const status = e instanceof ApiClientError ? e.status : 500;
+    return NextResponse.json({ ok: false, error: String(e) }, { status });
   }
 }

--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -59,6 +59,11 @@ To create the test account:
 The test account requires no pre-existing app data. All tests are written to pass on a
 freshly created account with zero lift records, no active program, and no training maxes.
 
+Note: the onboarding write-path test (see "What the tests cover" below) creates and then
+deletes a cycle for this account on every run, via a test-support cleanup route. If a CI run
+is interrupted mid-test (e.g. a hard timeout kill), the account may be left with a stray
+cycle for the `rpt` program; the next run's pre-test cleanup step removes it automatically.
+
 ## Authentication strategy
 
 The global setup uses the [Clerk Backend SDK sign-in token](https://clerk.com/docs/reference/backend-api/tag/Sign-in-Tokens)
@@ -85,10 +90,13 @@ The tests verify that the deployed stack is correctly wired:
 | History page tabs render | Auth-gated page renders structure (data may be empty) |
 | Cycle resolves to dashboard or onboarding | Server-side redirect logic works |
 | **Auth propagation** | `GET /api/health` (Next.js route handler) checks two things: (1) `auth().userId` non-null (Clerk session valid server-side), (2) `GET ${API_URL}/health` returns 200 (API reachable) |
+| **Onboarding write path** | Full onboarding flow (sign in → choose program → confirm maxes → Start My Program) actually writes a new cycle and the dashboard renders. Self-cleaning via `/api/test-support/reset-cycle` before and after — closes the gap where #644 (RLS silently disabled) could ship undetected because every other test here is read-only. |
 
 The auth propagation test is the only one that explicitly verifies the API is reachable and
 that the Clerk token is valid. Tests 1–4 assert page structure; because the server components
 handle API errors gracefully (redirect or render empty), they pass even if the API is down.
+The onboarding write-path test is the only one that performs a real write — see [ADR-023](../../../docs/adr/ADR-023-staging-integration-test-design.md)'s
+amended "Test scope" consequence for why this one deliberate exception exists.
 
 ## Playwright config
 

--- a/apps/web/e2e/staging.spec.ts
+++ b/apps/web/e2e/staging.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 
 // Staging integration tests — run against the live Cloud Run staging environment.
 // Auth state is provided by staging.setup.ts (signs in once, saves session).
@@ -7,6 +7,8 @@ import { test, expect } from '@playwright/test';
 // - No mock API, no __reset endpoint
 // - Assertions check structure/presence only — not hardcoded seed data values
 // - Write-path tests must be idempotent or self-cleaning
+//   (see test 6 for the first concrete example: onboarding write-path, self-
+//   cleaned via /api/test-support/reset-cycle before and after)
 
 // ---------------------------------------------------------------------------
 // 1. Home page redirects signed-in users to the authenticated landing page
@@ -123,4 +125,77 @@ test('authenticated API call succeeds (auth propagation)', async ({ page }) => {
       '503=Clerk valid but API call failed — check API_URL, IAM (web_invoker_on_api), or Cloud Run logs. ' +
       'Check that the staging API is deployed and Clerk is configured correctly.',
   ).toBe(200);
+});
+
+// ---------------------------------------------------------------------------
+// 6. Onboarding write path — sign in -> choose program -> confirm maxes ->
+//    Start My Program -> cycle dashboard renders
+//
+// This is the only write-path test in this file. It exists to close the gap
+// that let #644 (RLS silently disabled) ship undetected: every other test here
+// is read-only and would pass even if every write to Postgres were silently
+// failing. Per the file-level constraint above ("write-path tests must be
+// idempotent or self-cleaning"), this test deletes the test account's current
+// cycle via the /api/test-support/reset-cycle route handler BEFORE it runs
+// (so a fresh cycle-1 creation is actually exercised even on a re-run) AND
+// again AFTER (so a left-behind cycle never causes a future run of this test
+// to silently take the "cycle already exists" branch of switchProgram instead
+// of genuinely creating one — see apps/api/src/programs/switch-program.controller.ts).
+//
+// Cleanup runs via test.beforeAll/afterAll with the `request` fixture rather
+// than a try/finally in the test body — Playwright's per-test timeout does not
+// reliably let a `finally` block complete, whereas afterAll is guaranteed to
+// run regardless of how the test ended.
+//
+// The reset call uses the exact same auth path (X-Clerk-Authorization via
+// lib/api.ts) that "Start My Program" itself uses — see
+// docs/adr/ADR-023-staging-integration-test-design.md for why the two more
+// "obvious" alternatives (server-side getToken()+forward, client-side
+// getToken()+direct-fetch) are both already known to be flaky against this
+// specific staging Clerk instance.
+// ---------------------------------------------------------------------------
+
+test.describe('onboarding write path (creates and cleans up real data)', () => {
+  const RESET_URL = '/api/test-support/reset-cycle?program=rpt';
+
+  test.beforeAll(async ({ request }) => {
+    // Defensive: a prior run's own cleanup may not have completed (CI kill, etc).
+    await request.delete(RESET_URL);
+  });
+
+  test.afterAll(async ({ request }) => {
+    await request.delete(RESET_URL);
+  });
+
+  test('sign in -> choose program -> confirm maxes -> Start My Program -> cycle dashboard renders', async ({ page }: { page: Page }) => {
+    await page.goto('/onboarding');
+    await expect(page.getByRole('heading', { name: 'Get Started' })).toBeVisible();
+
+    // Step 1: Choose Method — pick "Enter training maxes" (weight-only, no reps needed)
+    await page.getByRole('button', { name: 'Enter training maxes' }).click();
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
+
+    // Step 2: Choose Program — switch to Intermediate tab, select RPT
+    await page.getByRole('tab', { name: 'Intermediate' }).click();
+    await page.getByRole('button', { name: /Reverse Pyramid Training/i }).click();
+    await page.getByRole('button', { name: 'Choose This Program' }).click();
+
+    // Step 3: Enter Lifts — RPT's 9 lifts are pre-seeded; enter a TM for each
+    const rptLifts = [
+      'Bench Press', 'Barbell Row', 'Overhead Press',
+      'Squat', 'Romanian Deadlift', 'Calf Raises',
+      'Deadlift', 'Weighted Pull-ups', 'Dips',
+    ];
+    for (const lift of rptLifts) {
+      await page.getByLabel(`${lift} weight`, { exact: true }).fill('225');
+    }
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
+
+    // Step 4: Confirm Maxes — submit to create the first cycle
+    await page.getByRole('button', { name: 'Start My Program' }).click();
+
+    // Lands on the cycle dashboard — the actual write-path assertion.
+    await expect(page).toHaveURL(/\/cycle\/1/, { timeout: 15_000 });
+    await expect(page.getByRole('heading', { name: /cycle/i }).first()).toBeVisible();
+  });
 });

--- a/apps/web/e2e/staging.spec.ts
+++ b/apps/web/e2e/staging.spec.ts
@@ -160,11 +160,19 @@ test.describe('onboarding write path (creates and cleans up real data)', () => {
 
   test.beforeAll(async ({ request }) => {
     // Defensive: a prior run's own cleanup may not have completed (CI kill, etc).
-    await request.delete(RESET_URL);
+    // Asserted, not fire-and-forget: a silently-failing reset here (e.g. an
+    // expired Clerk session returning 401) would leave a stale cycle in place,
+    // and switchProgram silently reuses an existing cycle rather than erroring
+    // (switch-program.controller.ts) — so the test below would still pass
+    // without ever exercising a genuine first-time write, defeating the entire
+    // point of this suite with no visible signal. Fail loudly here instead.
+    const res = await request.delete(RESET_URL);
+    expect(res.ok(), `Pre-test cleanup failed: ${res.status()} ${await res.text()}`).toBeTruthy();
   });
 
   test.afterAll(async ({ request }) => {
-    await request.delete(RESET_URL);
+    const res = await request.delete(RESET_URL);
+    expect(res.ok(), `Post-test cleanup failed: ${res.status()} ${await res.text()}`).toBeTruthy();
   });
 
   test('sign in -> choose program -> confirm maxes -> Start My Program -> cycle dashboard renders', async ({ page }: { page: Page }) => {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -71,6 +71,7 @@ async function getAuthHeaders(): Promise<Record<string, string>> {
 export const {
   fetchCycleDashboard,
   createCycle,
+  deleteCurrentCycle,
   fetchProgramSpec,
   fetchTrainingMaxes,
   fetchTrainingMaxHistory,

--- a/apps/web/playwright.config.staging.ts
+++ b/apps/web/playwright.config.staging.ts
@@ -8,6 +8,13 @@ export default defineConfig({
   testDir: './e2e',
   testMatch: ['staging.spec.ts'],
   globalSetup: './e2e/staging.setup.ts',
+  // fullyParallel: false + testMatch restricted to this one file is what keeps
+  // staging.spec.ts's tests running strictly in declaration order in a single
+  // worker, regardless of the `workers` count below. This matters because test
+  // 6 (the onboarding write-path test, issue #647) mutates the shared staging
+  // test account and must run last, after every read-only test — setting
+  // fullyParallel: true, or adding a second file to testMatch, would need test
+  // 6's placement reconsidered.
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/docs/adr/ADR-023-staging-integration-test-design.md
+++ b/docs/adr/ADR-023-staging-integration-test-design.md
@@ -176,6 +176,17 @@ It is the lightest possible probe that exercises the full auth path.
   per ADR-013. Adding data-assertions to staging tests (e.g., "specific lift record appears")
   would require seed data management, which is out of scope.
 
+  **Amendment (#647):** one deliberate, scoped exception to this narrowness exists —
+  `staging.spec.ts` test 6 performs a real write (completes onboarding end-to-end) and asserts
+  the resulting cycle dashboard renders. This is still "deployed stack wired correctly," not a
+  business-logic assertion: it does not check specific data values, only that a genuine
+  first-time write succeeds and is readable back. It exists because #644 (`RlsInterceptor`
+  silently never setting the RLS GUC) was live in staging identically to production, but every
+  staging test at the time was read-only and could not have surfaced it — the bug only
+  manifested on a write. The test is self-cleaning (deletes its own cycle before and after,
+  via a new `DELETE /programs/:program/cycles/current` endpoint) specifically so it does not
+  require the seed-data management this ADR flags as out of scope.
+
 ---
 
 ## Alternatives Considered

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -281,6 +281,12 @@ echo -n "pk_live_YOUR_KEY" | gcloud secrets versions add \
   --project=lifting-logbook-prod
 ```
 
+> **Staging test account.** The staging Clerk app also needs a dedicated test user for the
+> Playwright integration suite (`STAGING_CLERK_TEST_EMAIL`) — see
+> [`apps/web/e2e/README.md`](../apps/web/e2e/README.md#test-account-setup) for setup steps. As of
+> #647, that account has a cycle created and deleted on every staging CI run by a self-cleaning
+> onboarding write-path test; no extra setup is required beyond the initial account creation.
+
 ---
 
 ### Step 5 — Add GitHub repository secrets and variables

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -208,6 +208,14 @@ export function createApiClient(config: ApiClientConfig) {
         cache: 'no-store',
       });
     },
+    // Idempotent delete: a 404 (no existing cycle) is treated as success, matching
+    // deleteStrengthGoal/deleteCustomProgram below.
+    deleteCurrentCycle(programId: string): Promise<void> {
+      return requestVoidIdempotent(`/programs/${enc(programId)}/cycles/current`, {
+        method: 'DELETE',
+        cache: 'no-store',
+      });
+    },
 
     // -- Program spec ------------------------------------------------------
     fetchProgramSpec(program: string): Promise<LiftingProgramSpecResponse[]> {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -115,6 +115,21 @@ export interface CommitImportOpts {
   splitDest?: boolean;
 }
 
+// Carries the upstream HTTP status alongside the message so a caller that needs
+// to distinguish failure classes (e.g. 401/403 auth failures vs. a generic 500)
+// can do so without re-parsing the message string. Currently thrown only by
+// requestVoidIdempotent — the other request helpers can adopt this if a caller
+// needs it.
+export class ApiClientError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = 'ApiClientError';
+  }
+}
+
 // NestJS ValidationPipe returns { statusCode, message: string | string[], error }.
 // Surface that detail so error UIs can show actionable text instead of just
 // "Request failed: 400".
@@ -178,7 +193,7 @@ export function createApiClient(config: ApiClientConfig) {
   async function requestVoidIdempotent(path: string, init?: FetchInit): Promise<void> {
     const res = await rawFetch(path, init);
     if (!res.ok && res.status !== 404) {
-      throw new Error(await extractErrorMessage(res, path));
+      throw new ApiClientError(await extractErrorMessage(res, path), res.status);
     }
   }
 


### PR DESCRIPTION
## Summary

Closes staging's read-only test gap that let #644 (`RlsInterceptor` silently disabled) ship
undetected — every automated staging check (`deploy.yml` smoke test + the prior
`apps/web/e2e/staging.spec.ts` suite) was read-only, so a write-path bug was live in staging
identically to production but nothing could surface it.

Adds one Playwright test that walks the staging test user through onboarding end-to-end
(sign in → choose program → confirm maxes → "Start My Program") and asserts the resulting
cycle dashboard renders.

## Why this needed a new endpoint, not just a test

Onboarding is structurally a one-time action: `switchProgram` checks for an existing cycle
first and, if one exists, silently returns it instead of erroring — so re-running the test
against the same account would, after the first pass, quietly stop exercising the create-cycle
write path it exists to protect (no error, no visible signal). No delete/reset capability
existed anywhere in the API to make the test repeatable. Discussed the tradeoffs directly with
the repo owner: build a real `DELETE /programs/:program/cycles/current` endpoint (RLS + auth
already scope it to the caller's own data — it's also a legitimate future "restart my program"
capability, not a test-only backdoor) rather than a disposable-Clerk-user scheme that would
leave orphaned Postgres rows on every run.

The cleanup call is wired through the exact same `X-Clerk-Authorization` path (`lib/api.ts`)
that "Start My Program" itself already depends on — not a bespoke shortcut. `ADR-023`'s
"Alternatives Considered" already tried and rejected both more-obvious shortcuts (server-side
`getToken()` + JWT forwarding, client-side `getToken()` + direct fetch) for this exact staging
Clerk instance; routing around the established mechanism would just hide a problem that would
sink the onboarding flow itself. See the ADR-023 amendment in this PR for the full reasoning.

## Changes

**Backend** — `DELETE /programs/:program/cycles/current` (`cycle-dashboard.controller.ts` +
new `CycleGenerationService.deleteCurrentCycle`): sequential, independent deletes of
`LiftRecord`, `TrainingMaxHistory`, `TrainingMax`, and the `CycleScheduledWorkout`/
`CycleDashboard` rows for the caller's own program (no FK cascades exist between these tables,
so each needs an explicit delete; sequential rather than concurrent because they share one
request-scoped Prisma transaction connection — see Findings Disposition). New port methods on
`ICycleDashboardRepository`, `ILiftRecordRepository`, `ITrainingMaxRepository`,
`ITrainingMaxHistoryRepository`, implemented in both the Prisma and in-memory adapters.
`UserSettings.activeProgram` is deliberately left untouched.

**Frontend** — new `packages/api-client` endpoint (plus a new `ApiClientError` class carrying
the upstream HTTP status) + `apps/web/lib/api.ts` re-export, and a new test-support Next.js
route handler (`apps/web/app/api/test-support/reset-cycle`) that the Playwright test calls
before *and* after (via `test.beforeAll`/`afterAll`, which — unlike a `try/finally` in the test
body — is guaranteed to run even if the test times out mid-assertion). The route 404s in
production (keyed off `CLERK_PUBLISHABLE_KEY`'s `pk_live_` prefix) and relays real upstream
failure statuses instead of flattening everything to 500.

**Tests** — unit tests for the new service method (deterministic delete order,
404-on-nothing-to-delete, cycleNum scoping), a controller test, a new in-memory HTTP E2E
lifecycle test (`programs.e2e.spec.ts`), and a real-Postgres RLS test (`rls.db.e2e.spec.ts`)
seeding and verifying all five affected tables, proving the delete only ever removes the
requesting user's rows under the restricted `lifting_app` role — directly closing the loop on
the RLS-scoping risk class that motivated #644/#647 in the first place.

**Docs** — `apps/web/e2e/README.md` (new test-coverage row + test-account note),
`docs/deploy.md` (one-line pointer near the Clerk staging setup step, satisfying the issue's
literal acceptance criterion even though the Playwright suite's own detail lives in the e2e
README), and an amendment to `ADR-023`'s "Test scope" consequence recording this one
deliberate, scoped exception to "staging tests are read-only."

## Acceptance criteria (from #647)

- [x] A staging Playwright test creates a real cycle for a test user and verifies it renders
- [x] Test user's created data is cleaned up so staging doesn't accumulate cruft (before *and*
      after cleanup, both idempotent — a 404 from "nothing to delete" is treated as success,
      and both cleanup calls now assert success rather than failing silently)
- [x] Documented in `docs/deploy.md` alongside the existing staging smoke-test description (plus
      the full detail in `apps/web/e2e/README.md`, the file that actually documents the suite)

## Testing

Ran `npm test` from the repo root (full suite, all workspaces, including the Testcontainers-backed
DB E2E suites — Docker Desktop was running), after rebasing onto `origin/main` to pick up #667
(a critical fix — see Findings Disposition).

**Tests: 893 passed, 0 skipped, 0 failed** — core (280/37 suites), api-client (27/1 suite,
+2 from the rebased-in #667 test), web (152/25 suites), api (434/35 suites, including the RLS
DB E2E test). `npm run build` also passed cleanly across all 6 buildable packages (this PR
touches `packages/api-client`, consumed by `apps/web`).

The one thing that can't be verified pre-merge: the new test itself only runs for real against
live staging, via `.github/workflows/staging.yml`'s `staging-integration-tests` job on this PR.
No workflow changes were needed — that job already runs every file matched by
`playwright.config.staging.ts`'s `testMatch: ['staging.spec.ts']` with all the env vars/secrets
the new test needs.

Pre-PR policy checks (suppression grep, test-integrity grep, deleted-test-file check, coverage-
threshold check, manual `!`-scan of the diff) all came back clean — no findings to justify —
both before and after the rebase.

## Risk-dimension notes

- **Security** — the new DELETE endpoint is authenticated (standard `@CurrentUser()` guard),
  RLS-scoped to the caller's own rows (the RLS DB E2E test proves a second user's rows in all
  five tables survive), and environment-gated so it's inert in production.
- **Resilience** — the delete is a no-op-safe 404 (not a crash) when there's nothing to delete;
  the Playwright cleanup asserts success rather than silently tolerating a failed reset.
- **Data integrity** — no FK cascades exist between the affected tables, so each is deleted
  explicitly rather than relying on cascade behavior that doesn't exist; the five deletes run
  sequentially (not `Promise.all`) since they share one request-scoped transaction connection.
- **Observability** — no new logging conventions introduced; the new route handler logs failures
  via `console.error` consistent with other route handlers in this app (e.g. `/api/health`), and
  now relays the real upstream HTTP status instead of collapsing every failure to 500.

## Review findings disposition

`/review` ran with two parallel subagents (correctness/security + reliability/maintainability),
posted as a [PR comment](https://github.com/brownm09/lifting-logbook/pull/668#issuecomment-4879226390).
4 blocking + 5 non-blocking findings, all fixed in this PR (commit `a3292ce`):

| # | Finding | Category | Disposition |
|---|---|---|---|
| 1 | `Promise.all` over 4 writes doesn't parallelize inside one Prisma request transaction — could throw against real Postgres while passing against in-memory adapters (independently flagged by both review subagents) | correctness | **Fixed** — sequential `await`s |
| 2 | Playwright cleanup hooks never asserted the reset succeeded; route swallowed all failures to a generic 500 | correctness | **Fixed** — hooks assert `.ok()`; route relays real status via new `ApiClientError` |
| 3 | Reset-cycle route had no environment guard — a live destructive endpoint reachable in production | security | **Fixed** — 404s when `CLERK_PUBLISHABLE_KEY` is a live key |
| 4 | New RLS regression test only seeded/verified 1 of 5 affected tables, undermining its own stated purpose | correctness | **Fixed** — seeds and verifies all 5 tables for both users |
| 5 | `TrainingMax` deletion was read-then-delete-by-key, not matching its "all rows" doc comment | maintainability | **Fixed** — new `deleteAllTrainingMaxes` direct delete |
| 6 | Inconsistent naming across the 5 delete methods (`deleteAll*` vs keyed vs unprefixed) | maintainability | **Fixed** — resolved by fix #5's new method, consistent `deleteAll<X>` vs `delete<X>(program, keys)` pattern |
| 7 | Test 6's placement depends on an undocumented `workers`/ordering invariant | reliability | **Fixed** — documented in `playwright.config.staging.ts` (verified the actual risk: `fullyParallel: false`, not `true` as initially flagged — corrected before documenting) |
| 8 | Program name `'rpt'` hardcoded independently in 3 places, could drift silently | maintainability | **Fixed** — dead default removed, route now 400s on a missing param |
| 9 | Ordering unit test implied more than `Promise.all` actually guaranteed | maintainability | **Fixed** — retargeted to assert the now-deterministic full sequential order (fix #1 made this possible) |

Additionally, rebased onto `origin/main` after the review pass (3 commits had landed, including
#667 — a fix for `switchProgram` sending an empty body with a JSON content-type, which Fastify
rejects in production). #667 is directly load-bearing here: its own commit message notes the
existing RLS regression tests call `switchProgram` via Fastify's `.inject()`, which never sets
`Content-Type` and so never exercised the real client request shape — exactly the gap this PR's
new end-to-end Playwright test closes. Without the rebase, the new write-path test would have
failed in staging CI against the same bug #667 just fixed.

Closes #647
