### PR TITLE
[feat] Deploy job summary auditability + version-check docs/script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1232,6 +1232,11 @@ jobs:
             --wait --timeout=5m
 
       - name: Print deployment URLs and deployed version
+        # This is a post-deploy reporting step, exactly like the audit step below — the
+        # production deploy has already fully succeeded by the time this runs, so a git
+        # hiccup here (e.g. an unresolvable SHA) must never turn an already-green deploy
+        # red (#697 review).
+        continue-on-error: true
         run: |
           SHORT_SHA=$(git rev-parse --short "${{ github.sha }}")
           SUBJECT=$(git log -1 --format='%s' "${{ github.sha }}")
@@ -1288,9 +1293,21 @@ jobs:
 
           # select() excludes this in-progress run itself — belt and suspenders, since a
           # run in progress cannot yet show status=cancelled, but cheap to guard anyway.
+          # (A run's status is exactly one of success/cancelled/etc, so it can never also
+          # match the earlier success-run query — no double-count risk from that side.)
+          #
+          # >= (not strict >) on --created: gh's --created filter is timestamp-precise, not
+          # day-truncated (verified empirically against this repo's own run history), but a
+          # cancelled run created in the SAME SECOND as the last success would be excluded
+          # by strict >. >= closes that gap safely — it can never re-include the success run
+          # itself, since that run's status is "success", not "cancelled" (#697 review).
+          #
+          # Explicit --limit: without it, gh defaults to 30, which could silently truncate
+          # the audit during exactly the burst-cancellation scenario (#401) it exists to
+          # catch. 100 comfortably covers any realistic gap between successful deploys.
           CANCELLED_TSV=$(gh run list --repo "${{ github.repository }}" \
             --workflow deploy.yml --branch main --status cancelled \
-            --created ">${LAST_SUCCESS_CREATED}" \
+            --created ">=${LAST_SUCCESS_CREATED}" --limit 100 \
             --json databaseId,headSha,displayTitle \
             --jq "[.[] | select(.databaseId != ${{ github.run_id }})] | .[] | [.databaseId, .headSha, .displayTitle] | @tsv") || {
             echo ":warning: \`gh run list\` failed listing cancelled runs — skipping this audit (advisory; does not affect the deploy)." >> "$GITHUB_STEP_SUMMARY"
@@ -1329,6 +1346,10 @@ jobs:
             if git merge-base --is-ancestor "$SHA" "${{ github.sha }}" 2>/dev/null; then
               echo "| [${RUN_ID}](${RUN_URL}) — ${TITLE} | \`${SHORT}\` | :white_check_mark: yes |" >> "$GITHUB_STEP_SUMMARY"
             else
+              # rc=$? MUST be the first statement in this branch — it captures the
+              # merge-base call's exit code above. Inserting any command (even an echo)
+              # before this line would clobber $? and silently misclassify every
+              # non-ancestor (128 vs 1) — do not add anything above this line (#697 review).
               rc=$?
               if [ "$rc" -eq 1 ]; then
                 echo "| [${RUN_ID}](${RUN_URL}) — ${TITLE} | \`${SHORT}\` | :rotating_light: **NO — investigate** |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -854,6 +854,9 @@ jobs:
         needs.preflight.outputs.staging_enabled != 'true' ||
         needs.smoke-test.result == 'success'
       )
+    # gh run list (used by the cancelled-run ancestry audit near the end of this job)
+    # works with contents: read alone — see staging.yml's build-images job for the
+    # identical working precedent. Do not add actions: read for it.
     permissions:
       contents: read
       id-token: write
@@ -861,6 +864,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Full history, not the default shallow depth-1 clone: the cancelled-run
+          # ancestry audit below runs `git merge-base --is-ancestor` against SHAs
+          # that can be many commits back, which a shallow clone can't resolve
+          # reliably. This repo's entire history is ~400 commits, so the extra
+          # clone cost is negligible against this job's 45-minute budget (#672).
+          fetch-depth: 0
 
       - name: Authenticate to GCP (production)
         uses: google-github-actions/auth@v3
@@ -1221,8 +1231,118 @@ jobs:
             --values=infra/kubernetes/values/production-otel-collector.yaml \
             --wait --timeout=5m
 
-      - name: Print deployment URLs
+      - name: Print deployment URLs and deployed version
         run: |
