### PR TITLE
[chore] Add sync check between Dockerfile's pinned turbo version and package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Verify turbo version pin sync (Dockerfile ↔ package.json)
         run: node scripts/check-turbo-version-sync.mjs
 
+      - name: Unit test turbo version pin sync parsing
+        run: node --test scripts/check-turbo-version-sync.test.mjs
+
   db-integration:
     name: DB Integration Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Validate analytics taxonomy
         run: node scripts/validate-analytics-taxonomy.mjs
 
+      - name: Verify turbo version pin sync (Dockerfile ↔ package.json)
+        run: node scripts/check-turbo-version-sync.mjs
+
   db-integration:
     name: DB Integration Tests
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,6 +439,18 @@ npm run test:e2e -w @lifting-logbook/web
 
 Playwright browsers must be installed once (`npx playwright install chromium`; CI uses the `--with-deps` form for its Linux runner — that flag is a no-op on Windows). The config handles all env vars (dummy Clerk keys, `DEV_AUTH_TOKEN`, `API_URL`) so no manual setup is needed. The motivating incident is [#444](https://github.com/brownm09/lifting-logbook/issues/444) / PR #438, where an aria-label rename (`Back Squat` → `Squat`) passed Jest but broke the smoke spec and was only caught by CI.
 
+### Turbo version pin sync (Dockerfile ↔ package.json)
+
+`apps/web/Dockerfile`'s installer stage pins `npx turbo@<version> prune` to an exact version — `node_modules` is dockerignored ahead of that step, so a bare `npx turbo` has no local install to prefer and would fetch whatever the registry currently tags `latest`. That pin must match the root `package.json`'s `devDependencies.turbo` exactly, or the prune step and the later `npm ci`/build step in the same image run under two different turbo versions with nothing to catch the drift until an uncached Docker build. See [#674](https://github.com/brownm09/lifting-logbook/issues/674) / [#692](https://github.com/brownm09/lifting-logbook/issues/692).
+
+**Run before pushing whenever `apps/web/Dockerfile` or the root `package.json`'s `turbo` devDependency changes:**
+
+```bash
+node scripts/check-turbo-version-sync.mjs
+```
+
+This also runs as a CI step (`ci.yml` → `lint-and-test` → "Verify turbo version pin sync"), so a drifting PR fails either way — running it locally just catches the mismatch before waiting on CI.
+
 ### Coverage Requirements
 
 <!-- When #259 ships: remove the "until then" clause from the frontend row below. Tracked as a checklist item on issue #259. -->

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -52,6 +52,7 @@ Repository automation scripts. Grouped by lifecycle.
 | Script | Purpose |
 |---|---|
 | [`check-deployed-version.sh`](check-deployed-version.sh) | Curls `GET /version` on staging + production, api + web (#672 / #670): reports the deployed git SHA and prints `git log -1` context for each. api requires a Cloud Run identity token (mirrors the deploy pipeline's smoke test); web is `--allow-unauthenticated`. Attempts all 4 checks even if one fails, aggregating and reporting failures at the end. Pass `--env staging`/`--env production` to scope to one environment. See [`docs/runbooks/checking-deployed-version.md`](../docs/runbooks/checking-deployed-version.md). |
+| [`check-turbo-version-sync.mjs`](check-turbo-version-sync.mjs) | Verifies `apps/web/Dockerfile`'s pinned `npx turbo@<version> prune` step matches `package.json`'s `devDependencies.turbo` (#692). Runs in CI (`ci.yml`); also run locally before pushing whenever either file changes. |
 | [`smoke-test-observability.sh`](smoke-test-observability.sh) | End-to-end smoke test of the observability docker-compose stack: sends a synthetic OTLP trace and polls Tempo. Requires Docker Compose V2. |
 | [`validate-analytics-taxonomy.mjs`](validate-analytics-taxonomy.mjs) | Verifies `AnalyticsConstants.kt` is in sync with `packages/types/src/analytics.ts`. Exits 0 if the Kotlin file is absent (future work). |
 

--- a/scripts/check-turbo-version-sync.mjs
+++ b/scripts/check-turbo-version-sync.mjs
@@ -9,46 +9,63 @@
  * Usage: node scripts/check-turbo-version-sync.mjs
  */
 
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const root = resolve(__dirname, '..');
+// --- Pure parsing helpers (exported for unit testing — see check-turbo-version-sync.test.mjs) ---
 
-const DOCKERFILE = resolve(root, 'apps/web/Dockerfile');
-const PACKAGE_JSON = resolve(root, 'package.json');
-
-// --- Parse the Dockerfile's pinned prune-step version ---
-
-const dockerfileSource = readFileSync(DOCKERFILE, 'utf8');
-const pruneMatch = dockerfileSource.match(/npx turbo@(\S+)\s+prune\b/);
-
-if (!pruneMatch) {
-  console.error(`ERROR: Could not find a pinned "npx turbo@<version> prune" step in ${DOCKERFILE}`);
-  process.exit(1);
+export function extractDockerfileTurboVersion(dockerfileSource) {
+  const match = dockerfileSource.match(/npx turbo@(\S+)\s+prune\b/);
+  return match ? match[1] : null;
 }
 
-const dockerfileVersion = pruneMatch[1];
-
-// --- Parse package.json's declared turbo devDependency ---
-
-const pkg = JSON.parse(readFileSync(PACKAGE_JSON, 'utf8'));
-const packageJsonVersion = pkg.devDependencies && pkg.devDependencies.turbo;
-
-if (!packageJsonVersion) {
-  console.error(`ERROR: Could not read devDependencies.turbo from ${PACKAGE_JSON}`);
-  process.exit(1);
+export function extractPackageJsonTurboVersion(pkg) {
+  return (pkg.devDependencies && pkg.devDependencies.turbo) || null;
 }
 
-if (dockerfileVersion !== packageJsonVersion) {
-  console.error('ERROR: turbo version drift detected between apps/web/Dockerfile and package.json.');
-  console.error(`  apps/web/Dockerfile pins:  npx turbo@${dockerfileVersion}`);
-  console.error(`  package.json declares:     devDependencies.turbo = ${packageJsonVersion}`);
-  console.error("\nUpdate apps/web/Dockerfile's prune step to match package.json's turbo version (or vice versa),");
-  console.error('so the prune step and the later `npm ci` build against the same turbo release.');
-  process.exit(1);
+function main() {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const root = resolve(__dirname, '..');
+
+  const DOCKERFILE = resolve(root, 'apps/web/Dockerfile');
+  const PACKAGE_JSON = resolve(root, 'package.json');
+
+  for (const path of [DOCKERFILE, PACKAGE_JSON]) {
+    if (!existsSync(path)) {
+      console.error(`ERROR: Expected file not found: ${path}`);
+      process.exit(1);
+    }
+  }
+
+  const dockerfileVersion = extractDockerfileTurboVersion(readFileSync(DOCKERFILE, 'utf8'));
+  if (!dockerfileVersion) {
+    console.error(`ERROR: Could not find a pinned "npx turbo@<version> prune" step in ${DOCKERFILE}`);
+    process.exit(1);
+  }
+
+  const pkg = JSON.parse(readFileSync(PACKAGE_JSON, 'utf8'));
+  const packageJsonVersion = extractPackageJsonTurboVersion(pkg);
+  if (!packageJsonVersion) {
+    console.error(`ERROR: Could not read devDependencies.turbo from ${PACKAGE_JSON}`);
+    process.exit(1);
+  }
+
+  if (dockerfileVersion !== packageJsonVersion) {
+    console.error('ERROR: turbo version drift detected between apps/web/Dockerfile and package.json.');
+    console.error(`  apps/web/Dockerfile pins:  npx turbo@${dockerfileVersion}`);
+    console.error(`  package.json declares:     devDependencies.turbo = ${packageJsonVersion}`);
+    console.error("\nUpdate apps/web/Dockerfile's prune step to match package.json's turbo version (or vice versa),");
+    console.error('so the prune step and the later `npm ci` build against the same turbo release.');
+    process.exit(1);
+  }
+
+  console.log(`OK: turbo version in sync (${dockerfileVersion}).`);
+  process.exit(0);
 }
 
-console.log(`OK: turbo version in sync (${dockerfileVersion}).`);
-process.exit(0);
+// Only run when executed directly — lets check-turbo-version-sync.test.mjs import the
+// pure helpers above without triggering a real filesystem read + process.exit.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/check-turbo-version-sync.mjs
+++ b/scripts/check-turbo-version-sync.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Validates that apps/web/Dockerfile's pinned `npx turbo@<version> prune` step matches
+ * package.json's devDependencies.turbo. The prune step runs before `npm ci` (node_modules
+ * is dockerignored ahead of it), so a bare/mismatched turbo version there has no local
+ * install to prefer and would build against a different turbo release than the one locked
+ * for local dev, CI, and the later `npm ci` stage of the same image. See #674 / #692.
+ *
+ * Usage: node scripts/check-turbo-version-sync.mjs
+ */
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+const DOCKERFILE = resolve(root, 'apps/web/Dockerfile');
+const PACKAGE_JSON = resolve(root, 'package.json');
+
+// --- Parse the Dockerfile's pinned prune-step version ---
+
+const dockerfileSource = readFileSync(DOCKERFILE, 'utf8');
+const pruneMatch = dockerfileSource.match(/npx turbo@(\S+)\s+prune\b/);
+
+if (!pruneMatch) {
+  console.error(`ERROR: Could not find a pinned "npx turbo@<version> prune" step in ${DOCKERFILE}`);
+  process.exit(1);
+}
+
+const dockerfileVersion = pruneMatch[1];
+
+// --- Parse package.json's declared turbo devDependency ---
+
+const pkg = JSON.parse(readFileSync(PACKAGE_JSON, 'utf8'));
+const packageJsonVersion = pkg.devDependencies && pkg.devDependencies.turbo;
+
+if (!packageJsonVersion) {
+  console.error(`ERROR: Could not read devDependencies.turbo from ${PACKAGE_JSON}`);
+  process.exit(1);
+}
+
+if (dockerfileVersion !== packageJsonVersion) {
+  console.error('ERROR: turbo version drift detected between apps/web/Dockerfile and package.json.');
+  console.error(`  apps/web/Dockerfile pins:  npx turbo@${dockerfileVersion}`);
+  console.error(`  package.json declares:     devDependencies.turbo = ${packageJsonVersion}`);
+  console.error("\nUpdate apps/web/Dockerfile's prune step to match package.json's turbo version (or vice versa),");
+  console.error('so the prune step and the later `npm ci` build against the same turbo release.');
+  process.exit(1);
+}
+
+console.log(`OK: turbo version in sync (${dockerfileVersion}).`);
+process.exit(0);

--- a/scripts/check-turbo-version-sync.test.mjs
+++ b/scripts/check-turbo-version-sync.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { extractDockerfileTurboVersion, extractPackageJsonTurboVersion } from './check-turbo-version-sync.mjs';
+
+test('extractDockerfileTurboVersion finds the pinned prune-step version', () => {
+  const dockerfile = [
+    'FROM node:20.11.1-alpine AS installer',
+    'COPY . .',
+    'RUN npx turbo@2.9.3 prune --scope=@lifting-logbook/web --docker',
+  ].join('\n');
+
+  assert.equal(extractDockerfileTurboVersion(dockerfile), '2.9.3');
+});
+
+test('extractDockerfileTurboVersion returns null when no pinned prune step is present', () => {
+  const dockerfile = [
+    'FROM node:20.11.1-alpine AS installer',
+    'RUN npx turbo run build --filter=@lifting-logbook/web',
+  ].join('\n');
+
+  assert.equal(extractDockerfileTurboVersion(dockerfile), null);
+});
+
+test('extractPackageJsonTurboVersion reads devDependencies.turbo', () => {
+  assert.equal(
+    extractPackageJsonTurboVersion({ devDependencies: { turbo: '2.9.3' } }),
+    '2.9.3',
+  );
+});
+
+test('extractPackageJsonTurboVersion returns null when devDependencies is missing', () => {
+  assert.equal(extractPackageJsonTurboVersion({}), null);
+});
+
+test('extractPackageJsonTurboVersion returns null when turbo is not a devDependency', () => {
+  assert.equal(extractPackageJsonTurboVersion({ devDependencies: { typescript: '5.0.0' } }), null);
+});


### PR DESCRIPTION
## Summary

PR #691 (fixing #674) pinned `turbo` to an exact version (`2.9.3`) in three places: `apps/web/Dockerfile`'s `npx turbo@2.9.3 prune` step, `package.json`, and `package-lock.json`. Nothing mechanically kept the Dockerfile pin and `package.json` in sync — this adds that check.

- Adds `scripts/check-turbo-version-sync.mjs`: reads the Dockerfile's `npx turbo@<version> prune` pin and `package.json`'s `devDependencies.turbo`, and fails with a clear message if they differ. Mirrors the existing `scripts/validate-analytics-taxonomy.mjs` two-file-drift-check style (no external deps, plain Node ESM).
- Wires it into `.github/workflows/ci.yml`'s `lint-and-test` job, right next to `validate-analytics-taxonomy.mjs` — the established pattern in this repo for this class of mechanical drift check (CI-enforced, not just documented).
- Documents it in `CLAUDE.md`'s `## Testing` section (new "Turbo version pin sync" subsection, alongside the existing Playwright-E2E "run this locally before pushing when X changes" subsection) so it's part of the pre-PR checklist, not just a CI-only gate.
- Adds a row to `scripts/README.md`'s Verification/testing table.

## Acceptance criteria

- [x] Check asserts `apps/web/Dockerfile`'s `npx turbo@<version>` pin matches `package.json`'s `devDependencies.turbo`
- [x] Wired into the pre-PR checklist (CLAUDE.md `## Testing`) and into CI (`ci.yml`)
- [x] Drift is caught before merge, not just at the next `--no-cache` Docker build

## Testing

- `node scripts/check-turbo-version-sync.mjs` against current repo state: `OK: turbo version in sync (2.9.3).` (exit 0)
- Induced-drift test: temporarily bumped `package.json`'s `devDependencies.turbo` to `2.9.4` (Dockerfile left at `2.9.3`) and re-ran — script correctly failed with a clear diff message (exit 1), then `package.json` was restored (confirmed via `git status`/`git diff` — no residual change).
- `npm run typecheck`: passed (4/4 tasks, 3 cached).
- `npm test`: **Tests: 900 passed, 0 skipped, 0 failed** across isolated per-workspace runs — `@lifting-logbook/core` 280/280, `@lifting-logbook/api` 440/440, `@lifting-logbook/web` 180/180, `@lifting-logbook/mobile` no tests, `@lifting-logbook/eslint-rules` 14/14 (all passed; no application/test code is touched by this PR, so no new coverage applies — matches the precedent set by PR #697 for CI/docs-only changes).
  - The full concurrent `npm test` (`turbo run test`) hit pre-existing Windows parallel-load flakiness twice in this session, with two *different* transient symptoms (a `spawn UNKNOWN` jest-worker crash across api/web/mobile, then a Testcontainers/Prisma `migrate deploy` timing failure) — not a regression from this change, confirmed by the 100%-passing isolated runs above. This is a recurrence of the same root cause as the now-closed #567 with symptoms its fix didn't cover; filed and tracked as **[#710](https://github.com/brownm09/lifting-logbook/issues/710)** per the Failure-tracking rule, not fixed here (root-causing concurrent Jest/Testcontainers scheduling on Windows is well outside this PR's scope).
- Suppression / test-integrity / deleted-test / coverage-threshold pre-PR greps: all clean.
- Lockfile-sync check (`npm install --package-lock-only --ignore-scripts && git diff --exit-code package-lock.json`): clean — no dependency changes in this PR.

## Review findings disposition

`/review` ran a single pass on the initial 70-line diff (report: [PR comment](https://github.com/brownm09/lifting-logbook/pull/711#issuecomment-4888112034)). 0 blocking, 2 non-blocking findings — both fixed in this PR:

| Finding | Severity | Fixed in |
|---|---|---|
| Missing Dockerfile/package.json would throw a raw uncaught `ENOENT` instead of the script's own clean `ERROR:` message style | Non-blocking [reliability] | `1c73741` |
| Version-parsing logic (regex + JSON lookup) had no automated test, only manual verification | Non-blocking [maintainability] | `1c73741` |

Both re-verified after the fix: 5/5 new unit tests pass, main script's pass/fail cases still correct, missing-file case now exits 1 with a clean message, `npm run typecheck` and suppression/test-integrity greps still clean.
