### PR TITLE
[fix] Cycle Dashboard grid: group by (week, offset), expand to canonical length, lift no-schedule fetchWorkout cap

### DIFF
--- a/apps/api/src/programs/cycle-dashboard.controller.spec.ts
+++ b/apps/api/src/programs/cycle-dashboard.controller.spec.ts
@@ -119,6 +119,9 @@ describe('CycleDashboardController', () => {
       cycleStartDate: '2026-04-20',
       weeks: [],
       currentWeekType: 'training',
+      dateOverrides: {},
+      skippedWorkoutNums: [],
+      completedWorkoutNums: [],
     });
   });
 
@@ -208,6 +211,29 @@ describe('CycleDashboardController', () => {
     const result = await controller.getCurrentCycle('5-3-1', MOCK_USER);
 
     expect(result.weeks[0]?.completed).toBe(false);
+  });
+
+  it('surfaces per-workout metadata top-level in no-schedule mode (issue #740)', async () => {
+    // In no-schedule mode weeks is empty, so the Cycle Dashboard reads these
+    // top-level maps to render every tiled workout's status without a per-workout
+    // fetch. Verify they are populated from the bulk override/skip/record sources.
+    repo.getCycleDashboard.mockResolvedValue(stubDashboard());
+    specRepo.getProgramSpec.mockResolvedValue(stubSpec());
+    scheduledRepo.getScheduledWorkouts.mockResolvedValue([]);
+    overrideRepo.getOverridesForCycle.mockResolvedValue(
+      new Map([[2, new Date('2026-04-30T00:00:00.000Z')]]),
+    );
+    skipRepo.getSkipsForCycle.mockResolvedValue(new Set([3]));
+    liftRecordRepo.getLiftRecords.mockResolvedValue([
+      { program: '5-3-1', cycleNum: 2, workoutNum: 1, date: new Date(), lift: 'Squat', setNum: 1, weight: 200, reps: 5, notes: '' },
+    ]);
+
+    const result = await controller.getCurrentCycle('5-3-1', MOCK_USER);
+
+    expect(result.weeks).toEqual([]);
+    expect(result.dateOverrides).toEqual({ 2: '2026-04-30' });
+    expect(result.skippedWorkoutNums).toEqual([3]);
+    expect(result.completedWorkoutNums).toEqual([1]);
   });
 
   it('DELETE /programs/:program/cycles/current calls service.deleteCurrentCycle with repos and program', async () => {

--- a/apps/api/src/programs/cycle-generation.controller.spec.ts
+++ b/apps/api/src/programs/cycle-generation.controller.spec.ts
@@ -75,6 +75,9 @@ describe('CycleGenerationController', () => {
         cycleStartDate: '2026-04-27',
         weeks: [],
         currentWeekType: 'training',
+        dateOverrides: {},
+        skippedWorkoutNums: [],
+        completedWorkoutNums: [],
       });
     });
 
@@ -125,6 +128,9 @@ describe('CycleGenerationController', () => {
         cycleStartDate: '2026-05-12',
         weeks: [],
         currentWeekType: 'training',
+        dateOverrides: {},
+        skippedWorkoutNums: [],
+        completedWorkoutNums: [],
       });
     });
 

--- a/apps/api/src/programs/mappers.spec.ts
+++ b/apps/api/src/programs/mappers.spec.ts
@@ -21,50 +21,54 @@ const spec = (offset: number, lift: string, week?: number): LiftingProgramSpec =
   ...(week !== undefined ? { week } : {}),
 });
 
