### PR TITLE
[fix] Seed in-memory program-spec adapter from every preset (rpt returned [])

### DIFF
--- a/apps/api/src/adapters/in-memory/fixtures.ts
+++ b/apps/api/src/adapters/in-memory/fixtures.ts
@@ -1,20 +1,15 @@
-import {
-  CycleDashboard,
-  LiftRecord,
-  LiftingProgramSpec,
-  PRESET_BASE_SPECS,
-  TrainingMax,
-  Weekday,
-} from '@lifting-logbook/core';
+import { CycleDashboard, LiftRecord, TrainingMax, Weekday } from '@lifting-logbook/core';
 
 /**
  * Seed data for the in-memory adapters used in v0.2 to wire the API end-to-end
  * before real persistence (Google Sheets adapters + auth) lands. One program,
  * one cycle, enough records to render the "today's workout" UI path.
+ *
+ * Built-in program *specs* are no longer seeded here: the in-memory spec adapter
+ * seeds every entry of PRESET_BASE_SPECS directly (issue #739).
  */
 
 export const SEED_PROGRAM = '5-3-1';
-export const SEED_LEANGAINS = 'leangains';
 
 export const seedCycleDashboard = (): CycleDashboard => ({
   program: SEED_PROGRAM,
@@ -68,7 +63,3 @@ export const seedLiftRecords = (): LiftRecord[] => [
     notes: 'AMRAP',
   },
 ];
-
-export const seedLeangainsSpec = (): LiftingProgramSpec[] => PRESET_BASE_SPECS['leangains']?.slice() ?? [];
-
-export const seedProgramSpec = (): LiftingProgramSpec[] => PRESET_BASE_SPECS['5-3-1']?.slice() ?? [];

--- a/apps/api/src/adapters/in-memory/lifting-program-spec.adapter.ts
+++ b/apps/api/src/adapters/in-memory/lifting-program-spec.adapter.ts
@@ -1,6 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
 import {
   LiftingProgramSpec,
+  PRESET_BASE_SPECS,
   classifyAndCount,
   programSpecNaturalKey,
   programSpecRowKind,
@@ -9,7 +10,6 @@ import {
   ILiftingProgramSpecRepository,
   SaveProgramSpecResult,
 } from '../../ports/ILiftingProgramSpecRepository';
-import { SEED_PROGRAM, seedProgramSpec, SEED_LEANGAINS, seedLeangainsSpec } from './fixtures';
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -19,11 +19,16 @@ export class InMemoryLiftingProgramSpecRepository
   private specByProgram: Map<string, LiftingProgramSpec[]>;
 
   constructor(_preSeed = false) {
-    // Program specs are global (not per-user), so always seed them.
-    this.specByProgram = new Map([
-      [SEED_PROGRAM, seedProgramSpec()],
-      [SEED_LEANGAINS, seedLeangainsSpec()],
-    ]);
+    // Program specs are global (not per-user), so always seed them. Seed every
+    // built-in preset from the single source of truth (PRESET_BASE_SPECS) so a
+    // newly added preset is served automatically, with no second wiring step
+    // here (issue #739). `.slice()` hands out a copy so callers cannot mutate
+    // the shared module-level constant.
+    this.specByProgram = new Map(
+      Object.entries(PRESET_BASE_SPECS).map(
+        ([program, spec]): [string, LiftingProgramSpec[]] => [program, spec.slice()],
+      ),
+    );
   }
 
   async getProgramSpec(program: string): Promise<LiftingProgramSpec[]> {

--- a/apps/api/src/adapters/prisma/hybrid-program-spec.repository.spec.ts
+++ b/apps/api/src/adapters/prisma/hybrid-program-spec.repository.spec.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from '@prisma/client';
-import { LiftingProgramSpec } from '@lifting-logbook/core';
+import { LiftingProgramSpec, PRESET_BASE_SPECS } from '@lifting-logbook/core';
 import { HybridLiftingProgramSpecRepository } from './hybrid-program-spec.repository';
 
 const CUSTOM_PROGRAM_ID = '11111111-1111-4111-8111-111111111111';
@@ -68,6 +68,27 @@ describe('HybridLiftingProgramSpecRepository', () => {
     expect(leangainsSpec.length).toBeGreaterThan(0);
     expect(prisma.customProgramSpec.findMany).not.toHaveBeenCalled();
   });
+
+  // Regression guard for issue #739. The Hybrid repo delegates every built-in
+  // (non-UUID) program to the shared in-memory adapter — the exact path
+  // production traffic uses, in both the in-memory and Prisma factories. That
+  // adapter must serve EVERY PRESET_BASE_SPECS entry, not a hardcoded subset:
+  // `rpt` was added to PRESET_BASE_SPECS in #596 but never seeded, so
+  // getProgramSpec('rpt') silently returned []. Iterating the registry means a
+  // future preset cannot regress the same way without failing here.
+  it.each(Object.entries(PRESET_BASE_SPECS))(
+    'serves the full built-in %s spec from the in-memory adapter (issue #739)',
+    async (program, expectedSpec) => {
+      const prisma = makePrisma();
+      const repo = new HybridLiftingProgramSpecRepository(prisma, 'user-1');
+
+      const result = await repo.getProgramSpec(program);
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(result).toHaveLength(expectedSpec.length);
+      expect(prisma.customProgramSpec.findMany).not.toHaveBeenCalled();
+    },
+  );
 
   it('scopes custom-program lookups to the requesting user (isolation guard)', async () => {
     const prisma = makePrisma();

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -119,6 +119,19 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
     expect(res.json().length).toBeGreaterThan(0);
   });
 
+  it('GET /programs/rpt/spec returns the full seeded RPT spec (regression: issue #739)', async () => {
+    // `rpt` was added to PRESET_BASE_SPECS in #596 but never seeded into the
+    // in-memory adapter, so this endpoint silently returned [] for every
+    // onboarded RPT user. The RPT split is 9 rows across 3 workout days
+    // (offsets 0/2/4), each a distinct lift.
+    const res = await get('/programs/rpt/spec');
+    expect(res.statusCode).toBe(200);
+    const rows: { offset: number; lift: string }[] = res.json();
+    expect(rows).toHaveLength(9);
+    expect(new Set(rows.map((r) => r.offset))).toEqual(new Set([0, 2, 4]));
+    expect(new Set(rows.map((r) => r.lift)).size).toBe(9);
+  });
+
   it('GET unknown program returns 404', async () => {
     const res = await get('/programs/does-not-exist/cycles/current');
     expect(res.statusCode).toBe(404);

--- a/apps/web/lib/__tests__/programs.available-preset-invariant.test.ts
+++ b/apps/web/lib/__tests__/programs.available-preset-invariant.test.ts
@@ -1,0 +1,31 @@
+import { PRESET_BASE_SPECS } from '@lifting-logbook/core';
+import { PROGRAMS } from '../programs';
+
+/**
+ * Forward-looking guard for the issue #739 class of bug. Every program the
+ * onboarding catalog marks `available: true` must resolve to a non-empty
+ * built-in spec (`PRESET_BASE_SPECS[id]`), otherwise an onboarded user of that
+ * program gets an empty cycle view. This catches the *other* way this gap can
+ * open: flipping a catalog program to `available: true` without adding its
+ * preset (the seeding side is guarded by the API repository tests).
+ *
+ * Catalog programs left `available: false` are intentional future work and are
+ * deliberately not asserted here.
+ */
+describe('onboarding catalog ↔ preset spec invariant (issue #739)', () => {
+  const availablePrograms = PROGRAMS.filter((p) => p.available);
+
+  it('has at least one available program', () => {
+    // Guards against the filter silently matching nothing, which would make the
+    // per-program assertion below vacuously pass.
+    expect(availablePrograms.length).toBeGreaterThan(0);
+  });
+
+  it.each(availablePrograms.map((p) => p.id))(
+    'available program "%s" has a non-empty PRESET_BASE_SPECS entry',
+    (id) => {
+      const spec = PRESET_BASE_SPECS[id] ?? [];
+      expect(spec.length).toBeGreaterThan(0);
+    },
+  );
+});

--- a/packages/core/src/presets/index.ts
+++ b/packages/core/src/presets/index.ts
@@ -4,12 +4,16 @@ import { LiftingProgramSpec } from '../models/LiftingProgramSpec';
 export * from './programLengths';
 
 /**
- * Built-in program specs, keyed by program ID.
+ * Built-in program specs, keyed by program ID. Single source of truth for
+ * built-in spec data: the in-memory spec adapter
+ * (apps/api/src/adapters/in-memory/lifting-program-spec.adapter.ts) seeds itself
+ * from every entry here, so a preset added here is automatically served by
+ * getProgramSpec — no separate seed wiring step is required (issue #739).
  *
  * ADD AN ENTRY HERE when a new program is made available in onboarding.
- * Also update PROGRAM_DEFAULTS in apps/api/src/programs/cycle-generation.service.ts.
- * These two registries must stay in sync — a missing entry in either causes
- * a broken or degraded experience for new users of that program.
+ * Also update PROGRAM_DEFAULTS in apps/api/src/programs/cycle-generation.service.ts —
+ * that registry is separate, and a missing entry there degrades cycle generation
+ * for the new program.
  */
 export const PRESET_BASE_SPECS: Record<string, LiftingProgramSpec[]> = {
   // Presets are ordered most-specific first so inferProgramFromLiftRecords returns the tightest match.


### PR DESCRIPTION
## Summary

Built-in program specs are never read from Postgres — `HybridLiftingProgramSpecRepository` delegates every non-UUID (built-in) program id to a shared `InMemoryLiftingProgramSpecRepository`, in **both** the in-memory and Prisma factories. That adapter's constructor seeded only two hardcoded keys (`5-3-1`, `leangains`), so `rpt` — added to `PRESET_BASE_SPECS` in #596 — was **never seeded**. `getProgramSpec('rpt')` returned `[]` on every deployment mode, giving onboarded RPT users a silent, empty cycle view (PR #594's `spec.length > 0` guard is what kept it silent rather than a "0 workout days" crash).

This seeds the adapter's map **dynamically from every `PRESET_BASE_SPECS` entry**, so a newly added preset is served automatically with no second manual wiring step — the root-cause fix, not a one-off `rpt` patch. The now-dead `seedProgramSpec`/`seedLeangainsSpec`/`SEED_LEANGAINS` fixtures helpers (only the old adapter used them) are removed.

## Root cause

Issue #595's premise — *"the in-memory adapter only seeds from `PRESET_BASE_SPECS`"* — was false: it seeded two hardcoded keys. #596 added the `rpt` preset believing it would auto-wire, claimed *"getProgramSpec('rpt') returns a non-empty spec"*, and skipped the coverage gate as a *"data-only change"*, so nothing caught the gap.

## Empirical confirmation (red → green)

Compiled adapter, before the fix:
```
InMemory.getProgramSpec("5-3-1")   -> 12 rows
InMemory.getProgramSpec("leangains") -> 12 rows
InMemory.getProgramSpec("rpt")     -> 0 rows   <-- EMPTY / BROKEN
Hybrid(production path).getProgramSpec("rpt") -> 0 rows   <-- EMPTY / BROKEN
```
The new production-path regression test was verified to **fail** against the original code (`× serves the full built-in rpt spec (issue #739)`, `Tests: 1 failed, 9 passed`) and **pass** after the fix — so it genuinely catches the regression, not vacuously.

## Scope

Only `rpt` and `leangains` are `available: true` in the onboarding catalog. `leangains` was already seeded; `rpt` was the only onboardable program that was broken. The other 11 catalog programs are `available: false` (marketing / not-yet-implemented) and have no `PRESET_BASE_SPECS` entry — intentional future work, out of scope. The dynamic seed plus the new tests future-proof them: adding a preset now serves it automatically, and flipping a program to `available: true` without a preset fails the catalog-invariant test.

## Acceptance criteria (from #739)

- [x] `getProgramSpec('rpt')` returns the full 9-row RPT spec via the production repository path (`HybridLiftingProgramSpecRepository`)
- [x] The in-memory adapter seeds every `PRESET_BASE_SPECS` key, not a hardcoded subset
- [x] Regression test asserting every `PRESET_BASE_SPECS` key resolves non-empty through the production repository path
- [x] E2E test: `GET /programs/rpt/spec` returns a non-empty spec (9 rows, offsets 0/2/4)
- [x] Forward-looking guard: every `available: true` catalog program has a non-empty `PRESET_BASE_SPECS[id]`
- [x] `npm run typecheck` and `npm test` pass

## Testing

Full `turbo run test` hit the **known Windows concurrent-jest OOM flake** (#419 / #567) in `packages/core` — a worker crash under multi-process memory pressure, not an assertion failure (the crashed run still reported `Tests: 265 passed, 265 total`). Every workspace passes when run in isolation; Linux Node 20 CI runs per-workspace and is unaffected.

- `@lifting-logbook/core`  — `Tests: 311 passed, 0 skipped, 0 failed (4.8s)`
- `@lifting-logbook/api`   — `Tests: 457 passed, 0 skipped, 0 failed (47.7s)` (includes the Docker DB E2E suite)
- `@lifting-logbook/web`   — `Tests: 223 passed, 0 skipped, 0 failed`
- `npm run typecheck` — 4/4 tasks pass · `npm run build` — 6/6 tasks pass (nest build type-checks the api source)

New tests: `hybrid-program-spec.repository.spec.ts` (parametrized over `PRESET_BASE_SPECS`), `programs.e2e.spec.ts` (`GET /programs/rpt/spec`), `programs.available-preset-invariant.test.ts` (catalog ↔ preset invariant).

## Suppression / test-integrity checklist

- [x] No suppressions added (clean pre-PR grep)
- [x] No test-integrity violations — no skips, no deleted tests, no lowered thresholds (clean grep); `--passWithNoTests` seen in output is the web workspace's pre-existing test script, unchanged
- [x] No `package.json` change → lockfile drift gate N/A

## Risk dimensions

1. **Testing** — 3 new tests (production-path guard + e2e + catalog invariant); red→green verified.
2. **Observability** — N/A: in-memory seed data; no new runtime I/O, logging, spans, raw SQL, or LLM calls.
3. **Security** — N/A: built-in specs are global/non-user; the Hybrid repo's per-user custom-spec guard is untouched.
4. **Resilience** — Improves it: removes the empty-spec path that would otherwise trip `workoutNum N exceeds program spec (0 workout days)`. Rollback = revert the one constructor change.
5. **Performance** — Negligible: seeds 3 (was 2) small arrays once per process on a shared instance; no hot path / N+1.
6. **Data integrity & migrations** — N/A: no schema/DB change; the Prisma custom-spec path is untouched.

Accessibility — N/A (API-layer fix; the web change is a pure test assertion, no component).

## Review findings disposition

`/review` (`claude-opus-4-8`) posted an [inline review](https://github.com/brownm09/lifting-logbook/pull/742#issuecomment-4916329892): **0 blocking, 0 non-blocking findings** — clean. Nothing to fix or file. Gate markers: `adr_warrant=not-warranted`, `doc_reconciliation=not-applicable`.
