### PR TITLE
[fix] Fail-fast on missing CLERK_PUBLISHABLE_KEY in apps/web

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,7 +2,11 @@ import { ClerkProvider, SignedIn, UserButton } from '@clerk/nextjs';
 import type { Metadata } from "next";
 import { ClerkApiInitializer } from '@/components/ClerkApiInitializer';
 import { PublicConfigProvider } from '@/components/PublicConfigProvider';
-import { publicConfigScript, readServerPublicConfig } from '@/lib/public-config';
+import {
+  publicConfigScript,
+  readServerClerkPublishableKey,
+  readServerPublicConfig,
+} from '@/lib/public-config';
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -44,7 +48,10 @@ export default function RootLayout({
   // React components, and the Clerk publishable key is passed to <ClerkProvider> as
   // a prop (Clerk's runtime-key pattern). See ADR-028 / issue #396.
   const publicConfig = readServerPublicConfig();
-  const clerkPublishableKey = process.env.CLERK_PUBLISHABLE_KEY;
+  // Fail loud in a deployed runtime if the Clerk publishable key is missing, rather than
+  // rendering <ClerkProvider> with an undefined key (auth would break silently in the
+  // browser). Matches the API-side guard in apps/api/src/auth/auth.module.ts. See #687.
+  const clerkPublishableKey = readServerClerkPublishableKey();
 
   return (
     <ClerkProvider publishableKey={clerkPublishableKey}>

--- a/apps/web/lib/__tests__/public-config.test.tsx
+++ b/apps/web/lib/__tests__/public-config.test.tsx
@@ -3,6 +3,7 @@ import {
   PUBLIC_CONFIG_FALLBACK,
   getClientPublicConfig,
   publicConfigScript,
+  readServerClerkPublishableKey,
   readServerPublicConfig,
   type PublicConfig,
 } from '../public-config';
@@ -65,6 +66,48 @@ describe('readServerPublicConfig', () => {
     process.env.NEXT_PHASE = 'phase-production-build';
     delete process.env.PUBLIC_API_URL;
     expect(readServerPublicConfig().apiUrl).toBe(PUBLIC_CONFIG_FALLBACK.apiUrl);
+  });
+});
+
+describe('readServerClerkPublishableKey', () => {
+  const ORIGINAL = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL };
+  });
+
+  it('returns the publishable key when it is set', () => {
+    process.env.CLERK_PUBLISHABLE_KEY = 'pk_test_abc';
+    expect(readServerClerkPublishableKey()).toBe('pk_test_abc');
+  });
+
+  it('returns undefined outside a deployed runtime when the key is unset (local dev / test)', () => {
+    delete process.env.CLERK_PUBLISHABLE_KEY;
+    expect(readServerClerkPublishableKey()).toBeUndefined();
+  });
+
+  // Fail-loud guard: a deployed runtime missing the Clerk publishable key must throw rather
+  // than hand <ClerkProvider> an undefined key that breaks auth silently in the browser (#687).
+  it('throws in a deployed runtime when CLERK_PUBLISHABLE_KEY is unset', () => {
+    Object.defineProperty(process.env, 'NODE_ENV', { value: 'production', configurable: true });
+    delete process.env.NEXT_PHASE;
+    delete process.env.CLERK_PUBLISHABLE_KEY;
+    expect(() => readServerClerkPublishableKey()).toThrow(/CLERK_PUBLISHABLE_KEY is not set/);
+  });
+
+  it('throws in a deployed runtime when CLERK_PUBLISHABLE_KEY is the empty string', () => {
+    Object.defineProperty(process.env, 'NODE_ENV', { value: 'production', configurable: true });
+    delete process.env.NEXT_PHASE;
+    process.env.CLERK_PUBLISHABLE_KEY = '';
+    expect(() => readServerClerkPublishableKey()).toThrow(/CLERK_PUBLISHABLE_KEY is not set/);
+  });
+
+  it('does NOT throw during `next build` even with CLERK_PUBLISHABLE_KEY unset', () => {
+    // The keyless build the force-dynamic root layout relies on must never throw here (ADR-028).
+    Object.defineProperty(process.env, 'NODE_ENV', { value: 'production', configurable: true });
+    process.env.NEXT_PHASE = 'phase-production-build';
+    delete process.env.CLERK_PUBLISHABLE_KEY;
+    expect(readServerClerkPublishableKey()).toBeUndefined();
   });
 });
 

