### PR TITLE
[chore] Add scheduled --no-cache Docker build CI job to catch Linux-only build breaks

### DIFF
--- a/.github/workflows/docker-nocache-build.yml
+++ b/.github/workflows/docker-nocache-build.yml
@@ -1,0 +1,164 @@
+name: Docker No-Cache Build
+
+# Scheduled, cache-free rebuild of both production Dockerfiles. Unlike every other
+# workflow in this repo that builds a Docker image, this one never pushes anywhere —
+# its only output is pass/fail. It exists because #674 (fixed by #691) was a real
+# production-build regression that stayed invisible for a while: `deploy.yml` and
+# `staging.yml` both build with GHA layer caching (cache-from/cache-to: type=gha),
+# so a broken RUN/COPY layer can hide behind a stale-but-working cached layer
+# indefinitely. `npm run typecheck` deliberately can't catch this class of bug
+# either — it resolves workspace packages to source, not dist, specifically so it
+# stays cacheable without an upstream build (#651/#656) — so a dist/declaration-emit
+# regression like #674's is invisible to it by design. This workflow runs both
+# Dockerfiles through a genuinely fresh `docker build --no-cache` on a schedule, so
+# a similar regression surfaces within a day instead of only via manual
+# investigation (as #674 was, per #691). See #693.
+
+on:
+  schedule:
+    # Nightly, not weekly: the whole point of this workflow is to catch a build
+    # regression sooner than "someone happens to run an uncached build by hand"
+    # (#693) — a week is a long time to leave that invisible. 05:14 UTC is
+    # off-peak and avoids top-of-hour scheduler congestion (same rationale as
+    # required-checks-drift.yml).
+    - cron: '14 5 * * *'
+  workflow_dispatch:
+
+# Prevents a manual dispatch from racing the nightly tick and filing two issues
+# for the same failure. cancel-in-progress: false so an in-flight build always
+# finishes and reports, rather than being cancelled mid-build by an overlapping
+# trigger (same rationale as required-checks-drift.yml).
+concurrency:
+  group: docker-nocache-build
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Build apps/web ──────────────────────────────────────────────────────────
+  build-web:
+    name: Build apps/web (no cache)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # push: false, no cache-from/cache-to: this build's only purpose is to prove
+      # the Dockerfile still builds clean, so no registry auth is needed at all.
+      # no-cache: true forces every RUN/COPY instruction to re-execute from
+      # scratch (this is what actually re-exercises the `turbo run build` / .d.ts
+      # emission step that broke in #674) — it does not force re-pulling the
+      # pinned node:20.11.1-alpine base image if the runner already has that
+      # exact tag cached, which is fine: the regression this guards against lives
+      # in the RUN layers, not the base image. No wretry wrapper (unlike
+      # deploy.yml/staging.yml): that retry exists solely to absorb transient
+      # Artifact Registry 504s on registry push, which cannot happen when
+      # push: false.
+      - name: Build apps/web image (no cache, not pushed)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/web/Dockerfile
+          push: false
+          no-cache: true
+          tags: lifting-logbook-web:nocache-check
+
+  # ── Build apps/api ──────────────────────────────────────────────────────────
+  build-api:
+    name: Build apps/api (no cache)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build apps/api image (no cache, not pushed)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          push: false
+          no-cache: true
+          tags: lifting-logbook-api:nocache-check
+
+  # ── Report failure ───────────────────────────────────────────────────────────
+  # Independent jobs above run in parallel so a broken apps/web build can never
+  # mask an apps/api regression (or vice versa). This job aggregates both
+  # results and files/updates a single tracking issue — mirrors
+  # required-checks-drift.yml's idempotent create-or-comment pattern.
+  report-failure:
+    name: Report build failure
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [build-web, build-api]
+    if: always() && (needs.build-web.result == 'failure' || needs.build-api.result == 'failure')
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update failure issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh label create docker-nocache-build-failure \
+            --description "A scheduled --no-cache Docker build failed for apps/web and/or apps/api" \
+            --color B60205 \
+            --force
+
+          FAILED=""
+          if [ "${{ needs.build-web.result }}" = "failure" ]; then
+            FAILED="${FAILED}- \`apps/web/Dockerfile\`\n"
+          fi
+          if [ "${{ needs.build-api.result }}" = "failure" ]; then
+            FAILED="${FAILED}- \`apps/api/Dockerfile\`\n"
+          fi
+
+          {
+            echo "# Docker no-cache build failing"
+            echo ""
+            echo "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo ""
+            echo "## Failing Dockerfile(s)"
+            echo ""
+            printf "%b" "$FAILED"
+            echo ""
+            echo "## Why this matters"
+            echo ""
+            echo "A fresh, uncached \`docker build\` failed for the Dockerfile(s) above. This class of regression (e.g. #674) can hide behind GHA layer caching in \`deploy.yml\`/\`staging.yml\`, and is invisible to \`npm run typecheck\` by design (#651/#656). See #693."
+            echo ""
+            echo "## Reproduce locally"
+            echo ""
+            echo '```'
+            echo "docker build --no-cache -f apps/web/Dockerfile ."
+            echo "docker build --no-cache -f apps/api/Dockerfile ."
+            echo '```'
+          } > body.md
+
+          mapfile -t EXISTING < <(gh issue list \
+            --label docker-nocache-build-failure \
+            --state open \
+            --json number \
+            --jq '.[].number')
+          if [ "${#EXISTING[@]}" -gt 0 ]; then
+            for N in "${EXISTING[@]}"; do
+              echo "Updating existing issue #$N"
+              gh issue comment "$N" --body-file body.md
+            done
+          else
+            echo "Creating new failure issue"
+            gh issue create \
+              --label docker-nocache-build-failure \
+              --title "Docker no-cache build failing" \
+              --body-file body.md
+          fi
+
+      - name: Fail run
+        run: |
+          echo "Docker no-cache build failed — see the opened/updated issue."
+          exit 1