-          echo "## Production deployment complete" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Cloud Run web: ${{ steps.tf-prod.outputs.cloud_run_web_url }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Cloud Run API: ${{ steps.tf-prod.outputs.cloud_run_api_url }}" >> "$GITHUB_STEP_SUMMARY"
+          SHORT_SHA=$(git rev-parse --short "${{ github.sha }}")
+          SUBJECT=$(git log -1 --format='%s' "${{ github.sha }}")
+          COMMIT_URL="${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}"
+          {
+            echo "## Production deployment complete"
+            echo "- Cloud Run web: ${{ steps.tf-prod.outputs.cloud_run_web_url }}"
+            echo "- Cloud Run API: ${{ steps.tf-prod.outputs.cloud_run_api_url }}"
+            echo "- Deployed SHA: [\`${SHORT_SHA}\`](${COMMIT_URL}) — ${SUBJECT}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ── Cancelled-run ancestry audit (#672 / #670) ──────────────────────────
+      # 2026-07-03 (#670): a deploy-main run was silently cancelled by the concurrency
+      # group above (#401) and nobody could quickly tell whether its changes had shipped
+      # in a later run. This finds every `cancelled` deploy.yml run on main since the last
+      # `success` run and checks whether that run's head SHA is an ancestor of what THIS
+      # run deployed. On this repo's linear, squash-merge, fast-forward-only main history,
+      # "ancestor: yes" is the expected/healthy result — every earlier commit is trivially
+      # reachable from a later one. The value is making that confirmation automatic and
+      # visible instead of requiring a human to notice and check by hand; "ancestor: no"
+      # means something abnormal happened (rewritten history, a force-push) and should be
+      # investigated.
+      #
+      # Purely advisory — continue-on-error: true, matching this file's existing "never
+      # gate an already-succeeded production deploy on a reporting step" philosophy (see
+      # plan-production and the GKE Helm A/B steps above). Both `gh run list` calls below
+      # are `||`-guarded rather than left to the implicit `set -eo pipefail` GitHub Actions
+      # already applies to every `run:` step: a bare `VAR=$(cmd)` assignment is NOT exempt
+      # from that default, so an API hiccup is caught explicitly instead of aborting the
+      # script mid-way through an already-partially-written summary.
+      - name: Audit cancelled deploy runs since last success
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          {
+            echo ""
+            echo "## Cancelled-run ancestry audit"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          LAST_SUCCESS_CREATED=$(gh run list --repo "${{ github.repository }}" \
+            --workflow deploy.yml --branch main --status success \
+            --limit 1 --json createdAt --jq '.[0].createdAt // ""') || {
+            echo ":warning: \`gh run list\` failed looking up the last successful run — skipping this audit (advisory; does not affect the deploy)." >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning title=Cancelled-run audit skipped::gh run list (last success) failed."
+            exit 0
+          }
+
+          if [ -z "$LAST_SUCCESS_CREATED" ]; then
+            echo "No prior successful \`deploy.yml\` run found on \`main\` — nothing to bound the audit against (first successful deploy)." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # select() excludes this in-progress run itself — belt and suspenders, since a
+          # run in progress cannot yet show status=cancelled, but cheap to guard anyway.
+          CANCELLED_TSV=$(gh run list --repo "${{ github.repository }}" \
+            --workflow deploy.yml --branch main --status cancelled \
+            --created ">${LAST_SUCCESS_CREATED}" \
+            --json databaseId,headSha,displayTitle \
+            --jq "[.[] | select(.databaseId != ${{ github.run_id }})] | .[] | [.databaseId, .headSha, .displayTitle] | @tsv") || {
+            echo ":warning: \`gh run list\` failed listing cancelled runs — skipping this audit (advisory; does not affect the deploy)." >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning title=Cancelled-run audit skipped::gh run list (cancelled) failed."
+            exit 0
+          }
+
+          if [ -z "$CANCELLED_TSV" ]; then
+            echo "No \`deploy.yml\` runs on \`main\` were cancelled since the last successful run (\`$LAST_SUCCESS_CREATED\`)." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            echo "Cancelled run(s) on \`main\` since the last successful run:"
+            echo ""
+            echo "| Run | Cancelled SHA | Ancestor of deployed SHA? |"
+            echo "|---|---|---|"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Read from a plain variable via here-string, not piped into `while read` — a
+          # pipe forks a subshell for the loop body, which would silently discard the
+          # ANY_NON_ANCESTOR=1 set inside it.
+          ANY_NON_ANCESTOR=0
+          while IFS=$'\t' read -r RUN_ID SHA TITLE; do
+            RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${RUN_ID}"
+            SHORT="${SHA:0:7}"
+            # Four backslashes, not two: bash's ${var//pat/repl} replacement text needs
+            # \\\\ to produce a single literal backslash (verified empirically — the more
+            # obvious-looking \\ silently no-ops here).
+            TITLE="${TITLE//|/\\\\|}"
+
+            # Tested directly in the `if` condition (exempt from set -e's abort-on-nonzero)
+            # rather than capturing $? from a bare command, which would abort this script
+            # the moment a cancelled run turns out NOT to be an ancestor (exit 1). Exit
+            # codes: 0 = ancestor, 1 = not an ancestor, 128 = unresolvable SHA/error.
+            if git merge-base --is-ancestor "$SHA" "${{ github.sha }}" 2>/dev/null; then
+              echo "| [${RUN_ID}](${RUN_URL}) — ${TITLE} | \`${SHORT}\` | :white_check_mark: yes |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              rc=$?
+              if [ "$rc" -eq 1 ]; then
+                echo "| [${RUN_ID}](${RUN_URL}) — ${TITLE} | \`${SHORT}\` | :rotating_light: **NO — investigate** |" >> "$GITHUB_STEP_SUMMARY"
+                ANY_NON_ANCESTOR=1
+              else
+                echo "| [${RUN_ID}](${RUN_URL}) — ${TITLE} | \`${SHORT}\` | :warning: error resolving ancestry (exit ${rc}) |" >> "$GITHUB_STEP_SUMMARY"
+              fi
+            fi
+          done <<< "$CANCELLED_TSV"
+
+          if [ "$ANY_NON_ANCESTOR" -eq 1 ]; then
+            {
+              echo ""
+              echo ":rotating_light: **At least one cancelled run's changes do not appear to be an ancestor of this deploy.** Expected result on this repo's linear, fast-forward-only \`main\` history is always \"yes\" — investigate before assuming the cancelled run's changes shipped."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning title=Non-ancestor cancelled run detected::At least one cancelled deploy.yml run's head SHA is not an ancestor of ${{ github.sha }} — see the job summary table."
+          fi

--- a/docs/README.md
+++ b/docs/README.md
@@ -175,6 +175,7 @@ sequences the runbooks below in reading order and explains what the signals mean
 | Runbook | Covers |
 |---------|--------|
 | [Observability](runbooks/observability.md) | Local stack startup, Grafana dashboards, trace queries, log↔trace correlation, alert rules + notification routing + silencing, Grafana Cloud credential wiring |
+| [Checking the deployed version](runbooks/checking-deployed-version.md) | Confirming what commit is live in staging/production via `/version` + `check-deployed-version.sh` |
 | [API 5xx surge](runbooks/api-5xx-surge.md) | `APIRouteHighErrorRate` / `APIHighErrorRate` alert response — SEV2 |
 | [Database unreachable](runbooks/database-unreachable.md) | DB connection error triage — SEV1 |
 | [Auth provider outage](runbooks/auth-provider-outage.md) | 401/403 surge + Clerk status incident — SEV2 |

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -13,6 +13,7 @@ For severity levels, escalation paths, and the incident response checklist, see
 | Runbook | Trigger | Default severity |
 |---|---|---|
 | [Observability stack](observability.md) | Local dev / Grafana access reference | N/A |
+| [Checking the deployed version](checking-deployed-version.md) | Confirming what commit is live in staging/production | N/A |
 | [API 5xx surge](api-5xx-surge.md) | `APIHighErrorRate` alert | SEV2 |
 | [Database unreachable](database-unreachable.md) | DB connection errors in structured logs | SEV1 |
 | [Auth provider outage](auth-provider-outage.md) | 401/403 surge + Clerk status incident | SEV2 |

--- a/docs/runbooks/checking-deployed-version.md
+++ b/docs/runbooks/checking-deployed-version.md
@@ -1,0 +1,100 @@
+# Checking the Deployed Version
+
+Reports what commit is actually running in staging and production right now, via each
+service's `GET /version` endpoint. Closes the gap from the 2026-07-03 incident (#670): a
+`deploy.yml` run was silently cancelled mid-flight (see the `concurrency:` block's header
+comment in [`.github/workflows/deploy.yml`](../../.github/workflows/deploy.yml), #401) and
+there was no fast way to confirm what had actually shipped without a Cloud Console detour.
+
+---
+
+## The `/version` endpoint
+
+Both `apps/api` and `apps/web` expose an unauthenticated-at-the-app-level `GET /version`
+(#671) reporting the git commit baked into the running container image at build time:
+
+```json
+{ "gitSha": "<40-char sha, or \"unknown\">", "environment": "<NODE_ENV>" }
+```
+
+- [`apps/api/src/health/health.controller.ts`](../../apps/api/src/health/health.controller.ts) — `@Public() @Get('version')`
+- [`apps/web/app/version/route.ts`](../../apps/web/app/version/route.ts) — excluded from Clerk middleware entirely (see the matcher in [`apps/web/middleware.ts`](../../apps/web/middleware.ts))
+
+`gitSha` degrades to `"unknown"` rather than throwing if `GIT_SHA` was never baked in (e.g. a
+manual `docker build` without `--build-arg GIT_SHA=...`) — a missing SHA only degrades
+observability, not functionality.
+
+**`environment` is `NODE_ENV`, not the GCP project.** Staging's Cloud Run services run with
+`NODE_ENV=production` (the Node.js convention for "optimized build"), so staging's `/version`
+legitimately reports `"environment":"production"` — this does not mean you are looking at
+prod. Confirm which environment you're checking by the URL/project you queried, not this field.
+
+**On staging, the reported SHA can lag the PR's actual head commit.** `staging.yml`'s
+"Resolve image tag" step reuses a prior image (via a floating `pr-<N>` tag) when a push's diff
+is judged non-image-affecting, rather than rebuilding. On such a run, the baked-in `GIT_SHA` —
+and therefore what `/version` reports — reflects whichever earlier commit in the PR actually
+triggered the last real build, not the current head. This is documented in detail in the
+"Resolve image tag" step's comment in `staging.yml` (#671). Production never takes this
+shortcut — every production deploy builds and tags images against `github.sha` directly.
+
+### Reaching it
+
+| Service | Auth |
+|---|---|
+| `lifting-logbook-{stg,prod}-web` | none — `--allow-unauthenticated` |
+| `lifting-logbook-{stg,prod}-api` | Cloud Run identity token — `--no-allow-unauthenticated` |
+
+For the api services, mint a token the same way the deploy pipeline's own smoke test does
+(`.github/workflows/deploy.yml`, "Smoke test Cloud Run production — /readyz"):
+
+```sh
+gcloud auth print-identity-token \
+  --impersonate-service-account=<cicd-service-account-email> \
+  --audiences=<api-service-url> \
+  --include-email
+```
+
+then `curl -H "Authorization: Bearer $ID_TOKEN" <api-url>/version`. This requires
+`roles/iam.serviceAccountTokenCreator` on the impersonated CI/CD service account.
+
+---
+
+## `scripts/check-deployed-version.sh`
+
+Automates the above for all 4 services (staging + production, api + web) in one command, and
+prints `git log -1` context for each returned SHA so you can immediately see what that commit
+actually was — no separate `git log`/GitHub lookup needed. Attempts every check even if one
+fails, and reports an aggregate pass/fail summary at the end.
+
+```sh
+bash scripts/check-deployed-version.sh                    # both environments
+bash scripts/check-deployed-version.sh --env staging       # staging only
+```
+
+Requires `gcloud`, authenticated, with `roles/iam.serviceAccountTokenCreator` on the relevant
+CI/CD service account (the same `GCP_STAGING_SERVICE_ACCOUNT` / `GCP_PROD_SERVICE_ACCOUNT` used
+in `.github/workflows/deploy.yml` — see [`docs/deploy.md`](../deploy.md)) to mint identity
+tokens for the `*-api` checks; the `*-web` checks need no auth.
+
+Full flag reference: `bash scripts/check-deployed-version.sh --help`.
+
+---
+
+## Automated audit in the deploy pipeline
+
+Every `deploy.yml` production deploy prints the deployed SHA + commit link in its job summary,
+and separately audits any `cancelled` `deploy.yml` runs on `main` since the last successful
+run — checking whether each cancelled run's changes made it into what actually shipped
+(`git merge-base --is-ancestor`). See the "Audit cancelled deploy runs since last success" step
+in `deploy-production` (`.github/workflows/deploy.yml`). This is advisory (never fails the
+deploy) and is the automated version of the manual check this runbook otherwise describes.
+
+---
+
+## References
+
+- [GitHub Actions — Adding a job summary](https://docs.github.com/en/actions/how-tos/write-scripts/add-a-job-summary) — `GITHUB_STEP_SUMMARY` semantics and GFM rendering
+- [GitHub CLI — `gh run list`](https://cli.github.com/manual/gh_run_list) — flags for filtering runs by workflow, branch, status, and creation date
+- [Git — `git-merge-base`](https://git-scm.com/docs/git-merge-base) — `--is-ancestor` exit-code semantics
+- [Google Cloud — Authenticating service-to-service](https://cloud.google.com/run/docs/authenticating/service-to-service) — Cloud Run identity tokens and service account impersonation
+- [Google Cloud — `gcloud auth print-identity-token`](https://cloud.google.com/sdk/gcloud/reference/auth/print-identity-token) — command reference

--- a/docs/runbooks/checking-deployed-version.md
+++ b/docs/runbooks/checking-deployed-version.md
@@ -89,6 +89,12 @@ run — checking whether each cancelled run's changes made it into what actually
 in `deploy-production` (`.github/workflows/deploy.yml`). This is advisory (never fails the
 deploy) and is the automated version of the manual check this runbook otherwise describes.
 
+**The job-summary SHA and `check-deployed-version.sh`'s SHA answer different questions.** The
+job summary reports what a specific run *deployed at the time it ran*; the script reports what's
+*actually live right now*. These are usually the same commit, but can diverge — most commonly on
+staging after an image-reuse (skip-build) deploy, per the gotcha above. If the two disagree,
+trust the script — it reflects the live `/version` endpoint, not a historical CI record.
+
 ---
 
 ## References

--- a/docs/runbooks/deploy-regression-rollback.md
+++ b/docs/runbooks/deploy-regression-rollback.md
@@ -50,6 +50,11 @@ kubectl rollout history deployment/api --revision=<latest-revision>
 
 Note the image tag. In the GitHub repository, find the commit corresponding to that tag.
 
+**Faster alternative:** `bash scripts/check-deployed-version.sh` curls each service's
+`/version` endpoint directly and prints `git log -1` context for the returned SHA in one step,
+skipping the manual `kubectl rollout history` + tag lookup. See
+[`checking-deployed-version.md`](checking-deployed-version.md).
+
 ### 3. Identify the failing code path
 
 In Grafana Explore → Tempo:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,6 +51,7 @@ Repository automation scripts. Grouped by lifecycle.
 
 | Script | Purpose |
 |---|---|
+| [`check-deployed-version.sh`](check-deployed-version.sh) | Curls `GET /version` on staging + production, api + web (#672 / #670): reports the deployed git SHA and prints `git log -1` context for each. api requires a Cloud Run identity token (mirrors the deploy pipeline's smoke test); web is `--allow-unauthenticated`. Attempts all 4 checks even if one fails, aggregating and reporting failures at the end. Pass `--env staging`/`--env production` to scope to one environment. See [`docs/runbooks/checking-deployed-version.md`](../docs/runbooks/checking-deployed-version.md). |
 | [`smoke-test-observability.sh`](smoke-test-observability.sh) | End-to-end smoke test of the observability docker-compose stack: sends a synthetic OTLP trace and polls Tempo. Requires Docker Compose V2. |
 | [`validate-analytics-taxonomy.mjs`](validate-analytics-taxonomy.mjs) | Verifies `AnalyticsConstants.kt` is in sync with `packages/types/src/analytics.ts`. Exits 0 if the Kotlin file is absent (future work). |
 

--- a/scripts/check-deployed-version.sh
+++ b/scripts/check-deployed-version.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# check-deployed-version.sh — Reports the deployed git commit (via GET /version) for the
+# api and web Cloud Run services in staging and/or production, plus `git log -1` context
+# for each returned SHA (#672 / #670).
+#
+# Closes the gap from the 2026-07-03 incident (#670): there was no fast way to check "what
+# commit is actually running right now" without a Cloud Console detour. This curls the
+# live /version endpoint on each service instead. api requires a Cloud Run identity token
+# (mirrors the "Smoke test Cloud Run production — /readyz" step in
+# .github/workflows/deploy.yml); web is --allow-unauthenticated.
+#
+# Attempts all 4 checks even if one fails — aggregates failures and reports a summary at
+# the end, exiting non-zero only then (mirrors deploy.yml's "Validate production auth
+# secrets (pre-promote)" step rather than aborting on the first failure).
+#
+# Two things worth knowing before reading the output:
+#   * "environment" in the JSON response is NODE_ENV, not the GCP project. Staging's Cloud
+#     Run services run NODE_ENV=production (the Node convention for "optimized build"), so
+#     staging's /version legitimately reports "environment":"production" — this does not
+#     mean you're looking at prod. See docs/runbooks/checking-deployed-version.md.
+#   * On staging specifically, the reported SHA can lag the PR's actual head commit when a
+#     run reused a prior image via staging.yml's skip-build optimization (see the "Resolve
+#     image tag" step comment in staging.yml, #671) — this is expected, not a broken deploy.
+#
+# Prereqs:
+#   * gcloud CLI, authenticated, with roles/iam.serviceAccountTokenCreator on the relevant
+#     CI/CD service account (needed only for the *-api checks — see --staging-service-account
+#     / --prod-service-account below).
+#   * git (for the `git log -1` context; degrades gracefully — not a crash — if a SHA isn't
+#     resolvable in the local clone's history).
+#   * node (JSON parsing — this repo's local dev convention avoids requiring jq; see CLAUDE.md).
+#
+# Usage:
+#   bash scripts/check-deployed-version.sh [--env both|staging|production] \
+#       [--staging-project-id <id>] [--prod-project-id <id>] \
+#       [--staging-service-account <email>] [--prod-service-account <email>] \
+#       [--region <region>]
+#
+# Examples:
+#   bash scripts/check-deployed-version.sh                       # both environments
+#   bash scripts/check-deployed-version.sh --env staging          # staging only
+
+set -uo pipefail
+
+ENVS="both"
+STAGING_PROJECT_ID="lifting-logbook-staging"
+PROD_PROJECT_ID="lifting-logbook-prod"
+STAGING_SERVICE_ACCOUNT=""
+PROD_SERVICE_ACCOUNT=""
+REGION="us-central1"
+
+usage() {
+  echo "Usage: $0 [--env both|staging|production]" >&2
+  echo "          [--staging-project-id <id>] [--prod-project-id <id>]" >&2
+  echo "          [--staging-service-account <email>] [--prod-service-account <email>]" >&2
+  echo "          [--region <region>]" >&2
+  exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --env) ENVS="$2"; shift 2 ;;
+    --staging-project-id) STAGING_PROJECT_ID="$2"; shift 2 ;;
+    --prod-project-id) PROD_PROJECT_ID="$2"; shift 2 ;;
+    --staging-service-account) STAGING_SERVICE_ACCOUNT="$2"; shift 2 ;;
+    --prod-service-account) PROD_SERVICE_ACCOUNT="$2"; shift 2 ;;
+    --region) REGION="$2"; shift 2 ;;
+    -h|--help) usage 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage 1 ;;
+  esac
+done
+
+case "$ENVS" in
+  both|staging|production) ;;
+  *) echo "ERROR: --env must be both|staging|production (got '$ENVS')" >&2; exit 1 ;;
+esac
+
+command -v gcloud >/dev/null 2>&1 || { echo "ERROR: gcloud CLI not found on PATH." >&2; exit 1; }
+command -v node >/dev/null 2>&1 || { echo "ERROR: node not found on PATH (needed for JSON parsing)." >&2; exit 1; }
+
+FAILURES=0
+
+# Parses a /version JSON body on stdin; prints "gitSha<TAB>environment" and returns 0, or
+# returns 1 on invalid JSON / missing fields. Avoids a hard dependency on jq (not guaranteed
+# installed locally — see CLAUDE.md), matching scripts/smoke-test-observability.sh's
+# node-based JSON handling.
+parse_version_json() {
+  node -e '
+    let d = "";
+    process.stdin.on("data", c => d += c);
+    process.stdin.on("end", () => {
+      try {
+        const j = JSON.parse(d);
+        if (typeof j.gitSha !== "string" || typeof j.environment !== "string") {
+          process.exit(1);
+        }
+        process.stdout.write(j.gitSha + "\t" + j.environment);
+      } catch (e) {
+        process.exit(1);
+      }
+    });
+  '
+}
+
+# Maps the --env label to the abbreviated infix Cloud Run service names actually use
+# (lifting-logbook-stg-*, lifting-logbook-prod-* — see .github/workflows/deploy.yml's
+# `gcloud run deploy` steps). Kept as a separate mapping from the "staging"/"production"
+# labels used elsewhere in this script's flags/output, which read better for a human.
+service_env_infix() {
+  case "$1" in
+    staging) echo "stg" ;;
+    production) echo "prod" ;;
+  esac
+}
+
+# Prints `git log -1` context for a SHA, or a clear degraded-not-crashed note if the SHA
+# isn't resolvable in this local clone's history (e.g. a shallow clone, or truly unknown).
+print_commit_context() {
+  local sha="$1"
+  if [ "$sha" = "unknown" ]; then
+    echo "    (GIT_SHA was not baked into this image — cannot look up commit context)"
+    return
+  fi
+  if git cat-file -e "${sha}^{commit}" 2>/dev/null; then
+    git log -1 --format='    %h  %s  (%an, %ar)' "$sha"
+  else
+    echo "    (commit ${sha:0:7} not found in this local clone's history — try 'git fetch origin' or view it directly: https://github.com/brownm09/lifting-logbook/commit/${sha})"
+  fi
+}
+
+# Checks a --allow-unauthenticated web service. No identity token needed.
+#   $1 = env label ("staging"|"production"), $2 = GCP project id
+check_web() {
+  local env="$1" project="$2"
+  local service="lifting-logbook-$(service_env_infix "$env")-web"
+  echo "==> ${env} web (${service})"
+
+  local url
+  url=$(gcloud run services describe "$service" --project="$project" --region="$REGION" --format='value(status.url)')
+  if [ -z "$url" ]; then
+    echo "    FAIL: could not resolve service URL (see gcloud error above, if any)" >&2
+    FAILURES=$((FAILURES + 1))
+    echo
+    return
+  fi
+  url="${url%/}"
+
+  local status
+  status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "${url}/version" || echo "000")
+  if [ "$status" != "200" ]; then
+    echo "    FAIL: GET ${url}/version returned HTTP ${status} (expected 200)" >&2
+    FAILURES=$((FAILURES + 1))
+    echo
+    return
+  fi
+
+  local body parsed
+  body=$(curl -s --max-time 10 "${url}/version")
+  if ! parsed=$(printf '%s' "$body" | parse_version_json); then
+    echo "    FAIL: /version returned malformed JSON: ${body}" >&2
+    FAILURES=$((FAILURES + 1))
+    echo
+    return
+  fi
+
+  local sha="${parsed%%$'\t'*}" nodeenv="${parsed##*$'\t'}"
+  echo "    url:         ${url}"
+  echo "    gitSha:      ${sha}"
+  echo "    environment: ${nodeenv}  (NODE_ENV — not the GCP project; staging runs NODE_ENV=production by convention)"
+  print_commit_context "$sha"
+  echo
+}
+
+# Checks a --no-allow-unauthenticated api service. Mints a Cloud Run identity token via
+# impersonation (same pattern as deploy.yml's prod /readyz smoke test) and never echoes,
+# logs, or URL-embeds it — only ever passed via the Authorization header.
+#   $1 = env label, $2 = GCP project id, $3 = service account email to impersonate
+check_api() {
+  local env="$1" project="$2" service_account="$3"
+  local service="lifting-logbook-$(service_env_infix "$env")-api"
+  echo "==> ${env} api (${service})"
+
+  if [ -z "$service_account" ]; then
+    echo "    FAIL: no service account provided (--${env}-service-account) — cannot mint a Cloud Run identity token" >&2
+    FAILURES=$((FAILURES + 1))
+    echo
+    return
+  fi
+
+  local url
+  url=$(gcloud run services describe "$service" --project="$project" --region="$REGION" --format='value(status.url)')
+  if [ -z "$url" ]; then
+    echo "    FAIL: could not resolve service URL (see gcloud error above, if any)" >&2
+    FAILURES=$((FAILURES + 1))
+    echo
+    return
+  fi
+  url="${url%/}"
+
+  local id_token
+  id_token=$(gcloud auth print-identity-token \
+    --impersonate-service-account="$service_account" \
+    --audiences="$url" --include-email)
+  if [ -z "$id_token" ]; then
+    echo "    FAIL: could not mint a Cloud Run identity token impersonating ${service_account} (see gcloud error above, if any — check you have roles/iam.serviceAccountTokenCreator on it)" >&2
+    FAILURES=$((FAILURES + 1))
+    echo
+    return
+  fi
+
+  local status
+  status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 -H "Authorization: Bearer ${id_token}" "${url}/version" || echo "000")
+  if [ "$status" != "200" ]; then
+    echo "    FAIL: GET ${url}/version returned HTTP ${status} (expected 200)" >&2
+    FAILURES=$((FAILURES + 1))
+    unset id_token
+    echo
+    return
+  fi
+
+  local body parsed
+  body=$(curl -s --max-time 10 -H "Authorization: Bearer ${id_token}" "${url}/version")
+  unset id_token
+
+  if ! parsed=$(printf '%s' "$body" | parse_version_json); then
+    echo "    FAIL: /version returned malformed JSON: ${body}" >&2
+    FAILURES=$((FAILURES + 1))
+    echo
+    return
+  fi
+
+  local sha="${parsed%%$'\t'*}" nodeenv="${parsed##*$'\t'}"
+  echo "    url:         ${url}"
+  echo "    gitSha:      ${sha}"
+  echo "    environment: ${nodeenv}  (NODE_ENV — not the GCP project; staging runs NODE_ENV=production by convention)"
+  print_commit_context "$sha"
+  echo
+}
+
+if [ "$ENVS" = "both" ] || [ "$ENVS" = "staging" ]; then
+  check_web staging "$STAGING_PROJECT_ID"
+  check_api staging "$STAGING_PROJECT_ID" "$STAGING_SERVICE_ACCOUNT"
+fi
+
+if [ "$ENVS" = "both" ] || [ "$ENVS" = "production" ]; then
+  check_web production "$PROD_PROJECT_ID"
+  check_api production "$PROD_PROJECT_ID" "$PROD_SERVICE_ACCOUNT"
+fi
+
+if [ "$FAILURES" -eq 0 ]; then
+  echo "All checks passed."
+  exit 0
+else
+  echo "FAILED: ${FAILURES} check(s) did not succeed — see above." >&2
+  exit 1
+fi