--- a/apps/web/lib/__tests__/public-config.test.tsx
+++ b/apps/web/lib/__tests__/public-config.test.tsx
@@ -109,6 +109,15 @@ describe('readServerClerkPublishableKey', () => {
     delete process.env.CLERK_PUBLISHABLE_KEY;
     expect(readServerClerkPublishableKey()).toBeUndefined();
   });
+
+  it('does NOT throw in a deployed runtime when DEV_AUTH_TOKEN is set (dev-auth mode)', () => {
+    // Mirrors the API-side guard: a missing Clerk credential is intentional in dev-auth mode.
+    Object.defineProperty(process.env, 'NODE_ENV', { value: 'production', configurable: true });
+    delete process.env.NEXT_PHASE;
+    delete process.env.CLERK_PUBLISHABLE_KEY;
+    process.env.DEV_AUTH_TOKEN = 'tok';
+    expect(readServerClerkPublishableKey()).toBeUndefined();
+  });
 });
 
 describe('publicConfigScript', () => {

--- a/apps/web/lib/public-config.ts
+++ b/apps/web/lib/public-config.ts
@@ -93,13 +93,15 @@ export function readServerPublicConfig(): PublicConfig {
  * class as #395/#458, here for auth.
  *
  * An empty string is treated as unset (an empty `--set-env-vars=CLERK_PUBLISHABLE_KEY=` must
- * trip the guard too). Never throws during `next build` (phase-production-build) — the keyless
- * build the force-dynamic root layout relies on must not throw (ADR-028) — nor in local dev or
- * tests, where a missing key returns `undefined` unchanged. See #687.
+ * trip the guard too). Dev-auth mode is exempt: when `DEV_AUTH_TOKEN` is set a missing key is
+ * intentional, mirroring the API-side guard where an unset `CLERK_SECRET_KEY` selects
+ * `DevAuthProvider` rather than failing. Never throws during `next build` (phase-production-build)
+ * — the keyless build the force-dynamic root layout relies on must not throw (ADR-028) — nor in
+ * local dev or tests, where a missing key returns `undefined` unchanged. See #687.
  */
 export function readServerClerkPublishableKey(): string | undefined {
   const key = process.env.CLERK_PUBLISHABLE_KEY || undefined;
-  if (!key && isDeployedServerRuntime()) {
+  if (!key && isDeployedServerRuntime() && !process.env.DEV_AUTH_TOKEN) {
     throw new Error(
       'CLERK_PUBLISHABLE_KEY is not set in a deployed runtime. Clerk requires a publishable ' +
         'key injected at deploy time (Cloud Run --set-env-vars / GKE ConfigMap). Refusing to ' +

--- a/apps/web/lib/public-config.ts
+++ b/apps/web/lib/public-config.ts
@@ -85,6 +85,32 @@ export function readServerPublicConfig(): PublicConfig {
 }
 
 /**
+ * Resolve the Clerk publishable key passed to <ClerkProvider>, failing loud on a deployed
+ * misconfiguration. Mirrors readServerPublicConfig's PUBLIC_API_URL guard above (and the
+ * API-side guard in apps/api/src/auth/auth.module.ts): a deployed runtime missing its Clerk
+ * publishable key must refuse to render rather than hand <ClerkProvider> an `undefined` key,
+ * which fails only later in the browser with no server-side signal — the same silent-misconfig
+ * class as #395/#458, here for auth.
+ *
+ * An empty string is treated as unset (an empty `--set-env-vars=CLERK_PUBLISHABLE_KEY=` must
+ * trip the guard too). Never throws during `next build` (phase-production-build) — the keyless
+ * build the force-dynamic root layout relies on must not throw (ADR-028) — nor in local dev or
+ * tests, where a missing key returns `undefined` unchanged. See #687.
+ */
+export function readServerClerkPublishableKey(): string | undefined {
+  const key = process.env.CLERK_PUBLISHABLE_KEY || undefined;
+  if (!key && isDeployedServerRuntime()) {
+    throw new Error(
+      'CLERK_PUBLISHABLE_KEY is not set in a deployed runtime. Clerk requires a publishable ' +
+        'key injected at deploy time (Cloud Run --set-env-vars / GKE ConfigMap). Refusing to ' +
+        'render <ClerkProvider> with an undefined key, which would break auth silently in the ' +
+        'browser. See #687.',
+    );
+  }
+  return key;
+}
+
+/**
  * Build the inline-<script> body that sets window.__PUBLIC_CONFIG__ before React
  * hydrates. The `<` escape prevents a value containing `</script>` from breaking out
  * of the element (defense-in-depth — these values are GCP-controlled, but escape anyway).


### PR DESCRIPTION
## Summary

`apps/web/app/layout.tsx` passed `process.env.CLERK_PUBLISHABLE_KEY` — possibly `undefined` — straight to `<ClerkProvider>`. A deployed runtime missing its Clerk publishable key therefore shipped a broken auth provider to browsers, failing only later at browser runtime with no server-side signal. The API side already fails fast on a broken Clerk config (`apps/api/src/auth/auth.module.ts` throws on an empty `CLERK_SECRET_KEY`); this closes the equivalent gap on the web side.

Surfaced by the re-baseline investigation in #687 — the one finding of the three (S1/S2/S3) carrying genuine residual production-misconfig risk.

## Changes

- **`apps/web/lib/public-config.ts`** — new `readServerClerkPublishableKey()`, mirroring the existing `readServerPublicConfig()` `PUBLIC_API_URL` fail-loud guard. Throws in a deployed runtime (`isDeployedServerRuntime()`: `NODE_ENV==='production'` and not `next build`) when the key is missing/empty; treats `''` as unset; exempts dev-auth mode (`DEV_AUTH_TOKEN` set — mirrors the API guard's unset-secret→DevAuthProvider path); returns `undefined` unchanged in local dev, tests, and `next build` (the keyless build the `force-dynamic` root layout relies on — ADR-028).
- **`apps/web/app/layout.tsx`** — reads the key via the new guard instead of a raw `process.env` read.
- **`apps/web/lib/__tests__/public-config.test.tsx`** — 6 tests: key-present, local-dev-unset (no throw), deployed-unset (throw), deployed-empty (throw), `next build`-unset (no throw), deployed dev-auth-mode-unset (no throw), mirroring the `PUBLIC_API_URL` guard tests.

## Acceptance criteria (from #688)

- [x] Web startup fails loudly when `CLERK_PUBLISHABLE_KEY` is missing in a deployed / non-dev environment
- [x] Local dev (no real Clerk keys) unaffected — dev / `next dev` / Playwright run with `NODE_ENV != production`, and deployed dev-auth mode is exempted
- [x] Test coverage for the missing-key failure path

## Testing

`npm test -w @lifting-logbook/web` + `npm run typecheck` (repo root), on a branch cut fresh from `origin/main@9cfe04e`.

**Tests: 172 passed, 0 skipped, 0 failed** (26 web suites, incl. the 6 `readServerClerkPublishableKey` cases). Typecheck: 4/4 workspaces successful (web executed fresh).

No Playwright run needed: the change adds no UI string / aria-label / role-name and is inert in dev-auth / Playwright mode. Pre-PR suppression, test-integrity, deleted-test, and lockfile grep checks all clean (no `package.json` change).

## Risk-dimension notes

- **Security** — a missing Clerk key now fails closed at startup rather than shipping a silently-broken provider; nothing secret is logged (the publishable key is non-secret by design).
- **Resilience / failure modes** — the guard is scoped to genuinely deployed runtimes with a real-auth expectation; `next build`, local dev, tests, and deployed dev-auth mode are explicitly excluded so neither the keyless build nor any dev workflow can be broken by it.
- **Data integrity / Performance / Observability** — N/A (no data, hot-path, or logging change).

## Review findings disposition

`/review` ([comment](https://github.com/brownm09/lifting-logbook/pull/689#issuecomment-4887647837)) — **0 blocking, 1 non-blocking**, fixed in this PR:

| # | Finding | Category | Disposition |
|---|---|---|---|
| 1 | Guard threw in any deployed runtime with a missing key, not exempting dev-auth mode — stricter than the API-side guard it claims to mirror; would crash a future deployed dev-auth environment | reliability | **Fixed** in `09cf148` — added `&& !process.env.DEV_AUTH_TOKEN` to the condition + a covering test (16 cases in the suite) |

Closes #688 · part of #687
