### PR TITLE
[fix] Warm /import in e2e beforeAll to fix Windows cold-compile flake

### DIFF
--- a/apps/web/e2e/import.spec.ts
+++ b/apps/web/e2e/import.spec.ts
@@ -2,6 +2,20 @@ import { test, expect } from '@playwright/test';
 
 const MOCK_API = 'http://localhost:3004';
 
+// The heavy /import route compiles on-demand in Next dev. On Windows local dev the first,
+// cold compile of ImportWizard can exceed Playwright's 30s default test timeout, so the
+// first navigating test would otherwise fail at page.goto before any assertion runs. Warm
+// the route once here (with generous headroom) so every test navigates to an already-
+// compiled /import. CI (Linux) compiles fast enough that this is effectively a no-op.
+// See https://github.com/brownm09/lifting-logbook/issues/698.
+test.beforeAll(async ({ browser }, testInfo) => {
+  test.setTimeout(120_000);
+  const page = await browser.newPage({ baseURL: testInfo.project.use.baseURL });
+  await page.goto('/import', { timeout: 90_000 });
+  await expect(page.getByRole('heading', { name: 'Import a file' })).toBeVisible({ timeout: 90_000 });
+  await page.close();
+});
+
 // The Source step's program-picker lists custom programs; opt the mock into one.
 test.beforeEach(async ({ request }) => {
   await request.get(`${MOCK_API}/__reset?withCustomProgram=true`);
@@ -11,7 +25,7 @@ test('import wizard: Source → Classify → Review → Preview → Done', async
   await page.goto('/import');
 
   // Source step: pick a program (pre-selected) and upload a CSV.
-  await expect(page.getByRole('heading', { name: 'Import a file' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Import a file' })).toBeVisible({ timeout: 15_000 });
   await page.getByLabel('CSV file').setInputFiles({
     name: 'training_maxes.csv',
     mimeType: 'text/csv',
@@ -102,7 +116,7 @@ test('import wizard MAP_COLUMNS: fuzzy-matched columns shown; override unmapped 
   await page.goto('/import');
 
   // Source step: upload a CSV with non-standard headers (Date, Exercise, Max Weight).
-  await expect(page.getByRole('heading', { name: 'Import a file' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Import a file' })).toBeVisible({ timeout: 15_000 });
   await page.getByLabel('CSV file').setInputFiles({
     name: 'nonstandard.csv',
     mimeType: 'text/csv',


### PR DESCRIPTION
## Summary

Fixes the Windows-local Playwright flake in `apps/web/e2e/import.spec.ts` (#698). The heavy `/import` route (`ImportWizard`) compiles on-demand in Next dev; on Windows local dev that **cold compile is slow enough to blow through Playwright's default timeouts** on the first test to navigate there. CI (Linux) compiles fast enough to stay green, which is why the file ships passing.

## Root cause (what I actually observed)

The issue diagnosed the failure as the first heading assertion timing out at the 5 s `expect` default:

```
expect(getByRole('heading', { name: 'Import a file' })).toBeVisible()  // 5000ms → not found
```

That is the symptom on a *warm-ish* dev server (the shell loads, then the heading renders > 5 s later). But on a **fully cold** dev server (fresh checkout, empty `.next` cache) the compile also outlasts the **30 s test timeout**, so the very first `page.goto('/import')` never returns:

```
Error: page.goto: Test timeout of 30000ms exceeded.
  - navigating to "http://localhost:3000/import", waiting until "load"
```

A per-assertion `{ timeout: 15_000 }` on the heading **cannot** fix that case — the test dies at `goto`, upstream of any assertion. So the robust fix (the alternative the issue itself proposes) is a one-time **`beforeAll` warmup** that compiles `/import` once, with generous headroom, before the timed test bodies run.

## Change

`apps/web/e2e/import.spec.ts` only:

- **`beforeAll` warmup** — opens a throwaway page, navigates to `/import` with a 90 s nav budget (and `test.setTimeout(120_000)` so the hook itself isn't capped at 30 s), and waits for the `Import a file` heading. After it, every test navigates to an already-compiled route.
- **15 s headroom** kept on the two existing Source-step heading assertions (tests 1 & 4) — the issue's literal recommendation, and cheap insurance for residual client hydration variance.

No production/app code changes; no config changes (keeps the fix scoped to this spec rather than altering shared `playwright.config.ts` timeouts for every suite).

## Acceptance criteria

- [x] `npx playwright test e2e/import.spec.ts` passes in isolation on Windows local dev (verified against a **cold** `.next`)
- [x] Full `npm run test:e2e -w @lifting-logbook/web` passes locally on Windows

## Testing

Run on Windows local dev (Node 20.11.1), `.next` cache cleared beforehand to force a genuine cold compile:

- **Isolation** (`.next` cleared → genuine cold compile): `npx playwright test e2e/import.spec.ts` → **4 passed (55.0s)**
- **Full suite**: `npm run test:e2e -w @lifting-logbook/web` → **Tests: 19 passed, 0 skipped, 0 failed (40.8s)**

Pre-PR gates:
- Suppression grep — clean
- Test-integrity grep — clean (no skips/`.todo`/`--bail`/threshold changes; change only *adds* a hook and widens two timeouts)
- No deleted test files; no coverage-threshold changes
- Lockfile: no `package.json` change → no lockfile drift

Closes #698