--- a/scripts/check-deployed-version.sh
+++ b/scripts/check-deployed-version.sh
@@ -13,7 +13,7 @@
 # the end, exiting non-zero only then (mirrors deploy.yml's "Validate production auth
 # secrets (pre-promote)" step rather than aborting on the first failure).
 #
-# Two things worth knowing before reading the output:
+# Three things worth knowing before reading the output:
 #   * "environment" in the JSON response is NODE_ENV, not the GCP project. Staging's Cloud
 #     Run services run NODE_ENV=production (the Node convention for "optimized build"), so
 #     staging's /version legitimately reports "environment":"production" — this does not
@@ -21,6 +21,9 @@
 #   * On staging specifically, the reported SHA can lag the PR's actual head commit when a
 #     run reused a prior image via staging.yml's skip-build optimization (see the "Resolve
 #     image tag" step comment in staging.yml, #671) — this is expected, not a broken deploy.
+#   * This reports what's live *right now*, which answers a different question than
+#     deploy.yml's job-summary SHA (which reports what a specific run *deployed* at the
+#     time it ran). The two can legitimately differ — see docs/runbooks/checking-deployed-version.md.
 #
 # Prereqs:
 #   * gcloud CLI, authenticated, with roles/iam.serviceAccountTokenCreator on the relevant
