### PR TITLE
[fix] Program length: single source of truth + faithful Program Plan

### DIFF
--- a/apps/api/src/programs/cycle-generation.service.spec.ts
+++ b/apps/api/src/programs/cycle-generation.service.spec.ts
@@ -325,6 +325,29 @@ describe('CycleGenerationService', () => {
       );
     });
 
+    it('schedules the full canonical program length, not the stored block (issue #680)', async () => {
+      // PROGRAM = '5-3-1' has a canonical length of 12 weeks. Even though the stub
+      // spec is a single block week, the schedule must span all 12 weeks so the
+      // workout calendar matches the advertised plan length.
+      cycleDashboardRepo.getCycleDashboard.mockRejectedValue(
+        new ProgramNotFoundError(PROGRAM),
+      );
+      programSpecRepo.getProgramSpec.mockResolvedValue(stubProgramSpec());
+      userSettingsRepo.getSettings.mockResolvedValue({
+        activeProgram: null,
+        workoutSchedule: { type: 'fixed', days: [0, 2, 4] },
+        defaultWeightIncrement: null,
+      });
+
+      await service.initializeFirstCycle(repos, PROGRAM, { cycleDate: '2026-05-12' });
+
+      const calls = cycleScheduledWorkoutRepo.saveScheduledWorkouts.mock.calls;
+      expect(calls).toHaveLength(1);
+      const workouts: Array<{ weekNum: number }> = calls[0]?.[2] ?? [];
+      const weeks = [...new Set(workouts.map((w) => w.weekNum))].sort((a, b) => a - b);
+      expect(weeks).toEqual(Array.from({ length: 12 }, (_, i) => i + 1));
+    });
+
     it('does not save scheduled dates when user has no workout schedule', async () => {
       cycleDashboardRepo.getCycleDashboard.mockRejectedValue(
         new ProgramNotFoundError(PROGRAM),

--- a/apps/api/src/programs/cycle-generation.service.ts
+++ b/apps/api/src/programs/cycle-generation.service.ts
@@ -4,9 +4,11 @@ import {
   CycleDashboard,
   LiftingProgramSpec,
   distributeWorkouts,
+  expandSpecToLength,
   formatDateYYYYMMDD,
   getScheduleWorkoutsPerWeek,
   MaxReductionFlag,
+  programLengthWeeks,
   TrainingMax,
   TrainingMaxHistoryEntry,
   updateCycle,
@@ -67,10 +69,18 @@ async function saveScheduledDates(
   programSpec: LiftingProgramSpec[],
   workoutSchedule: UserWorkoutSchedule,
 ): Promise<void> {
+  // Schedule the program's canonical length, not its stored block: repeating
+  // programs (Leangains, RPT) persist a 1-week block but run 8–12 weeks, so tile
+  // the base spec to full length before distributing so the workout calendar
+  // spans the whole program (issue #680). Expanding an empty spec yields [] —
+  // the guard covers custom/unseeded programs, since Math.max(...[]) is -Infinity
+  // and would drive distributeWorkouts negative.
+  const fullSpec = expandSpecToLength(programSpec, programLengthWeeks(program, programSpec));
+  if (fullSpec.length === 0) return;
   // numWeeks * workoutsPerWeek assumes schedule days/week equals program
   // workouts/week. Phase 5 adds a user-confirmation prompt that validates
   // this match before schedule mode is activated.
-  const numWeeks = Math.max(...programSpec.map((s) => s.week));
+  const numWeeks = fullSpec.reduce((max, s) => Math.max(max, s.week), 0);
   const workoutsPerWeek = getScheduleWorkoutsPerWeek(workoutSchedule);
   const distributed = distributeWorkouts(numWeeks * workoutsPerWeek, workoutSchedule, cycleDate);
 

--- a/apps/api/src/programs/cycle-generation.service.ts
+++ b/apps/api/src/programs/cycle-generation.service.ts
@@ -42,7 +42,10 @@ type CycleRepos = Pick<
  * Without a spec, getProgramSpec() returns [] for that program. Users with a
  * workout schedule will have saveScheduledDates silently skipped (degraded but
  * safe), and the cycle view will render with no program spec data.
- * These two registries must stay in sync.
+ * ALSO add a canonical length to PROGRAM_LENGTHS (packages/core/src/presets/
+ * programLengths.ts), or the program's schedule and plan collapse to its 1-block
+ * length instead of the advertised duration (issue #680).
+ * These three registries must stay in sync.
  */
 const PROGRAM_DEFAULTS: Record<string, { cycleUnit: string; programType: string }> = {
   '5-3-1': { cycleUnit: 'week', programType: '5-3-1' },

--- a/apps/api/src/programs/workouts.controller.spec.ts
+++ b/apps/api/src/programs/workouts.controller.spec.ts
@@ -192,10 +192,44 @@ describe('WorkoutsController', () => {
         activation: 'compound',
       },
     ]);
+    // No scheduled row for workoutNum 2 (getScheduledWorkouts defaults to []), so
+    // week falls back to weekForWorkoutNum → undefined → 400. getWorkout is now
+    // reached before that check, so mock it explicitly.
+    workoutRepo.getWorkout.mockResolvedValue([]);
 
     await expect(controller.getWorkout('5-3-1', '2', MOCK_USER)).rejects.toBeInstanceOf(
       BadRequestException,
     );
+  });
+
+  it('resolves week from the scheduled row for a tiled week-2+ workout (issue #680)', async () => {
+    // A 12-week Leangains schedule tiles a 1-week block, so workoutNum 4 lands in
+    // week 2 — beyond the block's 2 distinct offsets. Without sourcing week from
+    // the scheduled row this would 400; planned lifts must still come from the block.
+    dashboardRepo.getCycleDashboard.mockResolvedValue({
+      program: 'leangains',
+      cycleUnit: 'week',
+      cycleNum: 1,
+      cycleDate: new Date('2026-04-20T00:00:00.000Z'),
+      sheetName: '',
+      cycleStartWeekday: Weekday.Monday,
+    });
+    specRepo.getProgramSpec.mockResolvedValue([
+      { week: 1, offset: 0, lift: 'Bench Press', increment: 5, order: 1, sets: 3, reps: 6, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+      { week: 1, offset: 2, lift: 'Squat', increment: 10, order: 1, sets: 3, reps: 6, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    ]);
+    workoutRepo.getWorkout.mockResolvedValue([]); // upcoming — no records yet
+    scheduledWorkoutRepo.getScheduledWorkouts.mockResolvedValue([
+      { workoutNum: 1, weekNum: 1, scheduledDate: new Date('2026-04-20T00:00:00.000Z') },
+      { workoutNum: 4, weekNum: 2, scheduledDate: new Date('2026-04-27T00:00:00.000Z') },
+    ]);
+
+    const result = await controller.getWorkout('leangains', '4', MOCK_USER);
+
+    expect(result.week).toBe(2);
+    // Planned lifts come from the tiled block week (block week 1 for a 1-week block).
+    expect(result.lifts.map((l) => l.lift).sort()).toEqual(['Bench Press', 'Squat']);
+    expect(result.lifts.every((l) => l.planned)).toBe(true);
   });
 
   describe('overrideDate', () => {

--- a/apps/api/src/programs/workouts.controller.ts
+++ b/apps/api/src/programs/workouts.controller.ts
@@ -5,7 +5,7 @@ import {
   Inject,
   Param,
 } from '@nestjs/common';
-import { LiftRecord } from '@lifting-logbook/core';
+import { baseSpecBlockWeeks, LiftRecord } from '@lifting-logbook/core';
 import { WorkoutResponse } from '@lifting-logbook/types';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../ports/auth';
@@ -45,16 +45,6 @@ export class WorkoutsController {
       }),
       liftingProgramSpec.getProgramSpec(program),
     ]);
-    const week = weekForWorkoutNum(spec, workoutNum);
-    if (week === undefined) {
-      throw new BadRequestException(
-        `workoutNum ${workoutNum} exceeds program spec (${new Set(spec.map((s) => s.offset)).size} workout days)`,
-      );
-    }
-
-    // Spec lifts for this workout's week — used to build the planned lift list.
-    const specLifts = [...new Set(spec.filter((s) => s.week === week).map((s) => s.lift))];
-
     const [records, overrideDate, liftOverrides, scheduledWorkouts, skippedNums] = await Promise.all([
       // fallback-covered-by: apps/api/src/programs/workouts.controller.spec.ts
       workout
@@ -73,7 +63,26 @@ export class WorkoutsController {
         return new Set<number>();
       }),
     ]);
-    const scheduledDate = scheduledWorkouts.find((s) => s.workoutNum === workoutNum)?.scheduledDate;
+    const scheduledWorkout = scheduledWorkouts.find((s) => s.workoutNum === workoutNum);
+    const scheduledDate = scheduledWorkout?.scheduledDate;
+
+    // The scheduled row's weekNum is authoritative for the program week. A global
+    // workoutNum spans the full tiled schedule, so it can exceed the base block's
+    // distinct-offset count — weekForWorkoutNum (offset-indexed within one block)
+    // only covers the no-schedule fallback. Without this, week-2+ workouts of a
+    // tiled program (Leangains 12w, 5-3-1 12w) would 400 (issue #680).
+    const week = scheduledWorkout?.weekNum ?? weekForWorkoutNum(spec, workoutNum);
+    if (week === undefined) {
+      throw new BadRequestException(
+        `workoutNum ${workoutNum} exceeds program spec (${new Set(spec.map((s) => s.offset)).size} workout days)`,
+      );
+    }
+
+    // Planned lifts come from the tiled block week: the stored spec is one block,
+    // so map the program week (which may exceed blockWeeks) back into the block.
+    const blockWeeks = baseSpecBlockWeeks(spec);
+    const blockWeek = blockWeeks > 0 ? ((week - 1) % blockWeeks) + 1 : week;
+    const specLifts = [...new Set(spec.filter((s) => s.week === blockWeek).map((s) => s.lift))];
 
     const plannedLifts = applyLiftOverrides(specLifts, liftOverrides);
 

--- a/apps/web/app/(authed)/cycle/[cycleNum]/plan/page.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/plan/page.tsx
@@ -2,7 +2,11 @@ import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
 import { fetchCycleDashboard, fetchProgramSpec } from '@/lib/api';
 import { getActiveProgram } from '@/lib/active-program';
-import { deriveProgramPhases, deriveProgramSummary } from '@/lib/programPlan';
+import {
+  deriveProgramPhases,
+  deriveProgramSummary,
+  resolveProgramPlanMeta,
+} from '@/lib/programPlan';
 import styles from './plan.module.css';
 
 const STATUS_ICON: Record<string, string> = {
@@ -36,9 +40,10 @@ export default async function ProgramPlanPage({
     redirect(`/cycle/${dashboard?.cycleNum ?? 1}/plan`);
   }
 
-  const { durationWeeks } = deriveProgramSummary(specs);
+  const meta = resolveProgramPlanMeta(program, specs);
+  const { durationWeeks } = deriveProgramSummary(specs, program);
   const today = new Date().toISOString().slice(0, 10);
-  const phases = deriveProgramPhases(dashboard.weeks, today);
+  const phases = deriveProgramPhases(dashboard.weeks, today, meta);
   const estCompletion = addDays(dashboard.cycleStartDate, durationWeeks * 7);
 
   return (

--- a/apps/web/app/(authed)/cycle/[cycleNum]/program/page.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/program/page.tsx
@@ -26,7 +26,7 @@ export default async function CycleProgramPage({
   }
 
   const { durationWeeks, frequency, exercises, warmUpSets, workingSets } =
-    deriveProgramSummary(specs);
+    deriveProgramSummary(specs, program);
 
   return (
     <section className={styles.container}>

--- a/apps/web/lib/__tests__/programPlan.test.ts
+++ b/apps/web/lib/__tests__/programPlan.test.ts
@@ -1,5 +1,10 @@
 import type { CycleWeekSummary, LiftingProgramSpecResponse } from '@lifting-logbook/types';
-import { deriveProgramPhases, deriveProgramSummary } from '../programPlan';
+import type { ProgramLengthMeta } from '@lifting-logbook/core';
+import {
+  deriveProgramPhases,
+  deriveProgramSummary,
+  resolveProgramPlanMeta,
+} from '../programPlan';
 
 const makeWeek = (
   week: number,
@@ -28,77 +33,132 @@ const makeSpec = (
   ...overrides,
 });
 
+// Leangains/RPT-shaped (autoregulated, repeating block) and 5-3-1-shaped (wave).
+const REPEATING_12: ProgramLengthMeta = { lengthWeeks: 12, blockWeeks: 1, phaseStyle: 'repeating' };
+const REPEATING_8: ProgramLengthMeta = { lengthWeeks: 8, blockWeeks: 1, phaseStyle: 'repeating' };
+const WAVE_12: ProgramLengthMeta = { lengthWeeks: 12, blockWeeks: 3, phaseStyle: 'wave' };
+
 // ---------------------------------------------------------------------------
-// deriveProgramPhases
+// resolveProgramPlanMeta
 // ---------------------------------------------------------------------------
 
-describe('deriveProgramPhases', () => {
-  const weeks12 = Array.from({ length: 12 }, (_, i) =>
-    makeWeek(i + 1, [`2026-01-${String(i * 7 + 1).padStart(2, '0')}`], false),
+describe('resolveProgramPlanMeta', () => {
+  it('resolves registered built-ins from the canonical registry', () => {
+    expect(resolveProgramPlanMeta('leangains', [])).toEqual(REPEATING_12);
+    expect(resolveProgramPlanMeta('rpt', [])).toEqual(REPEATING_8);
+    expect(resolveProgramPlanMeta('5-3-1', [])).toEqual(WAVE_12);
+  });
+
+  it('falls back to a flat block of the spec length for unregistered programs', () => {
+    const specs = [makeSpec({ week: 1 }), makeSpec({ week: 2 }), makeSpec({ week: 3 })];
+    expect(resolveProgramPlanMeta('custom-uuid', specs)).toEqual({
+      lengthWeeks: 3,
+      blockWeeks: 3,
+      phaseStyle: 'repeating',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveProgramPhases — repeating (Leangains / RPT)
+// ---------------------------------------------------------------------------
+
+describe('deriveProgramPhases — repeating programs', () => {
+  const futureWeeks12 = Array.from({ length: 12 }, (_, i) =>
+    makeWeek(i + 1, ['2099-01-01'], false),
   );
 
-  it('returns 6 phases for a 12-week input', () => {
-    const phases = deriveProgramPhases(weeks12, '2025-01-01');
-    expect(phases).toHaveLength(6);
+  it('renders a single flat Training phase spanning the whole program', () => {
+    const phases = deriveProgramPhases(futureWeeks12, '2026-01-01', REPEATING_12);
+    expect(phases).toHaveLength(1);
+    expect(phases[0]).toMatchObject({
+      name: 'Training',
+      startWeek: 1,
+      endWeek: 12,
+      type: 'training',
+    });
   });
 
-  it('phase names match the 5-3-1 block sequence', () => {
-    const phases = deriveProgramPhases(weeks12, '2025-01-01');
-    expect(phases.map((p) => p.name)).toEqual([
-      'Accumulation',
-      'Deload',
-      'Intensification',
-      'Deload',
-      'Realization',
-      'Test',
+  it('never fabricates a Test or Deload phase (issue #680)', () => {
+    const phases = deriveProgramPhases(futureWeeks12, '2026-01-01', REPEATING_12);
+    expect(phases.every((p) => p.type === 'training')).toBe(true);
+    expect(phases.some((p) => p.name === 'Test')).toBe(false);
+  });
+
+  it('spans the program length for an 8-week program', () => {
+    const weeks8 = Array.from({ length: 8 }, (_, i) => makeWeek(i + 1, ['2099-01-01'], false));
+    const phases = deriveProgramPhases(weeks8, '2026-01-01', REPEATING_8);
+    expect(phases).toHaveLength(1);
+    expect(phases[0]).toMatchObject({ startWeek: 1, endWeek: 8, type: 'training' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveProgramPhases — wave (5/3/1)
+// ---------------------------------------------------------------------------
+
+describe('deriveProgramPhases — wave programs', () => {
+  const futureWeeks12 = Array.from({ length: 12 }, (_, i) =>
+    makeWeek(i + 1, ['2099-01-01'], false),
+  );
+
+  it('renders one training phase per wave with correct week ranges', () => {
+    const phases = deriveProgramPhases(futureWeeks12, '2026-01-01', WAVE_12);
+    expect(phases.map((p) => [p.name, p.startWeek, p.endWeek])).toEqual([
+      ['Wave 1', 1, 3],
+      ['Wave 2', 4, 6],
+      ['Wave 3', 7, 9],
+      ['Wave 4', 10, 12],
     ]);
   });
 
-  it('phase types are correct', () => {
-    const phases = deriveProgramPhases(weeks12, '2025-01-01');
-    expect(phases.map((p) => p.type)).toEqual([
-      'training',
-      'deload',
-      'training',
-      'deload',
-      'training',
-      'test',
-    ]);
+  it('keeps every wave a training phase — no fabricated Test week', () => {
+    const phases = deriveProgramPhases(futureWeeks12, '2026-01-01', WAVE_12);
+    expect(phases.every((p) => p.type === 'training')).toBe(true);
   });
+});
 
-  it('status is completed when all weeks in phase are completed', () => {
-    const completedWeeks = [
+// ---------------------------------------------------------------------------
+// deriveProgramPhases — status
+// ---------------------------------------------------------------------------
+
+describe('deriveProgramPhases — status', () => {
+  it('marks a wave completed only when all its weeks are completed', () => {
+    const weeks = [
       makeWeek(1, ['2026-01-01'], true),
       makeWeek(2, ['2026-01-08'], true),
       makeWeek(3, ['2026-01-15'], true),
-      ...Array.from({ length: 9 }, (_, i) =>
-        makeWeek(i + 4, ['2099-01-01'], false),
-      ),
+      ...Array.from({ length: 9 }, (_, i) => makeWeek(i + 4, ['2099-01-01'], false)),
     ];
-    const phases = deriveProgramPhases(completedWeeks, '2026-02-01');
-    expect(phases[0]?.status).toBe('completed');
+    const phases = deriveProgramPhases(weeks, '2026-02-01', WAVE_12);
+    expect(phases[0]?.status).toBe('completed'); // Wave 1 (weeks 1-3)
+    expect(phases[1]?.status).toBe('upcoming'); // Wave 2 (weeks 4-6)
   });
 
-  it('status is in-progress when phase has past dates but not all weeks completed', () => {
-    const today = '2026-01-10';
-    const inProgressWeeks = [
+  it('marks a wave in-progress when it has past dates but is not fully completed', () => {
+    const weeks = [
       makeWeek(1, ['2026-01-01'], true),
       makeWeek(2, ['2026-01-08'], false),
       makeWeek(3, ['2026-01-15'], false),
-      ...Array.from({ length: 9 }, (_, i) =>
-        makeWeek(i + 4, ['2099-01-01'], false),
-      ),
+      ...Array.from({ length: 9 }, (_, i) => makeWeek(i + 4, ['2099-01-01'], false)),
     ];
-    const phases = deriveProgramPhases(inProgressWeeks, today);
+    const phases = deriveProgramPhases(weeks, '2026-01-10', WAVE_12);
     expect(phases[0]?.status).toBe('in-progress');
   });
 
-  it('status is upcoming when no workout dates have passed', () => {
-    const futureWeeks = Array.from({ length: 12 }, (_, i) =>
-      makeWeek(i + 1, ['2099-01-01'], false),
-    );
-    const phases = deriveProgramPhases(futureWeeks, '2026-01-01');
+  it('marks all phases upcoming when no workout dates have passed', () => {
+    const weeks = Array.from({ length: 12 }, (_, i) => makeWeek(i + 1, ['2099-01-01'], false));
+    const phases = deriveProgramPhases(weeks, '2026-01-01', REPEATING_12);
     expect(phases.every((p) => p.status === 'upcoming')).toBe(true);
+  });
+
+  it('shows the full-length plan as upcoming for a pre-#680 cycle with only week 1 scheduled', () => {
+    // Storage predates full-length expansion: only week 1 exists in the dashboard,
+    // but the plan still renders the canonical 12-week overview (weeks 2-12 upcoming).
+    const weeks = [makeWeek(1, ['2099-01-01'], false)];
+    const phases = deriveProgramPhases(weeks, '2026-01-01', REPEATING_12);
+    expect(phases).toHaveLength(1);
+    expect(phases[0]).toMatchObject({ startWeek: 1, endWeek: 12, status: 'upcoming' });
   });
 });
 
@@ -107,9 +167,18 @@ describe('deriveProgramPhases', () => {
 // ---------------------------------------------------------------------------
 
 describe('deriveProgramSummary', () => {
-  it('returns durationWeeks as the max week in specs', () => {
+  it('uses the canonical program length for duration, not the stored block', () => {
+    // A Leangains-shaped 1-week spec must still report its advertised 12 weeks.
+    const oneWeekSpecs = [
+      makeSpec({ week: 1 }),
+      makeSpec({ week: 1, lift: 'Bench Press', offset: 2 }),
+    ];
+    expect(deriveProgramSummary(oneWeekSpecs, 'leangains').durationWeeks).toBe(12);
+  });
+
+  it('falls back to the max spec week for unregistered programs', () => {
     const specs = [makeSpec({ week: 1 }), makeSpec({ week: 12 }), makeSpec({ week: 7 })];
-    expect(deriveProgramSummary(specs).durationWeeks).toBe(12);
+    expect(deriveProgramSummary(specs, 'custom-uuid').durationWeeks).toBe(12);
   });
 
   it('counts unique offsets in week 1 for frequency', () => {
@@ -119,7 +188,7 @@ describe('deriveProgramSummary', () => {
       makeSpec({ week: 1, offset: 4, lift: 'Deadlift' }),
       makeSpec({ week: 2, offset: 0 }),
     ];
-    expect(deriveProgramSummary(specs).frequency).toBe(3);
+    expect(deriveProgramSummary(specs, 'custom').frequency).toBe(3);
   });
 
   it('returns unique exercise names preserving insertion order', () => {
@@ -129,7 +198,7 @@ describe('deriveProgramSummary', () => {
       makeSpec({ lift: 'Squat', week: 2 }),
       makeSpec({ lift: 'Deadlift', week: 1 }),
     ];
-    expect(deriveProgramSummary(specs).exercises).toEqual([
+    expect(deriveProgramSummary(specs, 'custom').exercises).toEqual([
       'Squat',
       'Bench Press',
       'Deadlift',
@@ -138,21 +207,21 @@ describe('deriveProgramSummary', () => {
 
   it('derives warmUpSets from comma-separated warmUpPct on first week-1 spec', () => {
     const specs = [makeSpec({ week: 1, warmUpPct: '0.4,0.5,0.6' })];
-    expect(deriveProgramSummary(specs).warmUpSets).toBe(3);
+    expect(deriveProgramSummary(specs, 'custom').warmUpSets).toBe(3);
   });
 
   it('returns 0 warmUpSets when warmUpPct is empty', () => {
     const specs = [makeSpec({ week: 1, warmUpPct: '' })];
-    expect(deriveProgramSummary(specs).warmUpSets).toBe(0);
+    expect(deriveProgramSummary(specs, 'custom').warmUpSets).toBe(0);
   });
 
   it('returns 0 warmUpSets when warmUpPct is null (API omits field)', () => {
     const specs = [makeSpec({ week: 1, warmUpPct: null as unknown as string })];
-    expect(deriveProgramSummary(specs).warmUpSets).toBe(0);
+    expect(deriveProgramSummary(specs, 'custom').warmUpSets).toBe(0);
   });
 
   it('returns working sets from first week-1 spec sets field', () => {
     const specs = [makeSpec({ week: 1, sets: 5 })];
-    expect(deriveProgramSummary(specs).workingSets).toBe(5);
+    expect(deriveProgramSummary(specs, 'custom').workingSets).toBe(5);
   });
 });

--- a/apps/web/lib/__tests__/programs.test.ts
+++ b/apps/web/lib/__tests__/programs.test.ts
@@ -1,0 +1,22 @@
+import { PROGRAM_LENGTHS } from '@lifting-logbook/core';
+import { PROGRAMS } from '../programs';
+
+// Guards the single-source-of-truth wiring (issue #680): a program's advertised
+// onboarding length must equal the canonical core registry length, so the two
+// can never silently drift.
+describe('PROGRAMS ↔ PROGRAM_LENGTHS reconciliation', () => {
+  it('derives advertised weeks from the canonical registry for every registered program', () => {
+    for (const [id, meta] of Object.entries(PROGRAM_LENGTHS)) {
+      const card = PROGRAMS.find((p) => p.id === id);
+      // Some registry entries (e.g. the seed program '5-3-1') have no onboarding
+      // card; only reconcile the ones that appear in both.
+      if (!card) continue;
+      expect(card.weeks).toBe(meta.lengthWeeks);
+    }
+  });
+
+  it('advertises Leangains as 12 weeks and RPT as 8 weeks', () => {
+    expect(PROGRAMS.find((p) => p.id === 'leangains')?.weeks).toBe(12);
+    expect(PROGRAMS.find((p) => p.id === 'rpt')?.weeks).toBe(8);
+  });
+});

--- a/apps/web/lib/programPlan.ts
+++ b/apps/web/lib/programPlan.ts
@@ -2,6 +2,12 @@ import type {
   CycleWeekSummary,
   LiftingProgramSpecResponse,
 } from '@lifting-logbook/types';
+import {
+  PROGRAM_LENGTHS,
+  baseSpecBlockWeeks,
+  programLengthWeeks,
+  type ProgramLengthMeta,
+} from '@lifting-logbook/core';
 
 export type PhaseType = 'training' | 'deload' | 'test';
 export type PhaseStatus = 'completed' | 'in-progress' | 'upcoming';
@@ -22,15 +28,56 @@ export interface ProgramSummary {
   workingSets: number;
 }
 
-// Standard 5-3-1 block phase map (12-week cycle).
-const PHASE_MAP_12: Array<{ name: string; startWeek: number; endWeek: number; type: PhaseType }> = [
-  { name: 'Accumulation', startWeek: 1, endWeek: 3, type: 'training' },
-  { name: 'Deload', startWeek: 4, endWeek: 4, type: 'deload' },
-  { name: 'Intensification', startWeek: 5, endWeek: 7, type: 'training' },
-  { name: 'Deload', startWeek: 8, endWeek: 8, type: 'deload' },
-  { name: 'Realization', startWeek: 9, endWeek: 11, type: 'training' },
-  { name: 'Test', startWeek: 12, endWeek: 12, type: 'test' },
-];
+/**
+ * Resolves the canonical plan metadata for a program (issue #680). Registered
+ * built-ins come from the core PROGRAM_LENGTHS registry; unregistered / custom
+ * programs fall back to a single flat block of their own defined length,
+ * preserving pre-#680 behavior.
+ */
+export function resolveProgramPlanMeta(
+  program: string,
+  specs: LiftingProgramSpecResponse[],
+): ProgramLengthMeta {
+  const registered = PROGRAM_LENGTHS[program];
+  if (registered) return registered;
+  const blockWeeks = baseSpecBlockWeeks(specs);
+  return { lengthWeeks: blockWeeks, blockWeeks, phaseStyle: 'repeating' };
+}
+
+type PhaseTemplate = {
+  name: string;
+  startWeek: number;
+  endWeek: number;
+  type: PhaseType;
+};
+
+/**
+ * Builds the phase template from a program's canonical metadata — never from a
+ * fabricated week count (issue #680). Built-in programs carry no per-week
+ * deload/test markers, so every phase is a training phase:
+ *
+ *  - 'repeating' (Leangains, RPT): a single flat "Training" span. Progression is
+ *    autoregulated (AMRAP-driven via updateMaxes from actual lift records), not a
+ *    scheduled weekly deload or a test week — so we never invent a "Test" phase.
+ *  - 'wave' (5/3/1): one "Wave N" training phase per repeating block.
+ */
+function buildPhaseTemplate(meta: ProgramLengthMeta): PhaseTemplate[] {
+  const { lengthWeeks, blockWeeks, phaseStyle } = meta;
+  if (lengthWeeks <= 0) return [];
+
+  if (phaseStyle === 'wave' && blockWeeks > 1) {
+    const phases: PhaseTemplate[] = [];
+    let wave = 1;
+    for (let startWeek = 1; startWeek <= lengthWeeks; startWeek += blockWeeks) {
+      const endWeek = Math.min(startWeek + blockWeeks - 1, lengthWeeks);
+      phases.push({ name: `Wave ${wave}`, startWeek, endWeek, type: 'training' });
+      wave += 1;
+    }
+    return phases;
+  }
+
+  return [{ name: 'Training', startWeek: 1, endWeek: lengthWeeks, type: 'training' }];
+}
 
 function phaseStatus(
   phase: { startWeek: number; endWeek: number },
@@ -42,7 +89,10 @@ function phaseStatus(
     (_, i) => phase.startWeek + i,
   );
   const summaries = weeks.map((w) => weekMap.get(w));
-  if (summaries.every((s) => s?.completed)) return 'completed';
+  // Every week in the phase must exist and be completed. Missing weeks (e.g. a
+  // pre-#680 cycle whose stored schedule predates full-length expansion) read as
+  // not-yet-complete, so the phase shows as upcoming/in-progress rather than done.
+  if (summaries.length > 0 && summaries.every((s) => s?.completed)) return 'completed';
   const hasStarted = summaries.some((s) =>
     s?.workouts.some((w) => w.date <= today),
   );
@@ -52,37 +102,23 @@ function phaseStatus(
 export function deriveProgramPhases(
   weeks: CycleWeekSummary[],
   today: string,
+  meta: ProgramLengthMeta,
 ): ProgramPhase[] {
   const weekMap = new Map(weeks.map((w) => [w.week, w]));
-  const totalWeeks = Math.max(...weeks.map((w) => w.week), 0);
-
-  const template = totalWeeks === 12
-    ? PHASE_MAP_12
-    : buildFallbackPhases(totalWeeks);
-
-  return template.map((p) => ({
+  return buildPhaseTemplate(meta).map((p) => ({
     ...p,
     status: phaseStatus(p, weekMap, today),
   }));
 }
 
-// For programs other than 12 weeks: last week = test, second-to-last = deload if ≥2 weeks,
-// remaining weeks = training.
-function buildFallbackPhases(
-  totalWeeks: number,
-): Array<{ name: string; startWeek: number; endWeek: number; type: PhaseType }> {
-  if (totalWeeks <= 0) return [];
-  if (totalWeeks === 1) return [{ name: 'Test', startWeek: 1, endWeek: 1, type: 'test' }];
-  return [
-    { name: 'Training', startWeek: 1, endWeek: totalWeeks - 1, type: 'training' },
-    { name: 'Test', startWeek: totalWeeks, endWeek: totalWeeks, type: 'test' },
-  ];
-}
-
 export function deriveProgramSummary(
   specs: LiftingProgramSpecResponse[],
+  program: string,
 ): ProgramSummary {
-  const durationWeeks = Math.max(...specs.map((s) => s.week), 0);
+  // Duration is the canonical program length (single source of truth, issue #680),
+  // not Math.max(...specs.week) — the stored spec is only a repeating block, so
+  // Leangains would otherwise report "1 total week" against its advertised 12.
+  const durationWeeks = programLengthWeeks(program, specs);
 
   const week1Specs = specs.filter((s) => s.week === 1);
   const frequency = new Set(week1Specs.map((s) => s.offset)).size;

--- a/apps/web/lib/programPlan.ts
+++ b/apps/web/lib/programPlan.ts
@@ -9,6 +9,11 @@ import {
   type ProgramLengthMeta,
 } from '@lifting-logbook/core';
 
+// Phase rendering type. Built-in programs are autoregulated (Leangains, RPT) or a
+// no-deload wave (5/3/1), so their presets tag no deload/test weeks and
+// buildPhaseTemplate currently only emits 'training'. 'deload'/'test' (and their
+// plan.module.css styles) are retained for programs that define weekType-tagged
+// weeks — not dead code until such a program exists. See issue #680.
 export type PhaseType = 'training' | 'deload' | 'test';
 export type PhaseStatus = 'completed' | 'in-progress' | 'upcoming';
 

--- a/apps/web/lib/programs.ts
+++ b/apps/web/lib/programs.ts
@@ -1,4 +1,4 @@
-import { LiftingProgramSpec, PRESET_BASE_SPECS } from '@lifting-logbook/core';
+import { LiftingProgramSpec, PRESET_BASE_SPECS, PROGRAM_LENGTHS } from '@lifting-logbook/core';
 
 export type Experience = 'beginner' | 'intermediate' | 'advanced';
 export type Goal = 'strength' | 'muscle-gain' | 'body-composition' | 'fat-loss';
@@ -45,7 +45,11 @@ export const TEMPLATE_BUILDERS: Record<string, () => LiftingProgramSpec[]> = {
   [SEED_LEANGAINS]: seedLeangainsSpec,
 };
 
-export const PROGRAMS: Program[] = [
+// Base program catalog. `weeks` for programs wired to a core preset is reconciled
+// below from the canonical PROGRAM_LENGTHS registry, so onboarding copy can never
+// drift from the length the API actually schedules (issue #680). Unregistered
+// (marketing-only) programs keep their catalog literal.
+const PROGRAM_CATALOG: Program[] = [
   {
     id: 'starting-strength',
     name: 'Starting Strength',
@@ -383,3 +387,14 @@ export const PROGRAMS: Program[] = [
     available: false,
   },
 ];
+
+/**
+ * Onboarding/browse program catalog. For programs registered in the canonical
+ * core `PROGRAM_LENGTHS` (currently Leangains, RPT, 5-3-1), the advertised `weeks`
+ * is derived from that single source of truth rather than a standalone literal —
+ * see issue #680. Programs without a registry entry pass through unchanged.
+ */
+export const PROGRAMS: Program[] = PROGRAM_CATALOG.map((program) => {
+  const canonical = PROGRAM_LENGTHS[program.id];
+  return canonical ? { ...program, weeks: canonical.lengthWeeks } : program;
+});

--- a/packages/core/src/presets/index.ts
+++ b/packages/core/src/presets/index.ts
@@ -1,5 +1,8 @@
 import { LiftingProgramSpec } from '../models/LiftingProgramSpec';
 
+// Canonical program-length registry + read-time block expansion (issue #680).
+export * from './programLengths';
+
 /**
  * Built-in program specs, keyed by program ID.
  *

--- a/packages/core/src/presets/programLengths.test.ts
+++ b/packages/core/src/presets/programLengths.test.ts
@@ -81,6 +81,25 @@ describe('PROGRAM_LENGTHS', () => {
       expect(meta.lengthWeeks % meta.blockWeeks).toBe(0);
     }
   });
+
+  it('registers a canonical length for every seeded preset', () => {
+    // Any program with a PRESET_BASE_SPECS entry is schedulable/planable, so it
+    // must also have a canonical length here — otherwise programLengthWeeks silently
+    // falls back to the block size and the advertised length collapses (issue #680).
+    // This is the reciprocal guard: adding a preset without a length fails loudly.
+    for (const program of Object.keys(PRESET_BASE_SPECS)) {
+      expect(PROGRAM_LENGTHS[program]).toBeDefined();
+    }
+  });
+
+  it('every wave program has a multi-week block', () => {
+    // buildPhaseTemplate only renders per-wave phases when phaseStyle==='wave' AND
+    // blockWeeks>1; a wave program with a 1-week block would silently degrade to a
+    // single flat phase. Enforce the contract the plan renderer assumes.
+    for (const meta of Object.values(PROGRAM_LENGTHS)) {
+      if (meta.phaseStyle === 'wave') expect(meta.blockWeeks).toBeGreaterThan(1);
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -167,7 +186,7 @@ describe('expandSpecToLength', () => {
 
   it('preserves all non-week row fields', () => {
     const expanded = expandSpecToLength(block1, 3);
-    const first = expanded[0]!;
+    const first = expanded[0];
     expect(first).toMatchObject({
       lift: 'A',
       offset: 0,

--- a/packages/core/src/presets/programLengths.test.ts
+++ b/packages/core/src/presets/programLengths.test.ts
@@ -1,0 +1,215 @@
+import {
+  PRESET_BASE_SPECS,
+  PROGRAM_LENGTHS,
+  baseSpecBlockWeeks,
+  programLengthWeeks,
+  expandSpecToLength,
+} from '.';
+import { LiftingProgramSpec } from '../models/LiftingProgramSpec';
+
+const makeRow = (
+  overrides: Partial<LiftingProgramSpec> = {},
+): LiftingProgramSpec => ({
+  week: 1,
+  offset: 0,
+  lift: 'Squat',
+  increment: 5,
+  order: 1,
+  sets: 3,
+  reps: 5,
+  amrap: true,
+  warmUpPct: '0.4,0.5,0.6',
+  wtDecrementPct: 0.1,
+  activation: 'compound',
+  ...overrides,
+});
+
+// A synthetic 3-week block: 1 row per week, so tiling math is easy to assert.
+const block3 = [
+  makeRow({ week: 1, lift: 'A', reps: 5 }),
+  makeRow({ week: 2, lift: 'A', reps: 3 }),
+  makeRow({ week: 3, lift: 'A', reps: 1 }),
+];
+
+// A synthetic 1-week block with two rows (two lifts on one day).
+const block1 = [
+  makeRow({ week: 1, lift: 'A', offset: 0 }),
+  makeRow({ week: 1, lift: 'B', offset: 2 }),
+];
+
+// ---------------------------------------------------------------------------
+// PROGRAM_LENGTHS registry
+// ---------------------------------------------------------------------------
+
+describe('PROGRAM_LENGTHS', () => {
+  it('advertises Leangains as a 12-week repeating (autoregulated) program', () => {
+    expect(PROGRAM_LENGTHS['leangains']).toEqual({
+      lengthWeeks: 12,
+      blockWeeks: 1,
+      phaseStyle: 'repeating',
+    });
+  });
+
+  it('advertises RPT as an 8-week repeating program', () => {
+    expect(PROGRAM_LENGTHS['rpt']).toEqual({
+      lengthWeeks: 8,
+      blockWeeks: 1,
+      phaseStyle: 'repeating',
+    });
+  });
+
+  it('advertises 5-3-1 as a 12-week structured (wave) program', () => {
+    expect(PROGRAM_LENGTHS['5-3-1']).toEqual({
+      lengthWeeks: 12,
+      blockWeeks: 3,
+      phaseStyle: 'wave',
+    });
+  });
+
+  it('each registry blockWeeks matches its PRESET_BASE_SPECS block size', () => {
+    for (const [program, meta] of Object.entries(PROGRAM_LENGTHS)) {
+      const spec = PRESET_BASE_SPECS[program];
+      expect(spec).toBeDefined();
+      expect(baseSpecBlockWeeks(spec ?? [])).toBe(meta.blockWeeks);
+    }
+  });
+
+  it('each registry lengthWeeks is a whole multiple of its blockWeeks', () => {
+    // Tiling is cleanest when the program length is an exact number of blocks;
+    // partial trailing blocks are supported but not intended for built-ins.
+    for (const meta of Object.values(PROGRAM_LENGTHS)) {
+      expect(meta.lengthWeeks % meta.blockWeeks).toBe(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// baseSpecBlockWeeks
+// ---------------------------------------------------------------------------
+
+describe('baseSpecBlockWeeks', () => {
+  it('returns 0 for an empty spec', () => {
+    expect(baseSpecBlockWeeks([])).toBe(0);
+  });
+
+  it('returns the max week present in the block', () => {
+    expect(baseSpecBlockWeeks(block1)).toBe(1);
+    expect(baseSpecBlockWeeks(block3)).toBe(3);
+  });
+
+  it('matches the real Leangains (1) and 5-3-1 (3) presets', () => {
+    expect(baseSpecBlockWeeks((PRESET_BASE_SPECS['leangains'] ?? []))).toBe(1);
+    expect(baseSpecBlockWeeks((PRESET_BASE_SPECS['5-3-1'] ?? []))).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// programLengthWeeks
+// ---------------------------------------------------------------------------
+
+describe('programLengthWeeks', () => {
+  it('prefers the canonical registry length over the base-spec block size', () => {
+    // Leangains preset is a 1-week block, but the canonical length is 12.
+    expect(programLengthWeeks('leangains', (PRESET_BASE_SPECS['leangains'] ?? []))).toBe(12);
+    expect(programLengthWeeks('rpt', (PRESET_BASE_SPECS['rpt'] ?? []))).toBe(8);
+    expect(programLengthWeeks('5-3-1', (PRESET_BASE_SPECS['5-3-1'] ?? []))).toBe(12);
+  });
+
+  it('falls back to the base-spec block size for unregistered programs', () => {
+    // Preserves the historical Math.max(...spec.week) behavior for custom programs.
+    expect(programLengthWeeks('some-custom-uuid', block3)).toBe(3);
+    expect(programLengthWeeks('some-custom-uuid', block1)).toBe(1);
+  });
+
+  it('returns 0 for an unregistered program with an empty spec', () => {
+    expect(programLengthWeeks('unknown', [])).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// expandSpecToLength
+// ---------------------------------------------------------------------------
+
+describe('expandSpecToLength', () => {
+  it('tiles a 1-week block across N weeks with contiguous week numbers', () => {
+    const expanded = expandSpecToLength(block1, 12);
+    const weeks = [...new Set(expanded.map((r) => r.week))];
+    expect(weeks).toEqual(Array.from({ length: 12 }, (_, i) => i + 1));
+    // Two rows per week × 12 weeks.
+    expect(expanded).toHaveLength(24);
+  });
+
+  it('tiles a 3-week block across 12 weeks (4 waves)', () => {
+    const expanded = expandSpecToLength(block3, 12);
+    expect(expanded).toHaveLength(12); // 1 row/week × 12
+    expect(expanded.map((r) => r.week)).toEqual(
+      Array.from({ length: 12 }, (_, i) => i + 1),
+    );
+  });
+
+  it('repeats block-week attributes at the tiled position', () => {
+    const expanded = expandSpecToLength(block3, 12);
+    // block week 1 = reps 5, week 2 = reps 3, week 3 = reps 1; repeated every 3.
+    const repsByWeek = new Map(expanded.map((r) => [r.week, r.reps]));
+    expect(repsByWeek.get(1)).toBe(5);
+    expect(repsByWeek.get(4)).toBe(5); // wave 2, block week 1
+    expect(repsByWeek.get(5)).toBe(3); // wave 2, block week 2
+    expect(repsByWeek.get(12)).toBe(1); // wave 4, block week 3
+  });
+
+  it('includes a partial trailing block when length is not a whole multiple', () => {
+    const expanded = expandSpecToLength(block3, 8);
+    expect(expanded.map((r) => r.week)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    const repsByWeek = new Map(expanded.map((r) => [r.week, r.reps]));
+    expect(repsByWeek.get(7)).toBe(5); // block week 1
+    expect(repsByWeek.get(8)).toBe(3); // block week 2 (block week 3 truncated away)
+  });
+
+  it('preserves all non-week row fields', () => {
+    const expanded = expandSpecToLength(block1, 3);
+    const first = expanded[0]!;
+    expect(first).toMatchObject({
+      lift: 'A',
+      offset: 0,
+      increment: 5,
+      order: 1,
+      sets: 3,
+      warmUpPct: '0.4,0.5,0.6',
+      wtDecrementPct: 0.1,
+      activation: 'compound',
+    });
+  });
+
+  it('is a no-op (returns the same shape) when length equals the block size', () => {
+    const expanded = expandSpecToLength(block3, 3);
+    expect(expanded.map((r) => ({ week: r.week, reps: r.reps }))).toEqual([
+      { week: 1, reps: 5 },
+      { week: 2, reps: 3 },
+      { week: 3, reps: 1 },
+    ]);
+  });
+
+  it('returns [] for an empty base spec (zero-spec guard)', () => {
+    expect(expandSpecToLength([], 12)).toEqual([]);
+  });
+
+  it('returns [] for a non-positive length', () => {
+    expect(expandSpecToLength(block1, 0)).toEqual([]);
+    expect(expandSpecToLength(block1, -3)).toEqual([]);
+  });
+
+  it('does not mutate the input rows', () => {
+    const input = [makeRow({ week: 1, lift: 'A' })];
+    const snapshot = JSON.stringify(input);
+    expandSpecToLength(input, 5);
+    expect(JSON.stringify(input)).toBe(snapshot);
+  });
+
+  it('expands the real Leangains preset to a full 12-week schedule', () => {
+    const base = (PRESET_BASE_SPECS['leangains'] ?? []);
+    const expanded = expandSpecToLength(base, 12);
+    expect(baseSpecBlockWeeks(expanded)).toBe(12);
+    // Same rows per week as the 1-week block, tiled 12×.
+    expect(expanded).toHaveLength(base.length * 12);
+  });
+});

--- a/packages/core/src/presets/programLengths.ts
+++ b/packages/core/src/presets/programLengths.ts
@@ -34,6 +34,11 @@ export interface ProgramLengthMeta {
  * entry (custom user programs, not-yet-wired presets) fall back to their base-spec
  * block length via {@link programLengthWeeks}, preserving the historical
  * `Math.max(...spec.week)` behavior.
+ *
+ * KEEP IN SYNC: every {@link PRESET_BASE_SPECS} key must have an entry here — a
+ * seeded (schedulable) program without a canonical length silently collapses to
+ * its 1-block length. This is the third registry alongside PRESET_BASE_SPECS and
+ * apps/api `PROGRAM_DEFAULTS`; the reciprocal guard lives in `programLengths.test.ts`.
  */
 export const PROGRAM_LENGTHS: Record<string, ProgramLengthMeta> = {
   // 1-week repeating block tiled across 12 weeks; autoregulated (RPT + IF protocol).

--- a/packages/core/src/presets/programLengths.ts
+++ b/packages/core/src/presets/programLengths.ts
@@ -1,0 +1,108 @@
+import { WeekNumber } from '@lifting-logbook/types';
+import { LiftingProgramSpec } from '../models/LiftingProgramSpec';
+
+/**
+ * How a program's weeks are periodized for plan display.
+ *
+ * - 'repeating': autoregulated / repeating-block programs (Leangains, RPT). Every
+ *   week is a training week; progression is AMRAP-driven (via `updateMaxes` from
+ *   actual lift records), not a fixed weekly bump. Rendered as a single flat
+ *   "Training" span — never a fabricated deload/test week.
+ * - 'wave': structured, periodized programs (5/3/1). The repeating block is a
+ *   wave; the plan shows one training phase per wave.
+ */
+export type ProgramPhaseStyle = 'repeating' | 'wave';
+
+export interface ProgramLengthMeta {
+  /** Authoritative total program length in weeks — the single source of truth. */
+  lengthWeeks: number;
+  /** Size of the repeating block in {@link PRESET_BASE_SPECS} (its max `week`). */
+  blockWeeks: number;
+  /** Plan-display periodization style. */
+  phaseStyle: ProgramPhaseStyle;
+}
+
+/**
+ * Canonical program-length registry — the single source of truth for how long a
+ * built-in program runs and how it is periodized. Both API schedule generation
+ * (`cycle-generation.service.ts`) and web onboarding copy (`apps/web/lib/programs.ts`)
+ * derive from this, replacing three previously-disagreeing sources: the onboarding
+ * `weeks` literal, the 1-week preset block, and the `Math.max(...spec.week)`-derived
+ * duration (which collapsed Leangains to "1 total week"). See issue #680.
+ *
+ * Keyed by the same program IDs as {@link PRESET_BASE_SPECS}. Programs without an
+ * entry (custom user programs, not-yet-wired presets) fall back to their base-spec
+ * block length via {@link programLengthWeeks}, preserving the historical
+ * `Math.max(...spec.week)` behavior.
+ */
+export const PROGRAM_LENGTHS: Record<string, ProgramLengthMeta> = {
+  // 1-week repeating block tiled across 12 weeks; autoregulated (RPT + IF protocol).
+  leangains: { lengthWeeks: 12, blockWeeks: 1, phaseStyle: 'repeating' },
+  // 1-week repeating block tiled across 8 weeks; autoregulated (reverse-pyramid).
+  rpt: { lengthWeeks: 8, blockWeeks: 1, phaseStyle: 'repeating' },
+  // 3-week 5/3/1 wave tiled across 12 weeks (4 waves); structured / periodized.
+  '5-3-1': { lengthWeeks: 12, blockWeeks: 3, phaseStyle: 'wave' },
+};
+
+/**
+ * The size of a base spec's repeating block: the max `week` present in the rows
+ * (0 for an empty spec). Reads `week` only, so it accepts both the domain
+ * {@link LiftingProgramSpec} and its serialized `LiftingProgramSpecResponse`.
+ */
+export function baseSpecBlockWeeks(
+  spec: ReadonlyArray<{ week: WeekNumber }>,
+): number {
+  return spec.reduce((max, s) => Math.max(max, s.week), 0);
+}
+
+/**
+ * The authoritative program length in weeks. Prefers the canonical
+ * {@link PROGRAM_LENGTHS} registry; falls back to the base-spec block size for
+ * programs without an entry — this preserves the historical
+ * `Math.max(...spec.week)` behavior for custom / unregistered programs.
+ */
+export function programLengthWeeks(
+  program: string,
+  spec: ReadonlyArray<{ week: WeekNumber }>,
+): number {
+  return PROGRAM_LENGTHS[program]?.lengthWeeks ?? baseSpecBlockWeeks(spec);
+}
+
+/**
+ * Tiles a base spec (one repeating block) across `lengthWeeks` by repeating the
+ * block's rows with incremented `week` numbers. Read-time expansion only — stored
+ * specs are never mutated, so there is no DB migration and revert is a pure code
+ * change (see issue #680). The block size is the max `week` present in `baseSpec`.
+ *
+ * Week numbering is contiguous `1..lengthWeeks`. A partial trailing block is
+ * included: e.g. a 3-week block across 8 weeks yields weeks 1..8 with the final
+ * block truncated at week 8 (weeks 7,8 = block weeks 1,2).
+ *
+ * Returns `[]` for an empty base spec (zero-spec guard) or `lengthWeeks <= 0`,
+ * so callers computing `Math.max(...expanded.map(s => s.week))` must still guard
+ * the empty case (`Math.max(...[])` is `-Infinity`).
+ */
+export function expandSpecToLength(
+  baseSpec: LiftingProgramSpec[],
+  lengthWeeks: number,
+): LiftingProgramSpec[] {
+  const blockWeeks = baseSpecBlockWeeks(baseSpec);
+  if (blockWeeks <= 0 || lengthWeeks <= 0) return [];
+
+  // Group rows by their in-block week once, preserving each week's row order.
+  const rowsByWeek = new Map<number, LiftingProgramSpec[]>();
+  for (const row of baseSpec) {
+    const arr = rowsByWeek.get(row.week) ?? [];
+    arr.push(row);
+    rowsByWeek.set(row.week, arr);
+  }
+
+  const expanded: LiftingProgramSpec[] = [];
+  for (let week = 1; week <= lengthWeeks; week++) {
+    const blockWeek = ((week - 1) % blockWeeks) + 1;
+    for (const row of rowsByWeek.get(blockWeek) ?? []) {
+      expanded.push({ ...row, week });
+    }
+  }
+  return expanded;
+}


### PR DESCRIPTION
## Summary

Fixes symptom #1 (and the 5/3/1 dead-code item) from #677 — the riskiest PR in the consistency pass. Program "length" had **three disagreeing sources of truth**:
- web onboarding copy (`weeks: 12` in `apps/web/lib/programs.ts`),
- the 1-week repeating preset block (`packages/core/src/presets/index.ts`),
- `Math.max(...spec.week)` = 1 in both the API scheduler and web plan derivation.

Result on Leangains' `/cycle/1/plan`: **"Total weeks: 1"**, est. completion 1 week out, and a fabricated **"Test"** phase (from `buildFallbackPhases(1)`). 5/3/1's `PHASE_MAP_12` never triggered (dead code).

### Fix — one authoritative length in core
- **`packages/core/src/presets/programLengths.ts`** (new): canonical `PROGRAM_LENGTHS` registry — `leangains` (12wk / 1-wk block / repeating), `rpt` (8wk / 1-wk block / repeating), `5-3-1` (12wk / 3-wk block / wave) — plus `programLengthWeeks(program, spec)` (canonical length, or `Math.max(...spec.week)` fallback for custom programs) and read-time `expandSpecToLength(baseSpec, lengthWeeks)`. **No DB migration** — stored specs are untouched.
- **API** (`cycle-generation.service.ts`): scheduling tiles the base spec to the canonical length so the workout calendar spans the whole program. `updateMaxes` / `weekTypeForDate` keep the base spec — provably invariant to tiling (`.find()` returns the week-1 row; no preset sets `weekType`). Also hardens the empty-spec guard, fixing a latent `Math.max(...[]) = -Infinity` in `startNewCycle`.
- **API** (`workouts.controller.ts`): now that a repeating program schedules a full 12 weeks of clickable workouts, the workout-detail endpoint derives the program week from the scheduled row's `weekNum` (authoritative) rather than the offset-indexed `weekForWorkoutNum`, which 400'd for `workoutNum` beyond the base block; planned lifts map to the tiled block week. (Surfaced by `/review` — see disposition below.)
- **Web** (`programPlan.ts`): duration + phases derive from the canonical length. Phases are now **program-type-driven** — deleted `PHASE_MAP_12` / `buildFallbackPhases`:
  - `repeating` (Leangains, RPT) → a single flat **"Training"** span,
  - `wave` (5/3/1) → one **"Wave N"** training phase per 3-week block,
  - **never a fabricated "Test"/"Deload" week.**
  `programs.ts` `weeks` now derives from `PROGRAM_LENGTHS` (reconciliation test guards drift).

### Semantic caveat (per the issue)
Leangains and RPT are **autoregulated** (AMRAP-driven): "12 weeks" / "8 weeks" is the repeating block tiled across the program length. Training maxes still progress via `updateMaxes` from actual lift records, not a fixed weekly bump — so the plan shows flat Training weeks, not fictional periodization. The 5/3/1 preset is a repeated 3-week wave with **no deload/test rows**, so its plan shows per-wave Training phases rather than the old `PHASE_MAP_12`'s deloads/test (which never matched the generated workouts — that mismatch is exactly the fabrication this issue removes).

### Pre-existing cycles (data integrity)
Read-time expansion means **existing in-flight cycles are not migrated**: a Leangains cycle generated before this change still has only its originally-scheduled week(s) stored. The plan now renders the correct **12-week overview** (unscheduled weeks show as *upcoming*); the stored calendar fills to full length the next time a cycle is (re)generated. No stored data changes; revert = drop the helper + registry.

## Acceptance criteria
- [x] Leangains `/cycle/1/plan` shows **Total weeks = 12**, est. completion ≈ 12 weeks out, no "Test" phase
- [x] 5/3/1 shows structured (per-wave) phases; RPT shows flat Training weeks
- [x] Workout calendar spans the full program length (API schedules 12 weeks — asserted in `cycle-generation.service.spec.ts`)
- [x] Unit tests for `expandSpecToLength` (tiling, week numbering, partial block, zero-spec guard); updated programPlan + cycle-generation tests
- [x] No DB migration; revert = drop helper + metadata

## Testing
`npm run build` ✅ · `npm run typecheck` ✅ (4/4)

Full suite, Docker up for the API db-e2e — **968 passed, 0 skipped, 0 failed** (per-workspace, run in isolation): core 303, api 444, web 194, api-client 27.

> The full parallel `npm test` (turbo runs several jest processes concurrently) exhibits the known Windows-local isolation flake — unrelated core/web suites intermittently fail under CPU oversubscription (see CLAUDE.md → *Windows full-suite parallel-load flakes*, [#567](https://github.com/brownm09/lifting-logbook/issues/567)). Each workspace passes cleanly in isolation (counts above); Linux CI (Node 20) is unaffected.

Playwright e2e (plan-page rendered strings changed → run locally per CLAUDE.md): **21 passed**.

Pre-PR gates: suppression grep ✅ clean · test-integrity grep ✅ clean · no deleted tests · no coverage-threshold changes · no `package.json` change (lockfile gate N/A).

## Risk-dimension audit (Pass 3)
- **Testing** — core + programPlan + reconciliation + API 12-week-scheduling tests; Playwright re-run.
- **Observability** — N/A: existing NestJS/Pino path, no new boundary, no raw SQL, no LLM.
- **Security** — N/A: non-sensitive length metadata; no authz/secret changes.
- **Resilience / rollback** — read-time expansion, no migration; empty-spec guard prevents crash; revert is a pure code change.
- **Performance** — in-memory tiling over ≤48-row specs; negligible. No new queries.
- **Data integrity & migrations** — no schema change; stored blocks untouched; pre-existing cycles render the correct overview (display-only until regenerated).
- **Accessibility** — plan list semantics unchanged (`<ul>` / `<li>`, status-icon `aria-label` retained).

## Review findings disposition
`/review` ran two parallel subagents (correctness/security + reliability/perf/maintainability). **All findings fixed in this PR — none left as-is.**

- **[correctness] Workout-detail 400 for week-2+ workouts** (exposed by the 12-week schedule; Leangains is onboarding-available) — fixed in `5b6c692`: `workouts.controller.ts` derives the week from the scheduled `weekNum`; planned lifts map to the tiled block week; controller test added.
- **[maintainability] Three-registry drift risk** (`PROGRAM_LENGTHS` vs `PRESET_BASE_SPECS` / `PROGRAM_DEFAULTS`) — fixed in `5b6c692`: reciprocal key-set test + cross-reference doc comments.
- **[reliability] `wave` phase-style contract untested** — fixed in `5b6c692`: test asserts every `wave` registry entry has `blockWeeks > 1`.
- **[maintainability] Unreachable `deload`/`test` `PhaseType` + CSS** — documented (retained for `weekType`-tagged programs) in `5b6c692`.
- Non-actionable (perf micro-allocations, empty-spec guard soundness, `weekForWorkoutNum` no-schedule path) — confirmed no change needed.

Closes #680 · part of #677.
