### PR TITLE
[fix] Add /settings hub, settings sub-nav, and surface the Import wizard

### DIFF
--- a/apps/web/app/(authed)/AppNav.test.tsx
+++ b/apps/web/app/(authed)/AppNav.test.tsx
@@ -22,7 +22,7 @@ describe('AppNav', () => {
     expect(screen.getByRole('link', { name: 'Programs' })).toHaveAttribute('href', '/programs');
     expect(screen.getByRole('link', { name: 'Settings' })).toHaveAttribute(
       'href',
-      '/settings/training-maxes',
+      '/settings',
     );
   });
 

--- a/apps/web/app/(authed)/AppNav.tsx
+++ b/apps/web/app/(authed)/AppNav.tsx
@@ -8,8 +8,9 @@ import styles from './AppNav.module.css';
 const LINKS: ReadonlyArray<{ href: string; label: string; match: string }> = [
   { href: '/history', label: 'History', match: '/history' },
   { href: '/programs', label: 'Programs', match: '/programs' },
-  // PR 2 (#679) repoints this to the /settings hub once it exists.
-  { href: '/settings/training-maxes', label: 'Settings', match: '/settings' },
+  // Points at the /settings hub (#679), which lists every settings section plus
+  // the Import tool; `match` keeps this active across the whole /settings/* subtree.
+  { href: '/settings', label: 'Settings', match: '/settings' },
 ];
 
 /**

--- a/apps/web/app/(authed)/AppNav.tsx
+++ b/apps/web/app/(authed)/AppNav.tsx
@@ -33,7 +33,9 @@ export default function AppNav() {
       </Link>
       <nav aria-label="Primary" className={styles.nav}>
         {LINKS.map(({ href, label, match }) => {
-          const active = pathname.startsWith(match);
+          // Boundary-safe: exact hub match or a real sub-path, so a sibling like
+          // `/settings-export` can't mis-highlight `/settings` (mirrors SettingsNav).
+          const active = pathname === match || pathname.startsWith(`${match}/`);
           return (
             <Link
               key={href}

--- a/apps/web/app/(authed)/settings/SettingsNav.test.tsx
+++ b/apps/web/app/(authed)/settings/SettingsNav.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, within } from '@testing-library/react';
+import SettingsNav from './SettingsNav';
+import { SETTINGS_SECTIONS } from './sections';
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(),
+}));
+
+import { usePathname } from 'next/navigation';
+
+const mockedUsePathname = usePathname as unknown as jest.Mock;
+
+describe('SettingsNav', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders a labelled sub-nav with a tab per settings section', () => {
+    mockedUsePathname.mockReturnValue('/settings');
+    render(<SettingsNav />);
+
+    const nav = within(screen.getByRole('navigation', { name: 'Settings sections' }));
+    for (const { href, label } of SETTINGS_SECTIONS) {
+      expect(nav.getByRole('link', { name: label })).toHaveAttribute('href', href);
+    }
+    expect(nav.getAllByRole('link')).toHaveLength(SETTINGS_SECTIONS.length);
+  });
+
+  it('marks the current section with aria-current and leaves siblings unmarked', () => {
+    // aria-current stays set across a section's sub-routes, not just its index.
+    mockedUsePathname.mockReturnValue('/settings/schedule');
+    render(<SettingsNav />);
+
+    expect(screen.getByRole('link', { name: 'Schedule' })).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: 'Training Maxes' })).not.toHaveAttribute('aria-current');
+    expect(screen.getByRole('link', { name: 'Weight Rounding' })).not.toHaveAttribute('aria-current');
+  });
+
+  it('marks no tab active on the /settings hub itself', () => {
+    mockedUsePathname.mockReturnValue('/settings');
+    render(<SettingsNav />);
+
+    for (const { label } of SETTINGS_SECTIONS) {
+      expect(screen.getByRole('link', { name: label })).not.toHaveAttribute('aria-current');
+    }
+  });
+});

--- a/apps/web/app/(authed)/settings/SettingsNav.tsx
+++ b/apps/web/app/(authed)/settings/SettingsNav.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { SETTINGS_SECTIONS } from './sections';
+import styles from './settings.module.css';
+
+/**
+ * Sub-navigation for the settings area: one tab per settings section so a user
+ * can move directly between Training Maxes, Strength Goals, Schedule, and Weight
+ * Rounding — replacing the pre-#679 behaviour where "Settings" only ever opened
+ * Training Maxes and the sibling pages were unreachable.
+ *
+ * Mirrors the shell nav ({@link AppNav}): the active tab carries `aria-current`
+ * and the accent style. No tab is active on the `/settings` hub itself.
+ */
+export default function SettingsNav() {
+  const pathname = usePathname() ?? '';
+
+  return (
+    <nav aria-label="Settings sections" className={styles.subNav}>
+      {SETTINGS_SECTIONS.map(({ href, label }) => {
+        const active = pathname === href || pathname.startsWith(`${href}/`);
+        return (
+          <Link
+            key={href}
+            href={href}
+            className={active ? `${styles.subLink} ${styles.subActive}` : styles.subLink}
+            aria-current={active ? 'page' : undefined}
+          >
+            {label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/app/(authed)/settings/SettingsNav.tsx
+++ b/apps/web/app/(authed)/settings/SettingsNav.tsx
@@ -11,8 +11,11 @@ import styles from './settings.module.css';
  * Rounding — replacing the pre-#679 behaviour where "Settings" only ever opened
  * Training Maxes and the sibling pages were unreachable.
  *
- * Mirrors the shell nav ({@link AppNav}): the active tab carries `aria-current`
- * and the accent style. No tab is active on the `/settings` hub itself.
+ * Shares the shell nav's ({@link AppNav}) active-tab affordance (`aria-current` +
+ * accent style), but deliberately matches with exact-or-subtree
+ * (`pathname === href || pathname.startsWith(href + '/')`) rather than a plain
+ * prefix — specifically so no tab lights up on the bare `/settings` hub and a
+ * sibling-prefix route can't collide. (Encoded by the third SettingsNav test.)
  */
 export default function SettingsNav() {
   const pathname = usePathname() ?? '';

--- a/apps/web/app/(authed)/settings/layout.tsx
+++ b/apps/web/app/(authed)/settings/layout.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link';
+import SettingsNav from './SettingsNav';
+import styles from './settings.module.css';
 
 export default function SettingsLayout({
   children,
@@ -9,9 +11,10 @@ export default function SettingsLayout({
     <main>
       <header>
         <h1>Settings</h1>
-        <nav>
-          <Link href="/cycle">← Back to cycle</Link>
-        </nav>
+        <SettingsNav />
+        <Link href="/cycle" className={styles.backLink}>
+          ← Back to cycle
+        </Link>
       </header>
       {children}
     </main>

--- a/apps/web/app/(authed)/settings/page.test.tsx
+++ b/apps/web/app/(authed)/settings/page.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, within } from '@testing-library/react';
+import SettingsIndexPage from './page';
+import { SETTINGS_SECTIONS } from './sections';
+
+describe('Settings hub (index)', () => {
+  it('links to all four settings sections with a description each', () => {
+    render(<SettingsIndexPage />);
+
+    // Scope to the "Sections" region so the section links can never collide with
+    // the Import card (whose description also mentions "training maxes").
+    const sections = within(screen.getByRole('region', { name: 'Sections' }));
+
+    for (const { href, label, description } of SETTINGS_SECTIONS) {
+      const link = sections.getByRole('link', { name: new RegExp(label, 'i') });
+      expect(link).toHaveAttribute('href', href);
+      expect(sections.getByText(description)).toBeInTheDocument();
+    }
+
+    // Exactly the four sections — no extra/missing cards.
+    expect(sections.getAllByRole('link')).toHaveLength(SETTINGS_SECTIONS.length);
+  });
+
+  it('surfaces the previously-orphaned Import wizard as a data/tools entry point', () => {
+    render(<SettingsIndexPage />);
+
+    const tools = within(screen.getByRole('region', { name: /Data & tools/i }));
+    const importLink = tools.getByRole('link', { name: /Import data/i });
+    expect(importLink).toHaveAttribute('href', '/import');
+  });
+
+  it('groups the sections and tools under their own headings', () => {
+    render(<SettingsIndexPage />);
+
+    expect(screen.getByRole('heading', { name: 'Sections' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Data & tools/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(authed)/settings/page.tsx
+++ b/apps/web/app/(authed)/settings/page.tsx
@@ -1,0 +1,69 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { SETTINGS_SECTIONS } from './sections';
+import styles from './settings.module.css';
+
+export const metadata: Metadata = {
+  title: 'Settings — Lifting Logbook',
+  description:
+    'Manage training maxes, strength goals, schedule, and weight rounding, or import data from a CSV.',
+};
+
+/**
+ * Data/tools entry points surfaced alongside the settings sections. Kept
+ * separate from {@link SETTINGS_SECTIONS} because `/import` is a tool, not a
+ * settings page, and must not appear in the settings sub-nav.
+ */
+const TOOLS: ReadonlyArray<{ href: string; label: string; description: string }> = [
+  {
+    href: '/import',
+    label: 'Import data',
+    description:
+      'Bring in lift history, training maxes, strength goals, or a full program from a CSV file.',
+  },
+];
+
+/**
+ * Settings hub (`/settings`). The parent settings layout renders the "Settings"
+ * heading and the section sub-nav; this page is the descriptive landing that
+ * lists every section with a short summary and surfaces the (previously
+ * orphaned) `/import` wizard (#679). Intentionally static — no data fetch — so
+ * it always renders regardless of API state.
+ */
+export default function SettingsIndexPage() {
+  return (
+    <div className={styles.hub}>
+      <section aria-labelledby="settings-sections-heading">
+        <h2 id="settings-sections-heading" className={styles.groupHeading}>
+          Sections
+        </h2>
+        <ul className={styles.cardGrid}>
+          {SETTINGS_SECTIONS.map(({ href, label, description }) => (
+            <li key={href}>
+              <Link href={href} className={styles.card}>
+                <span className={styles.cardTitle}>{label}</span>
+                <span className={styles.cardDesc}>{description}</span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section aria-labelledby="settings-tools-heading">
+        <h2 id="settings-tools-heading" className={styles.groupHeading}>
+          Data &amp; tools
+        </h2>
+        <ul className={styles.cardGrid}>
+          {TOOLS.map(({ href, label, description }) => (
+            <li key={href}>
+              <Link href={href} className={styles.card}>
+                <span className={styles.cardTitle}>{label}</span>
+                <span className={styles.cardDesc}>{description}</span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/app/(authed)/settings/sections.ts
+++ b/apps/web/app/(authed)/settings/sections.ts
@@ -1,0 +1,42 @@
+/**
+ * The four user-configurable settings sections, in display order.
+ *
+ * Single source of truth for the settings sub-nav ({@link SettingsNav}) and the
+ * `/settings` hub cards, so the label/route pairs can never drift between the
+ * two surfaces (#679).
+ */
+export interface SettingsSection {
+  /** Route for the section page. */
+  href: string;
+  /** Nav label and hub-card title. */
+  label: string;
+  /** One-line summary shown on the hub card. */
+  description: string;
+}
+
+export const SETTINGS_SECTIONS: readonly SettingsSection[] = [
+  {
+    href: '/settings/training-maxes',
+    label: 'Training Maxes',
+    description:
+      'View, update, and track the history of the working maxes that drive every calculated lift.',
+  },
+  {
+    href: '/settings/strength-goals',
+    label: 'Strength Goals',
+    description:
+      'Set target weights or bodyweight ratios for each lift and track your progress toward them.',
+  },
+  {
+    href: '/settings/schedule',
+    label: 'Schedule',
+    description:
+      'Choose which days of the week you train so generated workouts land on the right dates.',
+  },
+  {
+    href: '/settings/weight-rounding',
+    label: 'Weight Rounding',
+    description:
+      'Set the smallest weight increment used when rounding calculated loads to a loadable weight.',
+  },
+];

--- a/apps/web/app/(authed)/settings/settings.module.css
+++ b/apps/web/app/(authed)/settings/settings.module.css
@@ -1,6 +1,9 @@
 /* Settings sub-nav — cross-navigation between the four settings sections.
    Mirrors the shell nav's token usage (AppNav.module.css) for a consistent
-   look and the same hover/focus/active affordances. */
+   look and the same hover/focus/active affordances.
+
+   KEEP IN SYNC: .subLink / .subActive intentionally duplicate AppNav.module.css's
+   .link / .active tab affordance — update both together so the two navs don't drift. */
 .subNav {
   display: flex;
   flex-wrap: wrap;

--- a/apps/web/app/(authed)/settings/settings.module.css
+++ b/apps/web/app/(authed)/settings/settings.module.css
@@ -1,0 +1,119 @@
+/* Settings sub-nav — cross-navigation between the four settings sections.
+   Mirrors the shell nav's token usage (AppNav.module.css) for a consistent
+   look and the same hover/focus/active affordances. */
+.subNav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1);
+  margin: var(--space-3) 0 var(--space-2);
+}
+
+.subLink {
+  display: inline-flex;
+  align-items: center;
+  min-height: 40px;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.subLink:hover {
+  background: var(--color-surface-alt);
+  color: var(--color-text-heading);
+}
+
+.subLink:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.subActive {
+  color: var(--color-on-accent);
+  background: var(--color-accent);
+}
+
+.subActive:hover {
+  color: var(--color-on-accent);
+  background: var(--color-accent-hover);
+}
+
+/* Escape link back to the cycle — de-emphasised relative to the section tabs. */
+.backLink {
+  display: inline-flex;
+  align-items: center;
+  min-height: 40px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.backLink:hover {
+  color: var(--color-text-heading);
+}
+
+.backLink:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* Settings hub — descriptive cards linking to each section plus data tools. */
+.hub {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  max-width: 720px;
+}
+
+.groupHeading {
+  margin: 0 0 var(--space-3);
+  color: var(--color-text-heading);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+}
+
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--space-3);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  height: 100%;
+  padding: var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.card:hover {
+  border-color: var(--color-accent);
+  background: var(--color-surface-alt);
+}
+
+.card:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.cardTitle {
+  color: var(--color-text-heading);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
+}
+
+.cardDesc {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  line-height: 1.45;
+}

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+
+const MOCK_API = 'http://localhost:3004';
+
+test.beforeEach(async ({ request }) => {
+  // The Import wizard's Source step lists custom programs; opt the mock into one
+  // so the wizard renders its normal flow when reached via the hub link.
+  await request.get(`${MOCK_API}/__reset?withCustomProgram=true`);
+});
+
+// ---------------------------------------------------------------------------
+// Settings hub: the four section tabs are present and cross-navigate.
+// ---------------------------------------------------------------------------
+
+test('settings hub exposes the four sections and the sub-nav cross-navigates', async ({ page }) => {
+  await page.goto('/settings');
+
+  const subNav = page.getByRole('navigation', { name: 'Settings sections' });
+  await expect(subNav.getByRole('link', { name: 'Training Maxes' })).toHaveAttribute(
+    'href',
+    '/settings/training-maxes',
+  );
+  await expect(subNav.getByRole('link', { name: 'Strength Goals' })).toHaveAttribute(
+    'href',
+    '/settings/strength-goals',
+  );
+  await expect(subNav.getByRole('link', { name: 'Schedule' })).toHaveAttribute(
+    'href',
+    '/settings/schedule',
+  );
+  await expect(subNav.getByRole('link', { name: 'Weight Rounding' })).toHaveAttribute(
+    'href',
+    '/settings/weight-rounding',
+  );
+
+  // The sub-nav actually moves between sections and marks the target active.
+  await subNav.getByRole('link', { name: 'Weight Rounding' }).click();
+  await expect(page).toHaveURL(/\/settings\/weight-rounding$/);
+  await expect(
+    page.getByRole('navigation', { name: 'Settings sections' }).getByRole('link', { name: 'Weight Rounding' }),
+  ).toHaveAttribute('aria-current', 'page');
+});
+
+// ---------------------------------------------------------------------------
+// Settings hub: the previously-orphaned /import wizard is reachable by link.
+// ---------------------------------------------------------------------------
+
+test('settings hub links to the Import wizard, which renders when reached', async ({ page }) => {
+  await page.goto('/settings');
+
+  await page.getByRole('link', { name: /Import data/i }).click();
+  await expect(page).toHaveURL(/\/import$/);
+  // A cold Next dev compile of the heavy import route can exceed the 5s default
+  // on Windows; give the first render headroom (mirrors smoke.spec's 15s nav waits).
+  await expect(page.getByRole('heading', { name: 'Import a file' })).toBeVisible({ timeout: 15_000 });
+});


### PR DESCRIPTION
## Summary

PR 2 of 6 in the app-shell / discoverability consistency pass (#677). Makes every settings section reachable and surfaces the previously-orphaned Import wizard.

- New **`/settings` hub** (static server component): descriptive cards for all four sections (Training Maxes, Strength Goals, Schedule, Weight Rounding) plus a **Data & tools** card linking `/import`.
- New **settings sub-nav** (`SettingsNav`, client) in the settings layout so the four pages are cross-navigable — mirrors the shell nav's active / `aria-current` pattern. The "← Back to cycle" escape link is retained.
- Shell **"Settings" link repointed** from `/settings/training-maxes` → `/settings` (`AppNav.tsx`).
- `SETTINGS_SECTIONS` (`settings/sections.ts`) is a shared single source of truth for the sub-nav and the hub cards, so the label/route pairs can't drift.

Depends on PR 1 (#690, shell nav) — merged. Fixes symptoms **#3** (Import unreachable) and **#5** (Settings only opened Training Maxes) from #677.

## Acceptance criteria (from #679)

- [x] `/settings` index lists Training Maxes, Strength Goals, Schedule, Weight Rounding
- [x] Shell "Settings" link points to `/settings`
- [x] Settings sub-nav lets a user move between all four settings pages
- [x] `/import` is reachable via a visible link and renders correctly
- [x] Index-page test added; e2e asserts the four settings links + Import

## Testing

Rebased onto `origin/main` first (picked up #689/#691 which merged during development; no file overlap).

- **Web unit/component (Jest):** `Tests: 181 passed, 0 skipped, 0 failed` (29 suites). Includes new `settings/page.test.tsx` (hub: 4 section links + descriptions + Import, correct hrefs) and `settings/SettingsNav.test.tsx` (sub-nav links + `aria-current` active state), and the updated `AppNav.test.tsx` (Settings → `/settings`).
- **Typecheck** (`npm run typecheck`, blocking CI gate): pass (4/4 tasks).
- **Playwright e2e** (`npm run test:e2e -w @lifting-logbook/web`, local Windows): **20 passed, 1 failed**. New `e2e/settings.spec.ts` (2 tests) passes in the full suite and in isolation.
- **Lint:** pre-commit `turbo run lint` clean.

### The one e2e failure is pre-existing and tracked

`import.spec.ts:10` fails on a **cold Next-dev compile of `/import` exceeding the default 5 s `expect` timeout** on Windows local dev. This diff does not touch `/import`, `ImportWizard`, or `import.spec.ts` — those files are byte-identical to `origin/main`, so the failure is pre-existing by construction (CI Linux is green — faster compile fits 5 s). Confirmed: my `settings.spec.ts` navigates to a cold `/import` with a 15 s headroom and renders `Import a file` reliably. **Tracked by #698.**

## Coverage

New frontend surface → index-page Jest test + sub-nav Jest test + Playwright e2e asserting the four section links (scoped to the sub-nav) and the Import link click-through. Satisfies the CLAUDE.md coverage gate for a new frontend page.

## Notes

- No `package.json` change → lockfile-sync gate N/A. Suppression and test-integrity greps: clean.
- Risk audit: Security/Observability/Data-integrity N/A (static nav/pages, no API boundary, no data fetch on the hub). Accessibility: sub-nav is a labelled `<nav aria-label="Settings sections">` with `aria-current`; hub sections/tools are labelled regions.

Closes #679


---

## Review findings disposition

Reviewed via `/review` (two parallel Opus subagents: correctness/security + reliability/perf/maintainability). **0 blocking, 4 non-blocking** — all resolved in `5a225ae`:

- **[correctness] `AppNav.tsx` prefix-boundary** (latent, pre-existing — not introduced here) → **fixed in `5a225ae`**: active-match is now boundary-safe (`pathname === match || startsWith(`${match}/`)`), so a sibling like `/settings-export` can't mis-highlight Settings. Behavior unchanged for all real routes.
- **[maintainability] `settings.module.css` duplicates `AppNav.module.css`** `.link`/`.active` → **fixed in `5a225ae`**: added a KEEP IN SYNC pointer comment.
- **[maintainability] `SettingsNav` docblock** overstated "mirrors AppNav" → **fixed in `5a225ae`**: docblock now states the deliberate exact-or-subtree match (so no tab lights on the `/settings` hub).
- **[correctness] Jest suites assert against imported `SETTINGS_SECTIONS`** (faithfulness, not value) → **no code change (this note is the disposition)**: route-value correctness is independently gated by `e2e/settings.spec.ts`, which hardcodes the literal expected hrefs. Jest = structure/faithfulness; e2e = value gate.

The reviewer's `beforeEach`-scope nit was assessed and **declined**: reset-for-both-tests is the intentional defensive choice (guarantees per-test clean mock state; narrowing would add order-dependence).