@@ -128,6 +131,83 @@ print_commit_context() {
   fi
 }
 
+# Fetches GET <url>/version in a single request (status and body must come from the same
+# response — checking status via one request and parsing the body from a second, separate
+# request leaves a window where a rolling deploy could swap revisions between the two calls
+# and produce a status/body mismatch), validates the status, and parses the body.
+# Prints "gitSha<TAB>environment" on success. On failure, prints a FAIL line (prefixed with
+# the given label) to stderr and returns 1 — callers just need to check the return status.
+#   $1 = label for FAIL messages (e.g. "staging web"), $2 = full URL (no trailing slash),
+#   remaining args = extra curl options (e.g. -H "Authorization: ...")
+fetch_version() {
+  local label="$1" url="$2"; shift 2
+  local response status body
+  if ! response=$(curl -s -w '\n%{http_code}' --max-time 10 "$@" "${url}/version"); then
+    echo "    FAIL: ${label} — curl could not reach ${url}/version" >&2
+    return 1
+  fi
+  status="${response##*$'\n'}"
+  body="${response%$'\n'*}"
+
+  if [ "$status" != "200" ]; then
+    echo "    FAIL: ${label} — GET ${url}/version returned HTTP ${status} (expected 200)" >&2
+    return 1
+  fi
+
+  local parsed
+  if ! parsed=$(printf '%s' "$body" | parse_version_json); then
+    echo "    FAIL: ${label} — /version returned malformed JSON: ${body}" >&2
+    return 1
+  fi
+
+  printf '%s' "$parsed"
+}
+
+# Resolves a Cloud Run service's URL, checking the actual gcloud exit status (not just
+# whether stdout came back empty — a denied/erroring gcloud call and a call that legitimately
+# returns nothing are different failures, and conflating them produces a misleading message).
+# Prints the URL (no trailing slash) on success; prints a FAIL line and returns 1 on failure.
+#   $1 = label for FAIL messages, $2 = service name, $3 = GCP project id
+resolve_service_url() {
+  local label="$1" service="$2" project="$3"
+  local url
+  if ! url=$(gcloud run services describe "$service" --project="$project" --region="$REGION" --format='value(status.url)'); then
+    echo "    FAIL: ${label} — could not resolve service URL for ${service} (gcloud exited non-zero — see error above)" >&2
+    return 1
+  fi
+  if [ -z "$url" ]; then
+    echo "    FAIL: ${label} — gcloud returned an empty URL for ${service} with no error (unexpected)" >&2
+    return 1
+  fi
+  printf '%s' "${url%/}"
+}
+
+# Checks one service's /version and prints the standard report block. Shared by the
+# --allow-unauthenticated (web) and identity-token (api) paths below — they differ only in
+# whether curl_auth_args carries an Authorization header.
+#   $1 = env label, $2 = service kind ("web"|"api"), $3 = service url,
+#   remaining args = extra curl options for fetch_version (e.g. -H "Authorization: ...")
+report_version() {
+  local env="$1" kind="$2" url="$3"; shift 3
+  local label="${env} ${kind}"
+
+  local parsed
+  if ! parsed=$(fetch_version "$label" "$url" "$@"); then
+    FAILURES=$((FAILURES + 1))
+    echo
+    return
+  fi
+
+  local sha nodeenv
+  IFS=$'\t' read -r sha nodeenv <<< "$parsed"
+
+  echo "    url:         ${url}"
+  echo "    gitSha:      ${sha}"
+  echo "    environment: ${nodeenv}  (NODE_ENV — not the GCP project; staging runs NODE_ENV=production by convention)"
+  print_commit_context "$sha"
+  echo
+}
+
 # Checks a --allow-unauthenticated web service. No identity token needed.
 #   $1 = env label ("staging"|"production"), $2 = GCP project id
 check_web() {
@@ -136,39 +216,13 @@ check_web() {
   echo "==> ${env} web (${service})"
 
   local url
-  url=$(gcloud run services describe "$service" --project="$project" --region="$REGION" --format='value(status.url)')
-  if [ -z "$url" ]; then
-    echo "    FAIL: could not resolve service URL (see gcloud error above, if any)" >&2
-    FAILURES=$((FAILURES + 1))
-    echo
-    return
-  fi
-  url="${url%/}"
-
-  local status
-  status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "${url}/version" || echo "000")
-  if [ "$status" != "200" ]; then
-    echo "    FAIL: GET ${url}/version returned HTTP ${status} (expected 200)" >&2
+  if ! url=$(resolve_service_url "${env} web" "$service" "$project"); then
     FAILURES=$((FAILURES + 1))
     echo
     return
   fi
 
-  local body parsed
-  body=$(curl -s --max-time 10 "${url}/version")
-  if ! parsed=$(printf '%s' "$body" | parse_version_json); then
-    echo "    FAIL: /version returned malformed JSON: ${body}" >&2
-    FAILURES=$((FAILURES + 1))
-    echo
-    return
-  fi
-
-  local sha="${parsed%%$'\t'*}" nodeenv="${parsed##*$'\t'}"
-  echo "    url:         ${url}"
-  echo "    gitSha:      ${sha}"
-  echo "    environment: ${nodeenv}  (NODE_ENV — not the GCP project; staging runs NODE_ENV=production by convention)"
-  print_commit_context "$sha"
-  echo
+  report_version "$env" "web" "$url"
 }
 
 # Checks a --no-allow-unauthenticated api service. Mints a Cloud Run identity token via
