### PR TITLE
[test] In-memory API E2E for POST /programs/:program/switch (close the #665 escape at the unit layer)

### DIFF
--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -1334,4 +1334,38 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
       expect(bobGet.json().cycleNum).toBe(1);
     });
   });
+
+  // Regression coverage for the production onboarding escape (#665 / #687).
+  // Onboarding's "Start My Program" called POST /programs/:program/switch. The api-client sent
+  // `Content-Type: application/json` with an EMPTY body; the real Fastify API rejects that with
+  // FST_ERR_CTP_EMPTY_JSON_BODY → 400 (fixed client-side in #667 by sending `{}`). The Playwright
+  // mock (apps/web/e2e/mock-api.mjs) had swallowed the empty body to a 200, so the broken request
+  // passed every mock-backed test while failing in production. This suite is the always-on
+  // (no-Docker) layer; locking the server's 400 here means a future client or mock regression is
+  // caught without a database. Fastify rejects the body before the handler runs, so these assert
+  // the contract without touching Prisma. The happy path (200 + cycle init) writes user-settings
+  // through Prisma and is covered by the DB-backed suite (programs.db.e2e.spec.ts). See #704.
+  describe('POST /programs/:program/switch — malformed/empty JSON body (regression for #665)', () => {
+    const AS_SWITCH = { authorization: 'Bearer switch-regression-user' };
+
+    it('rejects an empty application/json body with 400 (not a swallowed 200)', async () => {
+      const res = await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/switch`,
+        headers: { 'content-type': 'application/json', ...AS_SWITCH },
+        // No payload → an empty body under a JSON content-type: the exact shape #665 sent.
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('rejects a malformed JSON body with 400', async () => {
+      const res = await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/switch`,
+        headers: { 'content-type': 'application/json', ...AS_SWITCH },
+        payload: '{not valid json',
+      });
+      expect(res.statusCode).toBe(400);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds in-memory API E2E coverage for `POST /programs/:program/switch` — the endpoint whose empty-`application/json`-body 400 escaped every test layer to production (#665). The fast in-memory suite (`apps/api/src/programs/programs.e2e.spec.ts`, no Docker) had **zero** `/switch` coverage.

Part of #687 (production onboarding-escape hardening). Closes #704.

## What & why

- Onboarding's "Start My Program" called `POST /programs/:program/switch`. The api-client sent `Content-Type: application/json` with an **empty body**; the real Fastify API rejects that with `FST_ERR_CTP_EMPTY_JSON_BODY` → **400** (fixed client-side in #667 by sending `{}`).
- The Playwright mock (`apps/web/e2e/mock-api.mjs`) had **swallowed** the empty body to a 200, so the broken request passed every mock-backed test while failing in production (#665). PR #701 fixes the mock; this PR locks the **server-side** contract at the always-on in-memory layer so a future client or mock regression is caught without a database.
- Fastify rejects the body **before the handler runs**, so both tests assert the 400 without touching Prisma — they run in the no-Docker in-memory suite.

## Scope note — why regression-only (no in-memory happy path)

The `/switch` happy path (200 + cycle init) writes user-settings through `PrismaService.clientForRequest()` (`switch-program.controller.ts:37,45,67`). The in-memory suite has no database, so a happy-path assertion would hit the lazy Prisma connection and 500. The happy path is already covered by the DB-backed suite (`programs.db.e2e.spec.ts`, ~line 1348: asserts 200 + `activeProgram` + cycle row). This PR adds the **DB-independent** regression that the in-memory layer uniquely enables and that directly reproduces #665.

## Acceptance criteria (#704)

- [x] `/switch` empty-body test → 400
- [x] `/switch` malformed-body test → 400
- [x] in-memory spec green; lint + typecheck green
- [x] No new suppressions / skips
- [ ] ~~in-memory happy-path test~~ → re-scoped: happy path requires Prisma; covered by the DB suite (see Scope note)

## Testing

```
LIFTING_SKIP_DB_E2E=1 npm test -w @lifting-logbook/api -- programs.e2e.spec
Tests: 71 passed, 0 skipped, 0 failed (75.2 s)
```

`LIFTING_SKIP_DB_E2E=1` scopes the local run to the in-memory spec — valid per the #394 escape hatch (my diff touches no DB code: no `apps/api/prisma/` or repository changes). CI runs the full api suite against its Postgres service container. Lint + typecheck: `npx turbo run lint typecheck --filter=@lifting-logbook/api` → 3 successful.

**Gates:** suppression grep clean · test-integrity grep clean · no deleted tests · no `package.json` change (lockfile N/A). Baseline-failure tracking: branch cut via `git checkout -b … origin/main` (no snapshot); advisory only.

## Review findings disposition

Clean review — 0 blocking, 0 non-blocking findings ([review comment](https://github.com/brownm09/lifting-logbook/pull/709#issuecomment-4887947500)). Nothing to disposition.
