### PR TITLE
[feat] Thread weight-unit (lbs/kg) preference into the live WorkoutLogger

### DIFF
--- a/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.module.css
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.module.css
@@ -270,6 +270,14 @@
   margin: 0;
 }
 
+/* Read-only preferred-unit equivalent shown under the (lbs) weight input. */
+.conversionHint {
+  width: 100%;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  margin: 0;
+}
+
 .logBtn,
 .editBtn,
 .cancelBtn {

--- a/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.test.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.test.tsx
@@ -173,4 +173,27 @@ describe('WorkoutLogger — weight-unit display preference', () => {
       { date: '2026-07-08', weight: 80, unit: 'kg' },
     );
   });
+
+  it('rounds the bodyweight-component added-weight default (no float-precision artifact)', () => {
+    render(
+      <WorkoutLogger
+        {...makeProps({
+          // Body weight already recorded in lbs (page.tsx normalizes from the stored unit,
+          // so this value is a kg-derived conversion carrying float noise); gate is skipped.
+          initialBodyWeight: 176.3699237,
+          hasBodyweightComponent: true,
+          lifts: [
+            makeLift({
+              lift: 'Chin-up',
+              isBodyweightComponent: true,
+              workingSets: [{ setNum: 1, totalLoad: 200, reps: 5, amrap: false }],
+            }),
+          ],
+        })}
+      />,
+    );
+
+    // 200 - 176.3699237 = 23.6300763… -> rounded to 23.63, never a raw float like 23.630076300000013.
+    expect(screen.getByLabelText('Weight in lbs')).toHaveValue(23.63);
+  });
 });

