### PR TITLE
[fix] apps/web Docker build fails: implicit-any TypeScript error under turbo-pruned build context

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -7,7 +7,11 @@ FROM node:20.11.1-alpine AS installer
 WORKDIR /app
 
 COPY . .
-RUN npx turbo prune --scope=@lifting-logbook/web --docker
+# Pinned to an exact version: this runs before `npm ci` (node_modules is dockerignored
+# here), so a bare `npx turbo` has no local install to prefer and always fetches whatever
+# the registry currently tags "latest" — independent of the "turbo" version locked in
+# package-lock.json. Keep this pin in sync with the locked version. See #674.
+RUN npx turbo@2.9.3 prune --scope=@lifting-logbook/web --docker
 
 # ── Stage 2: builder ─────────────────────────────────────────────────────────
 # Install only the pruned dependency set, then compile and build Next.js.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "eslint": "^9.39.2",
         "jest": "^30.2.0",
         "ts-jest": "^29.4.11",
-        "turbo": "latest",
+        "turbo": "2.9.3",
         "typescript": "^5.9.3"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "eslint": "^9.39.2",
     "jest": "^30.2.0",
     "ts-jest": "^29.4.11",
-    "turbo": "latest",
+    "turbo": "2.9.3",
     "typescript": "^5.9.3"
   },
   "packageManager": "npm@10.2.4",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,12 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "declaration": true,
-    "declarationMap": true,
+    // declarationMap deliberately omitted: under composite:true, tsc's declaration-map
+    // emit intermittently drops the .d.ts file itself (still emits .js/.js.map/.d.ts.map)
+    // on Linux/musl (reproduced in the apps/web Docker build's Alpine builder stage;
+    // did not reproduce on Windows). declarationMap is an IDE-only "jump to .ts source"
+    // convenience with no role in the build/typecheck pipeline, so it isn't worth the
+    // reliability cost. See #674.
     "sourceMap": true,
     "strict": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
## Summary

- `packages/types`' composite TypeScript build was silently dropping its `.d.ts` declaration files (while still emitting `.js`, `.js.map`, and `.d.ts.map`) when compiled inside the Alpine/musl Linux container the `apps/web` Dockerfile builds in — reproducible only in that environment, not on Windows. This left `@lifting-logbook/api-client`'s own build unable to resolve `@lifting-logbook/types`' types (TS7016), which is what ultimately surfaced downstream as the implicit-any error reported in #674.
- Root cause isolated to `declarationMap: true` under `composite: true` (see investigation below) — removed from the shared `tsconfig.base.json`, since `declarationMap` has no role outside IDE "jump to source" navigation.
- Also pins `turbo` to the exact locked version (`2.9.3`) in both `package.json` and the Dockerfile's `npx turbo prune` step. That prune step runs *before* `npm ci` (node_modules is dockerignored there), so a bare `npx turbo` always resolves whatever the registry currently tags "latest" — independent of the lockfile. Found this during investigation; it wasn't the cause of the reported bug (confirmed identical pruned file output between the locked 2.9.3 and a freshly-fetched 2.10.3), but it's a real reliability gap in the same code path, worth closing while here.

## Investigation

A fresh `docker build --no-cache -f apps/web/Dockerfile .` reproduced the reported implicit-any error. Bisecting showed the *actual* failure is one level earlier than the reported symptom: `@lifting-logbook/api-client`'s own build step fails first, with:

```
src/index.ts(32,8): error TS7016: Could not find a declaration file for module '@lifting-logbook/types'. '/app/packages/types/dist/index.js' implicitly has an 'any' type.
```

Inspecting the container filesystem at that point showed `packages/types/dist/` had `.js`, `.js.map`, and `.d.ts.map` for every source file, but no `.d.ts` files at all. `tsc --listEmittedFiles` confirmed TypeScript itself never attempted to emit them. Isolated via a debug Dockerfile:
- Bypassing project-config mode entirely (`tsc src/index.ts --declaration --emitDeclarationOnly`) emitted `.d.ts` correctly.
- The same `tsconfig.json` with `declarationMap` forced to `false` (keeping `composite`/`incremental` true) emitted `.d.ts` correctly, every time.
- The unmodified `tsconfig.json` (composite + declarationMap both true) reproducibly dropped `.d.ts` emission, in the same container, same TypeScript version (5.9.3) as the successful Windows-side tests earlier in this investigation — confirming this is specific to the Linux/Alpine build environment, not the config alone or a TypeScript version skew.

This wasn't reproducible via `npm run typecheck` (by design — that gate resolves workspace packages to source, not `dist`, specifically so it doesn't need an upstream build; see #651) or via a full local `npm run build` on Windows (declaration emission isn't broken there). Only a real, uncached Docker build exercises the code path that broke, which is why this went unnoticed until a manual `--no-cache` build turned it up.

## Why not extend `npm run typecheck` to catch this?

The issue asked me to consider this. `tsconfig.typecheck.json`'s source-resolution design is deliberate (#651/#656) — it's what makes `typecheck` cacheable without an upstream build. Reintroducing a dist-based resolution path there would undo that tradeoff for every PR, not just Docker builds. The actual gap is that nothing exercises a *fresh, uncached* Docker build regularly; tracked as a follow-up in #693 instead of folding it into this PR.

## Testing

- `docker build --no-cache -f apps/web/Dockerfile .` — **fails** on `main` (reproduces #674 exactly, at the `@lifting-logbook/api-client#build` step), **succeeds** end-to-end on this branch (all 4 turbo tasks build, `next build` compiles and completes its TypeScript check, all routes including `/cycle/[cycleNum]` generate, the `/livez` + `/api/healthz` build-time guards pass, image exports).
- `npm run typecheck` — 4/4 workspaces pass.
- Tests: 913 passed, 0 skipped, 0 failed (~33s) — across api-client (27), core (280), web (166), api (440).
- Lockfile stays in sync: `npm install --package-lock-only --ignore-scripts` produces no diff beyond the intentional `turbo` pin.
- Suppression / test-integrity pre-PR greps: clean, no matches.

## Review findings disposition

`/review` found 0 blocking, 2 non-blocking findings — both filed as tracked issues rather than fixed inline (process/tooling gaps orthogonal to the declarationMap fix; implementing either inline would be disproportionate scope creep for this bug-fix PR):

1. **[maintainability]** Turbo version now pinned in three places (Dockerfile, package.json, lockfile) with no automated sync check → filed as #692.
2. **[maintainability]** Scheduled `--no-cache` Docker build CI job proposed but untracked → filed as #693.

Closes #674