### PR TITLE
[test] Make the Playwright mock-API reject malformed/empty JSON bodies like real Fastify

### DIFF
--- a/apps/web/e2e/mock-api.mjs
+++ b/apps/web/e2e/mock-api.mjs
@@ -130,18 +130,39 @@ function noContent(res) {
   res.end();
 }
 
+// The real Fastify API rejects an empty or malformed body on an application/json endpoint
+// with a 400 (FST_ERR_CTP_EMPTY_JSON_BODY / parse error — see #667). The mock previously
+// swallowed both into `{}` and returned 200/201, so a client bug that sent a broken body
+// passed the mock-backed Playwright tests while failing against the real API. readBody now
+// returns this sentinel for an empty/malformed body; JSON write handlers convert it to a
+// 400 via rejectIfInvalidBody() to match real Fastify (#687 / #699).
+const INVALID_JSON_BODY = Symbol('invalid-json-body');
+
 async function readBody(req) {
   return new Promise((resolve) => {
     let body = '';
     req.on('data', (chunk) => (body += chunk));
     req.on('end', () => {
+      if (body === '') {
+        resolve(INVALID_JSON_BODY);
+        return;
+      }
       try {
         resolve(JSON.parse(body));
       } catch {
-        resolve({});
+        resolve(INVALID_JSON_BODY);
       }
     });
   });
+}
+
+// Sends a Fastify-shaped 400 and returns true when the parsed body was empty/malformed.
+function rejectIfInvalidBody(res, body) {
+  if (body === INVALID_JSON_BODY) {
+    json(res, { statusCode: 400, message: 'Body is not valid JSON' }, 400);
+    return true;
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -274,6 +295,7 @@ const server = createServer(async (req, res) => {
     // PATCH /programs/:p/training-maxes
     if (method === 'PATCH' && rest[0] === 'training-maxes' && rest.length === 1) {
       const body = await readBody(req);
+      if (rejectIfInvalidBody(res, body)) return;
       if (Array.isArray(body.maxes)) {
         const today = new Date().toISOString().split('T')[0];
         for (const update of body.maxes) {
@@ -306,6 +328,7 @@ const server = createServer(async (req, res) => {
     // POST /programs/:p/lift-records
     if (method === 'POST' && rest[0] === 'lift-records' && rest.length === 1) {
       const body = await readBody(req);
+      if (rejectIfInvalidBody(res, body)) return;
       const record = { id: `r-${Date.now()}`, ...body };
       json(res, record, 201);
       return;
@@ -321,6 +344,7 @@ const server = createServer(async (req, res) => {
     if (method === 'PUT' && rest[0] === 'strength-goals' && rest.length === 2) {
       const lift = decodeURIComponent(rest[1]);
       const body = await readBody(req);
+      if (rejectIfInvalidBody(res, body)) return;
       const goal = { lift, ...body, updatedAt: new Date().toISOString() };
       const idx = state.strengthGoals.findIndex((g) => g.lift === lift);
       if (idx >= 0) {

--- a/apps/web/e2e/mock-api.mjs
+++ b/apps/web/e2e/mock-api.mjs
@@ -445,6 +445,9 @@ const server = createServer(async (req, res) => {
   json(res, { statusCode: 404, message: `Not found: ${method} ${url.pathname}` }, 404);
 });
 
-server.listen(3004, () => {
-  console.log('[mock-api] Listening on http://localhost:3004');
+// Port defaults to 3004 (what playwright.config expects); overridable via MOCK_API_PORT so a
+// unit test can spawn an isolated instance without colliding with a running Playwright/dev mock.
+const PORT = Number(process.env.MOCK_API_PORT) || 3004;
+server.listen(PORT, () => {
+  console.log(`[mock-api] Listening on http://localhost:${PORT}`);
 });

--- a/apps/web/e2e/mock-api.test.ts
+++ b/apps/web/e2e/mock-api.test.ts
@@ -1,0 +1,75 @@
+/** @jest-environment node */
+import { spawn, type ChildProcess } from 'node:child_process';
+import { join } from 'node:path';
+
+// The Playwright mock API (e2e/mock-api.mjs) must mirror the real Fastify API's rejection of an
+// empty or malformed JSON body with a 400 (FST_ERR_CTP_EMPTY_JSON_BODY / parse error — #667).
+// Before #699 it swallowed both into `{}` and returned 200/201, so a client bug that sent a
+// broken body passed the mock-backed tests while failing against the real API. This exercises
+// the mock over real HTTP (it starts a listener on import, so it is spawned as a child process
+// rather than imported). See #687 / #699.
+
+const BASE = 'http://localhost:3004';
+let mock: ChildProcess | undefined;
+
+async function waitForReady(timeoutMs = 15000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(`${BASE}/__reset`);
+      if (res.ok) return;
+    } catch {
+      /* server not listening yet */
+    }
+    await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+  throw new Error('mock-api did not become ready on :3004');
+}
+
+function jsonRequest(path: string, method: string, body?: string): Promise<Response> {
+  return fetch(`${BASE}${path}`, {
+    method,
+    headers: { 'content-type': 'application/json' },
+    ...(body !== undefined ? { body } : {}),
+  });
+}
+
+describe('mock-api JSON body fidelity (#699)', () => {
+  beforeAll(async () => {
+    mock = spawn(process.execPath, [join(__dirname, 'mock-api.mjs')], { stdio: 'ignore' });
+    await waitForReady();
+  }, 25000);
+
+  afterAll(() => {
+    mock?.kill();
+  });
+
+  it('rejects a malformed JSON body with 400 (like real Fastify), not a swallowed 200', async () => {
+    const res = await jsonRequest('/programs/rpt/lift-records', 'POST', '{not json');
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an empty JSON body with 400', async () => {
+    const res = await jsonRequest('/programs/rpt/lift-records', 'POST');
+    expect(res.status).toBe(400);
+  });
+
+  it('still accepts a valid JSON body (201)', async () => {
+    const res = await jsonRequest(
+      '/programs/rpt/lift-records',
+      'POST',
+      JSON.stringify({ lift: 'squat', weight: 100 }),
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it('rejects a malformed body on PATCH training-maxes with 400', async () => {
+    const res = await jsonRequest('/programs/rpt/training-maxes', 'PATCH', 'nope');
+    expect(res.status).toBe(400);
+  });
+
+  it('leaves body-less endpoints unaffected (switch → 200)', async () => {
+    const res = await jsonRequest('/programs/rpt/switch', 'POST');
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/web/e2e/mock-api.test.ts
+++ b/apps/web/e2e/mock-api.test.ts
@@ -9,7 +9,10 @@ import { join } from 'node:path';
 // the mock over real HTTP (it starts a listener on import, so it is spawned as a child process
 // rather than imported). See #687 / #699.
 
-const BASE = 'http://localhost:3004';
+// Run the mock on a dedicated port so this unit test never collides with a running
+// Playwright/dev mock on the default 3004 (mock-api.mjs honours MOCK_API_PORT).
+const PORT = 3105;
+const BASE = `http://localhost:${PORT}`;
 let mock: ChildProcess | undefined;
 
 async function waitForReady(timeoutMs = 15000): Promise<void> {
@@ -36,7 +39,10 @@ function jsonRequest(path: string, method: string, body?: string): Promise<Respo
 
 describe('mock-api JSON body fidelity (#699)', () => {
   beforeAll(async () => {
-    mock = spawn(process.execPath, [join(__dirname, 'mock-api.mjs')], { stdio: 'ignore' });
+    mock = spawn(process.execPath, [join(__dirname, 'mock-api.mjs')], {
+      stdio: 'ignore',
+      env: { ...process.env, MOCK_API_PORT: String(PORT) },
+    });
     await waitForReady();
   }, 25000);
 

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -5,7 +5,9 @@ export default defineConfig({
   // staging.spec.ts is only for playwright.config.staging.ts (live Cloud Run environment).
   // Excluding it here prevents accidental runs against the local dev server, which lacks a
   // real Clerk session (window.Clerk.session is null) and would produce false failures.
-  testIgnore: ['**/staging.spec.ts'],
+  // Playwright's default testMatch also grabs `*.test.ts`; those are Jest unit tests
+  // (e.g. e2e/mock-api.test.ts, which uses `describe`) and must not run under Playwright.
+  testIgnore: ['**/staging.spec.ts', '**/*.test.ts'],
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,


### PR DESCRIPTION
## Summary

`apps/web/e2e/mock-api.mjs`'s `readBody()` swallowed an empty or malformed JSON body into `{}` and let the handler return 200/201, diverging from the real Fastify API which rejects empty-body + `application/json` with a 400 (`FST_ERR_CTP_EMPTY_JSON_BODY` / parse error — cf. #667). A client bug that sent a broken body therefore passed the mock-backed Playwright/smoke tests while failing against the real API.

Surfaced by the re-baseline in #687 (S1). Note: the `/switch` onboarding endpoint is a canned stub that never called `readBody`, so this did **not** hide #665 — the gap affected the JSON write endpoints (lift-records, strength-goals, training-maxes).

## Changes

- **`apps/web/e2e/mock-api.mjs`** — `readBody()` now returns an `INVALID_JSON_BODY` sentinel for an empty/malformed body; the three JSON write handlers (POST lift-records, PUT strength-goals, PATCH training-maxes) convert it to a Fastify-shaped 400 via a shared `rejectIfInvalidBody()`. Body-less endpoints (switch, body-weight, skip) don't call `readBody` and are unaffected.
- **`apps/web/e2e/mock-api.test.ts`** (new) — node-env jest test that spawns the mock and asserts, over real HTTP: malformed→400, empty→400, valid→201, PATCH-malformed→400, switch(no body)→200.

## Acceptance criteria (from #699)

- [x] The mock rejects an empty/malformed JSON body on a write endpoint with a 4xx, matching real Fastify
- [x] Valid JSON bodies continue to parse and succeed
- [x] Coverage for the reject path

## Testing

`npm test -w @lifting-logbook/web` + `npm run typecheck`, on a branch cut from `origin/main@d08592f`.

**Tests: 180 passed, 0 skipped, 0 failed** (28 web suites, incl. the 5 new `mock-api` cases). Typecheck clean. Also manually verified the running mock via curl (malformed/empty→400, valid→201/200, switch→200, body-weight→204). The new jest test runs in the required "Lint & Test" check; it spawns the mock as a child process and asserts over real HTTP (node env) rather than importing the side-effectful listener.

Pre-PR suppression, test-integrity, deleted-test, and lockfile grep checks all clean (no `package.json` change).

## Risk-dimension notes

- **Resilience / failure modes** — the reject path only fires on empty/malformed bodies; existing flows send valid JSON via the real client, so they're unaffected (full web suite green). Body-less endpoints untouched.
- **Testing** — new HTTP-level regression test for the reject + accept paths.
- **Security / Performance / Data integrity / Observability** — N/A (test fixture only; no production code, data, or logging change).

## Review findings disposition

`/review` ([comment](https://github.com/brownm09/lifting-logbook/pull/701#issuecomment-4887842036)) — **0 blocking, 1 non-blocking**, fixed in this PR:

| # | Finding | Category | Disposition |
|---|---|---|---|
| 1 | New test spawned the mock on hardcoded port 3004 — could collide with a running Playwright/dev mock during a local `npm test` | reliability | **Fixed** in `b0dad3a` — `mock-api.mjs` honours `MOCK_API_PORT` (default 3004); test uses a dedicated port 3105 |

Closes #699 · part of #687