@@ -181,60 +235,37 @@ check_api() {
   echo "==> ${env} api (${service})"
 
   if [ -z "$service_account" ]; then
-    echo "    FAIL: no service account provided (--${env}-service-account) — cannot mint a Cloud Run identity token" >&2
+    echo "    FAIL: ${env} api — no service account provided (--${env}-service-account) — cannot mint a Cloud Run identity token" >&2
     FAILURES=$((FAILURES + 1))
     echo
     return
   fi
 
   local url
-  url=$(gcloud run services describe "$service" --project="$project" --region="$REGION" --format='value(status.url)')
-  if [ -z "$url" ]; then
-    echo "    FAIL: could not resolve service URL (see gcloud error above, if any)" >&2
+  if ! url=$(resolve_service_url "${env} api" "$service" "$project"); then
     FAILURES=$((FAILURES + 1))
     echo
     return
   fi
-  url="${url%/}"
 
   local id_token
-  id_token=$(gcloud auth print-identity-token \
-    --impersonate-service-account="$service_account" \
-    --audiences="$url" --include-email)
+  if ! id_token=$(gcloud auth print-identity-token \
+      --impersonate-service-account="$service_account" \
+      --audiences="$url" --include-email); then
+    echo "    FAIL: ${env} api — could not mint a Cloud Run identity token impersonating ${service_account} (gcloud exited non-zero — check you have roles/iam.serviceAccountTokenCreator on it)" >&2
+    FAILURES=$((FAILURES + 1))
+    echo
+    return
+  fi
   if [ -z "$id_token" ]; then
-    echo "    FAIL: could not mint a Cloud Run identity token impersonating ${service_account} (see gcloud error above, if any — check you have roles/iam.serviceAccountTokenCreator on it)" >&2
+    echo "    FAIL: ${env} api — gcloud returned an empty identity token with no error (unexpected)" >&2
     FAILURES=$((FAILURES + 1))
     echo
     return
   fi
 
-  local status
-  status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 -H "Authorization: Bearer ${id_token}" "${url}/version" || echo "000")
-  if [ "$status" != "200" ]; then
-    echo "    FAIL: GET ${url}/version returned HTTP ${status} (expected 200)" >&2
-    FAILURES=$((FAILURES + 1))
-    unset id_token
-    echo
-    return
-  fi
-
-  local body parsed
-  body=$(curl -s --max-time 10 -H "Authorization: Bearer ${id_token}" "${url}/version")
+  report_version "$env" "api" "$url" -H "Authorization: Bearer ${id_token}"
   unset id_token