--- a/.github/workflows/docker-nocache-build.yml
+++ b/.github/workflows/docker-nocache-build.yml
@@ -92,12 +92,19 @@ jobs:
   # mask an apps/api regression (or vice versa). This job aggregates both
   # results and files/updates a single tracking issue — mirrors
   # required-checks-drift.yml's idempotent create-or-comment pattern.
+  #
+  # Checks != 'success' rather than == 'failure': build-web/build-api have no
+  # if: of their own, so their only possible results are success, failure, or
+  # cancelled. A genuine hang that trips the 45-minute timeout-minutes bound is
+  # reported by GitHub Actions as cancelled, not failure — == 'failure' alone
+  # would silently skip the tracking-issue mechanism for exactly the kind of
+  # unattended regression this workflow exists to surface (review finding on #719).
   report-failure:
     name: Report build failure
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [build-web, build-api]
-    if: always() && (needs.build-web.result == 'failure' || needs.build-api.result == 'failure')
+    if: always() && (needs.build-web.result != 'success' || needs.build-api.result != 'success')
     permissions:
       issues: write
     steps:
@@ -111,12 +118,15 @@ jobs:
             --color B60205 \
             --force
 
+          # != "success" (not = "failure") to stay consistent with the job-level
+          # if: above — a timed-out/cancelled build must still be named here, or a
+          # hang would open an issue with an empty "Failing Dockerfile(s)" list.
           FAILED=""
-          if [ "${{ needs.build-web.result }}" = "failure" ]; then
-            FAILED="${FAILED}- \`apps/web/Dockerfile\`\n"
+          if [ "${{ needs.build-web.result }}" != "success" ]; then
+            FAILED="${FAILED}- \`apps/web/Dockerfile\` (${{ needs.build-web.result }})\n"
           fi
