### PR TITLE
[docs] Slim Standard Issue Workflow step 8 to a pointer at the global CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,9 @@ If `--format json` is not supported by the installed `gh` version, fall back to 
    rather than a single `gh pr merge <N> --squash --delete-branch`. This repo hits the squat
    variant of that failure often: 60+ concurrent worktrees under `.claude/worktrees/` make it
    common for some worktree to be holding `main` at merge time (confirmed on
-   [PR #664](https://github.com/brownm09/lifting-logbook/pull/664), 2026-07-03).
+   [PR #664](https://github.com/brownm09/lifting-logbook/pull/664), 2026-07-03). If a squat is
+   actively blocking a merge right now, the on-demand clear procedure is in the
+   [dev-env runbook](https://github.com/brownm09/dev-env/blob/main/docs/REFERENCE.md#git-workflow-runbooks).
 9. Move the issue to **Done** on the project board:
    ```bash
    TMPFILE="C:/Users/brown/.claude/scratch/tmp_item_<N>.json"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,21 +176,13 @@ If `--format json` is not supported by the installed `gh` version, fall back to 
 5. Commit with `Closes #<N>` in the message (see Commit Format)
 6. Push: `git push -u origin <branch>`
 7. Open a PR: `gh pr create --title "<prefix> <title>" --body "..."`
-8. After PR approval: squash merge using the two-step pattern below rather than a single
-   `gh pr merge <N> --squash --delete-branch` — the combined form fails at the local
-   checkout-and-delete step whenever **any** worktree in the repo (not just the canonical
-   checkout) currently holds `main` (a "squat"), which is likely given 60+ concurrent worktrees
-   under `.claude/worktrees/` (already confirmed on [PR #664](https://github.com/brownm09/lifting-logbook/pull/664),
-   2026-07-03). Splitting the merge into two API-only calls avoids the failure unconditionally,
-   regardless of which worktree currently holds `main`:
-   ```bash
-   gh pr merge <N> --squash                                                   # server-side only; always succeeds
-   gh api -X DELETE "repos/brownm09/lifting-logbook/git/refs/heads/<branch>"   # pure REST ref delete
-   ```
-   Root cause and full context: [dev-env ADR-058](https://github.com/brownm09/dev-env/blob/main/docs/adr/058-worktree-squatting-main-detection-correction.md)
-   (2026-07-03 amendment) and [REFERENCE.md → Git Workflow Runbooks](https://github.com/brownm09/dev-env/blob/main/docs/REFERENCE.md#git-workflow-runbooks).
-   If a squat is actively blocking other work, it can be cleared on demand rather than waiting for
-   the next scheduled prune — see the runbook link above.
+8. After PR approval: squash merge using the two-step pattern documented in the global
+   [`CLAUDE.md`](https://github.com/brownm09/dev-env/blob/main/claude/CLAUDE.md) under
+   "Worktree holding the base branch blocks `gh pr merge --delete-branch`'s local step" —
+   rather than a single `gh pr merge <N> --squash --delete-branch`. This repo hits the squat
+   variant of that failure often: 60+ concurrent worktrees under `.claude/worktrees/` make it
+   common for some worktree to be holding `main` at merge time (confirmed on
+   [PR #664](https://github.com/brownm09/lifting-logbook/pull/664), 2026-07-03).
 9. Move the issue to **Done** on the project board:
    ```bash
    TMPFILE="C:/Users/brown/.claude/scratch/tmp_item_<N>.json"


### PR DESCRIPTION
## Summary
- `CLAUDE.md` → Standard Issue Workflow step 8 carried a full inline copy of the two-step squash-merge pattern (rationale + command block + ADR/runbook links), added in #675 / PR #676.
- dev-env PR #585 (merged 2026-07-05) has since promoted this into a generalized subsection in the global `CLAUDE.md` ("Worktree holding the base branch blocks `gh pr merge --delete-branch`'s local step", in the Git Workflow section), which every session already loads automatically.
- Slims step 8 down to a short pointer at that global rule, keeping only what's genuinely lifting-logbook-specific: the 60+ concurrent worktree count that makes the squat variant common here, and the local [PR #664](https://github.com/brownm09/lifting-logbook/pull/664) citation.
- Removes the duplicated rationale paragraph, the inline two-step command block, and the duplicated ADR-058/REFERENCE.md links — those now live once, in the global CLAUDE.md, reducing drift risk if the recommended command pattern ever changes there.
- Verified the "Branch cleanup" bullet under PR Conventions (references "Standard Issue Workflow step 8" by number) still reads correctly — no change needed there.

## Acceptance Criteria
- [x] Standard Issue Workflow step 8 points to the global CLAUDE.md's generalized rule instead of duplicating it
- [x] Repo-specific detail (60+ worktrees, PR #664) is retained
- [x] PR Conventions "Branch cleanup" bullet still reads correctly after the trim

## Testing
Documentation-only change (`CLAUDE.md` only, no code touched). No automated tests are relevant per this repo's own coverage table ("Refactor / docs only: None required — existing tests must pass"). Verified via:
- Suppression grep (`ts-ignore`/`eslint-disable`/etc.): no matches
- Test-integrity grep (skip markers/deleted tests/lowered thresholds): no matches
- `git diff --stat origin/main`: confirms only `CLAUDE.md` changed
- Pre-commit `turbo run lint` hook: 7/7 packages passed

## Review findings disposition
`/review` ([comment](https://github.com/brownm09/lifting-logbook/pull/703#issuecomment-4887914439)) reported 0 blocking, 2 non-blocking findings:
- **[documentation]** Slimming dropped the original's direct runbook link for on-demand squat-clearing, adding a hop during an active incident — **fixed in `dcb2d57`**, restored a single direct runbook line without reintroducing the removed rationale/command block.
- **[maintainability]** The new cross-reference pins to the global CLAUDE.md heading's quoted text rather than a stable anchor, so a future reword there would go stale silently — **filed** [dev-env#589](https://github.com/brownm09/dev-env/issues/589) (Impact: Low).

Closes #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)
