### PR TITLE
[fix] Add persistent styled app-shell nav; remove the Programs dead-end

### DIFF
--- a/apps/web/app/(authed)/AppNav.module.css
+++ b/apps/web/app/(authed)/AppNav.module.css
@@ -1,0 +1,69 @@
+.appHeader {
+  position: sticky;
+  top: 0;
+  z-index: 40; /* below the fixed UserButton (z-index: 50) in the root layout */
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  /* Keep nav items clear of the fixed UserButton floating at the top-right. */
+  padding-right: calc(var(--space-4) + 3rem);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.brand {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: -0.01em;
+  background: linear-gradient(135deg, var(--color-header-from), var(--color-header-to));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  white-space: nowrap;
+}
+
+.brand:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 40px;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.link:hover {
+  background: var(--color-surface-alt);
+  color: var(--color-text-heading);
+}
+
+.link:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.active {
+  color: var(--color-on-accent);
+  background: var(--color-accent);
+}
+
+.active:hover {
+  color: var(--color-on-accent);
+  background: var(--color-accent-hover);
+}

--- a/apps/web/app/(authed)/AppNav.test.tsx
+++ b/apps/web/app/(authed)/AppNav.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import AppNav from './AppNav';
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(),
+}));
+
+import { usePathname } from 'next/navigation';
+
+const mockedUsePathname = usePathname as unknown as jest.Mock;
+
+describe('AppNav', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders the brand home-link and the three primary links', () => {
+    mockedUsePathname.mockReturnValue('/cycle/1');
+    render(<AppNav />);
+
+    expect(screen.getByRole('link', { name: 'Lifting Logbook' })).toHaveAttribute('href', '/cycle');
+    expect(screen.getByRole('navigation', { name: 'Primary' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'History' })).toHaveAttribute('href', '/history');
+    expect(screen.getByRole('link', { name: 'Programs' })).toHaveAttribute('href', '/programs');
+    expect(screen.getByRole('link', { name: 'Settings' })).toHaveAttribute(
+      'href',
+      '/settings/training-maxes',
+    );
+  });
+
+  it('marks the active section with aria-current for any sub-route', () => {
+    // Settings is active for the whole /settings/* subtree, not just the linked page.
+    mockedUsePathname.mockReturnValue('/settings/weight-rounding');
+    render(<AppNav />);
+
+    expect(screen.getByRole('link', { name: 'Settings' })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: 'History' })).not.toHaveAttribute('aria-current');
+    expect(screen.getByRole('link', { name: 'Programs' })).not.toHaveAttribute('aria-current');
+  });
+
+  it('renders nothing during the onboarding flow', () => {
+    mockedUsePathname.mockReturnValue('/onboarding');
+    const { container } = render(<AppNav />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/app/(authed)/AppNav.tsx
+++ b/apps/web/app/(authed)/AppNav.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import styles from './AppNav.module.css';
+
+/** Primary destinations surfaced on every authed screen. */
+const LINKS: ReadonlyArray<{ href: string; label: string; match: string }> = [
+  { href: '/history', label: 'History', match: '/history' },
+  { href: '/programs', label: 'Programs', match: '/programs' },
+  // PR 2 (#679) repoints this to the /settings hub once it exists.
+  { href: '/settings/training-maxes', label: 'Settings', match: '/settings' },
+];
+
+/**
+ * Persistent top navigation for the authenticated app shell. Rendered once by
+ * the (authed) layout so every protected screen has a consistent, styled way to
+ * move between sections — replacing the unstyled, cycle-only nav that left
+ * /programs a dead-end (#678).
+ */
+export default function AppNav() {
+  const pathname = usePathname() ?? '';
+  // Onboarding is a focused, nav-free flow — surfacing History/Programs/Settings
+  // before setup completes would let a user wander out mid-onboarding. Matches the
+  // pre-shell behavior, where the nav lived only under the cycle layout.
+  if (pathname.startsWith('/onboarding')) return null;
+
+  return (
+    <header className={styles.appHeader}>
+      <Link href="/cycle" className={styles.brand}>
+        Lifting Logbook
+      </Link>
+      <nav aria-label="Primary" className={styles.nav}>
+        {LINKS.map(({ href, label, match }) => {
+          const active = pathname.startsWith(match);
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={active ? `${styles.link} ${styles.active}` : styles.link}
+              aria-current={active ? 'page' : undefined}
+            >
+              {label}
+            </Link>
+          );
+        })}
+      </nav>
+    </header>
+  );
+}

--- a/apps/web/app/(authed)/cycle/[cycleNum]/CycleDashboardGrid.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/CycleDashboardGrid.tsx
@@ -82,7 +82,7 @@ export default function CycleDashboardGrid({
 
   return (
     <section className={styles.container}>
-      <h2 className={styles.heading}>Cycle {cycleNum}</h2>
+      <h1 className={styles.heading}>Cycle {cycleNum}</h1>
       <nav className={styles.quickNav}>
         <Link href={`/cycle/${cycleNum}/program`}>📋 Cycle Program</Link>
         <Link href={`/cycle/${cycleNum}/plan`}>🗓 Program Plan</Link>

--- a/apps/web/app/(authed)/cycle/[cycleNum]/plan/page.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/plan/page.tsx
@@ -47,7 +47,7 @@ export default async function ProgramPlanPage({
         <Link href={`/cycle/${dashboard.cycleNum}`}>← Back to Cycle</Link>
       </div>
 
-      <h2 className={styles.heading}>Program Plan</h2>
+      <h1 className={styles.heading}>Program Plan</h1>
 
       <dl className={styles.dataList}>
         <div className={styles.dataRow}>

--- a/apps/web/app/(authed)/cycle/[cycleNum]/program/page.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/program/page.tsx
@@ -35,7 +35,7 @@ export default async function CycleProgramPage({
       </div>
 
       <div className={styles.header}>
-        <h2 className={styles.heading}>{program}</h2>
+        <h1 className={styles.heading}>{program}</h1>
         <button type="button" className={styles.editButton} disabled title="Coming soon">
           Edit Program
         </button>

--- a/apps/web/app/(authed)/cycle/layout.tsx
+++ b/apps/web/app/(authed)/cycle/layout.tsx
@@ -3,17 +3,7 @@ export default function CycleLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <main>
-      <header>
-        <h1>Lifting Logbook</h1>
-        <nav>
-          <a href="/history">History</a>
-          <a href="/programs">Programs</a>
-          <a href="/settings/training-maxes">Settings</a>
-        </nav>
-      </header>
-      {children}
-    </main>
-  );
+  // The global app nav now lives in the (authed) shell (AppNav). This layout
+  // just provides the <main> landmark for cycle routes.
+  return <main>{children}</main>;
 }

--- a/apps/web/app/(authed)/history/page.tsx
+++ b/apps/web/app/(authed)/history/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { fetchLiftRecords, fetchTrainingMaxHistory } from '@/lib/api';
 import { getActiveProgram } from '@/lib/active-program';
 import type {
@@ -71,7 +70,6 @@ export default async function HistoryPage() {
 
   return (
     <main className={styles.pageContainer}>
-      <Link href="/" className={styles.backLink}>← Home</Link>
       <h1 className={styles.pageHeading}>Lift History</h1>
       <HistoryTabs records={enriched} tmEntries={tmEntries} />
     </main>

--- a/apps/web/app/(authed)/layout.test.tsx
+++ b/apps/web/app/(authed)/layout.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import AuthedLayout from './layout';
+import AppNav from './AppNav';
 
 jest.mock('@clerk/nextjs/server', () => ({
   auth: jest.fn(),
@@ -56,7 +57,11 @@ describe('(authed) layout — defense-in-depth auth guard', () => {
 
     expect(mockedRedirect).not.toHaveBeenCalled();
     expect(element.type).toBe(React.Fragment);
-    expect((element.props as { children: unknown }).children).toBe(SENTINEL);
+    // The shell now renders the global app nav alongside the protected content,
+    // which still passes through verbatim as the last child.
+    const kids = (element.props as { children: React.ReactNode[] }).children;
+    expect((kids[0] as React.ReactElement).type).toBe(AppNav);
+    expect(kids[kids.length - 1]).toBe(SENTINEL);
   });
 
   it('bypasses Clerk in non-production when DEV_AUTH_TOKEN is set', async () => {
@@ -67,7 +72,9 @@ describe('(authed) layout — defense-in-depth auth guard', () => {
     expect(mockedAuth).not.toHaveBeenCalled();
     expect(mockedRedirect).not.toHaveBeenCalled();
     expect(element.type).toBe(React.Fragment);
-    expect((element.props as { children: unknown }).children).toBe(SENTINEL);
+    const kids = (element.props as { children: React.ReactNode[] }).children;
+    expect((kids[0] as React.ReactElement).type).toBe(AppNav);
+    expect(kids[kids.length - 1]).toBe(SENTINEL);
   });
 
   it('ignores DEV_AUTH_TOKEN in production and still calls auth()', async () => {

--- a/apps/web/app/(authed)/layout.tsx
+++ b/apps/web/app/(authed)/layout.tsx
@@ -1,5 +1,6 @@
 import { auth } from '@clerk/nextjs/server';
 import { redirect } from 'next/navigation';
+import AppNav from './AppNav';
 
 /**
  * Defense-in-depth auth guard for all protected routes.
@@ -24,9 +25,19 @@ export default async function AuthedLayout({
     process.env['NODE_ENV'] !== 'production' &&
     process.env.DEV_AUTH_TOKEN
   ) {
-    return <>{children}</>;
+    return (
+      <>
+        <AppNav />
+        {children}
+      </>
+    );
   }
   const { userId } = await auth();
   if (!userId) redirect('/sign-in');
-  return <>{children}</>;
+  return (
+    <>
+      <AppNav />
+      {children}
+    </>
+  );
 }

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -194,3 +194,22 @@ test('strength goals: create a goal and delete it', async ({ page }) => {
   // Remove button should disappear once deleted
   await expect(page.getByRole('button', { name: /✕ Remove/i })).toHaveCount(0, { timeout: 5_000 });
 });
+
+// ---------------------------------------------------------------------------
+// 10. Persistent app nav: present across screens, escapes the Programs page
+// ---------------------------------------------------------------------------
+
+test('primary nav persists and provides an escape route from Programs', async ({ page }) => {
+  await page.goto('/programs');
+
+  // The Programs page used to be a dead-end; the global nav now offers a way out.
+  const nav = page.getByRole('navigation', { name: 'Primary' });
+  await expect(nav).toBeVisible();
+
+  await nav.getByRole('link', { name: 'History' }).click();
+  await expect(page).toHaveURL(/\/history/);
+
+  // The brand wordmark links back to the current cycle from anywhere.
+  await page.getByRole('link', { name: 'Lifting Logbook' }).click();
+  await expect(page).toHaveURL(/\/cycle\/1/);
+});

--- a/apps/web/e2e/staging.spec.ts
+++ b/apps/web/e2e/staging.spec.ts
@@ -50,7 +50,7 @@ test('programs page catalog loads', async ({ page }) => {
 //
 // Structure-only assertion is intentional: the staging test user has no
 // records, so neither real data nor the fallback `[]` from
-// apps/web/app/(authed)/history/page.tsx:37-38 produces visible content. The API
+// apps/web/app/(authed)/history/page.tsx:36-37 produces visible content. The API
 // success path for history fetches is covered indirectly by test 5
 // (auth/API propagation against /api/health).
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

First PR in the #677 consistency pass. Establishes a shared authenticated **app shell** so navigation is consistent, styled, and present on every protected screen — fixing two symptoms from the audit:

- **Symptom 4 — unstyled nav.** The History/Programs/Settings links were bare `<a>` tags with no class; the global reset (`a { color: inherit; text-decoration: none }`) stripped all affordance. They're now real, styled, keyboard-focusable links with active-route highlighting.
- **Symptom 7 — no escape route.** The nav was rendered only by the *cycle* layout, so it existed only on `/cycle/*`; `/programs` was a dead-end and `/history` had only a "← Home" link. The nav now lives in the `(authed)` shell, so it's on every authed screen.

### What changed
- New `AppNav` client component (`apps/web/app/(authed)/AppNav.tsx` + `.module.css`) rendered once by the `(authed)` layout. Uses `usePathname` for active-route highlighting (`aria-current="page"`), design tokens mirroring the home page's `.cta` pattern, and an `aria-label="Primary"` `<nav>`. The brand wordmark is a home link to `/cycle`. Hidden during `/onboarding` to preserve that focused, nav-free flow.
- Removed the old header/nav from the cycle layout (now just the `<main>` landmark).
- Promoted the cycle dashboard's `Cycle N` from `<h2>` to the page `<h1>` (the brand is a link, not a heading, so each page owns its own single `<h1>`). Same `.heading` class → no visual change.
- Dropped the now-redundant per-page "← Home" link on the history page.
- Updated the coverage line-reference in `staging.spec.ts` (`history/page.tsx:37-38` → `36-37`) after the import removal shifted the fallback lines up by one. The fallback stays covered — see Testing note.

## Acceptance criteria (#678)
- [x] Persistent styled nav present on `/cycle/*`, `/programs`, `/history`, `/settings/*`
- [x] Active route is visually indicated (`aria-current="page"` + active class)
- [x] `<nav>` has an accessible label; links have visible focus
- [x] `/programs` and `/history` have a working escape route
- [x] Jest component tests updated; new `AppNav.test.tsx`; e2e escape-hatch assertion added

## Testing

- `npm test -w @lifting-logbook/web` — **Tests: 155 passed, 0 skipped, 0 failed (47.0s)**, 26 suites. Includes the new `AppNav.test.tsx` (renders links, active-state, hidden on onboarding) and the updated `(authed)/layout.test.tsx` (shell now renders `AppNav` alongside the protected children — assertions updated to match; no test removed or skipped).
- `npx turbo run lint typecheck --filter=@lifting-logbook/web` — **green**.
- Suppression / test-integrity greps on the diff — **clean** (no suppressions, skips, or deleted tests).

### Playwright E2E — deferred to CI (local run blocked by environment)
The repo rule is to run `npm run test:e2e -w @lifting-logbook/web` locally for role/label changes. I could **not** run it in this worktree: a clean `npm ci` on this Windows host (disk at 99%) produced **incompletely-extracted packages** — the documented partial-extract failure (`@next/swc-win32-x64-msvc` native binary "not a valid Win32 application", missing `@testing-library/react` / `@vercel/otel` `.d.ts`, and `@clerk/nextjs` module-not-found). After re-extracting three of them, the dev server still **500s on the public `/` route** (Clerk module-not-found — a page that doesn't use this change), confirming the failure is environmental, not code. The **CI Playwright E2E job (Linux)** is the authoritative gate and runs the new `smoke.spec.ts` escape-hatch assertion. The `history/page.tsx` fallback remains covered by `staging.spec.ts`'s (corrected) line reference, verified green by the `no-uncovered-error-fallback` lint rule.

## Review findings disposition

`/review` (claude-opus-4-8) — blocking=1, non_blocking=1:
- **[accessibility] `/cycle/[n]/plan` & `/cycle/[n]/program` lost their `<h1>`** — introduced by removing the cycle-layout heading; the dashboard and workout pages have their own `<h1>` but these two relied on the layout's. **Fixed in 4f69506** (promoted both to `<h1>`).
- **[maintainability] double `<header>` on `/settings/*`** — AppNav's banner header now sits above the settings-layout header. Not a landmark conflict; **deferred to #679** (PR 2 reworks the settings shell with a hub + sub-nav).

Closes #678
