### PR TITLE
[docs] Document REST fallback for GitHub PR ops when GraphQL rate limit is exhausted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,45 @@ If `--format json` is not supported by the installed `gh` version, fall back to 
     - **ROADMAP.md**: if this PR completes a work stream listed in a milestone's Active Work table, move that row to the milestone's Shipped table; if the Active Work table becomes empty, replace it with `| *(all shipped)* | | |`
 13. Write a `<!-- next-session-context -->` block to the draft and display it as the closing output of the session
 
+### REST-endpoint fallback when the shared GraphQL rate limit is exhausted
+
+The `gh pr *` commands the steps above depend on — `gh pr create` (step 7), `gh pr merge`
+(step 8), `gh pr view --json`, `gh pr comment` — are **all GraphQL** calls, and this repo's 60+
+concurrent worktrees share **one GitHub API rate-limit bucket per resource class**. GraphQL can
+therefore exhaust while the separate **REST (core)** bucket is still healthy. Motivating incident:
+[PR #700](https://github.com/brownm09/lifting-logbook/pull/700)'s session (2026-07-05) — `gh pr
+create` died with `GraphQL: API rate limit already exceeded` while REST core showed 4999/5000. The
+buckets are independent, so when a `gh pr` command fails that way, don't wait for the reset — fall
+back to the REST equivalents. (The global
+[`CLAUDE.md`](https://github.com/brownm09/dev-env/blob/main/claude/CLAUDE.md) documents the rate-limit
+*hazard*; the steps below are the *mitigation*.)
+
+- **Compare both buckets first** — REST usually still has budget:
+  ```bash
+  gh api rate_limit
+  # resources.graphql = gh pr create / merge / view --json / comment
+  # resources.core    = the gh api REST calls below
+  ```
+- **Create a PR** instead of `gh pr create` — write the body to a scratch file first so backticks
+  aren't mangled by the shell:
+  ```bash
+  gh api -X POST repos/brownm09/lifting-logbook/pulls \
+    -f title="[docs] ..." -f head="<branch>" -f base=main \
+    -F body=@C:/Users/brown/.claude/scratch/pr-body.md
+  ```
+- **Merge.** `gh pr merge <N> --auto --squash` is a single lightweight GraphQL call that arms GitHub
+  to squash-merge once checks pass — prefer it while GraphQL has *any* budget. If GraphQL is fully
+  exhausted, merge and delete the branch entirely over REST (the same server-side merge + ref-delete
+  as step 8, reached without GraphQL):
+  ```bash
+  gh api -X PUT repos/brownm09/lifting-logbook/pulls/<N>/merge -f merge_method=squash
+  gh api -X DELETE "repos/brownm09/lifting-logbook/git/refs/heads/<branch>"
+  ```
+- **Inspect PR state** instead of `gh pr view --json`:
+  ```bash
+  gh api repos/brownm09/lifting-logbook/pulls/<N>
+  ```
+
 ---
 
 ## Branch Naming


### PR DESCRIPTION
## Summary

Documents the **REST-endpoint fallback** for GitHub PR operations when the shared **GraphQL** rate-limit bucket is exhausted while the **REST (core)** bucket is still healthy — a recurring hazard in this repo, where 60+ concurrent worktrees share one GitHub API rate-limit bucket per resource class.

Adds a `### REST-endpoint fallback when the shared GraphQL rate limit is exhausted` subsection to `CLAUDE.md`, directly under the Standard Issue Workflow (adjacent to the step-8 two-step-merge pattern, which already uses `gh api` REST calls). It covers:

- Comparing both buckets with `gh api rate_limit` (`resources.graphql` vs `resources.core`).
- Creating a PR via `gh api -X POST .../pulls` (body from a scratch file).
- Merging via `gh pr merge <N> --auto --squash` (single lightweight GraphQL call) or a fully-REST `gh api -X PUT .../pulls/<N>/merge` + ref-delete when GraphQL is exhausted.
- Inspecting PR state via `gh api .../pulls/<N>` instead of `gh pr view --json`.

The global `~/.claude/CLAUDE.md` already documents the rate-limit *hazard*; this is the *mitigation*. Motivating incident: [PR #700](https://github.com/brownm09/lifting-logbook/pull/700)'s session (2026-07-05), where `gh pr create` failed with `GraphQL: API rate limit already exceeded` while REST core showed 4999/5000.

## Acceptance Criteria

- [x] REST fallback subsection added near the step-8 two-step-merge pattern
- [x] Documents bucket check (`gh api rate_limit`), REST PR create, REST/`--auto` merge, and REST PR inspect
- [x] References the motivating incident (PR #700)

## Testing

Docs-only change (Markdown in `CLAUDE.md`) — no code, build, or test paths affected. Per the repo coverage matrix, "Refactor / docs only" requires no tests; existing tests are unaffected. Pre-PR quality gates:

- **Suppression grep** — N/A, clean (no code in diff).
- **Test-integrity grep** — N/A, clean (no test files touched).
- **Lockfile sync** — N/A (no `package.json` change; `package-lock.json` not modified).
- **Baseline test diff** — N/A (docs-only).

## Review findings disposition

`/review` completed — **clean review, 0 blocking / 0 non-blocking findings** ([review comment](https://github.com/brownm09/lifting-logbook/pull/714#issuecomment-4888142624)). Nothing to disposition.

## Follow-up

A one-line pointer from the global `~/.claude/CLAUDE.md` rate-limit *hazard* note to this *mitigation* is filed separately in `brownm09/dev-env` — [dev-env#591](https://github.com/brownm09/dev-env/issues/591).

Closes #713