-
-  if ! parsed=$(printf '%s' "$body" | parse_version_json); then
-    echo "    FAIL: /version returned malformed JSON: ${body}" >&2
-    FAILURES=$((FAILURES + 1))
-    echo
-    return
-  fi
-
-  local sha="${parsed%%$'\t'*}" nodeenv="${parsed##*$'\t'}"
-  echo "    url:         ${url}"
-  echo "    gitSha:      ${sha}"
-  echo "    environment: ${nodeenv}  (NODE_ENV — not the GCP project; staging runs NODE_ENV=production by convention)"
-  print_commit_context "$sha"
-  echo
 }
 
 if [ "$ENVS" = "both" ] || [ "$ENVS" = "staging" ]; then


### PR DESCRIPTION
## Summary

Sub-issue of #670; builds on #671 (merged in #686). Closes the CI-auditability half of #670's goal:

- Extends `deploy.yml`'s `deploy-production` job's final "Print deployment URLs" step to also print the deployed SHA, short commit subject, and a commit link.
- Adds a new "Audit cancelled deploy runs since last success" step: lists `deploy.yml` runs on `main` cancelled since the last successful run, and for each checks `git merge-base --is-ancestor <cancelled-sha> ${{ github.sha }}` — closing the exact gap from the 2026-07-03 incident where a silently-cancelled deploy's fate had to be checked by hand. Purely advisory (`continue-on-error: true`) — never gates an already-succeeded production deploy.
- Adds `scripts/check-deployed-version.sh`: curls `GET /version` on staging + production, api + web, mirroring the existing prod smoke-test's identity-token pattern for the api legs, and prints `git log -1` context for each returned SHA.
- Adds `docs/runbooks/checking-deployed-version.md` (reference-style, severity N/A, matching `observability.md`), indexed in `docs/runbooks/README.md` and `docs/README.md`, and cross-linked from `deploy-regression-rollback.md`'s Diagnosis step 2 as a faster alternative to `kubectl rollout history` + manual tag lookup.

