### PR TITLE
[fix] Consistency polish: Edit-Program affordance, History error state, TM terminology

### DIFF
--- a/apps/web/app/(authed)/cycle/[cycleNum]/program/page.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/program/page.tsx
@@ -36,9 +36,19 @@ export default async function CycleProgramPage({
 
       <div className={styles.header}>
         <h1 className={styles.heading}>{program}</h1>
-        <button type="button" className={styles.editButton} disabled title="Coming soon">
-          Edit Program
-        </button>
+        <div className={styles.editGroup}>
+          <button
+            type="button"
+            className={styles.editButton}
+            aria-disabled="true"
+            aria-describedby="edit-program-status"
+          >
+            Edit Program
+          </button>
+          <span id="edit-program-status" className={styles.editHint}>
+            Coming soon
+          </span>
+        </div>
       </div>
 
       <dl className={styles.dataList}>

--- a/apps/web/app/(authed)/cycle/[cycleNum]/program/program.module.css
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/program/program.module.css
@@ -21,6 +21,13 @@
   margin: 0;
 }
 
+.editGroup {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-1);
+}
+
 .editButton {
   padding: var(--space-2) var(--space-4);
   border: 1px solid var(--color-border-strong);
@@ -28,6 +35,18 @@
   background: var(--color-surface);
   cursor: not-allowed;
   font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+/* Focusable because it is aria-disabled (not `disabled`), so the "Coming soon"
+   reason is reachable by keyboard/AT users — give it a visible focus ring. */
+.editButton:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.editHint {
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 

--- a/apps/web/app/(authed)/history/history.module.css
+++ b/apps/web/app/(authed)/history/history.module.css
@@ -20,6 +20,23 @@
   margin-bottom: 1.5rem;
 }
 
+.pageIntro {
+  margin: -0.75rem 0 1.5rem;
+  color: var(--color-text-muted, #6b7280);
+  font-size: 0.875rem;
+}
+
+/* Non-blocking notice shown when a history fetch fails (page still renders). */
+.loadError {
+  margin-bottom: 1.5rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--color-warn-border, #ffeaa7);
+  border-radius: var(--radius-md, 6px);
+  background: var(--color-warn-bg, #fff3cd);
+  color: var(--color-warn-text, #856404);
+  font-size: 0.875rem;
+}
+
 .tabs {
   display: flex;
   gap: 0.5rem;

--- a/apps/web/app/(authed)/history/page.tsx
+++ b/apps/web/app/(authed)/history/page.tsx
@@ -31,12 +31,21 @@ function findTmAtTime(
 export default async function HistoryPage() {
   const program = await getActiveProgram();
 
-  // Wrap API calls so transient failures (expired session token, API unavailable)
-  // render an empty history page rather than crashing the server component.
-  // Pattern mirrors ProgramsPage — tabs always render; data may be empty.
+  // Wrap the API calls so a transient failure (expired session token, API
+  // unavailable) surfaces a non-blocking notice rather than crashing the server
+  // component or silently rendering an empty page that reads as "no history yet".
+  // The `.catch()` fallbacks keep the tabs rendering (graceful degradation);
+  // `loadFailed` distinguishes a real fetch failure from a genuinely empty history.
+  let loadFailed = false;
   const [records, { entries: tmEntries }, unit] = await Promise.all([
-    fetchLiftRecords(program).catch((): LiftRecordResponse[] => []),
-    fetchTrainingMaxHistory(program).catch(() => ({ entries: [] as TrainingMaxHistoryEntryResponse[] })),
+    fetchLiftRecords(program).catch((): LiftRecordResponse[] => {
+      loadFailed = true;
+      return [];
+    }),
+    fetchTrainingMaxHistory(program).catch(() => {
+      loadFailed = true;
+      return { entries: [] as TrainingMaxHistoryEntryResponse[] };
+    }),
     getPreferredUnit(),
   ]);
 
@@ -74,6 +83,15 @@ export default async function HistoryPage() {
   return (
     <main className={styles.pageContainer}>
       <h1 className={styles.pageHeading}>Lift History</h1>
+      <p className={styles.pageIntro}>
+        Your logged lifts and Training Max (TM) progression over time.
+      </p>
+      {loadFailed && (
+        <p role="status" className={styles.loadError}>
+          We couldn’t load your latest history just now. This is usually
+          temporary — refresh the page in a moment to try again.
+        </p>
+      )}
       <HistoryTabs records={enriched} tmEntries={tmEntries} unit={unit} />
     </main>
   );

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -79,6 +79,22 @@ test('cycle dashboard renders workout grid', async ({ page }) => {
 });
 
 // ---------------------------------------------------------------------------
+// 4b. Cycle program page: "Edit Program" reads as disabled-with-reason
+// ---------------------------------------------------------------------------
+
+test('cycle program page marks Edit Program as coming soon', async ({ page }) => {
+  await page.goto('/cycle/1/program');
+
+  // The action is not built yet: the button is aria-disabled (still focusable, so
+  // the reason is reachable by AT) with a visible "Coming soon" affordance beside
+  // it — not a bare `disabled` button whose title tooltip a keyboard user cannot reach.
+  const editButton = page.getByRole('button', { name: 'Edit Program' });
+  await expect(editButton).toBeVisible();
+  await expect(editButton).toHaveAttribute('aria-disabled', 'true');
+  await expect(page.getByText('Coming soon')).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
 // 5. Workout logger renders sets/reps and accepts a log submission
 // ---------------------------------------------------------------------------
 

--- a/apps/web/e2e/staging.spec.ts
+++ b/apps/web/e2e/staging.spec.ts
@@ -49,10 +49,14 @@ test('programs page catalog loads', async ({ page }) => {
 // 3. History page tabs render
 //
 // Structure-only assertion is intentional: the staging test user has no
-// records, so neither real data nor the fallback `[]` from
-// apps/web/app/(authed)/history/page.tsx:38-39 produces visible content. The API
-// success path for history fetches is covered indirectly by test 5
-// (auth/API propagation against /api/health).
+// records, so the success path renders empty tabs with no visible rows. The
+// two fetches in apps/web/app/(authed)/history/page.tsx:41-48 catch a failure
+// into a `[]` fallback that also flips a `loadFailed` flag driving a
+// non-blocking "couldn't load" banner — but that banner appears only when a
+// fetch REJECTS, which the live staging API (asserted up by test 5,
+// /api/health) does not do here. So no real-data assertion distinguishes the
+// success and fallback paths on this page; API-success detection stays
+// delegated to test 5.
 // ---------------------------------------------------------------------------
 
 test('history page renders both tabs', async ({ page }) => {


### PR DESCRIPTION
Part of #677 (the 6-PR app-shell / consistency pass) — this is **PR 6 of 6, the polish tail**. Closes #683. With this merged, all six sub-PRs (#690, #700, #727, #731, #733, this) are done and #677 can close.

## Summary

Clears the three remaining lower-severity rough edges from the #677 audit (symptom 6) that didn't belong in the functional PRs:

1. **"Edit Program" affordance** (`cycle/[cycleNum]/program/page.tsx`) — the button was a bare `disabled` `<button>` with a `title="Coming soon"` tooltip that a keyboard/AT user can never reach (disabled controls aren't focusable). It's now a focusable `aria-disabled="true"` button with a **visible** "Coming soon" hint linked via `aria-describedby`, plus a focus ring. It still does nothing when activated (no handler), but the reason is now discoverable by everyone.

2. **History silent-failure** (`history/page.tsx`) — the two API fetches previously caught errors into empty arrays and rendered a page indistinguishable from "you have no history yet". They now flip a `loadFailed` flag and the page renders a **non-blocking `role="status"` banner** ("We couldn't load your latest history…") on failure. Graceful degradation is preserved — the tabs still render (per ADR-023), so this is strictly additive to the existing fallback behavior.

3. **Terminology** — the History page used the abbreviation "TM" (table headers, `TM Timeline` tab, empty states) without ever expanding it. It now **defines "Training Max (TM)" on first use** via a page intro caption, making the surface self-consistent. `1RM` usages elsewhere are genuine one-rep-max references and are left as-is (they are correct, not drift). Test-keyed labels (`Lift History` / `TM Timeline`) were deliberately **not** renamed — both `smoke.spec.ts` and `staging.spec.ts` assert on them (the #444 trap).

### Also in this PR
- **Error-fallback coverage reference kept in sync**: the two `.catch()` calls moved, so the `no-uncovered-error-fallback` ESLint reference in `staging.spec.ts` was updated from `history/page.tsx:38-39` → `:41-48` and its prose refreshed to describe the new banner (which only appears on a *rejection*, something the live staging API — asserted up by test 5 — doesn't do, so the structure-only justification still holds). See `docs/standards/error-fallback-test-coverage.md`.
- **No trivial #677 items left to fold**: `PHASE_MAP_12` dead code was already removed by PR 3 (#727); units-hardcoded-`lbs` was handled by PR 5 (#733); back-links / nav-aria were handled by PR 1 (#690).

## Acceptance criteria (#683)
- [x] "Edit Program" reads as disabled-with-reason (visible + `aria-disabled`)
- [x] History shows an explicit state on API failure (with the coverage the standard requires)
- [x] Terminology is consistent across the touched surfaces

## Testing
All gates run locally from the worktree (turbo via the main-repo binary per the Windows worktree note):

- **Lint** (`turbo run lint`): 7/7 successful — includes `no-uncovered-error-fallback` over `apps/web`, confirming the updated coverage reference is valid.
- **Typecheck** (`turbo run typecheck`, blocking CI gate): 4/4 successful.
- **Unit/component** (`turbo run test`): 12/12 tasks successful — `Tests: 1005 passed, 0 skipped, 0 failed` (api 453, web 214, core 311, api-client 27). Docker was up, so the API DB E2E ran for real.
- **Playwright e2e** (`npm run test:e2e -w @lifting-logbook/web`, required — apps/web strings/aria changed, incident #444): **23 passed**, including the new `cycle program page marks Edit Program as coming soon` assertion.

**E2E environment note:** the first e2e run failed with `ECONNREFUSED ::1:3004` on every test — a Windows-local issue (orphaned IPv4-only dev servers from a prior run + `localhost`→`::1` resolution), unrelated to this diff. Clearing the ports and re-running with `NODE_OPTIONS=--dns-result-order=ipv4first` gave a clean 23/23. Filing a follow-up to document this in the project CLAUDE.md e2e section.

### Coverage
- **Edit-Program affordance**: covered by the new smoke e2e test (`aria-disabled="true"` + visible "Coming soon").
- **History banner**: covered per `error-fallback-test-coverage.md` option 3 — a documented structure-only assertion in `staging.spec.ts` naming the fallback's source (`history/page.tsx:41-48`); the async server component has no unit harness and the banner only appears on fetch rejection.

### Suppression / test-integrity
- Suppression grep: **clean** (no `ts-ignore` / `eslint-disable` / `!` assertions / `?? null`).
- Test-integrity grep: **clean** (no skips, no deleted tests, no lowered thresholds). This PR *adds* a test.
- No `package.json` changed → lockfile-sync check N/A.

## Review findings disposition
Review complete — **0 blocking, 0 non-blocking findings** ([review comment](https://github.com/brownm09/lifting-logbook/pull/736#issuecomment-4912048322)). Nothing to dispose.

