### PR TITLE
[docs] Document staging-deploy-mutex queue starvation as a known CI pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -496,6 +496,26 @@ gh pr view <N> --json mergeable,mergeStateStatus
 
 Motivating incident: [PR #604](https://github.com/brownm09/lifting-logbook/pull/604).
 
+### Staging-deploy queue starvation — cross-PR mutex preemption
+
+**Pattern:** `.github/workflows/staging.yml`'s `deploy-api`/`deploy-web` jobs serialize writes to the one shared staging Cloud Run service / Helm release via job-level concurrency groups (`staging-deploy-mutex-api`, `staging-deploy-mutex-web`, both `cancel-in-progress: false`). These groups are global, not per-PR. GitHub Actions keeps only the most-recently-queued run per concurrency group — when a third PR pushes while a second PR's deploy is already queued behind a first PR's running deploy, the second PR's queued run is silently cancelled and the third takes its place. Under sustained multi-PR throughput this can repeat for an unlucky PR across many cycles.
+
+**Symptom:** The required `Staging Integration Tests` check fails with "Staging did not become ready in time" or an empty `WEB_URL`, even on a PR whose diff cannot plausibly affect staging (e.g. docs-only). The `deploy-api` or `deploy-web` job's own result shows `cancelled` rather than `failure`.
+
+**Diagnosis:**
+```bash
+gh run list --workflow=staging.yml -R brownm09/lifting-logbook --limit 20
+```
+Open the cancelled run's job log — GitHub Actions annotates the cancellation directly: `Canceling since a higher priority waiting request for staging-deploy-mutex-web exists`.
+
+**Fix:** Re-run once the queue has a lull:
+```bash
+gh run rerun <run-id> --failed
+```
+This is a known, already-diagnosed CI mechanic, not a new bug — see [#673](https://github.com/brownm09/lifting-logbook/issues/673) for the full root-cause analysis and [ADR-030](docs/adr/ADR-030-github-merge-queue-adoption.md) for the accepted structural fix (GitHub merge queue). Activation is tracked in [#695](https://github.com/brownm09/lifting-logbook/issues/695); until it lands, re-running after the queue clears is the only workaround.
+
+Motivating incidents: [PR #703](https://github.com/brownm09/lifting-logbook/pull/703), [PR #711](https://github.com/brownm09/lifting-logbook/pull/711).
+
 ---
 
 ## Observability


### PR DESCRIPTION
## Summary

Documents the staging-deploy-mutex queue starvation pattern in `CLAUDE.md`, mirroring the existing "CI not firing — merge conflict silences GitHub Actions" entry's Pattern/Symptom/Diagnosis/Fix structure.

`.github/workflows/staging.yml`'s `deploy-api`/`deploy-web` jobs serialize writes to the one shared staging Cloud Run service / Helm release via *global* (not per-PR) concurrency groups. GitHub Actions keeps only the most-recently-queued run per group, so under concurrent PR throughput a newer PR's push can silently cancel an older PR's queued deploy, hard-failing that PR's required `Staging Integration Tests` check with no relation to its actual diff.

This is a documentation-only fix for the symptom/diagnosis/recovery steps. The structural root cause and fix were already investigated in [#673](https://github.com/brownm09/lifting-logbook/issues/673) and decided in [ADR-030](https://github.com/brownm09/lifting-logbook/blob/main/docs/adr/ADR-030-github-merge-queue-adoption.md) (adopt GitHub merge queue). The groundwork (`merge_group` triggers) merged in #696; activation is tracked separately in [#695](https://github.com/brownm09/lifting-logbook/issues/695), intentionally deferred for a soak period. This PR does not touch that decision or timeline — it just gives anyone who hits the symptom in the meantime a documented diagnosis + recovery path, per #712's explicit scope.

## Acceptance Criteria

- [x] Document the symptom (required check fails with `WEB_URL` empty / "Staging did not become ready in time")
- [x] Document diagnosis (check job annotations for the preemption message; `gh run list --workflow=staging.yml` for queue contention)
- [x] Document recovery (re-run once the queue has a lull; `gh run rerun <id> --failed`)
- [x] Match the style of the existing "CI not firing" `CLAUDE.md` entry
- [x] Link to #673 / ADR-030 / #695 rather than re-litigating the design question (explicitly out of scope per #712)

## Testing

Docs-only change (`CLAUDE.md` text only, no code/workflow files touched) — per this repo's Testing coverage table, "Refactor / docs only → None required — existing tests must pass." The pre-commit `turbo run lint` hook ran clean (7/7 tasks successful). Pre-PR suppression/test-integrity/lockfile-drift greps are trivially clean since the diff touches only one Markdown file.

Closes #712
