### PR TITLE
[feat] Training-max stepper honors the configured plate increment

### DIFF
--- a/apps/web/app/(authed)/settings/training-maxes/TrainingMaxesForm.test.tsx
+++ b/apps/web/app/(authed)/settings/training-maxes/TrainingMaxesForm.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { DEFAULT_WEIGHT_INCREMENT } from '@lifting-logbook/types';
+import TrainingMaxesForm from './TrainingMaxesForm';
+
+jest.mock('./actions', () => ({
+  saveTrainingMaxes: jest.fn(),
+}));
+
+describe('TrainingMaxesForm step increment', () => {
+  it("sets each lift's number-input step to its configured increment", () => {
+    render(
+      <TrainingMaxesForm
+        program="5-3-1"
+        lifts={['Squat', 'Weighted Pull-ups']}
+        maxes={[]}
+        increments={{ Squat: 10, 'Weighted Pull-ups': 2.5 }}
+      />,
+    );
+
+    expect(screen.getByLabelText('Squat training max')).toHaveAttribute(
+      'step',
+      '10',
+    );
+    expect(
+      screen.getByLabelText('Weighted Pull-ups training max'),
+    ).toHaveAttribute('step', '2.5');
+  });
+
+  it('falls back to DEFAULT_WEIGHT_INCREMENT when a lift has no resolved increment', () => {
+    render(
+      <TrainingMaxesForm
+        program="5-3-1"
+        lifts={['Deadlift']}
+        maxes={[]}
+        increments={{}}
+      />,
+    );
+
+    expect(screen.getByLabelText('Deadlift training max')).toHaveAttribute(
+      'step',
+      String(DEFAULT_WEIGHT_INCREMENT),
+    );
+  });
+});

--- a/apps/web/app/(authed)/settings/training-maxes/TrainingMaxesForm.tsx
+++ b/apps/web/app/(authed)/settings/training-maxes/TrainingMaxesForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import type { TrainingMaxResponse } from '@lifting-logbook/types';
+import { DEFAULT_WEIGHT_INCREMENT, type TrainingMaxResponse } from '@lifting-logbook/types';
 import { saveTrainingMaxes } from './actions';
 import styles from './TrainingMaxesForm.module.css';
 