--- a/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.test.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.test.tsx
@@ -1,0 +1,176 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { LiftRecordResponse } from '@lifting-logbook/types';
+import WorkoutLogger from './WorkoutLogger';
+import type { LiftData, WorkoutLoggerProps } from './types';
+import { createLiftRecord, recordBodyWeight } from '@/lib/client-api';
+
+// jest.mock is hoisted above the imports, so `createLiftRecord`/`recordBodyWeight`
+// resolve to the jest.fn() mocks below.
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock('@/lib/client-api', () => ({
+  createLiftRecord: jest.fn(),
+  updateLiftRecord: jest.fn(),
+  recordBodyWeight: jest.fn(),
+  rescheduleWorkout: jest.fn(),
+}));
+
+const mockCreateLiftRecord = createLiftRecord as jest.MockedFunction<typeof createLiftRecord>;
+const mockRecordBodyWeight = recordBodyWeight as jest.MockedFunction<typeof recordBodyWeight>;
+
+function makeLift(overrides: Partial<LiftData> = {}): LiftData {
+  return {
+    lift: 'Back Squat',
+    isBodyweightComponent: false,
+    warmUpSets: [],
+    workingSets: [{ setNum: 1, totalLoad: 100, reps: 5, amrap: false }],
+    ...overrides,
+  };
+}
+
+function makeProps(overrides: Partial<WorkoutLoggerProps> = {}): WorkoutLoggerProps {
+  return {
+    program: '5-3-1',
+    cycleNum: 1,
+    workoutNum: 1,
+    date: '2026-07-08',
+    lifts: [makeLift()],
+    hasBodyweightComponent: false,
+    isReadOnly: false,
+    initialBodyWeight: null,
+    unit: 'lbs',
+    ...overrides,
+  };
+}
+
+const LOGGED: LiftRecordResponse = {
+  id: 'rec-1',
+  program: '5-3-1',
+  cycleNum: 1,
+  workoutNum: 1,
+  date: '2026-07-08',
+  lift: 'Back Squat',
+  setNum: 1,
+  weight: 225,
+  reps: 5,
+  notes: '',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('WorkoutLogger — weight-unit display preference', () => {
+  it('renders planned warm-up and working-set weights converted to the preferred unit', () => {
+    render(
+      <WorkoutLogger
+        {...makeProps({
+          unit: 'kg',
+          isReadOnly: true,
+          lifts: [
+            makeLift({
+              warmUpSets: [{ reps: 5, totalLoad: 95 }],
+              workingSets: [{ setNum: 1, totalLoad: 100, reps: 5, amrap: false }],
+            }),
+          ],
+        })}
+      />,
+    );
+
+    // 95 lbs -> 43.09 kg (warm-up), 100 lbs -> 45.36 kg (working set).
+    expect(screen.getByText(/43\.09 kg/)).toBeInTheDocument();
+    expect(screen.getByText(/45\.36 kg/)).toBeInTheDocument();
+  });
+
+  it('renders a logged set summary in the preferred unit', () => {
+    render(
+      <WorkoutLogger
+        {...makeProps({
+          unit: 'kg',
+          lifts: [
+            makeLift({
+              workingSets: [
+                { setNum: 1, totalLoad: 100, reps: 5, amrap: false, existing: LOGGED },
+              ],
+            }),
+          ],
+        })}
+      />,
+    );
+
+    // LOGGED.weight is 225 lbs -> 102.06 kg.
+    expect(screen.getByText(/102\.06 kg/)).toBeInTheDocument();
+  });
+
+  it('leaves lbs display byte-identical and shows no conversion hint for lbs users', () => {
+    const { container } = render(
+      <WorkoutLogger
+        {...makeProps({
+          unit: 'lbs',
+          lifts: [makeLift({ warmUpSets: [{ reps: 5, totalLoad: 95 }] })],
+        })}
+      />,
+    );
+
+    expect(screen.getByText(/95 lbs/)).toBeInTheDocument();
+    // No approximate-conversion hint is rendered when the display unit is lbs.
+    expect(container.textContent).not.toContain('≈');
+  });
+
+  it('logs the weight in lbs, unchanged by the kg display preference', async () => {
+    const user = userEvent.setup();
+    mockCreateLiftRecord.mockResolvedValue(LOGGED);
+    render(<WorkoutLogger {...makeProps({ unit: 'kg' })} />);
+
+    const weightInput = screen.getByLabelText('Weight in lbs');
+    await user.clear(weightInput);
+    await user.type(weightInput, '225');
+
+    // A read-only kg hint is shown, but the editable value itself stays in lbs.
+    expect(screen.getByText(/≈ 102\.06 kg/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Log' }));
+
+    await waitFor(() => expect(mockCreateLiftRecord).toHaveBeenCalledTimes(1));
+    // The submitted weight is the lbs number the user typed — never the kg display value.
+    expect(mockCreateLiftRecord).toHaveBeenCalledWith(
+      '5-3-1',
+      expect.objectContaining({ weight: 225, reps: 5, setNum: 1, lift: 'Back Squat' }),
+    );
+  });
+
+  it('saves body weight in the preferred unit', async () => {
+    const user = userEvent.setup();
+    mockRecordBodyWeight.mockResolvedValue(undefined);
+    render(
+      <WorkoutLogger
+        {...makeProps({
+          unit: 'kg',
+          hasBodyweightComponent: true,
+          initialBodyWeight: null,
+          lifts: [
+            makeLift({
+              lift: 'Chin-up',
+              isBodyweightComponent: true,
+              workingSets: [{ setNum: 1, totalLoad: 100, reps: 5, amrap: false }],
+            }),
+          ],
+        })}
+      />,
+    );
+
+    const bwInput = screen.getByLabelText('Body weight (kg)');
+    await user.type(bwInput, '80');
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => expect(mockRecordBodyWeight).toHaveBeenCalledTimes(1));
+    // Persisted in the entered (preferred) unit — body-weight records store a per-record unit.
+    expect(mockRecordBodyWeight).toHaveBeenCalledWith(
+      '5-3-1',
+      { date: '2026-07-08', weight: 80, unit: 'kg' },
+    );
+  });
+});

--- a/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import type { LiftRecordResponse, WeightUnit } from '@lifting-logbook/types';
-import { convertWeight, formatWeight } from '@lifting-logbook/core';
+import { convertWeight, formatWeight, roundToDisplay } from '@lifting-logbook/core';
 import {
   createLiftRecord,
   recordBodyWeight,
@@ -46,9 +46,12 @@ function formatWorkingWeight(
   if (!isBodyweightComponent || bodyWeight === null) {
     return { display: formatWeight(totalLoad, 'lbs', unit), value: totalLoad };
   }
-  const added = Math.max(0, totalLoad - bodyWeight);
-  // `value` stays in lbs — it pre-fills the (lbs) weight input and must never be
-  // the converted display number, or logging would corrupt the stored weight.
+  // Round the added lbs load: a kg-entered body weight is a full-precision
+  // conversion, so `totalLoad - bodyWeight` carries float noise that would
+  // otherwise surface raw in the pre-filled (lbs) weight input. `value` stays in
+  // lbs — never the converted display number, or logging would corrupt the stored
+  // weight.
+  const added = roundToDisplay(Math.max(0, totalLoad - bodyWeight));
   return { display: `+${formatWeight(added, 'lbs', unit)}`, value: added };
 }
 

--- a/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
@@ -2,7 +2,8 @@
 
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import type { LiftRecordResponse } from '@lifting-logbook/types';
+import type { LiftRecordResponse, WeightUnit } from '@lifting-logbook/types';
+import { convertWeight, formatWeight } from '@lifting-logbook/core';
 import {
   createLiftRecord,
   recordBodyWeight,
@@ -16,30 +17,39 @@ import type { LiftData, WorkingSetData, WorkoutLoggerProps } from './types';
 // Helpers
 // ---------------------------------------------------------------------------
 
+// Plan loads and logged lift records are always stored in lbs; `unit` is the
+// user's display preference. These format helpers convert for display only — the
+// numeric value logged to the API is never converted (see
+// docs/standards/training-max-precision.md).
+
 function formatWarmUpWeight(
   totalLoad: number,
   bodyWeight: number | null,
   isBodyweightComponent: boolean,
+  unit: WeightUnit,
 ): string {
   if (!isBodyweightComponent || bodyWeight === null) {
-    return `${totalLoad} lbs`;
+    return formatWeight(totalLoad, 'lbs', unit);
   }
   if (totalLoad <= bodyWeight) {
     return 'BW';
   }
-  return `+${totalLoad - bodyWeight} lbs`;
+  return `+${formatWeight(totalLoad - bodyWeight, 'lbs', unit)}`;
 }
 
 function formatWorkingWeight(
   totalLoad: number,
   bodyWeight: number | null,
   isBodyweightComponent: boolean,
+  unit: WeightUnit,
 ): { display: string; value: number } {
   if (!isBodyweightComponent || bodyWeight === null) {
-    return { display: `${totalLoad} lbs`, value: totalLoad };
+    return { display: formatWeight(totalLoad, 'lbs', unit), value: totalLoad };
   }
   const added = Math.max(0, totalLoad - bodyWeight);
-  return { display: `+${added} lbs`, value: added };
+  // `value` stays in lbs — it pre-fills the (lbs) weight input and must never be
+  // the converted display number, or logging would corrupt the stored weight.
+  return { display: `+${formatWeight(added, 'lbs', unit)}`, value: added };
 }
 
 // ---------------------------------------------------------------------------
@@ -48,12 +58,19 @@ function formatWorkingWeight(
 
 function BodyWeightGate({
   onSubmit,
+  unit,
 }: {
   onSubmit: (weight: number) => Promise<void>;
+  unit: WeightUnit;
 }) {
   const [input, setInput] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Realistic body-weight bounds are defined in lbs; convert them so the input's
+  // min/max stay sensible when the preferred unit is kg.
+  const minWeight = Math.round(convertWeight(50, 'lbs', unit));
+  const maxWeight = Math.round(convertWeight(500, 'lbs', unit));
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -81,14 +98,14 @@ function BodyWeightGate({
       </p>
       <form className={styles.gateForm} onSubmit={handleSubmit}>
         <label className={styles.gateLabel} htmlFor="bw-input">
-          Body weight (lbs)
+          Body weight ({unit})
         </label>
         <input
           id="bw-input"
           className={styles.gateInput}
           type="number"
-          min="50"
-          max="500"
+          min={minWeight}
+          max={maxWeight}
           step="0.5"
           value={input}
           onChange={(e) => setInput(e.target.value)}
@@ -113,14 +130,16 @@ function WarmUpRow({
   reps,
   bodyWeight,
   isBodyweightComponent,
+  unit,
 }: {
   label: string;
   totalLoad: number;
   reps: number;
   bodyWeight: number | null;
   isBodyweightComponent: boolean;
+  unit: WeightUnit;
 }) {
-  const weightStr = formatWarmUpWeight(totalLoad, bodyWeight, isBodyweightComponent);
+  const weightStr = formatWarmUpWeight(totalLoad, bodyWeight, isBodyweightComponent, unit);
   return (
     <li className={styles.warmUpRow}>
       <span className={styles.warmUpLabel}>{label}</span>
@@ -143,6 +162,7 @@ function WorkingSetRow({
   cycleNum,
   workoutNum,
   date,
+  unit,
   onLogged,
   onEditStart,
   onEditSave,
@@ -158,6 +178,7 @@ function WorkingSetRow({
   cycleNum: number;
   workoutNum: number;
   date: string;
+  unit: WeightUnit;
   onLogged: (record: LiftRecordResponse) => void;
   onEditStart: () => void;
   onEditSave: (record: LiftRecordResponse) => void;
@@ -166,11 +187,14 @@ function WorkingSetRow({
     set.totalLoad,
     bodyWeight,
     isBodyweightComponent,
+    unit,
   );
   // Pre-fill from the logged record when entering edit mode; fall back to plan defaults for new logs.
+  // The pre-filled value is always the native lbs number — the input and everything submitted stay
+  // in lbs (lift records have no per-record unit); `unit` only drives the read-only ≈ hint below.
   const [weightInput, setWeightInput] = useState(
     loggedRecord
-      ? String(formatWorkingWeight(loggedRecord.weight, null, false).value)
+      ? String(formatWorkingWeight(loggedRecord.weight, null, false, unit).value)
       : String(defaultWeight),
   );
   const [repsInput, setRepsInput] = useState(String(loggedRecord?.reps ?? set.reps));
@@ -235,15 +259,15 @@ function WorkingSetRow({
 
   if (isReadOnly || isLogged) {
     const displayWeight = loggedRecord
-      ? formatWorkingWeight(loggedRecord.weight, null, false).display
-      : formatWorkingWeight(set.totalLoad, bodyWeight, isBodyweightComponent).display;
+      ? formatWorkingWeight(loggedRecord.weight, null, false, unit).display
+      : formatWorkingWeight(set.totalLoad, bodyWeight, isBodyweightComponent, unit).display;
     return (
       <li className={`${styles.setRow} ${styles.setRowLogged}`}>
         <span className={styles.setNum}>Set {set.setNum}</span>
         <span className={styles.setCheck}>✓</span>
         <span className={styles.setSummary}>
           {loggedRecord
-            ? `${loggedRecord.weight} lbs × ${loggedRecord.reps}`
+            ? `${formatWeight(loggedRecord.weight, 'lbs', unit)} × ${loggedRecord.reps}`
             : `${displayWeight} × ${set.reps}`}
           {set.amrap ? ' (AMRAP)' : ''}
         </span>
@@ -332,6 +356,12 @@ function WorkingSetRow({
             Cancel
           </button>
         )}
+        {/* Entry stays in lbs; show the preferred-unit equivalent as a read-only hint. */}
+        {unit !== 'lbs' && weightInput !== '' && !isNaN(Number(weightInput)) && (
+          <span className={styles.conversionHint}>
+            ≈ {formatWeight(Number(weightInput), 'lbs', unit)}
+          </span>
+        )}
       </form>
     </li>
   );
@@ -347,6 +377,7 @@ function LiftView({
   cycleNum,
   workoutNum,
   date,
+  unit,
   onLogged,
   onEditStart,
   onEditSave,
@@ -360,6 +391,7 @@ function LiftView({
   cycleNum: number;
   workoutNum: number;
   date: string;
+  unit: WeightUnit;
   onLogged: (key: string, record: LiftRecordResponse) => void;
   onEditStart: (key: string) => void;
   onEditSave: (key: string, record: LiftRecordResponse) => void;
@@ -384,6 +416,7 @@ function LiftView({
                 reps={s.reps}
                 bodyWeight={bodyWeight}
                 isBodyweightComponent={lift.isBodyweightComponent}
+                unit={unit}
               />
             ))}
           </ul>
@@ -408,6 +441,7 @@ function LiftView({
                 cycleNum={cycleNum}
                 workoutNum={workoutNum}
                 date={date}
+                unit={unit}
                 onLogged={(record) => onLogged(key, record)}
                 onEditStart={() => onEditStart(key)}
                 onEditSave={(record) => onEditSave(key, record)}
@@ -424,11 +458,13 @@ function OverviewRow({
   lift,
   bodyWeight,
   loggedSets,
+  unit,
   onGoTo,
 }: {
   lift: LiftData;
   bodyWeight: number | null;
   loggedSets: Map<string, LiftRecordResponse>;
+  unit: WeightUnit;
   onGoTo: () => void;
 }) {
   const logged = lift.workingSets.filter((ws) =>
@@ -454,6 +490,7 @@ function OverviewRow({
             firstWarmUp.totalLoad,
             bodyWeight,
             lift.isBodyweightComponent,
+            unit,
           )}{' '}
           × {firstWarmUp.reps}
           {lift.warmUpSets.length > 1 ? ` (+${lift.warmUpSets.length - 1} more)` : ''}
@@ -476,6 +513,7 @@ export default function WorkoutLogger({
   hasBodyweightComponent,
   isReadOnly,
   initialBodyWeight,
+  unit,
 }: WorkoutLoggerProps) {
   const router = useRouter();
 
@@ -500,19 +538,22 @@ export default function WorkoutLogger({
   const [editingSet, setEditingSet] = useState<string | null>(null);
   const [currentLiftIdx, setCurrentLiftIdx] = useState(0);
   const [viewMode, setViewMode] = useState<'per-lift' | 'overview'>('per-lift');
-  // initialBodyWeight is non-null when the server found a same-day body weight entry.
+  // initialBodyWeight is non-null (and in lbs) when the server found a same-day body weight entry.
   const [bodyWeight, setBodyWeight] = useState<number | null>(initialBodyWeight);
   const [bodyWeightDone, setBodyWeightDone] = useState(
     !hasBodyweightComponent || isReadOnly || initialBodyWeight !== null,
   );
 
   async function handleBodyWeightSubmit(weight: number) {
+    // The gate collects body weight in the preferred unit, and body-weight records
+    // persist a per-record unit, so save it as entered. Keep the in-memory bodyWeight
+    // in lbs, though — every added-load calculation subtracts it from an lbs plan load.
     await recordBodyWeight(program, {
       date: effectiveDate,
       weight,
-      unit: 'lbs',
+      unit,
     });
-    setBodyWeight(weight);
+    setBodyWeight(convertWeight(weight, unit, 'lbs'));
     setBodyWeightDone(true);
   }
 
@@ -536,7 +577,7 @@ export default function WorkoutLogger({
 
   // Body weight gate
   if (!bodyWeightDone) {
-    return <BodyWeightGate onSubmit={handleBodyWeightSubmit} />;
+    return <BodyWeightGate onSubmit={handleBodyWeightSubmit} unit={unit} />;
   }
 
   const currentLift = lifts[currentLiftIdx];
@@ -564,6 +605,7 @@ export default function WorkoutLogger({
               lift={lift}
               bodyWeight={bodyWeight}
               loggedSets={loggedSets}
+              unit={unit}
               onGoTo={() => {
                 setCurrentLiftIdx(i);
                 setViewMode('per-lift');
@@ -653,6 +695,7 @@ export default function WorkoutLogger({
           cycleNum={cycleNum}
           workoutNum={workoutNum}
           date={effectiveDate}
+          unit={unit}
           onLogged={handleLogged}
           onEditStart={handleEditStart}
           onEditSave={handleEditSave}
@@ -671,6 +714,7 @@ export default function WorkoutLogger({
                   nextLift.warmUpSets[0].totalLoad,
                   bodyWeight,
                   nextLift.isBodyweightComponent,
+                  unit,
                 )}{' '}
                 × {nextLift.warmUpSets[0].reps}
               </span>

--- a/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/page.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/page.tsx
@@ -5,6 +5,7 @@ import {
   PROG_SPEC_WARMUP_PCTS,
   WARMUP_BASE_REPS,
   DEFAULT_SLOT_MAP,
+  convertWeight,
 } from '@lifting-logbook/core';
 import {
   fetchLatestBodyWeight,
@@ -14,6 +15,7 @@ import {
   fetchWorkout,
 } from '@/lib/api';
 import { getActiveProgram } from '@/lib/active-program';
+import { getPreferredUnit } from '@/lib/preferences';
 import WorkoutLogger from './WorkoutLogger';
 import type { LiftData, WarmUpSetData, WorkingSetData, WorkoutLoggerProps } from './types';
 
@@ -48,12 +50,13 @@ export default async function WorkoutLoggingPage({
 
   const program = await getActiveProgram();
 
-  const [workout, specs, maxes, allRecords, latestBodyWeight] = await Promise.all([
+  const [workout, specs, maxes, allRecords, latestBodyWeight, unit] = await Promise.all([
     fetchWorkout(program, workoutNum),
     fetchProgramSpec(program),
     fetchTrainingMaxes(program),
     fetchLiftRecords(program),
     fetchLatestBodyWeight(program),
+    getPreferredUnit(),
   ]);
 
   if (!workout) {
@@ -114,9 +117,11 @@ export default async function WorkoutLoggingPage({
 
   // Re-use a same-day body weight so the gate doesn't re-fire mid-session.
   // If the stored entry is from a different day, pass null → gate fires again.
+  // Body weight may be stored in kg, but WorkoutLogger's added-load math runs in
+  // lbs, so normalize to lbs here (the per-record unit is preserved server-side).
   const initialBodyWeight =
     latestBodyWeight && latestBodyWeight.date === workout.date
-      ? latestBodyWeight.weight
+      ? convertWeight(latestBodyWeight.weight, latestBodyWeight.unit, 'lbs')
       : null;
 
   const props: WorkoutLoggerProps = {
@@ -128,6 +133,7 @@ export default async function WorkoutLoggingPage({
     hasBodyweightComponent,
     isReadOnly,
     initialBodyWeight,
+    unit,
   };
 
   return <WorkoutLogger {...props} />;

--- a/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/types.ts
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/types.ts
@@ -1,4 +1,4 @@
-import type { LiftRecordResponse } from '@lifting-logbook/types';
+import type { LiftRecordResponse, WeightUnit } from '@lifting-logbook/types';
 
 export interface WarmUpSetData {
   /** Number of reps for this warm-up set. */
@@ -43,9 +43,19 @@ export interface WorkoutLoggerProps {
   hasBodyweightComponent: boolean;
   isReadOnly: boolean;
   /**
-   * Body weight (lbs) already recorded for this workout's date, if any.
+   * Body weight in lbs already recorded for this workout's date, if any.
+   * page.tsx normalizes from the stored per-record unit so this is always lbs —
+   * every added-load calculation subtracts it from an lbs plan load.
    * When set, the bodyweight gate is skipped and this value is used directly.
    * When null, the gate fires on first render (unless isReadOnly or !hasBodyweightComponent).
    */
   initialBodyWeight: number | null;
+  /**
+   * Global weight-unit display preference. Planned and logged weights are
+   * rendered in this unit; the working-set weight input and everything submitted
+   * stay in lbs (lift records have no per-record unit), while body weight is
+   * entered and persisted in this unit. Display preference only — see
+   * docs/standards/training-max-precision.md.
+   */
+  unit: WeightUnit;
 }


### PR DESCRIPTION
## Summary

Threads the global lbs/kg weight-unit display preference (added in #733) into the live in-workout
logging screen, `WorkoutLogger.tsx` — the follow-up #733 deliberately deferred because this screen
mixes **display** of planned/logged weights with **entry** semantics.

Two treatments, mirroring the patterns #733 established:

- **Display** (warm-up + working-set planned weights, logged-set summaries): converted with
  `formatWeight(value, 'lbs', unit)`. lbs output is byte-identical to before
  (`formatWeight(x, 'lbs', 'lbs')` → `"x lbs"`), so nothing changes for lbs users.
- **Working-set weight entry** (TrainingMaxesForm pattern): lift records have no per-record unit and
  are stored in lbs, so the input and everything submitted stay in lbs. A read-only "≈ &lt;kg&gt;"
  hint shows the equivalent; the value passed to `createLiftRecord` / `updateLiftRecord` is never
  converted.
- **Body-weight entry** (StrengthGoalsForm pattern): body-weight records persist a per-record unit,
  so the gate collects and saves in the preferred unit (`recordBodyWeight({ ..., unit })`). To keep
  the added-load math correct (it subtracts body weight from lbs plan loads), the in-memory
  `bodyWeight` is normalized to lbs, and `page.tsx` converts the server-provided `initialBodyWeight`
  to lbs.

`page.tsx` reads `getPreferredUnit()` (a settings-cache hit, shared with `getActiveProgram`) and
threads `unit` down; `WorkoutLoggerProps` gains `unit`.

Closes #735. Follow-up to #733; parent #682.

## Acceptance criteria

- [x] Planned warm-up and working-set weights render in the preferred unit; lbs output byte-identical.
- [x] Logged-set summaries render in the preferred unit.
- [x] Working-set weight input stays in lbs with a read-only "≈" hint; submitted value unchanged by
      the display unit.
- [x] Body weight entered and saved in the preferred unit; added-load calculation unchanged (internal
      body weight kept in lbs).
- [x] `getPreferredUnit()` threaded via `page.tsx`; `WorkoutLoggerProps.unit` added.
- [x] Tests: display-conversion, submit-integrity (logged value not altered by display unit),
      body-weight-unit.

## Testing

New `apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.test.tsx` (6 tests):
kg display of warm-up/working weights, logged-summary conversion, lbs-unchanged + no-hint regression,
**submitted weight stays lbs under kg display**, **body weight saved in preferred unit**, and the
review-fix regression (rounded bodyweight-component added-weight default).

- `npm test` (full suite): all 12 turbo test tasks passed — web **Tests: 220 passed, 0 skipped,
  0 failed**; api 453 passed (DB E2E via Testcontainers, Docker up).
- `npm run typecheck`: pass (web executed fresh, not cached).
- `npm run test:e2e -w @lifting-logbook/web`: **22 passed** (the aria/string gate — for the default
  lbs settings the rendered strings are byte-identical, and all smoke specs pass).

Coverage gate: satisfied by the new display + entry-integrity tests. Suppression and test-integrity
greps on the diff: clean. No `package.json` / lockfile change (lockfile-sync check N/A).

## Review findings disposition

`/review` ([comment](https://github.com/brownm09/lifting-logbook/pull/737#issuecomment-4912090162)):
0 blocking, 1 non-blocking.

- **[maintainability] Bodyweight-component added-weight input default rendered a raw float** for kg
  users — `formatWorkingWeight` returned the unrounded `totalLoad - bodyWeight`, and a kg-entered body
  weight is a full-precision conversion, so the subtraction reintroduced IEEE-754 noise (e.g.
  `200 - 176.3699 = 23.63019025…`) in the (lbs) weight input for Chin-up/Pull-up/Dips.
  **Fixed in `91ee0af`** — round the added lbs load via `roundToDisplay`; regression test added. lbs
  output is unchanged (no-op on clean values). Re-verified: web `220 passed, 0 skipped, 0 failed`,
  typecheck clean.