## Acceptance criteria

- [x] Deploy job summary shows the deployed SHA + commit link
- [x] Cancelled-run ancestry audit step added and correctly reports non-ancestor cancellations
- [x] `scripts/check-deployed-version.sh` added and dry-run against staging
- [x] New runbook added, indexed, and cross-linked

## Notable implementation details

- `deploy-production`'s checkout now uses `fetch-depth: 0` (full history) — `git merge-base --is-ancestor` needs it against arbitrary historical SHAs; this repo is ~400 commits, so the cost is negligible.
- Deliberately did **not** add `actions: read` to the job's permissions — verified `staging.yml`'s `build-images` job already calls `gh run list` successfully with just `contents: read`/`id-token: write` today, and added a comment pointing at that precedent so it isn't "fixed" unnecessarily later.
- The audit step is careful about GitHub Actions' implicit `bash -eo pipefail` default: both `gh run list` calls are explicitly `||`-guarded (a bare `VAR=$(cmd)` isn't exempt from that default), and the per-run ancestry check is tested directly in an `if` condition (also exempt) rather than reading `$?` from a bare command, so a "not an ancestor" result (exit 1) can't abort the script.

## Testing

No application/TypeScript code is touched (CI YAML + bash + docs only), so no new automated test coverage applies — matches the existing precedent for `bootstrap-otel-secrets.sh`/`smoke-test-observability.sh`, which also shipped without dedicated tests.