@@ -34,10 +34,13 @@ export default function TrainingMaxesForm({
   program,
   lifts,
   maxes,
+  increments,
 }: {
   program: string;
   lifts: string[];
   maxes: TrainingMaxResponse[];
+  /** Per-lift spinner `step`, keyed by lift name (see resolveStepIncrements). */
+  increments: Record<string, number>;
 }) {
   const [rows, setRows] = useState<Record<string, RowState>>(() =>
     buildInitialState(lifts, maxes),
@@ -135,6 +138,7 @@ export default function TrainingMaxesForm({
                   <td className={styles.weightCell} data-label="Weight">
                     <input
                       type="number"
+                      step={increments[lift] ?? DEFAULT_WEIGHT_INCREMENT}
                       value={row.value}
                       placeholder="—"
                       aria-label={`${lift} training max`}

--- a/apps/web/app/(authed)/settings/training-maxes/increments.test.ts
+++ b/apps/web/app/(authed)/settings/training-maxes/increments.test.ts
@@ -1,0 +1,64 @@
+import type { LiftingProgramSpecResponse } from '@lifting-logbook/types';
+import { resolveStepIncrements } from './increments';
+
+const spec = (
+  overrides: Partial<LiftingProgramSpecResponse>,
+): LiftingProgramSpecResponse => ({
+  week: 1,
+  lift: 'Squat',
+  order: 1,
+  offset: 0,
+  increment: 5,
+  sets: 3,
+  reps: 5,
+  amrap: false,
+  warmUpPct: '0.4,0.5,0.6',
+  wtDecrementPct: 0,
+  activation: 'compound',
+  ...overrides,
+});
+
+describe('resolveStepIncrements', () => {
+  it("uses each lift's configured per-program increment", () => {
+    const specs = [
+      spec({ lift: 'Squat', increment: 10 }),
+      spec({ lift: 'Weighted Pull-ups', increment: 2.5 }),
+      spec({ lift: 'Bench Press', increment: 5 }),
+    ];
+
+    expect(
+      resolveStepIncrements(
+        ['Squat', 'Weighted Pull-ups', 'Bench Press'],
+        specs,
+        1.25,
+      ),
+    ).toEqual({ Squat: 10, 'Weighted Pull-ups': 2.5, 'Bench Press': 5 });
+  });
+
+  it('falls back to the default increment for a lift with no spec row', () => {
+    // Deadlift has a training max but is not in the active program's specs
+    // (e.g. a stale max left over from a previously-active program).
+    const specs = [spec({ lift: 'Squat', increment: 10 })];
+
+    const steps = resolveStepIncrements(['Squat', 'Deadlift'], specs, 1.25);
+
+    expect(steps.Squat).toBe(10);
+    expect(steps.Deadlift).toBe(1.25);
+  });
+
+  it('takes the first spec row per lift (increment is constant across weeks)', () => {
+    const specs = [
+      spec({ lift: 'Squat', week: 1, increment: 10 }),
+      spec({ lift: 'Squat', week: 2, increment: 10 }),
+    ];
+
+    expect(resolveStepIncrements(['Squat'], specs, 1.25)).toEqual({ Squat: 10 });
+  });
+
+  it('falls back for every lift when the program has no specs', () => {
+    expect(resolveStepIncrements(['Squat', 'Bench Press'], [], 2.5)).toEqual({
+      Squat: 2.5,
+      'Bench Press': 2.5,
+    });
+  });
+});

--- a/apps/web/app/(authed)/settings/training-maxes/increments.ts
+++ b/apps/web/app/(authed)/settings/training-maxes/increments.ts
@@ -1,0 +1,35 @@
+import type { LiftingProgramSpecResponse } from '@lifting-logbook/types';
+
+/**
+ * Resolve the numeric-input `step` for each training-max row.
+ *
+ * The step honors the lift's per-program plate increment when the active
+ * program's specs define one (e.g. Squat steps by 10, Weighted Pull-ups by
+ * 2.5). A lift with no matching spec row — e.g. a stale training max carried
+ * over from a previously-active program — falls back to `defaultIncrement`,
+ * which the caller derives from the user's `defaultWeightIncrement` setting
+ * (itself already defaulted to `DEFAULT_WEIGHT_INCREMENT` when unset).
+ *
+ * `step` only drives the spinner buttons; it never rounds the directly-known
+ * training-max value the user typed (see docs/standards/training-max-precision.md).
+ *
+ * The returned map contains an entry for every lift in `lifts` so callers can
+ * index it per row. Spec rows repeat per program week; the first row seen for a
+ * lift wins because a lift's increment is constant across a program's weeks.
+ */
+export function resolveStepIncrements(
+  lifts: string[],
+  specs: LiftingProgramSpecResponse[],
+  defaultIncrement: number,
+): Record<string, number> {
+  const byLift = new Map<string, number>();
+  for (const spec of specs) {
+    if (!byLift.has(spec.lift)) byLift.set(spec.lift, spec.increment);
+  }
+
+  const steps: Record<string, number> = {};
+  for (const lift of lifts) {
+    steps[lift] = byLift.get(lift) ?? defaultIncrement;
+  }
+  return steps;
+}

--- a/apps/web/app/(authed)/settings/training-maxes/page.tsx
+++ b/apps/web/app/(authed)/settings/training-maxes/page.tsx
@@ -1,19 +1,36 @@
-import { fetchTrainingMaxes, fetchTrainingMaxHistory } from '@/lib/api';
+import {
+  fetchProgramSpec,
+  fetchTrainingMaxes,
+  fetchTrainingMaxHistory,
+  fetchUserSettings,
+} from '@/lib/api';
+import { DEFAULT_WEIGHT_INCREMENT } from '@lifting-logbook/types';
 import { getActiveProgram } from '@/lib/active-program';
 import TrainingMaxesForm from './TrainingMaxesForm';
+import { resolveStepIncrements } from './increments';
 import MaxHistory from './MaxHistory';
 
 export default async function TrainingMaxesPage() {
   const program = await getActiveProgram();
-  const [maxes, history] = await Promise.all([
+  const [maxes, history, specs, settings] = await Promise.all([
     fetchTrainingMaxes(program),
     fetchTrainingMaxHistory(program),
+    fetchProgramSpec(program),
+    fetchUserSettings(),
   ]);
   const lifts = maxes.map((m) => m.lift);
+  const defaultIncrement =
+    settings.defaultWeightIncrement ?? DEFAULT_WEIGHT_INCREMENT;
+  const increments = resolveStepIncrements(lifts, specs, defaultIncrement);
 
   return (
     <>
-      <TrainingMaxesForm program={program} lifts={lifts} maxes={maxes} />
+      <TrainingMaxesForm
+        program={program}
+        lifts={lifts}
+        maxes={maxes}
+        increments={increments}
+      />
       <MaxHistory initialEntries={history.entries} program={program} />
     </>
   );

--- a/apps/web/app/(authed)/settings/training-maxes/page.tsx
+++ b/apps/web/app/(authed)/settings/training-maxes/page.tsx
@@ -2,10 +2,9 @@ import {
   fetchProgramSpec,
   fetchTrainingMaxes,
   fetchTrainingMaxHistory,
-  fetchUserSettings,
 } from '@/lib/api';
 import { DEFAULT_WEIGHT_INCREMENT } from '@lifting-logbook/types';
-import { getActiveProgram } from '@/lib/active-program';
+import { getActiveProgram, getUserSettings } from '@/lib/active-program';
 import TrainingMaxesForm from './TrainingMaxesForm';
 import { resolveStepIncrements } from './increments';
 import MaxHistory from './MaxHistory';
@@ -16,7 +15,7 @@ export default async function TrainingMaxesPage() {
     fetchTrainingMaxes(program),
     fetchTrainingMaxHistory(program),
     fetchProgramSpec(program),
-    fetchUserSettings(),
+    getUserSettings(),
   ]);
   const lifts = maxes.map((m) => m.lift);
   const defaultIncrement =

--- a/apps/web/lib/active-program.ts
+++ b/apps/web/lib/active-program.ts
@@ -2,9 +2,17 @@ import 'server-only';
 import { cache } from 'react';
 import { fetchUserSettings } from './api';
 
+/**
+ * Request-cached user-settings fetch. React `cache()` dedupes calls within a
+ * single server render, so consumers that each need settings on the same page
+ * (e.g. getActiveProgram plus a page that also reads defaultWeightIncrement)
+ * share one network round-trip instead of issuing duplicate /user-settings GETs.
+ */
+export const getUserSettings = cache(fetchUserSettings);
+
 export const getActiveProgram = cache(async (): Promise<string> => {
   try {
-    const settings = await fetchUserSettings();
+    const settings = await getUserSettings();
     return settings.activeProgram ?? process.env.DEFAULT_PROGRAM ?? '5-3-1';
   } catch (e) {
     console.error('getActiveProgram: failed to fetch user settings, falling back to default', e);


### PR DESCRIPTION
## Summary

The Training Maxes editor's weight field was a bare `<input type="number">` with **no `step`** attribute, so the spinner stepped by the browser default of 1 — ignoring both the per-lift program `increment` and the user's `defaultWeightIncrement` setting.

This wires the configured increment through to the input's `step`:

- **New `increments.ts`** — a pure, tested helper `resolveStepIncrements(lifts, specs, defaultIncrement)` that builds a per-lift step map: the active program spec's `increment` wins (e.g. Squat 10, Weighted Pull-ups 2.5); a lift with no matching spec row — a stale training max carried over from a previously-active program — falls back to `defaultIncrement`.
- **`page.tsx`** — adds `fetchProgramSpec` + `getUserSettings` to the existing `Promise.all`, resolves `defaultIncrement = settings.defaultWeightIncrement ?? DEFAULT_WEIGHT_INCREMENT`, and passes the resolved `increments` map to the form.
- **`TrainingMaxesForm.tsx`** — new `increments` prop; sets `step={increments[lift] ?? DEFAULT_WEIGHT_INCREMENT}` on each row's number input.

`step` only drives the spinner buttons — it never rounds the directly-known, user-entered training-max value, honoring `docs/standards/training-max-precision.md` (category 1: directly-known values are not rounded). Verified there is no `:invalid` CSS anywhere and the Save path uses a custom `onClick` handler (not native form-submit validation), so a decimal TM under an integer step is neither flagged nor coerced.

"Reuse `WEIGHT_INCREMENT_OPTIONS`" is satisfied transitively: the fallback value is `settings.defaultWeightIncrement`, already constrained to those options at the settings layer; per-lift program increments (e.g. Squat 10) legitimately exceed that set and are used as-is.

Part of #677. Fixes symptom Q2 from the consistency-pass audit.

## Acceptance criteria

- [x] The number spinner steps by each lift's configured increment (e.g. Squat 10, Weighted Pull-ups 2.5), not 1
- [x] Falls back to `defaultWeightIncrement` when no per-lift increment is available
- [x] Component test asserts the `step` attribute equals the lift's configured increment

## Testing

- **`npm run typecheck`** (blocking CI gate) — 4 successful (web + core + all workspaces). Green.
- **New tests — 6 passed:**
  - `increments.test.ts` (4): spec increment wins (Squat→10, Weighted Pull-ups→2.5); fallback to `defaultIncrement` for a lift with no spec row; first spec row per lift wins across weeks; empty specs → all fallback.
  - `TrainingMaxesForm.test.tsx` (2): `step` renders per row from the resolved map (Squat `step="10"`, Weighted Pull-ups `step="2.5"`); a lift missing from the map falls back to `DEFAULT_WEIGHT_INCREMENT`.
- **`npm test -w @lifting-logbook/web`** — Tests: 200 passed, 0 skipped, 0 failed, across all 33 suites.
  - _Note:_ an earlier run had `SettingsNav.test.tsx` (unrelated — untouched here) crash with a Jest worker OOM, the documented **Windows-only, local-only parallel-load flake** ([#567](https://github.com/brownm09/lifting-logbook/issues/567)); it passes in isolation and the subsequent full run was clean (200/200). CI (Linux, Node 20) is unaffected by this flake class.

**Playwright E2E not required:** this change adds a `step` attribute only — no UI string, `aria-label`, or role-name change — so the project's e2e-before-push trigger does not apply.

**Pre-PR gates:** suppression grep clean; test-integrity grep clean; no deleted tests; lockfile-sync check N/A (no `package.json` change).

## Review findings disposition

Reviewed by `claude-opus-4-8` ([review comment](https://github.com/brownm09/lifting-logbook/pull/731#issuecomment-4896624726)) — 0 blocking, 1 non-blocking.

- **Non-blocking [performance]** — `page.tsx` issued a duplicate `/user-settings` fetch (settings were already fetched inside `getActiveProgram`). **Fixed in `045adcd`:** `fetchUserSettings` is now request-cached as `getUserSettings` (React `cache()`) in `lib/active-program.ts`, and both callers consume it so they dedupe to a single round-trip. Behavior-preserving; typecheck + full web suite (200 passed) green.

Closes #681
