### PR TITLE
[feat] Add global lbs/kg weight-unit preference

### DIFF
--- a/apps/api/prisma/migrations/20260707140000_add_user_settings_unit/migration.sql
+++ b/apps/api/prisma/migrations/20260707140000_add_user_settings_unit/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user_settings" ADD COLUMN     "unit" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -171,6 +171,7 @@ model UserSettings {
   activeProgram          String?
   workoutSchedule        Json?
   defaultWeightIncrement Float?
+  unit                   String?
 
   @@map("user_settings")
 }

--- a/apps/api/src/adapters/in-memory/user-settings.adapter.ts
+++ b/apps/api/src/adapters/in-memory/user-settings.adapter.ts
@@ -1,16 +1,18 @@
-import { UserSettingsResponse, UserWorkoutSchedule } from '@lifting-logbook/types';
+import { UserSettingsResponse, UserWorkoutSchedule, WeightUnit } from '@lifting-logbook/types';
 import { IUserSettingsRepository } from '../../ports/IUserSettingsRepository';
 
 export class InMemoryUserSettingsRepository implements IUserSettingsRepository {
   private activeProgram: string | null = null;
   private workoutSchedule: UserWorkoutSchedule | null = null;
   private defaultWeightIncrement: number | null = null;
+  private unit: WeightUnit | null = null;
 
   async getSettings(): Promise<UserSettingsResponse> {
     return {
       activeProgram: this.activeProgram,
       workoutSchedule: this.workoutSchedule,
       defaultWeightIncrement: this.defaultWeightIncrement,
+      unit: this.unit,
     };
   }
 
@@ -24,5 +26,9 @@ export class InMemoryUserSettingsRepository implements IUserSettingsRepository {
 
   setDefaultWeightIncrement(increment: number | null): void {
     this.defaultWeightIncrement = increment;
+  }
+
+  setUnit(unit: WeightUnit | null): void {
+    this.unit = unit;
   }
 }

--- a/apps/api/src/ports/ports.compile-test.ts
+++ b/apps/api/src/ports/ports.compile-test.ts
@@ -178,7 +178,7 @@ const _workoutSkipOverrideRepo: IWorkoutSkipOverrideRepository = {
 
 const _userSettingsRepo: IUserSettingsRepository = {
   getSettings: () =>
-    Promise.resolve({ activeProgram: null, workoutSchedule: null, defaultWeightIncrement: null }),
+    Promise.resolve({ activeProgram: null, workoutSchedule: null, defaultWeightIncrement: null, unit: null }),
 };
 
 const _customLiftRepo: ICustomLiftRepository = {

--- a/apps/api/src/programs/programs.db.e2e.spec.ts
+++ b/apps/api/src/programs/programs.db.e2e.spec.ts
@@ -1071,6 +1071,25 @@ describeOrSkip('Programs HTTP (e2e, PrismaRepositoryFactory)', () => {
       expect(getRes.json()).toMatchObject({ activeProgram: SEED_PROGRAM });
     });
 
+    it('PATCH /users/me/settings updates unit and persists to DB', async () => {
+      const injectRaw = app.getHttpAdapter().getInstance().inject.bind(app.getHttpAdapter().getInstance());
+
+      const patchRes = await injectRaw({
+        method: 'PATCH',
+        url: '/users/me/settings',
+        headers: { 'content-type': 'application/json', ...AS_SETT },
+        payload: JSON.stringify({ unit: 'kg' }),
+      });
+      expect(patchRes.statusCode).toBe(200);
+      expect(patchRes.json()).toMatchObject({ unit: 'kg' });
+
+      const row = await prisma.userSettings.findFirst({ where: { userId: USER_SETT } });
+      expect(row?.unit).toBe('kg');
+
+      const getRes = await injectRaw({ method: 'GET', url: '/users/me/settings', headers: AS_SETT });
+      expect(getRes.json()).toMatchObject({ unit: 'kg' });
+    });
+
     it('user isolation — settings are scoped to userId', async () => {
       const injectRaw = app.getHttpAdapter().getInstance().inject.bind(app.getHttpAdapter().getInstance());
       const AS_OTHER = { authorization: `Bearer ${USER_SETT_OTHER}` };

--- a/apps/api/src/user-settings/update-settings.dto.ts
+++ b/apps/api/src/user-settings/update-settings.dto.ts
@@ -19,8 +19,13 @@ import {
   ValidatorConstraintInterface,
   ValidationArguments,
 } from 'class-validator';
-import { SCHEDULE_LIMITS, WEIGHT_INCREMENT_OPTIONS, isValidSchedule } from '@lifting-logbook/types';
-import type { UserWorkoutSchedule } from '@lifting-logbook/types';
+import {
+  SCHEDULE_LIMITS,
+  WEIGHT_INCREMENT_OPTIONS,
+  WEIGHT_UNIT_OPTIONS,
+  isValidSchedule,
+} from '@lifting-logbook/types';
+import type { UserWorkoutSchedule, WeightUnit } from '@lifting-logbook/types';
 
 // Delegates to the shared `isValidSchedule` predicate so the write-side and read-side
 // bounds (range, uniqueness, max weeks, max days/week) cannot drift.
@@ -97,4 +102,11 @@ export class UpdateSettingsDto {
   @ValidateIf((o: UpdateSettingsDto) => o.defaultWeightIncrement !== null)
   @IsIn(WEIGHT_INCREMENT_OPTIONS)
   defaultWeightIncrement?: number | null;
+
+  // null clears the preference (falls back to 'lbs'); undefined leaves it unchanged.
+  // Display preference only — never rounds or rewrites stored weights.
+  @IsOptional()
+  @ValidateIf((o: UpdateSettingsDto) => o.unit !== null)
+  @IsIn(WEIGHT_UNIT_OPTIONS)
+  unit?: WeightUnit | null;
 }

--- a/apps/api/src/user-settings/user-settings.controller.spec.ts
+++ b/apps/api/src/user-settings/user-settings.controller.spec.ts
@@ -13,6 +13,7 @@ type Row = {
   activeProgram: string | null;
   workoutSchedule: unknown;
   defaultWeightIncrement: number | null;
+  unit: string | null;
 };
 
 function makePrismaMock(): { service: PrismaService; store: Map<string, Row> } {
@@ -45,6 +46,7 @@ function makePrismaMock(): { service: PrismaService; store: Map<string, Row> } {
                 activeProgram: create.activeProgram ?? null,
                 workoutSchedule: create.workoutSchedule ?? null,
                 defaultWeightIncrement: create.defaultWeightIncrement ?? null,
+                unit: create.unit ?? null,
               };
           store.set(where.userId, next);
           return next;
@@ -74,6 +76,7 @@ describe('UserSettingsController', () => {
       activeProgram: null,
       workoutSchedule: null,
       defaultWeightIncrement: null,
+      unit: null,
     });
   });
 
@@ -95,12 +98,40 @@ describe('UserSettingsController', () => {
       activeProgram: null,
       workoutSchedule: null,
       defaultWeightIncrement: 2.5,
+      unit: null,
     });
     const dto = plainToInstance(UpdateSettingsDto, { defaultWeightIncrement: null });
     const errors = await validate(dto);
     expect(errors).toEqual([]);
     const result = await controller.updateSettings(MOCK_USER, dto);
     expect(result.defaultWeightIncrement).toBeNull();
+  });
+
+  it('persists a unit preference and reads it back', async () => {
+    const dto = plainToInstance(UpdateSettingsDto, { unit: 'kg' });
+    const errors = await validate(dto);
+    expect(errors).toEqual([]);
+
+    const patched = await controller.updateSettings(MOCK_USER, dto);
+    expect(patched.unit).toBe('kg');
+
+    const fetched = await controller.getSettings(MOCK_USER);
+    expect(fetched.unit).toBe('kg');
+  });
+
+  it('clears the unit preference when patched with null', async () => {
+    prismaMock.store.set(MOCK_USER.id, {
+      userId: MOCK_USER.id,
+      activeProgram: null,
+      workoutSchedule: null,
+      defaultWeightIncrement: null,
+      unit: 'kg',
+    });
+    const dto = plainToInstance(UpdateSettingsDto, { unit: null });
+    const errors = await validate(dto);
+    expect(errors).toEqual([]);
+    const result = await controller.updateSettings(MOCK_USER, dto);
+    expect(result.unit).toBeNull();
   });
 
   it('persists a fixed schedule and reads it back', async () => {
@@ -126,6 +157,7 @@ describe('UserSettingsController', () => {
       activeProgram: null,
       workoutSchedule: { type: 'fixed', days: [0, 99] },
       defaultWeightIncrement: null,
+      unit: null,
     });
     const result = await controller.getSettings(MOCK_USER);
     expect(result.workoutSchedule).toBeNull();
@@ -137,6 +169,7 @@ describe('UserSettingsController', () => {
       activeProgram: null,
       workoutSchedule: { type: 'fixed', days: [0, 2, 4] },
       defaultWeightIncrement: null,
+      unit: null,
     });
     const dto = plainToInstance(UpdateSettingsDto, { workoutSchedule: null });
     const errors = await validate(dto);
@@ -215,6 +248,19 @@ describe('UpdateSettingsDto validation', () => {
 
   it.each([0, 1, 3, 10, -2.5])('rejects %s as an out-of-range defaultWeightIncrement', async (value) => {
     const errs = await check({ defaultWeightIncrement: value });
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it.each(['lbs', 'kg'])('accepts %s as a valid unit', async (value) => {
+    expect(await check({ unit: value })).toEqual([]);
+  });
+
+  it('accepts an explicit null to clear unit', async () => {
+    expect(await check({ unit: null })).toEqual([]);
+  });
+
+  it.each(['pounds', 'KG', ''])('rejects %s as an invalid unit', async (value) => {
+    const errs = await check({ unit: value });
     expect(errs.length).toBeGreaterThan(0);
   });
 

--- a/apps/api/src/user-settings/user-settings.repository.ts
+++ b/apps/api/src/user-settings/user-settings.repository.ts
@@ -2,6 +2,7 @@ import { Prisma } from '@prisma/client';
 import {
   UserSettingsResponse,
   UserWorkoutSchedule,
+  WeightUnit,
   isValidSchedule,
 } from '@lifting-logbook/types';
 import { PrismaExecutor } from '../adapters/prisma/prisma-tx.util';
@@ -14,6 +15,9 @@ export interface UpsertSettingsPatch {
   // Explicit `null` clears the override (falls back to the 1.25 app default);
   // `undefined` leaves it unchanged.
   defaultWeightIncrement?: number | null;
+  // Explicit `null` clears the preference (falls back to 'lbs'); `undefined`
+  // leaves it unchanged.
+  unit?: WeightUnit | null;
 }
 
 // Runtime guard for values read from the JSONB column. Prisma returns whatever JSON is
@@ -23,6 +27,12 @@ export interface UpsertSettingsPatch {
 function parseSchedule(value: unknown): UserWorkoutSchedule | null {
   if (value === null || value === undefined) return null;
   return isValidSchedule(value) ? value : null;
+}
+
+// Runtime guard for the plain-string `unit` column — same rationale as parseSchedule
+// above. The column has no DB-level CHECK constraint, only DTO validation on write.
+function parseUnit(value: unknown): WeightUnit | null {
+  return value === 'lbs' || value === 'kg' ? value : null;
 }
 
 export class UserSettingsRepository implements IUserSettingsRepository {
@@ -42,6 +52,7 @@ export class UserSettingsRepository implements IUserSettingsRepository {
       activeProgram: row?.activeProgram ?? null,
       workoutSchedule: parseSchedule(row?.workoutSchedule),
       defaultWeightIncrement: row?.defaultWeightIncrement ?? null,
+      unit: parseUnit(row?.unit),
     };
   }
 
@@ -58,6 +69,7 @@ export class UserSettingsRepository implements IUserSettingsRepository {
     if (patch.defaultWeightIncrement !== undefined) {
       update.defaultWeightIncrement = patch.defaultWeightIncrement;
     }
+    if (patch.unit !== undefined) update.unit = patch.unit;
 
     const create: Prisma.UserSettingsUncheckedCreateInput = { userId: this.userId };
     if (patch.activeProgram !== undefined) create.activeProgram = patch.activeProgram;
@@ -67,6 +79,7 @@ export class UserSettingsRepository implements IUserSettingsRepository {
     if (patch.defaultWeightIncrement != null) {
       create.defaultWeightIncrement = patch.defaultWeightIncrement;
     }
+    if (patch.unit != null) create.unit = patch.unit;
 
     const row = await this.prisma.userSettings.upsert({
       where: { userId: this.userId },
@@ -77,6 +90,7 @@ export class UserSettingsRepository implements IUserSettingsRepository {
       activeProgram: row.activeProgram ?? null,
       workoutSchedule: parseSchedule(row.workoutSchedule),
       defaultWeightIncrement: row.defaultWeightIncrement ?? null,
+      unit: parseUnit(row.unit),
     };
   }
 }

--- a/apps/web/app/(authed)/cycle/[cycleNum]/CycleDashboardGrid.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/CycleDashboardGrid.tsx
@@ -2,6 +2,8 @@
 
 import Link from 'next/link';
 import { useState } from 'react';
+import { formatWeight } from '@lifting-logbook/core';
+import type { WeightUnit } from '@lifting-logbook/types';
 import type { WeekRow, WorkoutCell } from '@/lib/workoutPlan';
 import styles from './CycleDashboardGrid.module.css';
 
@@ -32,9 +34,11 @@ function StatusBadge({ status }: { status: WorkoutCell['status'] }) {
 function WorkoutCard({
   cell,
   cycleNum,
+  unit,
 }: {
   cell: WorkoutCell;
   cycleNum: number;
+  unit: WeightUnit;
 }) {
   return (
     <Link
@@ -52,7 +56,7 @@ function WorkoutCard({
             <ol className={styles.setList}>
               {lift.sets.map((s) => (
                 <li key={s.setLabel}>
-                  {s.setLabel}: {s.weight} lbs × {s.reps}
+                  {s.setLabel}: {formatWeight(s.weight, 'lbs', unit)} × {s.reps}
                 </li>
               ))}
             </ol>
@@ -66,9 +70,11 @@ function WorkoutCard({
 export default function CycleDashboardGrid({
   cycleNum,
   weeks,
+  unit,
 }: {
   cycleNum: number;
   weeks: WeekRow[];
+  unit: WeightUnit;
 }) {
   const currentWeek = findCurrentWeek(weeks);
 
@@ -118,7 +124,7 @@ export default function CycleDashboardGrid({
               {isExpanded && (
                 <div className={styles.workouts}>
                   {row.workouts.map((cell) => (
-                    <WorkoutCard key={cell.workoutNum} cell={cell} cycleNum={cycleNum} />
+                    <WorkoutCard key={cell.workoutNum} cell={cell} cycleNum={cycleNum} unit={unit} />
                   ))}
                 </div>
               )}

--- a/apps/web/app/(authed)/cycle/[cycleNum]/page.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/page.tsx
@@ -6,6 +6,7 @@ import {
   fetchWorkout,
 } from '@/lib/api';
 import { getActiveProgram } from '@/lib/active-program';
+import { getPreferredUnit } from '@/lib/preferences';
 import {
   buildWorkoutDays,
   computePlannedSets,
@@ -23,10 +24,11 @@ export default async function CycleDashboardPage({
   const requestedCycleNum = Number(cycleNumParam);
   const program = await getActiveProgram();
 
-  const [dashboard, specs, maxes] = await Promise.all([
+  const [dashboard, specs, maxes, unit] = await Promise.all([
     fetchCycleDashboard(program),
     fetchProgramSpec(program),
     fetchTrainingMaxes(program),
+    getPreferredUnit(),
   ]);
 
   if (!dashboard || dashboard.cycleNum !== requestedCycleNum) {
@@ -85,5 +87,5 @@ export default async function CycleDashboardPage({
       }),
   }));
 
-  return <CycleDashboardGrid cycleNum={dashboard.cycleNum} weeks={weeks} />;
+  return <CycleDashboardGrid cycleNum={dashboard.cycleNum} weeks={weeks} unit={unit} />;
 }

--- a/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/detail/CollapsibleLiftList.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/detail/CollapsibleLiftList.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import { formatWeight } from '@lifting-logbook/core';
+import type { WeightUnit } from '@lifting-logbook/types';
 import type { PlannedSet } from '@/lib/workoutPlan';
 import styles from './detail.module.css';
 
@@ -17,12 +19,14 @@ interface Props {
   liftDetails: LiftDetail[];
   cycleNum: number;
   workoutNum: number;
+  unit: WeightUnit;
 }
 
 export default function CollapsibleLiftList({
   liftDetails,
   cycleNum,
   workoutNum,
+  unit,
 }: Props) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
@@ -63,7 +67,7 @@ export default function CollapsibleLiftList({
                 <span className={styles.liftName}>
                   {lift}
                   {tm > 0 && (
-                    <span className={styles.liftTM}>TM: {tm} lbs</span>
+                    <span className={styles.liftTM}>TM: {formatWeight(tm, 'lbs', unit)}</span>
                   )}
                 </span>
 
@@ -93,7 +97,7 @@ export default function CollapsibleLiftList({
                       <div key={s.setLabel} className={styles.setRow}>
                         <span className={styles.setLabel}>{s.setLabel}</span>
                         <span className={styles.setSpec}>
-                          {s.reps} × {s.weight} lbs
+                          {s.reps} × {formatWeight(s.weight, 'lbs', unit)}
                         </span>
                       </div>
                     ))}
@@ -107,7 +111,7 @@ export default function CollapsibleLiftList({
                       <div key={s.setLabel} className={styles.setRow}>
                         <span className={styles.setLabel}>{s.setLabel}</span>
                         <span className={styles.setSpec}>
-                          {s.reps} × {s.weight} lbs
+                          {s.reps} × {formatWeight(s.weight, 'lbs', unit)}
                         </span>
                       </div>
                     ))}

--- a/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/detail/[lift]/LiftHistoryFilters.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/detail/[lift]/LiftHistoryFilters.tsx
@@ -1,19 +1,23 @@
 'use client';
 
 import { useState } from 'react';
-import type { LiftRecordResponse } from '@lifting-logbook/types';
+import { convertWeight, formatWeight } from '@lifting-logbook/core';
+import type { LiftRecordResponse, WeightUnit } from '@lifting-logbook/types';
 import styles from './lift.module.css';
 
 interface Props {
   records: LiftRecordResponse[];
+  unit: WeightUnit;
 }
 
-export default function LiftHistoryFilters({ records }: Props) {
+export default function LiftHistoryFilters({ records, unit }: Props) {
   const [minWeight, setMinWeight] = useState('');
   const [dateFilter, setDateFilter] = useState('');
 
+  // records are always stored in lbs; the "min weight" filter is entered in the
+  // display unit, so convert each record to that unit before comparing.
   const filtered = records.filter((r) => {
-    if (minWeight !== '' && r.weight < Number(minWeight)) return false;
+    if (minWeight !== '' && convertWeight(r.weight, 'lbs', unit) < Number(minWeight)) return false;
     if (dateFilter !== '' && !r.date.includes(dateFilter)) return false;
     return true;
   });
@@ -22,7 +26,7 @@ export default function LiftHistoryFilters({ records }: Props) {
     <div>
       <div className={styles.filters}>
         <label className={styles.filterLabel}>
-          Min weight
+          Min weight ({unit})
           <input
             type="number"
             min={0}
@@ -63,7 +67,7 @@ export default function LiftHistoryFilters({ records }: Props) {
                 <td>{r.date}</td>
                 <td>{r.workoutNum}</td>
                 <td>{r.setNum}</td>
-                <td>{r.weight} lbs</td>
+                <td>{formatWeight(r.weight, 'lbs', unit)}</td>
                 <td>{r.reps}</td>
               </tr>
             ))}

--- a/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/detail/[lift]/page.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/detail/[lift]/page.tsx
@@ -1,7 +1,9 @@
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
+import { formatWeight } from '@lifting-logbook/core';
 import { fetchTrainingMaxes, fetchTrainingMaxHistory, fetchLiftRecords } from '@/lib/api';
 import { getActiveProgram } from '@/lib/active-program';
+import { getPreferredUnit } from '@/lib/preferences';
 import LiftHistoryFilters from './LiftHistoryFilters';
 import styles from './lift.module.css';
 
@@ -21,10 +23,11 @@ export default async function LiftDetailPage({
 
   const program = await getActiveProgram();
 
-  const [maxes, history, allRecords] = await Promise.all([
+  const [maxes, history, allRecords, unit] = await Promise.all([
     fetchTrainingMaxes(program),
     fetchTrainingMaxHistory(program),
     fetchLiftRecords(program),
+    getPreferredUnit(),
   ]);
 
   const currentMax = maxes.find((m) => m.lift === lift);
@@ -53,7 +56,7 @@ export default async function LiftDetailPage({
         <h2 className={styles.sectionHeading}>Current Training Max</h2>
         {currentMax ? (
           <p className={styles.currentMax}>
-            {currentMax.weight} {currentMax.unit}
+            {formatWeight(currentMax.weight, currentMax.unit, unit)}
           </p>
         ) : (
           <p className={styles.empty}>No training max set.</p>
@@ -79,7 +82,7 @@ export default async function LiftDetailPage({
                   <tr key={entry.id}>
                     <td>{entry.date}</td>
                     <td>
-                      {entry.weight} {entry.unit}
+                      {formatWeight(entry.weight, entry.unit, unit)}
                     </td>
                     <td>{entry.isPR && <span className={styles.prBadge}>PR</span>}</td>
                   </tr>
@@ -94,7 +97,7 @@ export default async function LiftDetailPage({
         {setHistory.length === 0 ? (
           <p className={styles.empty}>No sets logged yet.</p>
         ) : (
-          <LiftHistoryFilters records={setHistory} />
+          <LiftHistoryFilters records={setHistory} unit={unit} />
         )}
       </section>
     </main>

--- a/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/detail/page.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/detail/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { fetchWorkout, fetchProgramSpec, fetchTrainingMaxes } from '@/lib/api';
 import { getActiveProgram } from '@/lib/active-program';
+import { getPreferredUnit } from '@/lib/preferences';
 import { computePlannedSets } from '@/lib/workoutPlan';
 import CollapsibleLiftList from './CollapsibleLiftList';
 import RescheduleForm from './RescheduleForm';
@@ -35,10 +36,11 @@ export default async function WorkoutDetailPage({
 
   const program = await getActiveProgram();
 
-  const [workout, specs, maxes] = await Promise.all([
+  const [workout, specs, maxes, unit] = await Promise.all([
     fetchWorkout(program, workoutNum),
     fetchProgramSpec(program),
     fetchTrainingMaxes(program),
+    getPreferredUnit(),
   ]);
 
   if (!workout) {
@@ -117,6 +119,7 @@ export default async function WorkoutDetailPage({
           liftDetails={liftDetails}
           cycleNum={cycleNum}
           workoutNum={workoutNum}
+          unit={unit}
         />
       </section>
 

--- a/apps/web/app/(authed)/history/HistoryTabs.test.tsx
+++ b/apps/web/app/(authed)/history/HistoryTabs.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { TrainingMaxHistoryEntryResponse } from '@lifting-logbook/types';
+import HistoryTabs from './HistoryTabs';
+import type { EnrichedRecord } from './page';
+
+const RECORD: EnrichedRecord = {
+  id: 'rec-1',
+  program: '5-3-1',
+  cycleNum: 1,
+  workoutNum: 1,
+  date: '2026-06-01',
+  lift: 'Back Squat',
+  setNum: 1,
+  weight: 225,
+  reps: 5,
+  notes: '',
+  tmAtTime: 315,
+  tmUnit: 'lbs',
+  tmPercent: 71.4,
+  isPR: false,
+};
+
+const TM_ENTRY: TrainingMaxHistoryEntryResponse = {
+  id: 'tm-1',
+  lift: 'Back Squat',
+  weight: 315,
+  unit: 'lbs',
+  date: '2026-06-01',
+  isPR: false,
+  source: 'program',
+  goalMet: false,
+};
+
+describe('HistoryTabs — unit conversion', () => {
+  it('renders lift-history weight and TM-at-time converted to the preferred unit', () => {
+    render(<HistoryTabs records={[RECORD]} tmEntries={[TM_ENTRY]} unit="kg" />);
+
+    // 225 lbs -> 102.06 kg, 315 lbs -> 142.88 kg (see packages/core weightUnit.test.ts).
+    expect(screen.getByText(/102\.06 kg × 5/)).toBeInTheDocument();
+    expect(screen.getByText('142.88 kg')).toBeInTheDocument();
+  });
+
+  it('renders the raw value unconverted when the preferred unit is lbs', () => {
+    render(<HistoryTabs records={[RECORD]} tmEntries={[TM_ENTRY]} unit="lbs" />);
+
+    expect(screen.getByText(/225 lbs × 5/)).toBeInTheDocument();
+    expect(screen.getByText('315 lbs')).toBeInTheDocument();
+  });
+
+  it('renders TM Timeline entries converted to the preferred unit', async () => {
+    const user = userEvent.setup();
+    render(<HistoryTabs records={[RECORD]} tmEntries={[TM_ENTRY]} unit="kg" />);
+
+    await user.click(screen.getByRole('tab', { name: 'TM Timeline' }));
+    expect(screen.getByText('142.88 kg')).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/(authed)/history/HistoryTabs.tsx
+++ b/apps/web/app/(authed)/history/HistoryTabs.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import type { TrainingMaxHistoryEntryResponse } from '@lifting-logbook/types';
+import { formatWeight } from '@lifting-logbook/core';
+import type { TrainingMaxHistoryEntryResponse, WeightUnit } from '@lifting-logbook/types';
 import type { EnrichedRecord } from './page';
 import styles from './history.module.css';
 
@@ -10,9 +11,11 @@ type Tab = 'history' | 'timeline';
 export default function HistoryTabs({
   records,
   tmEntries,
+  unit,
 }: {
   records: EnrichedRecord[];
   tmEntries: TrainingMaxHistoryEntryResponse[];
+  unit: WeightUnit;
 }) {
   const [tab, setTab] = useState<Tab>('history');
 
@@ -41,16 +44,16 @@ export default function HistoryTabs({
 
       <div role="tabpanel">
         {tab === 'history' ? (
-          <LiftHistoryTab records={records} />
+          <LiftHistoryTab records={records} unit={unit} />
         ) : (
-          <TmTimelineTab entries={tmEntries} />
+          <TmTimelineTab entries={tmEntries} unit={unit} />
         )}
       </div>
     </div>
   );
 }
 
-function LiftHistoryTab({ records }: { records: EnrichedRecord[] }) {
+function LiftHistoryTab({ records, unit }: { records: EnrichedRecord[]; unit: WeightUnit }) {
   const [search, setSearch] = useState('');
   const [liftFilter, setLiftFilter] = useState('');
 
@@ -120,11 +123,11 @@ function LiftHistoryTab({ records }: { records: EnrichedRecord[] }) {
                   <td>{r.date}</td>
                   <td>{r.lift}</td>
                   <td>
-                    {r.weight} {r.tmUnit ?? 'lbs'} × {r.reps}
+                    {formatWeight(r.weight, 'lbs', unit)} × {r.reps}
                   </td>
                   <td>
                     {r.tmAtTime !== null
-                      ? `${r.tmAtTime} ${r.tmUnit ?? 'lbs'}`
+                      ? formatWeight(r.tmAtTime, r.tmUnit ?? 'lbs', unit)
                       : '—'}
                   </td>
                   <td>{r.tmPercent !== null ? `${r.tmPercent}%` : '—'}</td>
@@ -147,8 +150,10 @@ function LiftHistoryTab({ records }: { records: EnrichedRecord[] }) {
 
 function TmTimelineTab({
   entries,
+  unit,
 }: {
   entries: TrainingMaxHistoryEntryResponse[];
+  unit: WeightUnit;
 }) {
   const [liftFilter, setLiftFilter] = useState('');
 
@@ -212,7 +217,7 @@ function TmTimelineTab({
                     <tr key={e.id}>
                       <td>{e.date}</td>
                       <td>
-                        {e.weight} {e.unit}
+                        {formatWeight(e.weight, e.unit, unit)}
                       </td>
                       <td>
                         {e.source === 'test' ? 'Test Week' : 'Program'}

--- a/apps/web/app/(authed)/history/page.tsx
+++ b/apps/web/app/(authed)/history/page.tsx
@@ -1,15 +1,17 @@
 import { fetchLiftRecords, fetchTrainingMaxHistory } from '@/lib/api';
 import { getActiveProgram } from '@/lib/active-program';
+import { getPreferredUnit } from '@/lib/preferences';
 import type {
   LiftRecordResponse,
   TrainingMaxHistoryEntryResponse,
+  WeightUnit,
 } from '@lifting-logbook/types';
 import HistoryTabs from './HistoryTabs';
 import styles from './history.module.css';
 
 export type EnrichedRecord = LiftRecordResponse & {
   tmAtTime: number | null;
-  tmUnit: string | null;
+  tmUnit: WeightUnit | null;
   tmPercent: number | null;
   isPR: boolean;
 };
@@ -32,9 +34,10 @@ export default async function HistoryPage() {
   // Wrap API calls so transient failures (expired session token, API unavailable)
   // render an empty history page rather than crashing the server component.
   // Pattern mirrors ProgramsPage — tabs always render; data may be empty.
-  const [records, { entries: tmEntries }] = await Promise.all([
+  const [records, { entries: tmEntries }, unit] = await Promise.all([
     fetchLiftRecords(program).catch((): LiftRecordResponse[] => []),
     fetchTrainingMaxHistory(program).catch(() => ({ entries: [] as TrainingMaxHistoryEntryResponse[] })),
+    getPreferredUnit(),
   ]);
 
   const sortedRecords = records.slice().sort((a, b) => b.date.localeCompare(a.date));
@@ -71,7 +74,7 @@ export default async function HistoryPage() {
   return (
     <main className={styles.pageContainer}>
       <h1 className={styles.pageHeading}>Lift History</h1>
-      <HistoryTabs records={enriched} tmEntries={tmEntries} />
+      <HistoryTabs records={enriched} tmEntries={tmEntries} unit={unit} />
     </main>
   );
 }

--- a/apps/web/app/(authed)/import/ImportWizard.tsx
+++ b/apps/web/app/(authed)/import/ImportWizard.tsx
@@ -11,8 +11,9 @@ import type {
   ImportKind,
   ImportPreviewResponse,
   ImportUndoResponse,
+  WeightUnit,
 } from '@lifting-logbook/types';
-import { CANONICAL_LIFT_IDS } from '@lifting-logbook/core';
+import { CANONICAL_LIFT_IDS, formatWeight } from '@lifting-logbook/core';
 import { commitImport, previewImport, undoImport } from '@/lib/client-api';
 import { Step, STEP_LABELS } from './steps';
 import styles from './import.module.css';
@@ -101,7 +102,20 @@ function filterDeltas(deltas: ImportDelta[], filter: ReviewFilter): ImportDelta[
   return deltas;
 }
 
-export function ImportWizard({ programs }: { programs: CustomProgramSummaryResponse[] }) {
+export function ImportWizard({
+  programs,
+  unit = 'lbs',
+}: {
+  programs: CustomProgramSummaryResponse[];
+  /**
+   * Display-only preference for a read-only conversion hint. Imported
+   * training-max values are directly-known (see
+   * docs/standards/training-max-precision.md) and always committed in lbs —
+   * this API has no real per-record unit storage — so the editable weight
+   * value itself is never converted.
+   */
+  unit?: WeightUnit;
+}) {
   const [step, setStep] = useState<typeof Step[keyof typeof Step]>(Step.SOURCE);
   const [programId, setProgramId] = useState<string>(programs[0]?.id ?? '');
   const [file, setFile] = useState<File | null>(null);
@@ -610,6 +624,11 @@ export function ImportWizard({ programs }: { programs: CustomProgramSummaryRespo
                                 }
                               />
                               <span className={styles.stepHint}>lbs</span>
+                              {unit !== 'lbs' && row.weight !== '' && !isNaN(Number(row.weight)) && (
+                                <span className={styles.stepHint}>
+                                  ≈ {formatWeight(Number(row.weight), 'lbs', unit)}
+                                </span>
+                              )}
                               <button
                                 type="button"
                                 className={styles.maxEditRemove}

--- a/apps/web/app/(authed)/import/page.tsx
+++ b/apps/web/app/(authed)/import/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import type { CustomProgramSummaryResponse } from '@lifting-logbook/types';
 import { fetchCustomPrograms } from '@/lib/api';
+import { getPreferredUnit } from '@/lib/preferences';
 import { ImportWizard } from './ImportWizard';
 
 export const metadata: Metadata = {
@@ -21,6 +22,7 @@ export default async function ImportPage() {
     console.error('ImportPage: custom programs fetch failed, rendering empty picker', e);
     programs = [];
   }
+  const unit = await getPreferredUnit();
 
-  return <ImportWizard programs={programs} />;
+  return <ImportWizard programs={programs} unit={unit} />;
 }

--- a/apps/web/app/(authed)/programs/page.tsx
+++ b/apps/web/app/(authed)/programs/page.tsx
@@ -7,6 +7,7 @@ const DEFAULT_SETTINGS: UserSettingsResponse = {
   activeProgram: null,
   workoutSchedule: null,
   defaultWeightIncrement: null,
+  unit: null,
 };
 
 export default async function ProgramsPage() {

--- a/apps/web/app/(authed)/settings/page.test.tsx
+++ b/apps/web/app/(authed)/settings/page.test.tsx
@@ -3,7 +3,7 @@ import SettingsIndexPage from './page';
 import { SETTINGS_SECTIONS } from './sections';
 
 describe('Settings hub (index)', () => {
-  it('links to all four settings sections with a description each', () => {
+  it('links to all settings sections with a description each', () => {
     render(<SettingsIndexPage />);
 
     // Scope to the "Sections" region so the section links can never collide with
@@ -16,7 +16,7 @@ describe('Settings hub (index)', () => {
       expect(sections.getByText(description)).toBeInTheDocument();
     }
 
-    // Exactly the four sections — no extra/missing cards.
+    // Exactly SETTINGS_SECTIONS.length cards — no extra/missing entries.
     expect(sections.getAllByRole('link')).toHaveLength(SETTINGS_SECTIONS.length);
   });
 

--- a/apps/web/app/(authed)/settings/schedule/page.tsx
+++ b/apps/web/app/(authed)/settings/schedule/page.tsx
@@ -6,6 +6,7 @@ const DEFAULT_SETTINGS: UserSettingsResponse = {
   activeProgram: null,
   workoutSchedule: null,
   defaultWeightIncrement: null,
+  unit: null,
 };
 
 export default async function SchedulePage() {

--- a/apps/web/app/(authed)/settings/sections.ts
+++ b/apps/web/app/(authed)/settings/sections.ts
@@ -39,4 +39,9 @@ export const SETTINGS_SECTIONS: readonly SettingsSection[] = [
     description:
       'Set the smallest weight increment used when rounding calculated loads to a loadable weight.',
   },
+  {
+    href: '/settings/units',
+    label: 'Units',
+    description: 'Choose lbs or kg for how weights are displayed across the app.',
+  },
 ];

--- a/apps/web/app/(authed)/settings/strength-goals/StrengthGoalsForm.test.tsx
+++ b/apps/web/app/(authed)/settings/strength-goals/StrengthGoalsForm.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import type { StrengthGoalResponse, TrainingMaxResponse } from '@lifting-logbook/types';
+import StrengthGoalsForm from './StrengthGoalsForm';
+
+jest.mock('./actions', () => ({
+  saveStrengthGoal: jest.fn(),
+  removeStrengthGoal: jest.fn(),
+  saveBodyWeight: jest.fn(),
+}));
+
+const SQUAT_TM: TrainingMaxResponse = {
+  lift: 'Back Squat',
+  weight: 100,
+  unit: 'lbs',
+  dateUpdated: '2026-06-01',
+};
+
+describe('StrengthGoalsForm — cross-unit progress', () => {
+  // 45.359237 kg is the exact conversion of 100 lbs, so a correctly unit-aware
+  // comparison lands at exactly 100%. Before the cross-unit fix, the training max
+  // (100, implicitly lbs) was compared directly against the body weight/target
+  // number without converting units first, which would have shown ~220% here
+  // instead — this test pins the correct behavior and would catch a regression.
+  it('converts the training max into the body-weight unit for a relative goal', () => {
+    const goals: StrengthGoalResponse[] = [
+      { lift: 'Back Squat', goalType: 'relative', ratio: 1, unit: 'kg', updatedAt: '2026-06-01' },
+    ];
+    render(
+      <StrengthGoalsForm
+        program="5-3-1"
+        trainingMaxes={[SQUAT_TM]}
+        goals={goals}
+        bodyWeight={{ date: '2026-06-01', weight: 45.359237, unit: 'kg' }}
+        preferredUnit="kg"
+      />,
+    );
+
+    expect(screen.getByText(/100% of goal/)).toBeInTheDocument();
+  });
+
+  it('converts the training max into the target unit for an absolute goal', () => {
+    const goals: StrengthGoalResponse[] = [
+      { lift: 'Back Squat', goalType: 'absolute', target: 45.359237, unit: 'kg', updatedAt: '2026-06-01' },
+    ];
+    render(
+      <StrengthGoalsForm
+        program="5-3-1"
+        trainingMaxes={[SQUAT_TM]}
+        goals={goals}
+        bodyWeight={{ date: '2026-06-01', weight: 70, unit: 'kg' }}
+        preferredUnit="kg"
+      />,
+    );
+
+    expect(screen.getByText(/100% of goal/)).toBeInTheDocument();
+  });
+
+  it('shows the current training max converted to the preferred unit', () => {
+    render(
+      <StrengthGoalsForm
+        program="5-3-1"
+        trainingMaxes={[SQUAT_TM]}
+        goals={[]}
+        bodyWeight={null}
+        preferredUnit="kg"
+      />,
+    );
+
+    // 100 lbs -> 45.36 kg.
+    expect(screen.getByText(/Current max: 45\.36 kg/)).toBeInTheDocument();
+  });
+
+  it('defaults a new goal row to the preferred unit', () => {
+    render(
+      <StrengthGoalsForm
+        program="5-3-1"
+        trainingMaxes={[SQUAT_TM]}
+        goals={[]}
+        bodyWeight={null}
+        preferredUnit="kg"
+      />,
+    );
+
+    // New rows default to the 'relative' goal type, whose unit select shares
+    // the same aria-label as the 'absolute' branch's.
+    expect(screen.getByLabelText('Unit for Back Squat')).toHaveValue('kg');
+  });
+});

--- a/apps/web/app/(authed)/settings/strength-goals/StrengthGoalsForm.tsx
+++ b/apps/web/app/(authed)/settings/strength-goals/StrengthGoalsForm.tsx
@@ -1,8 +1,13 @@
 'use client';
 
 import { useState } from 'react';
-import { evaluateStrengthTier } from '@lifting-logbook/core';
-import type { BodyWeightResponse, StrengthGoalResponse, TrainingMaxResponse } from '@lifting-logbook/types';
+import { convertWeight, evaluateStrengthTier, formatWeight } from '@lifting-logbook/core';
+import type {
+  BodyWeightResponse,
+  StrengthGoalResponse,
+  TrainingMaxResponse,
+  WeightUnit,
+} from '@lifting-logbook/types';
 import { saveStrengthGoal, removeStrengthGoal, saveBodyWeight } from './actions';
 
 interface Props {
@@ -10,6 +15,8 @@ interface Props {
   trainingMaxes: TrainingMaxResponse[];
   goals: StrengthGoalResponse[];
   bodyWeight: BodyWeightResponse | null;
+  /** Global display preference — also the default unit for new goal/body-weight entries. */
+  preferredUnit: WeightUnit;
 }
 
 interface GoalRowState {
@@ -21,29 +28,39 @@ interface GoalRowState {
   error: string | null;
 }
 
+// trainingMaxWeight is always stored in lbs (see docs/standards/training-max-precision.md);
+// bw and target are user-facing values in whatever unit is currently selected for each. Convert
+// the training max into that unit before comparing so progress is correct regardless of which
+// unit the user picked for body weight vs. this specific goal.
 function computeProgress(
   trainingMaxWeight: number,
+  trainingMaxUnit: WeightUnit,
   bw: number,
+  bwUnit: WeightUnit,
   goalType: 'absolute' | 'relative',
   target: string,
+  targetUnit: WeightUnit,
   ratio: string,
 ): number | null {
   if (goalType === 'relative') {
     const r = parseFloat(ratio);
     if (!isNaN(r) && r > 0 && bw > 0) {
-      return evaluateStrengthTier(trainingMaxWeight, bw, r).progressRatio;
+      const tmInBwUnit = convertWeight(trainingMaxWeight, trainingMaxUnit, bwUnit);
+      return evaluateStrengthTier(tmInBwUnit, bw, r).progressRatio;
     }
   } else {
     const t = parseFloat(target);
     if (!isNaN(t) && t > 0) {
-      return trainingMaxWeight / t;
+      const tmInTargetUnit = convertWeight(trainingMaxWeight, trainingMaxUnit, targetUnit);
+      return tmInTargetUnit / t;
     }
   }
   return null;
 }
 
-export default function StrengthGoalsForm({ program, trainingMaxes, goals, bodyWeight }: Props) {
+export default function StrengthGoalsForm({ program, trainingMaxes, goals, bodyWeight, preferredUnit }: Props) {
   const [currentBw, setCurrentBw] = useState<number | null>(bodyWeight?.weight ?? null);
+  const [currentBwUnit, setCurrentBwUnit] = useState<WeightUnit>(bodyWeight?.unit ?? preferredUnit);
   const [bwInput, setBwInput] = useState(String(bodyWeight?.weight ?? ''));
   const [editingBw, setEditingBw] = useState(false);
   const [savingBw, setSavingBw] = useState(false);
@@ -57,7 +74,7 @@ export default function StrengthGoalsForm({ program, trainingMaxes, goals, bodyW
         {
           goalType: (existing?.goalType ?? 'relative') as 'absolute' | 'relative',
           target: String(existing?.target ?? ''),
-          unit: (existing?.unit ?? 'lbs') as 'lbs' | 'kg',
+          unit: (existing?.unit ?? preferredUnit) as 'lbs' | 'kg',
           ratio: String(existing?.ratio ?? ''),
           saving: false,
           error: null,
@@ -84,8 +101,9 @@ export default function StrengthGoalsForm({ program, trainingMaxes, goals, bodyW
     setSavingBw(true);
     setBwError(null);
     try {
-      await saveBodyWeight(program, w, 'lbs');
+      await saveBodyWeight(program, w, preferredUnit);
       setCurrentBw(w);
+      setCurrentBwUnit(preferredUnit);
       setEditingBw(false);
     } catch {
       setBwError('Save failed');
@@ -154,7 +172,7 @@ export default function StrengthGoalsForm({ program, trainingMaxes, goals, bodyW
               aria-label="Body weight"
               autoFocus
             />
-            <span>lbs</span>
+            <span>{preferredUnit}</span>
             <button type="button" onClick={handleSaveBw} disabled={savingBw}>
               {savingBw ? '…' : '✓'}
             </button>
@@ -176,12 +194,19 @@ export default function StrengthGoalsForm({ program, trainingMaxes, goals, bodyW
               cursor: 'pointer',
               width: 'fit-content',
             }}
-            onClick={() => { setEditingBw(true); setBwInput(String(currentBw ?? '')); }}
+            onClick={() => {
+              setEditingBw(true);
+              setBwInput(
+                currentBw !== null
+                  ? String(Math.round(convertWeight(currentBw, currentBwUnit, preferredUnit) * 100) / 100)
+                  : '',
+              );
+            }}
             role="button"
             aria-label="Record new body weight"
           >
             <span style={{ fontWeight: 600 }}>
-              {currentBw !== null ? `${currentBw} lbs` : 'No weight recorded'}
+              {currentBw !== null ? formatWeight(currentBw, currentBwUnit, preferredUnit) : 'No weight recorded'}
             </span>
             <span style={{ fontSize: '0.8rem', color: '#7f8c8d' }}>✎ Record new weight</span>
           </div>
@@ -194,18 +219,19 @@ export default function StrengthGoalsForm({ program, trainingMaxes, goals, bodyW
         {trainingMaxes.map((m) => {
           const row = rows[m.lift];
           const hasGoal = savedGoals[m.lift];
+          const bwInRowUnit = currentBw !== null ? convertWeight(currentBw, currentBwUnit, row.unit) : null;
           const progress = currentBw
-            ? computeProgress(m.weight, currentBw, row.goalType, row.target, row.ratio)
+            ? computeProgress(m.weight, m.unit, currentBw, currentBwUnit, row.goalType, row.target, row.unit, row.ratio)
             : null;
 
           const computedTarget =
-            row.goalType === 'relative' && currentBw && parseFloat(row.ratio) > 0
-              ? Math.round(currentBw * parseFloat(row.ratio))
+            row.goalType === 'relative' && bwInRowUnit && parseFloat(row.ratio) > 0
+              ? Math.round(bwInRowUnit * parseFloat(row.ratio))
               : null;
 
           const bwPercent =
-            row.goalType === 'absolute' && currentBw && parseFloat(row.target) > 0
-              ? Math.round((parseFloat(row.target) / currentBw) * 100)
+            row.goalType === 'absolute' && bwInRowUnit && parseFloat(row.target) > 0
+              ? Math.round((parseFloat(row.target) / bwInRowUnit) * 100)
               : null;
 
           return (
@@ -221,7 +247,7 @@ export default function StrengthGoalsForm({ program, trainingMaxes, goals, bodyW
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: '0.5rem' }}>
                 <strong>{m.lift}</strong>
                 <span style={{ fontSize: '0.85rem', color: '#666' }}>
-                  Current max: {m.weight} {m.unit}
+                  Current max: {formatWeight(m.weight, m.unit, preferredUnit)}
                 </span>
               </div>
 
@@ -262,9 +288,9 @@ export default function StrengthGoalsForm({ program, trainingMaxes, goals, bodyW
                   {computedTarget !== null && (
                     <span
                       style={{ fontSize: '0.8rem', color: '#666' }}
-                      title={`${row.ratio}× BW = ${computedTarget} lbs at current weight`}
+                      title={`${row.ratio}× BW = ${computedTarget} ${row.unit} at current weight`}
                     >
-                      = {computedTarget} lbs
+                      = {computedTarget} {row.unit}
                     </span>
                   )}
                   <select

--- a/apps/web/app/(authed)/settings/strength-goals/StrengthGoalsForm.tsx
+++ b/apps/web/app/(authed)/settings/strength-goals/StrengthGoalsForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { convertWeight, evaluateStrengthTier, formatWeight } from '@lifting-logbook/core';
+import { convertWeight, evaluateStrengthTier, formatWeight, roundToDisplay } from '@lifting-logbook/core';
 import type {
   BodyWeightResponse,
   StrengthGoalResponse,
@@ -28,30 +28,45 @@ interface GoalRowState {
   error: string | null;
 }
 
-// trainingMaxWeight is always stored in lbs (see docs/standards/training-max-precision.md);
-// bw and target are user-facing values in whatever unit is currently selected for each. Convert
-// the training max into that unit before comparing so progress is correct regardless of which
-// unit the user picked for body weight vs. this specific goal.
-function computeProgress(
-  trainingMaxWeight: number,
-  trainingMaxUnit: WeightUnit,
-  bw: number,
-  bwUnit: WeightUnit,
-  goalType: 'absolute' | 'relative',
-  target: string,
-  targetUnit: WeightUnit,
-  ratio: string,
-): number | null {
+// The training max is always stored in lbs (see docs/standards/training-max-precision.md);
+// `bw` and `target` are user-facing values in whatever unit is currently selected for each.
+// Convert the training max into that unit before comparing so progress is correct regardless
+// of which unit the user picked for body weight vs. this specific goal.
+//
+// Passed as a single options object rather than positional args: `tmUnit`, `bwUnit`, and
+// `targetUnit` are all `WeightUnit`, so a positional signature would let two units be
+// transposed silently — reintroducing exactly the cross-unit class of bug this function fixes.
+interface ProgressArgs {
+  tmWeight: number;
+  tmUnit: WeightUnit;
+  bw: number;
+  bwUnit: WeightUnit;
+  goalType: 'absolute' | 'relative';
+  target: string;
+  targetUnit: WeightUnit;
+  ratio: string;
+}
+
+function computeProgress({
+  tmWeight,
+  tmUnit,
+  bw,
+  bwUnit,
+  goalType,
+  target,
+  targetUnit,
+  ratio,
+}: ProgressArgs): number | null {
   if (goalType === 'relative') {
     const r = parseFloat(ratio);
     if (!isNaN(r) && r > 0 && bw > 0) {
-      const tmInBwUnit = convertWeight(trainingMaxWeight, trainingMaxUnit, bwUnit);
+      const tmInBwUnit = convertWeight(tmWeight, tmUnit, bwUnit);
       return evaluateStrengthTier(tmInBwUnit, bw, r).progressRatio;
     }
   } else {
     const t = parseFloat(target);
     if (!isNaN(t) && t > 0) {
-      const tmInTargetUnit = convertWeight(trainingMaxWeight, trainingMaxUnit, targetUnit);
+      const tmInTargetUnit = convertWeight(tmWeight, tmUnit, targetUnit);
       return tmInTargetUnit / t;
     }
   }
@@ -198,7 +213,7 @@ export default function StrengthGoalsForm({ program, trainingMaxes, goals, bodyW
               setEditingBw(true);
               setBwInput(
                 currentBw !== null
-                  ? String(Math.round(convertWeight(currentBw, currentBwUnit, preferredUnit) * 100) / 100)
+                  ? String(roundToDisplay(convertWeight(currentBw, currentBwUnit, preferredUnit)))
                   : '',
               );
             }}
@@ -221,7 +236,16 @@ export default function StrengthGoalsForm({ program, trainingMaxes, goals, bodyW
           const hasGoal = savedGoals[m.lift];
           const bwInRowUnit = currentBw !== null ? convertWeight(currentBw, currentBwUnit, row.unit) : null;
           const progress = currentBw
-            ? computeProgress(m.weight, m.unit, currentBw, currentBwUnit, row.goalType, row.target, row.unit, row.ratio)
+            ? computeProgress({
+                tmWeight: m.weight,
+                tmUnit: m.unit,
+                bw: currentBw,
+                bwUnit: currentBwUnit,
+                goalType: row.goalType,
+                target: row.target,
+                targetUnit: row.unit,
+                ratio: row.ratio,
+              })
             : null;
 
           const computedTarget =

--- a/apps/web/app/(authed)/settings/strength-goals/page.tsx
+++ b/apps/web/app/(authed)/settings/strength-goals/page.tsx
@@ -1,13 +1,15 @@
 import { fetchLatestBodyWeight, fetchStrengthGoals, fetchTrainingMaxes } from '@/lib/api';
 import { getActiveProgram } from '@/lib/active-program';
+import { getPreferredUnit } from '@/lib/preferences';
 import StrengthGoalsForm from './StrengthGoalsForm';
 
 export default async function StrengthGoalsPage() {
   const program = await getActiveProgram();
-  const [maxes, goals, bodyWeight] = await Promise.all([
+  const [maxes, goals, bodyWeight, preferredUnit] = await Promise.all([
     fetchTrainingMaxes(program),
     fetchStrengthGoals(program),
     fetchLatestBodyWeight(program),
+    getPreferredUnit(),
   ]);
 
   return (
@@ -16,6 +18,7 @@ export default async function StrengthGoalsPage() {
       trainingMaxes={maxes}
       goals={goals}
       bodyWeight={bodyWeight}
+      preferredUnit={preferredUnit}
     />
   );
 }

--- a/apps/web/app/(authed)/settings/training-maxes/MaxHistory.tsx
+++ b/apps/web/app/(authed)/settings/training-maxes/MaxHistory.tsx
@@ -11,11 +11,11 @@ type Filter = 'pr' | 'test' | 'goalMet';
 export default function MaxHistory({
   initialEntries,
   program,
-  unit = 'lbs',
+  unit,
 }: {
   initialEntries: TrainingMaxHistoryEntryResponse[];
   program: string;
-  unit?: WeightUnit;
+  unit: WeightUnit;
 }) {
   const [entries, setEntries] = useState(initialEntries);
   const [view, setView] = useState<View>('list');

--- a/apps/web/app/(authed)/settings/training-maxes/MaxHistory.tsx
+++ b/apps/web/app/(authed)/settings/training-maxes/MaxHistory.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import type { TrainingMaxHistoryEntryResponse } from '@lifting-logbook/types';
+import { formatWeight } from '@lifting-logbook/core';
+import type { TrainingMaxHistoryEntryResponse, WeightUnit } from '@lifting-logbook/types';
 import { toggleHistoryPR, toggleHistoryGoalMet } from './actions';
 
 type View = 'timeline' | 'list';
@@ -10,9 +11,11 @@ type Filter = 'pr' | 'test' | 'goalMet';
 export default function MaxHistory({
   initialEntries,
   program,
+  unit = 'lbs',
 }: {
   initialEntries: TrainingMaxHistoryEntryResponse[];
   program: string;
+  unit?: WeightUnit;
 }) {
   const [entries, setEntries] = useState(initialEntries);
   const [view, setView] = useState<View>('list');
@@ -142,6 +145,7 @@ export default function MaxHistory({
           pending={pending}
           onTogglePR={handleTogglePR}
           onToggleGoalMet={handleToggleGoalMet}
+          unit={unit}
         />
       ) : (
         <TimelineView
@@ -149,6 +153,7 @@ export default function MaxHistory({
           pending={pending}
           onTogglePR={handleTogglePR}
           onToggleGoalMet={handleToggleGoalMet}
+          unit={unit}
         />
       )}
     </section>
@@ -159,6 +164,7 @@ type EntryHandlers = {
   pending: Set<string>;
   onTogglePR: (e: TrainingMaxHistoryEntryResponse) => void;
   onToggleGoalMet: (e: TrainingMaxHistoryEntryResponse) => void;
+  unit: WeightUnit;
 };
 
 function ListView({
@@ -224,13 +230,14 @@ function EntryRow({
   pending,
   onTogglePR,
   onToggleGoalMet,
+  unit,
 }: { entry: TrainingMaxHistoryEntryResponse } & EntryHandlers) {
   const busy = pending.has(entry.id);
   return (
     <tr>
       <td>{entry.date}</td>
       <td>{entry.lift}</td>
-      <td style={{ textAlign: 'right' }}>{entry.weight} {entry.unit}</td>
+      <td style={{ textAlign: 'right' }}>{formatWeight(entry.weight, entry.unit, unit)}</td>
       <td style={{ textAlign: 'center' }}>
         <span title={entry.source === 'test' ? 'Test week' : 'Program cycle'}>
           {entry.source === 'test' ? 'Test' : 'Program'}

--- a/apps/web/app/(authed)/settings/training-maxes/TrainingMaxesForm.module.css
+++ b/apps/web/app/(authed)/settings/training-maxes/TrainingMaxesForm.module.css
@@ -70,6 +70,13 @@
   margin-top: 2px;
 }
 
+.conversionHint {
+  display: block;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  margin-top: 2px;
+}
+
 .unit {
   color: var(--color-text-muted);
   white-space: nowrap;

--- a/apps/web/app/(authed)/settings/training-maxes/TrainingMaxesForm.tsx
+++ b/apps/web/app/(authed)/settings/training-maxes/TrainingMaxesForm.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import { useState } from 'react';
-import { DEFAULT_WEIGHT_INCREMENT, type TrainingMaxResponse } from '@lifting-logbook/types';
+import { formatWeight } from '@lifting-logbook/core';
+import {
+  DEFAULT_WEIGHT_INCREMENT,
+  type TrainingMaxResponse,
+  type WeightUnit,
+} from '@lifting-logbook/types';
 import { saveTrainingMaxes } from './actions';
 import styles from './TrainingMaxesForm.module.css';
 
@@ -35,12 +40,22 @@ export default function TrainingMaxesForm({
   lifts,
   maxes,
   increments,
+  unit = 'lbs',
 }: {
   program: string;
   lifts: string[];
   maxes: TrainingMaxResponse[];
   /** Per-lift spinner `step`, keyed by lift name (see resolveStepIncrements). */
   increments: Record<string, number>;
+  /**
+   * Display-only preference, used for a read-only conversion hint next to the
+   * input. The input itself and everything submitted on Save always stay in
+   * the record's native unit — training maxes are directly-known values (see
+   * docs/standards/training-max-precision.md), and this API has no real
+   * per-record unit storage today, so converting the editable value itself
+   * would risk silently corrupting a saved max.
+   */
+  unit?: WeightUnit;
 }) {
   const [rows, setRows] = useState<Record<string, RowState>>(() =>
     buildInitialState(lifts, maxes),
@@ -149,6 +164,11 @@ export default function TrainingMaxesForm({
                     />
                     {row.error && (
                       <span className={styles.errorText}>{row.error}</span>
+                    )}
+                    {unit !== row.unit && row.value !== '' && !isNaN(Number(row.value)) && (
+                      <span className={styles.conversionHint}>
+                        ≈ {formatWeight(Number(row.value), row.unit as WeightUnit, unit)}
+                      </span>
                     )}
                   </td>
                   <td className={styles.unit} data-label="Unit">{row.unit}</td>

--- a/apps/web/app/(authed)/settings/training-maxes/TrainingMaxesForm.tsx
+++ b/apps/web/app/(authed)/settings/training-maxes/TrainingMaxesForm.tsx
@@ -12,7 +12,7 @@ import styles from './TrainingMaxesForm.module.css';
 
 type RowState = {
   value: string;
-  unit: string;
+  unit: WeightUnit;
   dateUpdated: string | null;
   error: string | null;
 };
@@ -98,7 +98,7 @@ export default function TrainingMaxesForm({
       .map((lift) => ({
         lift: lift as TrainingMaxResponse['lift'],
         weight: Number(rows[lift].value),
-        unit: rows[lift].unit as TrainingMaxResponse['unit'],
+        unit: rows[lift].unit,
       }));
 
     if (changed.length === 0) {
@@ -167,7 +167,7 @@ export default function TrainingMaxesForm({
                     )}
                     {unit !== row.unit && row.value !== '' && !isNaN(Number(row.value)) && (
                       <span className={styles.conversionHint}>
-                        ≈ {formatWeight(Number(row.value), row.unit as WeightUnit, unit)}
+                        ≈ {formatWeight(Number(row.value), row.unit, unit)}
                       </span>
                     )}
                   </td>

--- a/apps/web/app/(authed)/settings/training-maxes/page.tsx
+++ b/apps/web/app/(authed)/settings/training-maxes/page.tsx
@@ -5,17 +5,19 @@ import {
 } from '@/lib/api';
 import { DEFAULT_WEIGHT_INCREMENT } from '@lifting-logbook/types';
 import { getActiveProgram, getUserSettings } from '@/lib/active-program';
+import { getPreferredUnit } from '@/lib/preferences';
 import TrainingMaxesForm from './TrainingMaxesForm';
 import { resolveStepIncrements } from './increments';
 import MaxHistory from './MaxHistory';
 
 export default async function TrainingMaxesPage() {
   const program = await getActiveProgram();
-  const [maxes, history, specs, settings] = await Promise.all([
+  const [maxes, history, specs, settings, unit] = await Promise.all([
     fetchTrainingMaxes(program),
     fetchTrainingMaxHistory(program),
     fetchProgramSpec(program),
     getUserSettings(),
+    getPreferredUnit(),
   ]);
   const lifts = maxes.map((m) => m.lift);
   const defaultIncrement =
@@ -29,8 +31,9 @@ export default async function TrainingMaxesPage() {
         lifts={lifts}
         maxes={maxes}
         increments={increments}
+        unit={unit}
       />
-      <MaxHistory initialEntries={history.entries} program={program} />
+      <MaxHistory initialEntries={history.entries} program={program} unit={unit} />
     </>
   );
 }

--- a/apps/web/app/(authed)/settings/units/UnitForm.test.tsx
+++ b/apps/web/app/(authed)/settings/units/UnitForm.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UnitForm from './UnitForm';
+import { saveUnit } from './actions';
+
+jest.mock('./actions', () => ({
+  saveUnit: jest.fn(),
+}));
+
+const mockSave = saveUnit as jest.MockedFunction<typeof saveUnit>;
+
+describe('UnitForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('defaults the select to lbs when no unit is set yet', () => {
+    render(<UnitForm initialUnit={null} />);
+    expect(screen.getByLabelText('Weight unit')).toHaveValue('lbs');
+  });
+
+  it('preselects the stored unit', () => {
+    render(<UnitForm initialUnit="kg" />);
+    expect(screen.getByLabelText('Weight unit')).toHaveValue('kg');
+  });
+
+  it('lists exactly the two allowed units', () => {
+    render(<UnitForm initialUnit={null} />);
+    const options = screen.getAllByRole('option').map((o) => (o as HTMLOptionElement).value);
+    expect(options).toEqual(['lbs', 'kg']);
+  });
+
+  it('saves the selected unit and shows a confirmation', async () => {
+    const user = userEvent.setup();
+    mockSave.mockResolvedValue({
+      activeProgram: null,
+      workoutSchedule: null,
+      defaultWeightIncrement: null,
+      unit: 'kg',
+    });
+
+    render(<UnitForm initialUnit="lbs" />);
+    await user.selectOptions(screen.getByLabelText('Weight unit'), 'kg');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(mockSave).toHaveBeenCalledWith('kg'));
+    expect(await screen.findByText(/^Saved at /)).toBeInTheDocument();
+  });
+
+  it('shows an error message when the save fails', async () => {
+    const user = userEvent.setup();
+    mockSave.mockRejectedValue(new Error('network down'));
+
+    render(<UnitForm initialUnit="lbs" />);
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('network down');
+  });
+});

--- a/apps/web/app/(authed)/settings/units/UnitForm.tsx
+++ b/apps/web/app/(authed)/settings/units/UnitForm.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState } from 'react';
+import { WEIGHT_UNIT_OPTIONS, DEFAULT_WEIGHT_UNIT } from '@lifting-logbook/types';
+import type { WeightUnit } from '@lifting-logbook/types';
+import { saveUnit } from './actions';
+
+export default function UnitForm({
+  initialUnit,
+}: {
+  initialUnit: WeightUnit | null;
+}) {
+  const [unit, setUnit] = useState<WeightUnit>(initialUnit ?? DEFAULT_WEIGHT_UNIT);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  async function handleSave() {
+    setError(null);
+    setSavedAt(null);
+    setSaving(true);
+    try {
+      const result = await saveUnit(unit);
+      setUnit(result.unit ?? DEFAULT_WEIGHT_UNIT);
+      setSavedAt(new Date().toLocaleTimeString());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save weight unit.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section>
+      <h2>Units</h2>
+      <p>
+        Sets the unit weights are displayed in across the app — dashboard, plan, history,
+        and training maxes. This only changes how weights are shown; everything is still
+        stored and compared at full precision.
+      </p>
+
+      <label htmlFor="weight-unit-select">Weight unit</label>
+      <select
+        id="weight-unit-select"
+        value={unit}
+        onChange={(e) => {
+          setUnit(e.target.value as WeightUnit);
+          setSavedAt(null);
+        }}
+      >
+        {WEIGHT_UNIT_OPTIONS.map((opt) => (
+          <option key={opt} value={opt}>
+            {opt}
+          </option>
+        ))}
+      </select>
+
+      <div>
+        <button type="button" onClick={handleSave} disabled={saving}>
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+        {error && <p role="alert">{error}</p>}
+        {savedAt && <p>Saved at {savedAt}.</p>}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/(authed)/settings/units/actions.ts
+++ b/apps/web/app/(authed)/settings/units/actions.ts
@@ -1,0 +1,13 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { updateUserSettings } from '@/lib/api';
+import type { UserSettingsResponse, WeightUnit } from '@lifting-logbook/types';
+
+// Server-side boundary: lib/api.ts is 'server-only', so a client component cannot import
+// it directly. Mirrors settings/weight-rounding/actions.ts's saveWeightIncrement.
+export async function saveUnit(unit: WeightUnit): Promise<UserSettingsResponse> {
+  const result = await updateUserSettings({ unit });
+  revalidatePath('/settings/units');
+  return result;
+}

--- a/apps/web/app/(authed)/settings/units/page.test.tsx
+++ b/apps/web/app/(authed)/settings/units/page.test.tsx
@@ -1,0 +1,54 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { ReactElement } from 'react';
+
+jest.mock('@/lib/api', () => ({
+  fetchUserSettings: jest.fn(),
+}));
+
+// Stub the client form so the test isolates the page's data-fetch fallback.
+// It echoes the resolved unit so we can assert what the page passed down.
+// initialUnit is a plain string | null (unlike weight-rounding's numeric prop), so
+// render it directly rather than via JSON.stringify — stringifying a string wraps
+// it in quote characters that React then HTML-escapes in the attribute output.
+jest.mock('./UnitForm', () => ({
+  __esModule: true,
+  default: ({ initialUnit }: { initialUnit: string | null }) => (
+    <div data-unit={initialUnit ?? 'null'}>unit-form</div>
+  ),
+}));
+
+import { fetchUserSettings } from '@/lib/api';
+import UnitsPage from './page';
+
+const mockedFetch = fetchUserSettings as unknown as jest.Mock;
+
+describe('UnitsPage — fetch fallback', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders the form with the fetched unit on success', async () => {
+    mockedFetch.mockResolvedValue({
+      activeProgram: null,
+      workoutSchedule: null,
+      defaultWeightIncrement: null,
+      unit: 'kg',
+    });
+
+    const element = (await UnitsPage()) as ReactElement;
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain('unit-form');
+    // Data-level assertion: the real fetched unit reached the form.
+    expect(html).toContain('data-unit="kg"');
+  });
+
+  it('falls back to a null unit (no throw) when the API is unreachable', async () => {
+    mockedFetch.mockRejectedValue(new Error('API down'));
+
+    const element = (await UnitsPage()) as ReactElement;
+    const html = renderToStaticMarkup(element);
+
+    expect(html).toContain('unit-form');
+    // The fallback passes unit: null — distinct from any fetched value.
+    expect(html).toContain('data-unit="null"');
+  });
+});

--- a/apps/web/app/(authed)/settings/units/page.tsx
+++ b/apps/web/app/(authed)/settings/units/page.tsx
@@ -1,6 +1,6 @@
 import { fetchUserSettings } from '@/lib/api';
 import type { UserSettingsResponse } from '@lifting-logbook/types';
-import WeightIncrementForm from './WeightIncrementForm';
+import UnitForm from './UnitForm';
 
 const DEFAULT_SETTINGS: UserSettingsResponse = {
   activeProgram: null,
@@ -9,11 +9,11 @@ const DEFAULT_SETTINGS: UserSettingsResponse = {
   unit: null,
 };
 
-export default async function WeightRoundingPage() {
+export default async function UnitsPage() {
   // Fall back to empty settings when the API is unreachable — matches
-  // settings/schedule/page.tsx, and keeps the build-time prerender from crashing
+  // settings/weight-rounding/page.tsx, and keeps the build-time prerender from crashing
   // when no API is running.
-  // fallback-covered-by: apps/web/app/(authed)/settings/weight-rounding/page.test.tsx
+  // fallback-covered-by: apps/web/app/(authed)/settings/units/page.test.tsx
   const settings = await fetchUserSettings().catch(() => DEFAULT_SETTINGS);
-  return <WeightIncrementForm initialIncrement={settings.defaultWeightIncrement} />;
+  return <UnitForm initialUnit={settings.unit} />;
 }

--- a/apps/web/app/(authed)/settings/weight-rounding/WeightIncrementForm.test.tsx
+++ b/apps/web/app/(authed)/settings/weight-rounding/WeightIncrementForm.test.tsx
@@ -36,6 +36,7 @@ describe('WeightIncrementForm', () => {
       activeProgram: null,
       workoutSchedule: null,
       defaultWeightIncrement: 5,
+      unit: null,
     });
 
     render(<WeightIncrementForm initialIncrement={1.25} />);

--- a/apps/web/app/(authed)/settings/weight-rounding/page.test.tsx
+++ b/apps/web/app/(authed)/settings/weight-rounding/page.test.tsx
@@ -27,6 +27,7 @@ describe('WeightRoundingPage — fetch fallback', () => {
       activeProgram: null,
       workoutSchedule: null,
       defaultWeightIncrement: 0.625,
+      unit: null,
     });
 
     const element = (await WeightRoundingPage()) as ReactElement;

--- a/apps/web/e2e/mock-api.mjs
+++ b/apps/web/e2e/mock-api.mjs
@@ -102,6 +102,7 @@ function createInitialState() {
     skippedWorkouts: new Set(),
     workoutSchedule: null,
     defaultWeightIncrement: null,
+    unit: null,
     // Empty by default so the /programs page test still sees RPT as the only
     // program; the import test opts in via /__reset?withCustomProgram=true.
     customPrograms: [],
@@ -216,6 +217,25 @@ const server = createServer(async (req, res) => {
       activeProgram: '5-3-1',
       workoutSchedule: state.workoutSchedule,
       defaultWeightIncrement: state.defaultWeightIncrement,
+      unit: state.unit,
+    });
+    return;
+  }
+
+  // -------------------------------------------------------------------------
+  // PATCH /users/me/settings
+  // -------------------------------------------------------------------------
+  if (method === 'PATCH' && url.pathname === '/users/me/settings') {
+    const body = await readBody(req);
+    if (rejectIfInvalidBody(res, body)) return;
+    if ('workoutSchedule' in body) state.workoutSchedule = body.workoutSchedule;
+    if ('defaultWeightIncrement' in body) state.defaultWeightIncrement = body.defaultWeightIncrement;
+    if ('unit' in body) state.unit = body.unit;
+    json(res, {
+      activeProgram: '5-3-1',
+      workoutSchedule: state.workoutSchedule,
+      defaultWeightIncrement: state.defaultWeightIncrement,
+      unit: state.unit,
     });
     return;
   }

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -9,10 +9,10 @@ test.beforeEach(async ({ request }) => {
 });
 
 // ---------------------------------------------------------------------------
-// Settings hub: the four section tabs are present and cross-navigate.
+// Settings hub: the section tabs are present and cross-navigate.
 // ---------------------------------------------------------------------------
 
-test('settings hub exposes the four sections and the sub-nav cross-navigates', async ({ page }) => {
+test('settings hub exposes the sections and the sub-nav cross-navigates', async ({ page }) => {
   await page.goto('/settings');
 
   const subNav = page.getByRole('navigation', { name: 'Settings sections' });
@@ -32,6 +32,10 @@ test('settings hub exposes the four sections and the sub-nav cross-navigates', a
     'href',
     '/settings/weight-rounding',
   );
+  await expect(subNav.getByRole('link', { name: 'Units' })).toHaveAttribute(
+    'href',
+    '/settings/units',
+  );
 
   // The sub-nav actually moves between sections and marks the target active.
   await subNav.getByRole('link', { name: 'Weight Rounding' }).click();
@@ -39,6 +43,21 @@ test('settings hub exposes the four sections and the sub-nav cross-navigates', a
   await expect(
     page.getByRole('navigation', { name: 'Settings sections' }).getByRole('link', { name: 'Weight Rounding' }),
   ).toHaveAttribute('aria-current', 'page');
+});
+
+// ---------------------------------------------------------------------------
+// Settings hub: the Units section round-trips the lbs/kg preference.
+// ---------------------------------------------------------------------------
+
+test('units section saves the selected weight unit', async ({ page }) => {
+  await page.goto('/settings/units');
+
+  await expect(page.getByRole('heading', { name: 'Units' })).toBeVisible();
+  await page.getByLabel('Weight unit').selectOption('kg');
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  await expect(page.getByText(/^Saved at /)).toBeVisible();
+  await expect(page.getByLabel('Weight unit')).toHaveValue('kg');
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/e2e/staging.spec.ts
+++ b/apps/web/e2e/staging.spec.ts
@@ -33,7 +33,7 @@ test('home page redirects signed-in users to /cycle (or /onboarding)', async ({ 
 // Structure-only assertion is intentional: the program catalog is rendered
 // from static data in apps/web/lib/programs.ts, so the page renders even
 // when the `.catch(() => DEFAULT_SETTINGS)` and `.catch(() => [])` fallbacks
-// in apps/web/app/(authed)/programs/page.tsx:14-15 are exercised. The staging test
+// in apps/web/app/(authed)/programs/page.tsx:15-16 are exercised. The staging test
 // user has no custom programs, so no real-data assertion would distinguish
 // the success and fallback paths here. API-success detection is delegated
 // to test 5 (auth/API propagation against /api/health).
@@ -50,7 +50,7 @@ test('programs page catalog loads', async ({ page }) => {
 //
 // Structure-only assertion is intentional: the staging test user has no
 // records, so neither real data nor the fallback `[]` from
-// apps/web/app/(authed)/history/page.tsx:36-37 produces visible content. The API
+// apps/web/app/(authed)/history/page.tsx:38-39 produces visible content. The API
 // success path for history fetches is covered indirectly by test 5
 // (auth/API propagation against /api/health).
 // ---------------------------------------------------------------------------

--- a/apps/web/lib/preferences.ts
+++ b/apps/web/lib/preferences.ts
@@ -2,15 +2,20 @@ import 'server-only';
 
 import { DEFAULT_WEIGHT_UNIT } from '@lifting-logbook/types';
 import type { WeightUnit } from '@lifting-logbook/types';
-import { fetchUserSettings } from './api';
+import { getUserSettings } from './active-program';
 
 /**
  * The user's preferred weight-display unit, falling back to 'lbs' when unset
  * or when the API is unreachable — never throws. Display preference only;
  * every weight stays stored/compared in its original unit at full precision
  * (see docs/standards/training-max-precision.md).
+ *
+ * Reads through the React-`cache()`-wrapped `getUserSettings` (not a raw
+ * `fetchUserSettings`) so a page that also calls `getActiveProgram()` — nearly
+ * all of them do — shares a single `/users/me/settings` round-trip per render
+ * instead of issuing a duplicate GET.
  */
 export async function getPreferredUnit(): Promise<WeightUnit> {
-  const settings = await fetchUserSettings().catch(() => null);
+  const settings = await getUserSettings().catch(() => null);
   return settings?.unit ?? DEFAULT_WEIGHT_UNIT;
 }

--- a/apps/web/lib/preferences.ts
+++ b/apps/web/lib/preferences.ts
@@ -1,0 +1,16 @@
+import 'server-only';
+
+import { DEFAULT_WEIGHT_UNIT } from '@lifting-logbook/types';
+import type { WeightUnit } from '@lifting-logbook/types';
+import { fetchUserSettings } from './api';
+
+/**
+ * The user's preferred weight-display unit, falling back to 'lbs' when unset
+ * or when the API is unreachable — never throws. Display preference only;
+ * every weight stays stored/compared in its original unit at full precision
+ * (see docs/standards/training-max-precision.md).
+ */
+export async function getPreferredUnit(): Promise<WeightUnit> {
+  const settings = await fetchUserSettings().catch(() => null);
+  return settings?.unit ?? DEFAULT_WEIGHT_UNIT;
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './import';
 export * from './mapper';
 export * from './parser';
 export * from './jsUtil';
+export * from './weightUnit';

--- a/packages/core/src/utils/weightUnit.ts
+++ b/packages/core/src/utils/weightUnit.ts
@@ -15,17 +15,28 @@ export function convertWeight(
 }
 
 /**
- * Converts a weight for display, rounded to 2 decimal places. Display-only —
- * the result must never be persisted or fed back into a comparison; the
- * stored value stays in its original unit at full precision (see
- * docs/standards/training-max-precision.md).
+ * Rounds a *converted* weight to 2 decimal places for display. Only apply this
+ * to a value produced by an lbs<->kg conversion — a conversion introduces
+ * irrational-looking trailing digits that must be trimmed for display. Never
+ * apply it to a directly-known value being shown in its own unit; those must
+ * display at full precision (see docs/standards/training-max-precision.md).
+ */
+export function roundToDisplay(weight: number): number {
+  return Math.round(weight * 100) / 100;
+}
+
+/**
+ * Formats a weight for display in the target unit. When `from === to` the value
+ * is a directly-known weight shown in its own unit and is rendered at full
+ * precision (no rounding) per docs/standards/training-max-precision.md category
+ * 1 — e.g. a 316.875 lbs training max (0.625 increment) stays "316.875 lbs".
+ * Only a genuine cross-unit conversion is rounded to 2 dp for display.
  */
 export function formatWeight(
   weight: number,
   from: WeightUnit,
   to: WeightUnit,
 ): string {
-  const converted = convertWeight(weight, from, to);
-  const rounded = Math.round(converted * 100) / 100;
-  return `${rounded} ${to}`;
+  if (from === to) return `${weight} ${to}`;
+  return `${roundToDisplay(convertWeight(weight, from, to))} ${to}`;
 }

--- a/packages/core/src/utils/weightUnit.ts
+++ b/packages/core/src/utils/weightUnit.ts
@@ -1,0 +1,31 @@
+import { WeightUnit } from "@lifting-logbook/types";
+
+// Exact international pound (1 lb = 0.45359237 kg, defined). Used instead of
+// an approximate reciprocal so lbs->kg->lbs round-trips don't drift.
+const KG_PER_LB = 0.45359237;
+
+/** Converts a weight between lbs and kg at full precision (no rounding). */
+export function convertWeight(
+  weight: number,
+  from: WeightUnit,
+  to: WeightUnit,
+): number {
+  if (from === to) return weight;
+  return from === "lbs" ? weight * KG_PER_LB : weight / KG_PER_LB;
+}
+
+/**
+ * Converts a weight for display, rounded to 2 decimal places. Display-only —
+ * the result must never be persisted or fed back into a comparison; the
+ * stored value stays in its original unit at full precision (see
+ * docs/standards/training-max-precision.md).
+ */
+export function formatWeight(
+  weight: number,
+  from: WeightUnit,
+  to: WeightUnit,
+): string {
+  const converted = convertWeight(weight, from, to);
+  const rounded = Math.round(converted * 100) / 100;
+  return `${rounded} ${to}`;
+}

--- a/packages/core/tests/core/utils/weightUnit.test.ts
+++ b/packages/core/tests/core/utils/weightUnit.test.ts
@@ -1,4 +1,4 @@
-import { convertWeight, formatWeight } from "@src/core";
+import { convertWeight, formatWeight, roundToDisplay } from "@src/core";
 
 describe("weightUnit", () => {
   describe("convertWeight", () => {
@@ -33,8 +33,25 @@ describe("weightUnit", () => {
       expect(formatWeight(100, "kg", "lbs")).toBe("220.46 lbs");
     });
 
-    it("does not convert or round when from and to units match", () => {
-      expect(formatWeight(316.25, "lbs", "lbs")).toBe("316.25 lbs");
+    it("does not convert or round a directly-known value shown in its own unit", () => {
+      // A >2-decimal training max (0.625 plate increment) must render at full
+      // precision when displayed in its stored unit — see
+      // docs/standards/training-max-precision.md category 1. Uses a 3-decimal
+      // fixture so a reintroduced same-unit round() would fail this assertion.
+      expect(formatWeight(316.875, "lbs", "lbs")).toBe("316.875 lbs");
+      expect(formatWeight(142.881, "kg", "kg")).toBe("142.881 kg");
+    });
+  });
+
+  describe("roundToDisplay", () => {
+    it("rounds to 2 decimal places", () => {
+      expect(roundToDisplay(142.881596)).toBe(142.88);
+      expect(roundToDisplay(220.462262)).toBe(220.46);
+    });
+
+    it("leaves a value with <=2 decimals unchanged", () => {
+      expect(roundToDisplay(316.25)).toBe(316.25);
+      expect(roundToDisplay(100)).toBe(100);
     });
   });
 });

--- a/packages/core/tests/core/utils/weightUnit.test.ts
+++ b/packages/core/tests/core/utils/weightUnit.test.ts
@@ -1,0 +1,40 @@
+import { convertWeight, formatWeight } from "@src/core";
+
+describe("weightUnit", () => {
+  describe("convertWeight", () => {
+    it("returns the input unchanged when from and to units match", () => {
+      expect(convertWeight(316.25, "lbs", "lbs")).toBe(316.25);
+      expect(convertWeight(143.5, "kg", "kg")).toBe(143.5);
+    });
+
+    it("converts lbs to kg at full precision", () => {
+      expect(convertWeight(1, "lbs", "kg")).toBeCloseTo(0.45359237, 8);
+      expect(convertWeight(315, "lbs", "kg")).toBeCloseTo(142.8815966, 6);
+    });
+
+    it("converts kg to lbs at full precision", () => {
+      expect(convertWeight(100, "kg", "lbs")).toBeCloseTo(220.462262185, 6);
+    });
+
+    it("round-trips lbs -> kg -> lbs without drift beyond floating-point noise", () => {
+      const original = 316.25;
+      const roundTripped = convertWeight(
+        convertWeight(original, "lbs", "kg"),
+        "kg",
+        "lbs",
+      );
+      expect(roundTripped).toBeCloseTo(original, 9);
+    });
+  });
+
+  describe("formatWeight", () => {
+    it("formats a converted weight rounded to 2 decimal places with the target unit suffix", () => {
+      expect(formatWeight(315, "lbs", "kg")).toBe("142.88 kg");
+      expect(formatWeight(100, "kg", "lbs")).toBe("220.46 lbs");
+    });
+
+    it("does not convert or round when from and to units match", () => {
+      expect(formatWeight(316.25, "lbs", "lbs")).toBe("316.25 lbs");
+    });
+  });
+});

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -369,17 +369,25 @@ export interface UserSettingsResponse {
   workoutSchedule: UserWorkoutSchedule | null;
   /** Null when unset — callers fall back to 1.25 (see docs/standards/training-max-precision.md). */
   defaultWeightIncrement: number | null;
+  /** Null when unset — callers fall back to 'lbs' (see DEFAULT_WEIGHT_UNIT). Display preference only; stored weights are unaffected. */
+  unit: WeightUnit | null;
 }
 
 export interface UpdateUserSettingsRequest {
   workoutSchedule?: UserWorkoutSchedule | null;
   defaultWeightIncrement?: number | null;
+  unit?: WeightUnit | null;
 }
 
 /** The only values `defaultWeightIncrement` may take, matching plate sizes users actually have. */
 export const WEIGHT_INCREMENT_OPTIONS = [0.625, 1.25, 2.5, 5] as const;
 
 export const DEFAULT_WEIGHT_INCREMENT = 1.25;
+
+/** The only values the global `unit` preference may take. */
+export const WEIGHT_UNIT_OPTIONS = ['lbs', 'kg'] as const;
+
+export const DEFAULT_WEIGHT_UNIT: WeightUnit = 'lbs';
 
 // ---------------------------------------------------------------------------
 // Custom Programs


### PR DESCRIPTION
## Summary

PR 5 of 6 in the [#677](https://github.com/brownm09/lifting-logbook/issues/677) consistency pass — adds a global lbs/kg weight-unit display preference.

- **Persistence:** `UserSettings.unit` (nullable `String`, mirrors the `defaultWeightIncrement` pattern — migration `20260707140000_add_user_settings_unit`), `UpdateSettingsDto` validation (`@IsIn(['lbs','kg'])`), `UserSettingsResponse.unit` / `UpdateUserSettingsRequest.unit` in `packages/types`.
- **Settings UI:** new `/settings/units` page (mirrors the `weight-rounding` page/form/action triple exactly), added to the hub's `SETTINGS_SECTIONS`.
- **Conversion utility:** `packages/core`'s new `convertWeight`/`formatWeight` (none existed anywhere in the repo before this PR) — full-precision conversion, 2-decimal display rounding only.
- **Threaded through:** dashboard (`CycleDashboardGrid`), workout plan (`CollapsibleLiftList`), lift/TM history (`HistoryTabs`, `LiftHistoryFilters`, `MaxHistory`), training-max display + import/strength-goals unit defaults.

## Design decisions

**Storage stays canonical lbs everywhere it already was.** The preference is a pure display-time conversion layer — it never rounds or rewrites a stored value, per [`docs/standards/training-max-precision.md`](docs/standards/training-max-precision.md). Training-max weights in particular have **no real per-record unit column** in Postgres today — the API hardcodes `unit: 'lbs'` at the response-mapping boundary (`apps/api/src/programs/mappers.ts`). So the "reconcile the global preference with per-record storage (`tmUnit`)" ask from the issue resolves to: treat each record's own `unit` field as the conversion source, convert to the preference for display, done.

**Two genuinely write-path entry points are deliberately left unconverted:** `TrainingMaxesForm`'s weight input and `ImportWizard`'s editable training-max review rows. Both are directly-known-value entry points into a backend that has no real per-record unit storage for training maxes (whatever `weight` arrives is stored as-is, implicitly lbs) — converting the editable value would either silently corrupt a saved max (if an unsubmitted converted value got included in a save) or require a larger backend change to genuinely persist per-record units, which is out of this issue's scope. Both get a read-only "≈ X kg" hint next to the input instead, so the preference is still visible without touching what's actually stored.

**`StrengthGoalsForm` is different** — `StrengthGoalResponse.unit` and `BodyWeightResponse.unit` are genuinely persisted (not coerced), so the per-row unit `<select>` (already existed, already fully user-overridable) now *defaults* to the global preference instead of a hardcoded `'lbs'`, and body-weight entry now saves using the preference as the value's real unit. Making kg a reachable default here exposed a latent bug: `computeProgress` was comparing a training max (always lbs) directly against a body-weight/target value that could now genuinely be in kg, with no conversion — e.g. a 100 lbs TM against a 45.36 kg bodyweight target would have shown ~220% instead of the correct 100%. Fixed as part of this PR (`computeProgress` now converts the training max into whichever unit it's being compared against) since the bug was latent until this PR made kg reachable through normal use; see `StrengthGoalsForm.test.tsx` for a regression test that pins the correct value.

**Deferred:** `WorkoutLogger.tsx` (the live in-workout logging screen). Not named in the issue's problem statement or acceptance criteria (which name dashboard/plan/history/training-maxes/import/strength-goals), and it mixes display conversion with entry semantics in a way that deserved its own focused pass rather than being rushed into an already-large PR. Filing a follow-up issue/tile at merge.

## Acceptance criteria

- [x] Settings exposes a lbs/kg toggle that round-trips through the API
- [x] Weights render/convert consistently across dashboard, plan, history, training maxes
- [x] Settings round-trip test; display test asserting kg rendering + conversion

## Testing

`npm test`: **1003 passed, 0 skipped, 0 failed** across all workspaces (core 309, api-client 27, web 214, api 453 — including a real-Postgres DB E2E case for the new `unit` field).
`npm run typecheck`: clean.
`npm run lint`: clean (including the custom `no-uncovered-error-fallback` rule — two `staging.spec.ts` `file:line` references needed updating since my edits shifted the line numbers of pre-existing, unrelated `.catch()` fallbacks they pointed at).
`npx turbo run build --filter=@lifting-logbook/api`: clean (Prisma migration applies correctly).
`npm run test:e2e -w @lifting-logbook/web`: **22 passed** (Playwright) — new coverage for the Units settings section, hub nav now asserts the 5th "Units" tab.

New tests: `packages/core/tests/core/utils/weightUnit.test.ts` (conversion math), `apps/web/.../settings/units/{page,UnitForm}.test.tsx` (settings round-trip), `apps/web/.../history/HistoryTabs.test.tsx` (display conversion — kg rendering asserted against exact expected values), `apps/web/.../strength-goals/StrengthGoalsForm.test.tsx` (cross-unit progress-calculation regression test), plus a new DB E2E case in `programs.db.e2e.spec.ts`.

No suppressions added (grep clean after replacing a `row.unit as WeightUnit` cast with a real runtime `parseUnit()` guard, mirroring the existing `parseSchedule()` pattern for the JSONB `workoutSchedule` column). No test-integrity violations, no deleted tests.

## Risk-dimension audit

1. **Testing** — see above.
2. **Observability** — no new endpoint; existing `PATCH /users/me/settings` gets one more field, covered by existing nestjs-pino auto-logging + OTel HTTP-level spans. No new instrumentation needed.
3. **Security** — N/A; non-sensitive user preference. DTO whitelist validation (`@IsIn(['lbs','kg'])`) rejects any other value.
4. **Resilience/rollback** — nullable column, no DB-level default (mirrors `defaultWeightIncrement`); fully reversible by dropping the migration. Existing rows get `unit = NULL` → falls back to `'lbs'` in code, so no existing user's display silently changes.
5. **Performance** — negligible; pure in-memory arithmetic.
6. **Data integrity & migrations** — single nullable column add; RLS policy is row-scoped so unaffected.
7. **Accessibility** — new `<select id="weight-unit-select">` has an associated `<label>`; e2e asserts it's reachable via `getByLabel`.

Closes #682


---

## Review findings disposition

`/review` (2 parallel Opus subagents) ran on this PR — all findings fixed in-PR, none filed or deferred:

- **[correctness]** `formatWeight` rounded the same-unit passthrough (dropped precision on directly-known values, contra `training-max-precision.md`) — **fixed in `60c4440`**.
- **[performance]** `getPreferredUnit()` bypassed the cached `getUserSettings`, causing a duplicate `/users/me/settings` GET per render — **fixed in `60c4440`**.
- **[maintainability]** `computeProgress` 8 positional args (unit-transposition hazard) → options object — **fixed in `60c4440`**.
- **[maintainability]** `RowState.unit` `string`→`WeightUnit` (2 casts dropped); `MaxHistory.unit` made required — **fixed in `60c4440`**.

Full review: https://github.com/brownm09/lifting-logbook/pull/733#issuecomment-4906203657