+// Pre-#740 weekForWorkoutNum indexed workoutNum into the stored block's distinct
+// offsets and returned undefined (→ 400) beyond that count. #740 tiles the block to
+// the program's canonical length first and indexes into the ordered (week, offset)
+// workout days (the same orderedWorkoutKeys mapping the web grid uses), so week-2+
+// workouts resolve in no-schedule mode too; undefined now means past the *full*
+// canonical length. These tests replace the old offset-cap assertions.
 describe('weekForWorkoutNum', () => {
-  it('returns 1 (default) when spec has no week field and workoutNum is 1', () => {
-    const s = [spec(0, 'Squat'), spec(0, 'Bench Press')];
-    expect(weekForWorkoutNum(s, 1)).toBe(1);
-  });
-
   it('returns undefined for empty spec', () => {
     expect(weekForWorkoutNum([], 1)).toBeUndefined();
   });
 
-  it('returns undefined when workoutNum exceeds distinct offset count', () => {
-    const s = [spec(0, 'Squat'), spec(2, 'Deadlift')];
-    expect(weekForWorkoutNum(s, 3)).toBeUndefined();
-  });
-
-  it('returns explicit week value when spec entries carry week', () => {
-    const s = [spec(0, 'Squat', 1), spec(2, 'Deadlift', 1), spec(4, 'OHP', 2)];
-    expect(weekForWorkoutNum(s, 3)).toBe(2);
-  });
-
-  it('correctly maps workoutNum across multiple distinct offsets', () => {
+  it('maps workoutNum to the (week, offset) day in order for a multi-week block', () => {
+    // Two offsets per week across weeks 1..2. No registered program → canonical
+    // length falls back to the base block size (2 weeks) = 4 workout days.
     const s = [
       spec(0, 'Squat', 1),
-      spec(0, 'Bench Press', 1),
-      spec(2, 'Deadlift', 1),
-      spec(4, 'OHP', 2),
+      spec(3, 'Deadlift', 1),
+      spec(0, 'Squat', 2),
+      spec(3, 'Deadlift', 2),
     ];
-    expect(weekForWorkoutNum(s, 1)).toBe(1);
-    expect(weekForWorkoutNum(s, 2)).toBe(1);
-    expect(weekForWorkoutNum(s, 3)).toBe(2);
-    expect(weekForWorkoutNum(s, 4)).toBeUndefined();
+    expect(weekForWorkoutNum(s, 1)).toBe(1); // (w1, o0)
+    expect(weekForWorkoutNum(s, 2)).toBe(1); // (w1, o3)
+    expect(weekForWorkoutNum(s, 3)).toBe(2); // (w2, o0)
+    expect(weekForWorkoutNum(s, 4)).toBe(2); // (w2, o3)
+    expect(weekForWorkoutNum(s, 5)).toBeUndefined(); // past full length
   });
 
-  it('deduplicates offsets — two lifts at the same offset count as one workout', () => {
-    const s = [spec(0, 'Squat', 1), spec(0, 'Bench Press', 1), spec(7, 'Deadlift', 2)];
+  it('deduplicates offsets — two lifts at the same offset are one workout day', () => {
+    const s = [spec(0, 'Squat', 1), spec(0, 'Bench Press', 1), spec(3, 'Deadlift', 1)];
+    // 1-week block of 2 offsets → base length 1 week → 2 workout days.
     expect(weekForWorkoutNum(s, 1)).toBe(1);
-    expect(weekForWorkoutNum(s, 2)).toBe(2);
+    expect(weekForWorkoutNum(s, 2)).toBe(1);
     expect(weekForWorkoutNum(s, 3)).toBeUndefined();
   });
 
-  it('uses ?? 1 fallback when first matching spec entry has no week field', () => {
-    const s = [spec(0, 'Squat'), spec(7, 'Deadlift')];
-    expect(weekForWorkoutNum(s, 1)).toBe(1);
-    expect(weekForWorkoutNum(s, 2)).toBe(1);
+  it('tiles a single-week repeating block to the program canonical length (issue #740)', () => {
+    // Leangains: a 1-week block of offsets {0,2,4} tiled across 12 weeks = 36 days.
+    const s = [spec(0, 'Bench Press', 1), spec(2, 'Squat', 1), spec(4, 'Overhead Press', 1)];
+    expect(weekForWorkoutNum(s, 3, 'leangains')).toBe(1); // last workout of week 1
+    expect(weekForWorkoutNum(s, 4, 'leangains')).toBe(2); // first of week 2 — 400'd pre-#740
+    expect(weekForWorkoutNum(s, 36, 'leangains')).toBe(12); // final workout
+    expect(weekForWorkoutNum(s, 37, 'leangains')).toBeUndefined(); // beyond 12 weeks
+  });
+
+  it('falls back to the base-spec block length for an unregistered program', () => {
+    const s = [spec(0, 'Squat', 1), spec(0, 'Squat', 2), spec(0, 'Squat', 3)];
+    expect(weekForWorkoutNum(s, 3, 'a-custom-uuid')).toBe(3);
+    expect(weekForWorkoutNum(s, 4, 'a-custom-uuid')).toBeUndefined();
   });
 });
 
@@ -254,5 +258,31 @@ describe('buildCycleDashboardResponse', () => {
     const skipped = new Set([1]);
     const result = buildCycleDashboardResponse(baseDashboard, WEEK_TYPE, scheduled, new Map(), new Set(), skipped);
     expect(result.weeks[0]!.completed).toBe(false);
+  });
+
+  it('surfaces per-workout metadata top-level in no-schedule mode (issue #740)', () => {
+    const overrides = new Map([[2, new Date('2026-05-22T00:00:00.000Z')]]);
+    const result = buildCycleDashboardResponse(
+      baseDashboard,
+      WEEK_TYPE,
+      [], // no schedule → weeks: []
+      overrides,
+      new Set([1]), // completed
+      new Set([3]), // skipped
+    );
+    expect(result.weeks).toEqual([]);
+    expect(result.dateOverrides).toEqual({ 2: '2026-05-22' });
+    expect(result.completedWorkoutNums).toEqual([1]);
+    expect(result.skippedWorkoutNums).toEqual([3]);
+  });
+
+  it('surfaces the same top-level metadata in schedule mode', () => {
+    const scheduled = [sw(1, 1, '2026-05-19'), sw(2, 1, '2026-05-21')];
+    const overrides = new Map([[1, new Date('2026-05-20T00:00:00.000Z')]]);
+    const result = buildCycleDashboardResponse(baseDashboard, WEEK_TYPE, scheduled, overrides, new Set([1]), new Set());
+    expect(result.weeks).toHaveLength(1);
+    expect(result.dateOverrides).toEqual({ 1: '2026-05-20' });
+    expect(result.completedWorkoutNums).toEqual([1]);
+    expect(result.skippedWorkoutNums).toEqual([]);
   });
 });

--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -5,7 +5,10 @@ import {
   StrengthGoalEntry,
   TrainingMax,
   TrainingMaxHistoryEntry,
+  expandSpecToLength,
   normalizeAmrap,
+  orderedWorkoutKeys,
+  programLengthWeeks,
 } from '@lifting-logbook/core';
 import {
   CycleDashboardResponse,
@@ -102,12 +105,18 @@ export const toLiftingProgramSpecResponse = (
 export const toCycleDashboardResponse = (
   d: CycleDashboard,
   currentWeekType: WeekType,
+  dateOverrides: Record<number, string> = {},
+  skippedWorkoutNums: number[] = [],
+  completedWorkoutNums: number[] = [],
 ): CycleDashboardResponse => ({
   program: d.program,
   cycleNum: d.cycleNum,
   cycleStartDate: isoDate(d.cycleDate),
   weeks: [],
   currentWeekType,
+  dateOverrides,
+  skippedWorkoutNums,
+  completedWorkoutNums,
 });
 
 /**
@@ -124,8 +133,24 @@ export function buildCycleDashboardResponse(
   completedWorkoutNums: Set<number>,
   skippedNums: Set<number> = new Set(),
 ): CycleDashboardResponse {
+  // Per-workout metadata for the whole cycle, surfaced top-level so the Cycle
+  // Dashboard can render every tiled workout's status without a per-workout fetch
+  // (issue #740). Populated identically in both modes; only `weeks` differs.
+  const dateOverrides: Record<number, string> = {};
+  for (const [workoutNum, date] of overrides) {
+    dateOverrides[workoutNum] = isoDate(date);
+  }
+  const skippedList = [...skippedNums].sort((a, b) => a - b);
+  const completedList = [...completedWorkoutNums].sort((a, b) => a - b);
+
   if (scheduled.length === 0) {
-    return toCycleDashboardResponse(d, currentWeekType);
+    return toCycleDashboardResponse(
+      d,
+      currentWeekType,
+      dateOverrides,
+      skippedList,
+      completedList,
+    );
   }
 
   const weekAcc = new Map<number, { workouts: WorkoutSummary[]; scheduled: ScheduledWorkout[] }>();
@@ -160,6 +185,9 @@ export function buildCycleDashboardResponse(
     cycleStartDate: isoDate(d.cycleDate),
     weeks,
     currentWeekType,
+    dateOverrides,
+    skippedWorkoutNums: skippedList,
+    completedWorkoutNums: completedList,
   };
 }
 
@@ -205,21 +233,28 @@ export const isValidWorkoutNum = (n: number): boolean =>
   Number.isInteger(n) && n >= 1;
 
 /**
- * Derives the training week for a given workoutNum from the program spec.
- * Deduplicates offsets, sorts ascending, maps workoutNum to the Nth offset,
- * then reads the `week` field from the first matching spec entry (defaulting
- * to 1 when the field is absent). Returns undefined when workoutNum exceeds
- * the number of distinct offsets.
+ * Derives the training week for a global `workoutNum` from the program spec — the
+ * no-schedule fallback (a scheduled row's `weekNum` is authoritative when present).
+ *
+ * The stored spec is one repeating block, so it is first tiled to the program's
+ * canonical length ({@link expandSpecToLength} + {@link programLengthWeeks}); the
+ * `workoutNum` then indexes into the ordered `(week, offset)` workout days
+ * ({@link orderedWorkoutKeys}) — the *same* mapping the web Cycle Dashboard grid
+ * (`buildWorkoutDays`) uses, so a card and the workout it opens never disagree.
+ *
+ * Returns undefined only when `workoutNum` exceeds the *full* canonical length
+ * (surfaced as 400 by the controller). Before #740 the cap was one block's
+ * distinct-offset count, which 400'd every week-2+ workout of a tiled program in
+ * no-schedule mode (#680 fixed this only for schedule mode). `program` defaults to
+ * the base-spec block length for custom / unregistered programs.
  */
 export const weekForWorkoutNum = (
   spec: LiftingProgramSpec[],
   workoutNum: number,
+  program = '',
 ): WeekNumber | undefined => {
-  const offsets = [...new Set(spec.map((s) => s.offset))].sort((a, b) => a - b);
-  const offset = offsets[workoutNum - 1];
-  return offset !== undefined
-    ? (spec.find((s) => s.offset === offset)?.week ?? 1)
-    : undefined;
+  const fullSpec = expandSpecToLength(spec, programLengthWeeks(program, spec));
+  return orderedWorkoutKeys(fullSpec)[workoutNum - 1]?.week;
 };
 
 /**

--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -99,6 +99,19 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
     expect(body.lifts.length).toBeGreaterThan(0);
   });
 
+  it('GET /programs/:program/workouts/:workoutNum resolves a tiled week-2 workout in no-schedule mode (issue #740)', async () => {
+    // The seeded 5-3-1 program is a 3-week block of offsets {0,3} but a canonical
+    // length of 12 weeks, and the seeded user has no workout schedule. Workout 3 is
+    // the first workout of week 2. Pre-#740 the no-schedule cap was the block's 2
+    // distinct offsets, so this 400'd; now it tiles to the full length and resolves.
+    const res = await get(`/programs/${SEED_PROGRAM}/workouts/3`);
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.workoutNum).toBe(3);
+    expect(body.week).toBe(2);
+    expect(body.lifts.length).toBeGreaterThan(0);
+  });
+
   it('GET /programs/:program/training-maxes returns the seeded maxes', async () => {
     const res = await get(`/programs/${SEED_PROGRAM}/training-maxes`);
     expect(res.statusCode).toBe(200);

--- a/apps/api/src/programs/workouts.controller.spec.ts
+++ b/apps/api/src/programs/workouts.controller.spec.ts
@@ -132,23 +132,17 @@ describe('WorkoutsController', () => {
     ]);
   });
 
-  it('throws BadRequestException when workoutNum exceeds spec offset count', async () => {
+  it('returns 400 only when workoutNum exceeds the full canonical length, not one block (issue #740)', async () => {
+    // Leangains tiles a 1-week / 3-offset block across 12 weeks = 36 workout days.
+    // Pre-#740 the no-schedule cap was 3 (one block); now it is the full 36, so a
+    // 400 means the workoutNum is past the whole cycle, not merely past week 1.
     specRepo.getProgramSpec.mockResolvedValue([
-      {
-        offset: 0,
-        lift: 'Squat',
-        increment: 5,
-        order: 1,
-        sets: 3,
-        reps: 5,
-        amrap: true,
-        warmUpPct: '0.4,0.5,0.6',
-        wtDecrementPct: 0.1,
-        activation: 'compound',
-      },
+      { week: 1, offset: 0, lift: 'Bench Press', increment: 5, order: 1, sets: 3, reps: 6, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+      { week: 1, offset: 2, lift: 'Squat', increment: 10, order: 1, sets: 3, reps: 6, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+      { week: 1, offset: 4, lift: 'Overhead Press', increment: 5, order: 1, sets: 3, reps: 6, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
     ]);
     dashboardRepo.getCycleDashboard.mockResolvedValue({
-      program: '5-3-1',
+      program: 'leangains',
       cycleUnit: 'week',
       cycleNum: 3,
       cycleDate: new Date('2026-04-20T00:00:00.000Z'),
@@ -157,7 +151,7 @@ describe('WorkoutsController', () => {
     });
     workoutRepo.getWorkout.mockResolvedValue([]);
 
-    await expect(controller.getWorkout('5-3-1', '2', MOCK_USER)).rejects.toBeInstanceOf(
+    await expect(controller.getWorkout('leangains', '37', MOCK_USER)).rejects.toBeInstanceOf(
       BadRequestException,
     );
   });
@@ -168,9 +162,13 @@ describe('WorkoutsController', () => {
     );
   });
 
-  it('rejects workoutNum that exceeds the number of offset groups in the spec', async () => {
+  it('resolves a no-schedule tiled week-2 workout to its program week (issue #740)', async () => {
+    // Leangains 1-week block of 2 offsets tiled across 12 weeks; workout 3 lands in
+    // week 2. Pre-#740 this 400'd in no-schedule mode — #680 fixed only schedule
+    // mode (see the scheduled-row test below). Planned lifts still come from the
+    // tiled block week (block week 1 for a 1-week block).
     dashboardRepo.getCycleDashboard.mockResolvedValue({
-      program: '5-3-1',
+      program: 'leangains',
       cycleUnit: 'week',
       cycleNum: 3,
       cycleDate: new Date('2026-04-20T00:00:00.000Z'),
@@ -178,28 +176,16 @@ describe('WorkoutsController', () => {
       cycleStartWeekday: Weekday.Monday,
     });
     specRepo.getProgramSpec.mockResolvedValue([
-      {
-        week: 1,
-        offset: 0,
-        lift: 'Squat',
-        increment: 5,
-        order: 1,
-        sets: 3,
-        reps: 5,
-        amrap: true,
-        warmUpPct: '0.4,0.5,0.6',
-        wtDecrementPct: 0.1,
-        activation: 'compound',
-      },
+      { week: 1, offset: 0, lift: 'Bench Press', increment: 5, order: 1, sets: 3, reps: 6, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+      { week: 1, offset: 2, lift: 'Squat', increment: 10, order: 1, sets: 3, reps: 6, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
     ]);
-    // No scheduled row for workoutNum 2 (getScheduledWorkouts defaults to []), so
-    // week falls back to weekForWorkoutNum → undefined → 400. getWorkout is now
-    // reached before that check, so mock it explicitly.
-    workoutRepo.getWorkout.mockResolvedValue([]);
+    workoutRepo.getWorkout.mockResolvedValue([]); // upcoming — no records, no schedule
 
-    await expect(controller.getWorkout('5-3-1', '2', MOCK_USER)).rejects.toBeInstanceOf(
-      BadRequestException,
-    );
+    const result = await controller.getWorkout('leangains', '3', MOCK_USER);
+
+    expect(result.week).toBe(2);
+    expect(result.lifts.map((l) => l.lift).sort()).toEqual(['Bench Press', 'Squat']);
+    expect(result.lifts.every((l) => l.planned)).toBe(true);
   });
 
   it('resolves week from the scheduled row for a tiled week-2+ workout (issue #680)', async () => {

--- a/apps/api/src/programs/workouts.controller.ts
+++ b/apps/api/src/programs/workouts.controller.ts
@@ -5,7 +5,7 @@ import {
   Inject,
   Param,
 } from '@nestjs/common';
-import { baseSpecBlockWeeks, LiftRecord, programLengthWeeks } from '@lifting-logbook/core';
+import { baseSpecBlockWeeks, blockWeekForProgramWeek, LiftRecord, programLengthWeeks } from '@lifting-logbook/core';
 import { WorkoutResponse } from '@lifting-logbook/types';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../ports/auth';
@@ -80,9 +80,9 @@ export class WorkoutsController {
     }
 
     // Planned lifts come from the tiled block week: the stored spec is one block,
-    // so map the program week (which may exceed blockWeeks) back into the block.
-    const blockWeeks = baseSpecBlockWeeks(spec);
-    const blockWeek = blockWeeks > 0 ? ((week - 1) % blockWeeks) + 1 : week;
+    // so map the program week (which may exceed blockWeeks) back into the block —
+    // via the same helper expandSpecToLength tiles with, so the two never disagree.
+    const blockWeek = blockWeekForProgramWeek(week, baseSpecBlockWeeks(spec));
     const specLifts = [...new Set(spec.filter((s) => s.week === blockWeek).map((s) => s.lift))];
 
     const plannedLifts = applyLiftOverrides(specLifts, liftOverrides);

--- a/apps/api/src/programs/workouts.controller.ts
+++ b/apps/api/src/programs/workouts.controller.ts
@@ -5,7 +5,7 @@ import {
   Inject,
   Param,
 } from '@nestjs/common';
-import { baseSpecBlockWeeks, LiftRecord } from '@lifting-logbook/core';
+import { baseSpecBlockWeeks, LiftRecord, programLengthWeeks } from '@lifting-logbook/core';
 import { WorkoutResponse } from '@lifting-logbook/types';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../ports/auth';
@@ -66,15 +66,16 @@ export class WorkoutsController {
     const scheduledWorkout = scheduledWorkouts.find((s) => s.workoutNum === workoutNum);
     const scheduledDate = scheduledWorkout?.scheduledDate;
 
-    // The scheduled row's weekNum is authoritative for the program week. A global
-    // workoutNum spans the full tiled schedule, so it can exceed the base block's
-    // distinct-offset count — weekForWorkoutNum (offset-indexed within one block)
-    // only covers the no-schedule fallback. Without this, week-2+ workouts of a
-    // tiled program (Leangains 12w, 5-3-1 12w) would 400 (issue #680).
-    const week = scheduledWorkout?.weekNum ?? weekForWorkoutNum(spec, workoutNum);
+    // The scheduled row's weekNum is authoritative for the program week. With no
+    // schedule, weekForWorkoutNum tiles the stored block to the program's canonical
+    // length and indexes the global workoutNum into the ordered (week, offset)
+    // workout days — so week-2+ workouts of a tiled program (Leangains 12w, 5-3-1
+    // 12w) resolve in no-schedule mode too, not only schedule mode (#680 completed
+    // by #740). Undefined now means workoutNum is past the *full* canonical length.
+    const week = scheduledWorkout?.weekNum ?? weekForWorkoutNum(spec, workoutNum, program);
     if (week === undefined) {
       throw new BadRequestException(
-        `workoutNum ${workoutNum} exceeds program spec (${new Set(spec.map((s) => s.offset)).size} workout days)`,
+        `workoutNum ${workoutNum} exceeds the program's ${programLengthWeeks(program, spec)}-week schedule`,
       );
     }
 

--- a/apps/web/app/(authed)/cycle/[cycleNum]/page.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/page.tsx
@@ -3,7 +3,6 @@ import {
   fetchCycleDashboard,
   fetchProgramSpec,
   fetchTrainingMaxes,
-  fetchWorkout,
 } from '@/lib/api';
 import { getActiveProgram } from '@/lib/active-program';
 import { getPreferredUnit } from '@/lib/preferences';
@@ -35,24 +34,20 @@ export default async function CycleDashboardPage({
     notFound();
   }
 
-  const workoutDays = buildWorkoutDays(specs, dashboard.cycleStartDate);
-  const workoutResponseList = await Promise.all(
-    workoutDays.map((w) => fetchWorkout(program, w.workoutNum)),
-  );
-  const workoutResponseMap = new Map(
-    workoutDays.map((w, i) => [w.workoutNum, workoutResponseList[i]]),
-  );
+  const workoutDays = buildWorkoutDays(specs, dashboard.cycleStartDate, program);
 
-  // Build a flat workoutNum → scheduled date lookup from the cycle dashboard response.
-  // This is populated when schedule mode is active; empty when no schedule is set.
+  // Per-workout status comes entirely from the cycle dashboard response — no
+  // per-workout fetch. `weeks` carries schedule-mode dates; the top-level maps
+  // cover both modes and, crucially, the tiled week-2+ workouts a no-schedule
+  // cycle would otherwise 400 on if fetched one-by-one (issue #740).
   const scheduledDateMap = new Map<number, string>();
-  const skippedWorkoutNums = new Set<number>();
   for (const week of dashboard.weeks) {
     for (const ws of week.workouts) {
       scheduledDateMap.set(ws.workoutNum, ws.date);
-      if (ws.skipped) skippedWorkoutNums.add(ws.workoutNum);
     }
   }
+  const skippedWorkoutNums = new Set(dashboard.skippedWorkoutNums);
+  const completedWorkoutNums = new Set(dashboard.completedWorkoutNums);
 
   const today = new Date().toISOString().slice(0, 10);
   const maxMap = new Map(maxes.map((m) => [m.lift, m.weight]));
@@ -64,10 +59,12 @@ export default async function CycleDashboardPage({
     workouts: workoutDays
       .filter((w) => w.week === week)
       .map((w): WorkoutCell => {
-        const response = workoutResponseMap.get(w.workoutNum);
-        const logged = response != null && response.lifts.some((l) => !l.planned);
+        const logged = completedWorkoutNums.has(w.workoutNum);
         // Priority: user override date > API scheduled date > spec-computed date.
-        const effectiveDate = response?.overrideDate ?? scheduledDateMap.get(w.workoutNum) ?? w.date;
+        const effectiveDate =
+          dashboard.dateOverrides[w.workoutNum] ??
+          scheduledDateMap.get(w.workoutNum) ??
+          w.date;
         const status: WorkoutCell['status'] = logged
           ? 'completed'
           : skippedWorkoutNums.has(w.workoutNum)

--- a/apps/web/app/(authed)/cycle/[cycleNum]/page.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/page.tsx
@@ -34,20 +34,31 @@ export default async function CycleDashboardPage({
     notFound();
   }
 
+  // Grid spans the program's full canonical length (leangains 12w → 36 workout
+  // days). We eagerly compute planned sets for every tiled workout here: the RSC
+  // payload now scales with program length rather than a single block, a conscious
+  // trade for dropping the per-workout fetch fan-out below. CycleDashboardGrid only
+  // mounts the current week's cards, so client render stays cheap regardless.
   const workoutDays = buildWorkoutDays(specs, dashboard.cycleStartDate, program);
 
   // Per-workout status comes entirely from the cycle dashboard response — no
   // per-workout fetch. `weeks` carries schedule-mode dates; the top-level maps
   // cover both modes and, crucially, the tiled week-2+ workouts a no-schedule
-  // cycle would otherwise 400 on if fetched one-by-one (issue #740).
+  // cycle would otherwise 400 on if fetched one-by-one (issue #740). The `?.`/`?? []`
+  // guards tolerate a response missing the (required) fields — e.g. an older API
+  // pod during a non-atomic web/api rolling deploy — degrading rather than crashing
+  // the whole dashboard, matching how the two Sets already tolerate `undefined`.
   const scheduledDateMap = new Map<number, string>();
   for (const week of dashboard.weeks) {
     for (const ws of week.workouts) {
       scheduledDateMap.set(ws.workoutNum, ws.date);
     }
   }
-  const skippedWorkoutNums = new Set(dashboard.skippedWorkoutNums);
-  const completedWorkoutNums = new Set(dashboard.completedWorkoutNums);
+  const skippedWorkoutNums = new Set(dashboard.skippedWorkoutNums ?? []);
+  // `logged` derives from lift records (like the dashboard's own week-completion,
+  // cycle-dashboard.controller.ts) rather than the removed per-workout response, so a
+  // workout with any logged record counts as done — consistent across the dashboard.
+  const completedWorkoutNums = new Set(dashboard.completedWorkoutNums ?? []);
 
   const today = new Date().toISOString().slice(0, 10);
   const maxMap = new Map(maxes.map((m) => [m.lift, m.weight]));
@@ -62,7 +73,7 @@ export default async function CycleDashboardPage({
         const logged = completedWorkoutNums.has(w.workoutNum);
         // Priority: user override date > API scheduled date > spec-computed date.
         const effectiveDate =
-          dashboard.dateOverrides[w.workoutNum] ??
+          dashboard.dateOverrides?.[w.workoutNum] ??
           scheduledDateMap.get(w.workoutNum) ??
           w.date;
         const status: WorkoutCell['status'] = logged

--- a/apps/web/e2e/mock-api.mjs
+++ b/apps/web/e2e/mock-api.mjs
@@ -23,6 +23,11 @@ const CYCLE_DASHBOARD = {
       ],
     },
   ],
+  // Top-level per-workout metadata the Cycle Dashboard reads instead of a
+  // per-workout fetch (issue #740). skippedWorkoutNums is filled from state below.
+  dateOverrides: {},
+  skippedWorkoutNums: [],
+  completedWorkoutNums: [],
 };
 
 const WORKOUT = {
@@ -266,6 +271,7 @@ const server = createServer(async (req, res) => {
           }
           week.completed = week.workouts.every((wo) => wo.skipped);
         }
+        dashboard.skippedWorkoutNums = [...state.skippedWorkouts];
         json(res, dashboard);
       }
       return;

--- a/apps/web/e2e/scheduling.spec.ts
+++ b/apps/web/e2e/scheduling.spec.ts
@@ -39,7 +39,10 @@ test('skip a workout — cycle dashboard card shows Skipped status', async ({ pa
   await page.goto('/cycle/1');
   await expect(page).toHaveURL(/\/cycle\/1/);
 
-  // The workout card for workout 1 should show the Skipped badge
+  // The grid renders one collapsible section per program week (issue #740); the mock
+  // cycle's dates are in the past, so Week 1 (holding workout 1) starts collapsed —
+  // expand it, then assert the workout card's Skipped badge.
+  await page.getByRole('button', { name: 'Week 1', exact: true }).click();
   await expect(page.locator('text=Skipped').first()).toBeVisible();
 });
 

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -75,7 +75,11 @@ test('onboarding: choose program → enter lifts → confirm → lands on cycle'
 test('cycle dashboard renders workout grid', async ({ page }) => {
   await page.goto('/cycle');
   await expect(page).toHaveURL(/\/cycle\/1/);
-  // Dashboard should show at least one workout entry from the mock (week 1, workouts 1-3)
+  await expect(page.getByRole('heading', { name: 'Cycle 1' })).toBeVisible();
+  // The grid renders one collapsible section per program week (issue #740). The mock
+  // cycle's dates are all in the past, so the current-week heuristic expands a later
+  // week and Week 1 starts collapsed — expand it, then assert its workout entry shows.
+  await page.getByRole('button', { name: 'Week 1', exact: true }).click();
   await expect(page.locator('text=2025-01-06').first()).toBeVisible();
 
   // The screen is discoverably labeled as the dashboard.

--- a/apps/web/lib/__tests__/workoutPlan.test.ts
+++ b/apps/web/lib/__tests__/workoutPlan.test.ts
@@ -83,6 +83,63 @@ describe('buildWorkoutDays', () => {
   });
 });
 
+describe('buildWorkoutDays — multi-week grouping and canonical-length expansion (issue #740)', () => {
+  it('does not collide workouts that share an offset across different weeks', () => {
+    // 5-3-1-shaped base spec: offsets {0,3} repeated across weeks 1..3. Grouping by
+    // offset alone would collapse the three weeks' offset-0 (and offset-3) workouts
+    // into two mega-cards of 6 lifts. No `program` → canonical length falls back to
+    // the base-spec block size (3 weeks), isolating the grouping behavior.
+    const specs = [1, 2, 3].flatMap((week) => [
+      makeSpec({ week, offset: 0, lift: 'Squat', order: 1 }),
+      makeSpec({ week, offset: 0, lift: 'Bench Press', order: 2 }),
+      makeSpec({ week, offset: 3, lift: 'Deadlift', order: 1 }),
+      makeSpec({ week, offset: 3, lift: 'Overhead Press', order: 2 }),
+    ]);
+
+    const days = buildWorkoutDays(specs, '2026-01-05');
+
+    expect(days).toHaveLength(6); // 3 weeks × 2 offsets — NOT 2 collided cards
+    expect(days.every((d) => d.lifts.length === 2)).toBe(true); // 2 lifts each, not 6
+    expect(days.map((d) => d.week)).toEqual([1, 1, 2, 2, 3, 3]);
+    expect(days.map((d) => d.workoutNum)).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(days[0]?.lifts.map((l) => l.lift)).toEqual(['Squat', 'Bench Press']);
+    // Dates advance a full week per program week: week-2 offset-0 is 7 days after week-1 offset-0.
+    expect(days[0]?.date).toBe('2026-01-05');
+    expect(days[2]?.date).toBe('2026-01-12');
+  });
+
+  it('expands a single-week repeating program to its canonical length', () => {
+    // Leangains: a 1-week block of 3 offsets tiled across 12 canonical weeks.
+    const base = [0, 2, 4].map((offset, i) =>
+      makeSpec({ week: 1, offset, lift: `Lift${i}` }),
+    );
+
+    const days = buildWorkoutDays(base, '2026-01-05', 'leangains');
+
+    expect(days).toHaveLength(36); // 12 weeks × 3 workouts
+    expect(new Set(days.map((d) => d.week)).size).toBe(12);
+    expect(days.filter((d) => d.week === 12)).toHaveLength(3);
+    // workoutNum is a global sequential index over (week, offset).
+    expect(days[3]?.workoutNum).toBe(4);
+    expect(days[3]?.week).toBe(2);
+  });
+
+  it('does not collide a 3-week custom program whose lifts all share offset 0', () => {
+    // Every ProgramEditor custom program is a 3-week spec with all lifts at offset 0.
+    const specs = [1, 2, 3].flatMap((week) =>
+      ['Squat', 'Bench Press'].map((lift, i) =>
+        makeSpec({ week, offset: 0, lift, order: i + 1 }),
+      ),
+    );
+
+    const days = buildWorkoutDays(specs, '2026-01-05');
+
+    expect(days).toHaveLength(3); // one workout per week — NOT one collided card of 6 lifts
+    expect(days.map((d) => d.week)).toEqual([1, 2, 3]);
+    expect(days.every((d) => d.lifts.length === 2)).toBe(true);
+  });
+});
+
 describe('computePlannedSets', () => {
   it('computes warmup and work sets from training max', () => {
     const spec = makeSpec({

--- a/apps/web/lib/workoutPlan.ts
+++ b/apps/web/lib/workoutPlan.ts
@@ -4,6 +4,9 @@ import {
   PROG_SPEC_WORK_PCTS,
   WARMUP_BASE_REPS,
   addDaysUTC,
+  expandSpecToLength,
+  orderedWorkoutKeys,
+  programLengthWeeks,
 } from '@lifting-logbook/core';
 import type { LiftingProgramSpecResponse } from '@lifting-logbook/types';
 
@@ -34,15 +37,24 @@ export interface WeekRow {
 }
 
 /**
- * Groups program specs by their offset (workout day) and returns an ordered
- * list of workout days with derived dates.
+ * Tiles a program's stored block to its canonical length and returns the ordered
+ * list of workout days, one per distinct `(week, offset)`, with derived dates.
  *
- * Lifts sharing the same offset belong to the same workout session. Offsets
- * are sorted ascending so workoutNum maps 1:1 to chronological order.
+ * Grouping is by `(week, offset)` — not `offset` alone, which collides workouts
+ * that share an offset across weeks (5-3-1's 6 workouts, or a 3-week custom
+ * program with every lift at offset 0) into a single card. The stored spec is
+ * only one repeating block, so it is first expanded to `programLengthWeeks`
+ * (leangains 12 wks, rpt 8, etc.); `program` is optional and falls back to the
+ * base-spec block length for custom / unregistered programs.
+ *
+ * `workoutNum` is a global sequential index over {@link orderedWorkoutKeys} — the
+ * same helper the API's no-schedule `weekForWorkoutNum` uses — so a card's
+ * `workoutNum` always resolves to the workout it links to (issue #740).
  */
 export function buildWorkoutDays(
   specs: LiftingProgramSpecResponse[],
   cycleStartDate: string,
+  program?: string,
 ): WorkoutDay[] {
   const [y, m, d] = cycleStartDate.split('-').map(Number) as [
     number,
@@ -51,24 +63,32 @@ export function buildWorkoutDays(
   ];
   const startDate = new Date(Date.UTC(y, m - 1, d));
 
-  const byOffset = new Map<number, LiftingProgramSpecResponse[]>();
-  for (const spec of specs) {
-    const lifts = byOffset.get(spec.offset) ?? [];
+  const fullSpec = expandSpecToLength(specs, programLengthWeeks(program ?? '', specs));
+
+  const byKey = new Map<string, LiftingProgramSpecResponse[]>();
+  for (const spec of fullSpec) {
+    const key = `${spec.week}:${spec.offset}`;
+    const lifts = byKey.get(key) ?? [];
     lifts.push(spec);
-    byOffset.set(spec.offset, lifts);
+    byKey.set(key, lifts);
   }
 
-  return Array.from(byOffset.keys())
-    .sort((a, b) => a - b)
-    .map((offset, i) => {
-      const lifts = (byOffset.get(offset) ?? []).sort((a, b) => a.order - b.order);
-      return {
-        workoutNum: i + 1,
-        week: lifts[0]?.week ?? 1,
-        date: addDaysUTC(startDate, offset).toISOString().slice(0, 10),
-        lifts,
-      };
-    });
+  return orderedWorkoutKeys(fullSpec).map((k, i) => {
+    const lifts = (byKey.get(`${k.week}:${k.offset}`) ?? []).sort(
+      (a, b) => a.order - b.order,
+    );
+    return {
+      workoutNum: i + 1,
+      week: k.week,
+      // Program weeks are 7 calendar days (distributeWorkouts), so a workout's
+      // absolute offset from the cycle start is (week-1)*7 + its in-week offset.
+      // Week 1 is unchanged from the pre-#740 single-block behavior.
+      date: addDaysUTC(startDate, (k.week - 1) * 7 + k.offset)
+        .toISOString()
+        .slice(0, 10),
+      lifts,
+    };
+  });
 }
 
 /**

--- a/packages/core/src/presets/programLengths.test.ts
+++ b/packages/core/src/presets/programLengths.test.ts
@@ -2,6 +2,7 @@ import {
   PRESET_BASE_SPECS,
   PROGRAM_LENGTHS,
   baseSpecBlockWeeks,
+  blockWeekForProgramWeek,
   programLengthWeeks,
   expandSpecToLength,
   orderedWorkoutKeys,
@@ -231,6 +232,39 @@ describe('expandSpecToLength', () => {
     expect(baseSpecBlockWeeks(expanded)).toBe(12);
     // Same rows per week as the 1-week block, tiled 12×.
     expect(expanded).toHaveLength(base.length * 12);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// blockWeekForProgramWeek — inverse of expandSpecToLength's tiling (issue #740)
+// ---------------------------------------------------------------------------
+
+describe('blockWeekForProgramWeek', () => {
+  it('maps a program week back into a 3-week block (5-3-1 waves)', () => {
+    expect(blockWeekForProgramWeek(1, 3)).toBe(1);
+    expect(blockWeekForProgramWeek(2, 3)).toBe(2);
+    expect(blockWeekForProgramWeek(3, 3)).toBe(3);
+    expect(blockWeekForProgramWeek(4, 3)).toBe(1); // wave 2, block week 1
+    expect(blockWeekForProgramWeek(12, 3)).toBe(3);
+  });
+
+  it('is the identity for a 1-week repeating block', () => {
+    expect(blockWeekForProgramWeek(1, 1)).toBe(1);
+    expect(blockWeekForProgramWeek(12, 1)).toBe(1);
+  });
+
+  it('returns the program week unchanged when blockWeeks <= 0 (empty spec)', () => {
+    expect(blockWeekForProgramWeek(5, 0)).toBe(5);
+  });
+
+  it('stays in lockstep with expandSpecToLength tiling', () => {
+    // Every tiled row's program week must map back to the block week it came from
+    // — this is the invariant the workouts controller relies on for planned lifts.
+    // block3 encodes its block week in `reps` (wk1→5, wk2→3, wk3→1).
+    const repsForBlockWeek: Record<number, number> = { 1: 5, 2: 3, 3: 1 };
+    for (const row of expandSpecToLength(block3, 12)) {
+      expect(row.reps).toBe(repsForBlockWeek[blockWeekForProgramWeek(row.week, 3)]);
+    }
   });
 });
 

--- a/packages/core/src/presets/programLengths.test.ts
+++ b/packages/core/src/presets/programLengths.test.ts
@@ -4,6 +4,7 @@ import {
   baseSpecBlockWeeks,
   programLengthWeeks,
   expandSpecToLength,
+  orderedWorkoutKeys,
 } from '.';
 import { LiftingProgramSpec } from '../models/LiftingProgramSpec';
 
@@ -230,5 +231,45 @@ describe('expandSpecToLength', () => {
     expect(baseSpecBlockWeeks(expanded)).toBe(12);
     // Same rows per week as the 1-week block, tiled 12×.
     expect(expanded).toHaveLength(base.length * 12);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// orderedWorkoutKeys — the shared workoutNum ↔ (week, offset) mapping (issue #740)
+// ---------------------------------------------------------------------------
+
+describe('orderedWorkoutKeys', () => {
+  it('returns distinct (week, offset) keys ordered by week then offset', () => {
+    // Rows deliberately out of order, with duplicate (week, offset) pairs and
+    // multiple lifts sharing a workout day.
+    const spec = [
+      makeRow({ week: 2, offset: 3, lift: 'A' }),
+      makeRow({ week: 1, offset: 3, lift: 'B' }),
+      makeRow({ week: 1, offset: 0, lift: 'C' }),
+      makeRow({ week: 1, offset: 0, lift: 'D' }), // duplicate key with row C
+      makeRow({ week: 2, offset: 0, lift: 'E' }),
+    ];
+    expect(orderedWorkoutKeys(spec)).toEqual([
+      { week: 1, offset: 0 },
+      { week: 1, offset: 3 },
+      { week: 2, offset: 0 },
+      { week: 2, offset: 3 },
+    ]);
+  });
+
+  it('returns [] for an empty spec', () => {
+    expect(orderedWorkoutKeys([])).toEqual([]);
+  });
+
+  it('indexes workoutNum → (week, offset) consistently with a tiled Leangains block', () => {
+    // Both the web grid (buildWorkoutDays) and the API (weekForWorkoutNum) call
+    // orderedWorkoutKeys(expandSpecToLength(...)), so this is the single contract
+    // that keeps a Dashboard card's workoutNum aligned with the workout it opens.
+    const base = (PRESET_BASE_SPECS['leangains'] ?? []);
+    const keys = orderedWorkoutKeys(expandSpecToLength(base, 12));
+    expect(keys).toHaveLength(36); // 12 weeks × 3 offsets {0,2,4}
+    expect(keys[0]).toEqual({ week: 1, offset: 0 });
+    expect(keys[3]).toEqual({ week: 2, offset: 0 }); // workoutNum 4 → week 2
+    expect(keys[35]?.week).toBe(12);
   });
 });

--- a/packages/core/src/presets/programLengths.ts
+++ b/packages/core/src/presets/programLengths.ts
@@ -1,5 +1,4 @@
 import { WeekNumber } from '@lifting-logbook/types';
-import { LiftingProgramSpec } from '../models/LiftingProgramSpec';
 
 /**
  * How a program's weeks are periodized for plan display.
@@ -86,23 +85,27 @@ export function programLengthWeeks(
  * Returns `[]` for an empty base spec (zero-spec guard) or `lengthWeeks <= 0`,
  * so callers computing `Math.max(...expanded.map(s => s.week))` must still guard
  * the empty case (`Math.max(...[])` is `-Infinity`).
+ *
+ * Generic over the row type so both the domain {@link LiftingProgramSpec} (API)
+ * and its serialized `LiftingProgramSpecResponse` (web) can be tiled without a
+ * cast — only the `week` field is read or rewritten.
  */
-export function expandSpecToLength(
-  baseSpec: LiftingProgramSpec[],
+export function expandSpecToLength<T extends { week: WeekNumber }>(
+  baseSpec: T[],
   lengthWeeks: number,
-): LiftingProgramSpec[] {
+): T[] {
   const blockWeeks = baseSpecBlockWeeks(baseSpec);
   if (blockWeeks <= 0 || lengthWeeks <= 0) return [];
 
   // Group rows by their in-block week once, preserving each week's row order.
-  const rowsByWeek = new Map<number, LiftingProgramSpec[]>();
+  const rowsByWeek = new Map<number, T[]>();
   for (const row of baseSpec) {
     const arr = rowsByWeek.get(row.week) ?? [];
     arr.push(row);
     rowsByWeek.set(row.week, arr);
   }
 
-  const expanded: LiftingProgramSpec[] = [];
+  const expanded: T[] = [];
   for (let week = 1; week <= lengthWeeks; week++) {
     const blockWeek = ((week - 1) % blockWeeks) + 1;
     for (const row of rowsByWeek.get(blockWeek) ?? []) {
@@ -110,4 +113,29 @@ export function expandSpecToLength(
     }
   }
   return expanded;
+}
+
+/**
+ * The distinct `(week, offset)` workout-day keys of a spec, ordered by week then
+ * offset. This is the canonical `workoutNum ↔ (week, offset)` mapping — the Nth
+ * entry (1-based) is `workoutNum` N.
+ *
+ * Both the web Cycle Dashboard grid (`buildWorkoutDays`) and the API's no-schedule
+ * `weekForWorkoutNum` fallback derive `workoutNum` from this single helper, so a
+ * card's `workoutNum` and the workout it opens can never disagree. Callers pass a
+ * spec already tiled to the canonical length via {@link expandSpecToLength}, so the
+ * ordering spans the whole cycle rather than a single repeating block (issue #740).
+ */
+export function orderedWorkoutKeys(
+  spec: ReadonlyArray<{ week: WeekNumber; offset: number }>,
+): { week: WeekNumber; offset: number }[] {
+  const seen = new Set<string>();
+  const keys: { week: WeekNumber; offset: number }[] = [];
+  for (const row of spec) {
+    const key = `${row.week}:${row.offset}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    keys.push({ week: row.week, offset: row.offset });
+  }
+  return keys.sort((a, b) => a.week - b.week || a.offset - b.offset);
 }

--- a/packages/core/src/presets/programLengths.ts
+++ b/packages/core/src/presets/programLengths.ts
@@ -73,6 +73,18 @@ export function programLengthWeeks(
 }
 
 /**
+ * Maps a program week (`1..lengthWeeks`) back to its week within the repeating
+ * block. This is the inverse of {@link expandSpecToLength}'s tiling: the workouts
+ * controller derives a tiled workout's planned lifts from its block week, so it
+ * must pick the *same* block week `expandSpecToLength` tiled into that program
+ * week — sharing this one function keeps the two in lockstep (issue #740).
+ * `blockWeeks <= 0` (empty spec) returns the program week unchanged.
+ */
+export function blockWeekForProgramWeek(week: number, blockWeeks: number): number {
+  return blockWeeks > 0 ? ((week - 1) % blockWeeks) + 1 : week;
+}
+
+/**
  * Tiles a base spec (one repeating block) across `lengthWeeks` by repeating the
  * block's rows with incremented `week` numbers. Read-time expansion only — stored
  * specs are never mutated, so there is no DB migration and revert is a pure code
@@ -107,7 +119,7 @@ export function expandSpecToLength<T extends { week: WeekNumber }>(
 
   const expanded: T[] = [];
   for (let week = 1; week <= lengthWeeks; week++) {
-    const blockWeek = ((week - 1) % blockWeeks) + 1;
+    const blockWeek = blockWeekForProgramWeek(week, blockWeeks);
     for (const row of rowsByWeek.get(blockWeek) ?? []) {
       expanded.push({ ...row, week });
     }

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -206,6 +206,11 @@ export interface CycleDashboardResponse {
    * modes — `weeks` is empty in no-schedule mode, so the Cycle Dashboard reads
    * these to render every tiled workout's status without a per-workout fetch
    * (issue #740). Keys are global `workoutNum`s.
+   *
+   * These three are the canonical per-workout source of truth. The per-week
+   * `weeks[].workouts[].date` / `.skipped` fields are a schedule-mode display
+   * projection derived from the same override/skip data — prefer these top-level
+   * maps in new consumers.
    */
   /** `workoutNum` → override date (ISO 8601). Absent key = no override. */
   dateOverrides: Record<number, string>;

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -201,6 +201,18 @@ export interface CycleDashboardResponse {
   cycleStartDate: string; // ISO 8601 date string
   weeks: CycleWeekSummary[];
   currentWeekType: WeekType;
+  /**
+   * Per-workout metadata for the *whole* cycle, in both schedule and no-schedule
+   * modes — `weeks` is empty in no-schedule mode, so the Cycle Dashboard reads
+   * these to render every tiled workout's status without a per-workout fetch
+   * (issue #740). Keys are global `workoutNum`s.
+   */
+  /** `workoutNum` → override date (ISO 8601). Absent key = no override. */
+  dateOverrides: Record<number, string>;
+  /** `workoutNum`s explicitly skipped in this cycle. */
+  skippedWorkoutNums: number[];
+  /** `workoutNum`s with at least one logged lift record in this cycle. */
+  completedWorkoutNums: number[];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The Cycle Dashboard grid (`apps/web/app/(authed)/cycle/[cycleNum]/page.tsx` → `buildWorkoutDays`) grouped spec rows by **`offset` alone**, producing two shipped defects, and fixing them unmasked a coupled backend cap that would have crashed the page. This PR fixes all three together and folds the Dashboard's per-workout fetch fan-out into O(1) bulk reads.

Follow-up to #680 (single source of truth for program length + schedule-mode tiling) and #727 (faithful Program Plan). Those fixed the Program Plan page and schedule generation but not the direct `page.tsx → buildWorkoutDays` Dashboard path or the no-schedule `fetchWorkout` cap.

## Root cause (two coupled layers)

1. **Web — `buildWorkoutDays` keyed on `offset` alone.** It collapsed workouts that share an offset across weeks into one card (5-3-1's 6 workouts → 2 cards of 6 lifts; **every** `ProgramEditor` custom program is a 3-week spec with all lifts at `offset:0` → a single mega-card) and never expanded past the stored block, so leangains/rpt showed only 1 week — contradicting the Program Plan page's canonical length.
2. **API — the no-schedule `weekForWorkoutNum` fallback capped `workoutNum` at one block's distinct offsets** (`400` beyond). `fetchWorkout` throws on `400` (`requestNullable` nulls only 404/204), and `page.tsx` `Promise.all`s a `fetchWorkout` per workout day — so **any** `400` crashed the whole Dashboard. #680 fixed this only for schedule mode. Fixing (1) alone would have unmasked this and crashed the page for the default (no-schedule) user, so the backend fix is mandatory, not optional.

## What changed

- **core (`programLengths.ts`)** — `expandSpecToLength` is now generic over `{ week }` (callable with the web `LiftingProgramSpecResponse` and API `LiftingProgramSpec`). New `orderedWorkoutKeys(spec)` returns distinct `(week, offset)` keys ordered by week then offset — the single `workoutNum ↔ (week, offset)` mapping used by **both** the web grid and the API, so a card's `workoutNum` always resolves to the workout it links to.
- **web (`workoutPlan.ts`, `page.tsx`)** — `buildWorkoutDays(specs, cycleStartDate, program)` tiles to `programLengthWeeks`, groups by `(week, offset)` via `orderedWorkoutKeys`, and computes week-aware dates `(week-1)*7 + offset` (week 1 unchanged). `page.tsx` drops the N× `fetchWorkout` fan-out entirely: `logged`/`overrideDate`/`skipped` now come from bulk dashboard fields.
- **API (`mappers.ts`, `workouts.controller.ts`, `cycle-dashboard.controller.ts`) + types** — `weekForWorkoutNum(spec, workoutNum, program)` tiles to the full canonical length (cap moves from one block to the whole cycle) via the same `orderedWorkoutKeys` helper. `CycleDashboardResponse` gains additive `dateOverrides` / `skippedWorkoutNums` / `completedWorkoutNums`, populated in both modes from the bulk repos the dashboard controller already fetches (the Program Plan page ignores them — no ripple).

## Acceptance criteria

- [x] Grid groups by `(week, offset)` — multi-week and all-`offset:0` custom programs no longer collide.
- [x] Grid spans each program's canonical length (leangains 12w, rpt 8w, 5-3-1 12w), matching the Program Plan page.
- [x] No-schedule `fetchWorkout` resolves tiled `workoutNum`s up to the canonical length (no `400`); still `400`s beyond it.
- [x] `workoutNum ↔ (week, offset)` mapping is identical between the web grid and the API (shared `orderedWorkoutKeys`).
- [x] Dashboard no longer crashes for custom / multi-week programs.
- [x] Per-workout fetch fan-out reduced to O(1) (zero per-workout `fetchWorkout`).
- [x] Tests: unit (`buildWorkoutDays`, `orderedWorkoutKeys`), API (`weekForWorkoutNum` tiling + controller + dashboard fields), and in-memory E2E (no-schedule tiled `GET workouts/3`).

## Testing

`npm run typecheck` — 4 packages, clean. All suites green:

- `@lifting-logbook/core`: **Tests: 314 passed, 0 skipped, 0 failed** (`programLengths` incl. new `orderedWorkoutKeys` + generic `expandSpecToLength`)
- `@lifting-logbook/api-client`: **Tests: 27 passed, 0 skipped, 0 failed**
- `@lifting-logbook/web` (jest): **Tests: 228 passed, 0 skipped, 0 failed** (`workoutPlan` collision/expansion/date tests)
- `@lifting-logbook/api` (unit + in-memory E2E): **Tests: 380 passed, 0 skipped, 0 failed** (`mappers`, `workouts.controller`, `cycle-dashboard.controller`, `programs.e2e` tiled-workout)
- `@lifting-logbook/api` (DB E2E, Testcontainers Postgres): **Tests: 75 passed, 0 skipped, 0 failed** — run separately with Docker up (no `LIFTING_SKIP_DB_E2E` skip in the final aggregate)
- `apps/web` Playwright E2E `smoke.spec.ts`: **11 passed** (the Dashboard grid renders + the merged `#738` progress bar reads the true full-length total)

The failing-then-passing collision/expansion tests were written first (red on the pre-fix `buildWorkoutDays`, which returned 1 card of 6 lifts / 3 days instead of 6 / 36).

### Test-integrity note (ADR-029)

No skips added, no test files deleted, no thresholds lowered. Several **assertions were rewritten to match the intentionally-changed contract**, each justified:

- `apps/api/src/programs/mappers.spec.ts` — the `weekForWorkoutNum` describe asserted the pre-#740 offset-cap (undefined beyond one block's distinct offsets). Rewritten to assert the new tiled `(week, offset)` mapping and the full-length cap. The no-`week`-field defensive cases were dropped because `LiftingProgramSpec.week` is a required field (the scenario was type-invalid).
- `apps/api/src/programs/workouts.controller.spec.ts` — the two tests asserting the offset-cap 400 were rewritten: one to the new full-length cap (workout 37 of a 36-workout leangains cycle still 400s), the other to the key new behavior (no-schedule tiled week-2 workout now resolves instead of 400ing).
- `cycle-dashboard.controller.spec.ts` / `cycle-generation.controller.spec.ts` — full-response `toEqual`s extended with the 3 additive fields.

## Note — rebased onto #738

[#738](https://github.com/brownm09/lifting-logbook/pull/738) (Cycle Progress bar) merged to `main` mid-work and also touched `workoutPlan.ts`, its test, and `smoke.spec.ts`. Rebased cleanly (auto-merged); my expansion makes #738's "N of M workouts" readout reflect the true canonical length. The combined `smoke` dashboard test (my expand-Week-1 + #738's progress-bar assertions) passes.

## Review findings disposition

`/review` (2 parallel Opus passes over the 516-line diff) found **1 blocking + 6 non-blocking** findings — all resolved. Full review: [PR comment](https://github.com/brownm09/lifting-logbook/pull/743#issuecomment-4916821523). Core web↔API `workoutNum ↔ (week, offset)` mapping confirmed sound by construction; no correctness/security blockers.

| # | Category | Finding | Disposition |
|---|---|---|---|
| 1 | reliability (blocking) | Unguarded `dateOverrides` access crashes dashboard if a rolling deploy serves web ahead of api | Fixed in `d8d8d32` (guard all three fields) |
| 2 | maintainability | `((week-1)%blockWeeks)+1` duplicated core↔api | Fixed in `d8d8d32` — extracted `blockWeekForProgramWeek` + lockstep test |
| 3 | performance | Full-length RSC payload (~12×) | Documented in `d8d8d32` (conscious trade for dropping ~36 round-trips) |
| 4 | correctness | `logged` from raw records (removed-lift edge) | Documented in `d8d8d32` (intentional; matches dashboard week-completion logic) |
| 5 | maintainability | Top-level vs `weeks[]` "skipped" redundancy | Fixed in `d8d8d32` (canonical-vs-display JSDoc) |
| 6 | maintainability | `*7` / `offset<7` invariant | Documented (existing date-formula comment) |
| 7 | correctness | No-schedule card-vs-detail date divergence (pre-existing, amplified) | Filed #745 |

Closes #740

🤖 Generated with [Claude Code](https://claude.com/claude-code)