- `npm run typecheck`: passed, unchanged (4/4 tasks successful — re-confirmed full cache hit after the review-fix commit, since no application code changed).
- `npm test`: **Tests: 440 passed, 0 skipped, 0 failed** (api suite, 96s; 12/12 turbo tasks successful overall, 7 cached).
- `bash -n scripts/check-deployed-version.sh`: syntax OK (re-checked after the review-fix refactor).
- **Live dry-run against real staging infra** (not just `--help`/syntax), re-run after the review-fix refactor: `bash scripts/check-deployed-version.sh --env staging --staging-service-account lifting-logbook-stg-cicd@lifting-logbook-staging.iam.gserviceaccount.com`. Web leg fully succeeded end-to-end — real URL, real `gitSha`, real `git log -1` context. The api leg correctly failed with the improved, more precise error message (confirming the gcloud-exit-status fix from review is live) — this is an IAM-grant gap on my personal dev identity, not a script defect.
- **Live-exercised the `deploy.yml` audit-step bash directly against the real repo** (this workflow has no `workflow_dispatch` trigger, so it can't be dry-run in Actions itself), both before and after the review fixes: confirmed `gh run list --created`/`--jq` return correct data, forced all three ancestry-check branches (yes/no/error), and re-verified the `>=`/`--limit 100` boundary fix against a real cancelled run that appeared mid-session (PR #691) — correctly resolved as an ancestor of `origin/main`'s actual tip. Caught and fixed two real bugs this way: the `TITLE` pipe-escaping four-backslash requirement (pre-review), and confirmed the `--created` filter is timestamp-precise, not day-truncated, empirically (during review-fix verification).

Suppression / test-integrity / lockfile-drift pre-PR greps: all clean (no `package.json` changes either, so lockfile check is N/A).

## Review findings disposition

`/review` ran two parallel passes (correctness/security; reliability/performance/maintainability — full report: [PR comment](https://github.com/brownm09/lifting-logbook/pull/697#issuecomment-4887835231)). All findings were fixed in this PR, none filed/deferred:

| Finding | Severity | Fixed in |
|---|---|---|
| SHA/subject summary step missing `continue-on-error`, inconsistent with file philosophy | Blocking [correctness] | `9cb5cad` |
| Cancelled-run query missing explicit `--limit` (default-30 truncation risk) | Blocking [reliability] | `9cb5cad` |
| `gcloud` calls only checked emptiness, not actual exit status | Blocking [reliability] | `9cb5cad` |
| curl status/body fetched via two separate requests (TOCTOU gap) | Non-blocking [correctness] | `9cb5cad` |
| `--created` used strict `>` (same-second boundary gap) | Non-blocking [correctness] | `9cb5cad` |
| `rc=$?` capture fragility (comment-only fix — declined the suggested restructuring, which would reintroduce the `set -e` bug this code avoids) | Non-blocking [correctness] | `9cb5cad` |
| `check_web`/`check_api` ~90% duplicated | Non-blocking [maintainability] | `9cb5cad` |
| Tab-delimited field extraction via `%%`/`##` was fragile | Non-blocking [maintainability] | `9cb5cad` |
| Runbook didn't distinguish job-summary SHA vs. script's live SHA | Non-blocking [documentation] | `9cb5cad` |
| `docs/README.md`'s runbooks index missing the new runbook | Non-blocking [documentation] | `9cb5cad` |

All fixes re-verified live against real staging infrastructure and real repo/`gh` data (details in Testing above), not just re-read.