-          if [ "${{ needs.build-api.result }}" = "failure" ]; then
-            FAILED="${FAILED}- \`apps/api/Dockerfile\`\n"
+          if [ "${{ needs.build-api.result }}" != "success" ]; then
+            FAILED="${FAILED}- \`apps/api/Dockerfile\` (${{ needs.build-api.result }})\n"
           fi
 
           {

--- a/.github/workflows/docker-nocache-build.yml
+++ b/.github/workflows/docker-nocache-build.yml
@@ -57,7 +57,10 @@ jobs:
       # in the RUN layers, not the base image. No wretry wrapper (unlike
       # deploy.yml/staging.yml): that retry exists solely to absorb transient
       # Artifact Registry 504s on registry push, which cannot happen when
-      # push: false.
+      # push: false. A transient failure pulling the base image on a cold runner
+      # is possible, but report-failure's idempotent create-or-comment caps that
+      # at one comment on the existing issue, so a build-step retry isn't worth
+      # the added complexity here.
       - name: Build apps/web image (no cache, not pushed)
         uses: docker/build-push-action@v6
         with:
@@ -111,6 +114,10 @@ jobs:
       - name: Open or update failure issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This job has no checkout step, so gh has no git remote to infer the
+          # target repo from; GH_REPO gives every gh call below its repository
+          # (matches required-checks-drift.yml, which achieves this via checkout).
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           gh label create docker-nocache-build-failure \


### PR DESCRIPTION
## Summary

Adds a scheduled, cache-free Docker build workflow (`.github/workflows/docker-nocache-build.yml`) that rebuilds **both** `apps/web/Dockerfile` and `apps/api/Dockerfile` with `docker build --no-cache` (`push: false`) on a nightly cron (`05:14 UTC`) plus manual `workflow_dispatch`.

It exists because [#674](https://github.com/brownm09/lifting-logbook/issues/674) (fixed by #691) was a real production-build regression that stayed invisible: `deploy.yml`/`staging.yml` build with GHA layer caching (`cache-from/cache-to: type=gha`), so a broken `RUN`/`COPY` layer can hide behind a stale-but-working cached layer, and `npm run typecheck` can't catch this class by design (it resolves workspace packages to source, not `dist`, per #651/#656). A genuinely fresh uncached build re-exercises the `turbo run build` / `.d.ts`-emit step that broke, surfacing that regression within a day.

- `build-web` and `build-api` run **in parallel** so a broken web build can't mask an api regression (or vice-versa).
- On failure, a `report-failure` job opens-or-updates a **single** tracking issue (idempotent create-or-comment, mirroring `required-checks-drift.yml`). Reports on any non-success result (`!= 'success'`), not just `'failure'`, so a genuine timeout/hang still gets tracked (see Review findings disposition below).
- **Least-privilege permissions:** top-level `contents: read`; `issues: write` is scoped to the `report-failure` job only.

> **Provenance:** this work was found complete but **uncommitted** in a local git worktree during a worktree audit/prune — it had never been committed, pushed, or opened as a PR. The branch was fast-forwarded onto current `main` before committing; the file is unchanged from the rescued original.

## Acceptance criteria (from #693)

- [x] Scheduled CI workflow running `docker build --no-cache` for `apps/web/Dockerfile`
- [x] Same for `apps/api/Dockerfile`
- [x] Independent of the cached deploy pipeline (`push: false`, no `cache-from`/`cache-to`)
- [x] Surfaces a regression on a schedule instead of only via a manual uncached build (nightly cron + `workflow_dispatch`)

## Testing

This change touches only `.github/workflows/docker-nocache-build.yml` — no application, package, or build code — so `npm test` / `npm run typecheck` outcomes are unaffected by the diff itself (analogous to the project's *"Refactor / docs only — existing tests must pass"* coverage tier). Verification performed:

- `docker build --no-cache -f apps/web/Dockerfile .` and `-f apps/api/Dockerfile .` run locally — both build clean, directly exercising the workflow's core logic and reconfirming #691's fix holds.
- Workflow YAML parses cleanly (`js-yaml`) — 3 jobs (`build-web`, `build-api`, `report-failure`).
- Pre-commit `turbo run lint` passed: **7 successful, 7 total** (FULL TURBO, cached).
- Pre-PR suppression + test-integrity greps: **clean** (YAML-only diff).
- `npm test`: **Tests: 935 passed, 0 skipped, 0 failed (2m23s)** — full workspace suite (api-client 27, core 280, web 186, api 442), including the DB E2E suite (Docker was available; `LIFTING_SKIP_DB_E2E` was not needed).
- End-to-end validation of the job graph itself (permissions, `needs`/`if` wiring, the failure-reporting path) runs on GitHub Actions post-merge via **`workflow_dispatch`** — a brand-new workflow can't be manually dispatched before it exists on the default branch, so this is deferred by necessity, matching this repo's own precedent in PRs #381 and #553.

No suppressions, skips, or coverage-threshold changes introduced.

## Review findings disposition

Two `/review` passes ran on this PR; all four findings addressed:

**Pass 1:**
1. **[correctness] (blocking)** PR body's Testing section lacked the literal `Tests: N passed, N skipped, N failed` summary line required unconditionally by this project's Test Integrity Policy. → **Fixed** in the PR-body edit (summary line added above).
2. **[reliability] (non-blocking)** `report-failure`'s `if:` only checked `== 'failure'`; a build that hangs and trips the 45-minute `timeout-minutes` bound resolves to `cancelled`, not `failure`, silently skipping the tracking-issue mechanism. → **Fixed** in `ddf2bf7` — both the job-level `if:` and the failing-Dockerfile list now check `!= 'success'`.

**Pass 2** ([review comment](https://github.com/brownm09/lifting-logbook/pull/719#issuecomment-4889200339)):
3. **[reliability] (blocking)** `report-failure`'s `gh label`/`gh issue` calls had no repository context — no `actions/checkout`, no `--repo`, no `GH_REPO` — so `gh` could not resolve the target repo and the tracking-issue mechanism (the job's entire purpose) would fail exactly when a build breaks. Both sibling `gh`-using workflows (`required-checks-drift.yml`, `merge-ready-digest.yml`) provide repo context; this job provided none. → **Fixed** in `d395260` — `GH_REPO: ${{ github.repository }}` added to the `report-failure` step env.
4. **[reliability] (non-blocking)** No retry on the build step; a fresh runner pulls the `node:20.11.1-alpine` base image every run, so a transient pull failure could file a false-positive tracking issue. → **Fixed** in `d395260` — the "no wretry" rationale comment now notes the idempotent create-or-comment caps a transient pull failure at one comment, so a build-step retry isn't warranted.

Closes #693

