### PR TITLE
[fix] No-schedule workout-detail date matches Cycle Dashboard card (#745)

### DIFF
--- a/apps/api/src/programs/mappers.spec.ts
+++ b/apps/api/src/programs/mappers.spec.ts
@@ -1,5 +1,11 @@
 import { CycleDashboard, LiftingProgramSpec, Weekday } from '@lifting-logbook/core';
-import { applyLiftOverrides, buildCycleDashboardResponse, toWorkoutResponse, weekForWorkoutNum } from './mappers';
+import {
+  applyLiftOverrides,
+  buildCycleDashboardResponse,
+  toWorkoutResponse,
+  weekForWorkoutNum,
+  workoutKeyForWorkoutNum,
+} from './mappers';
 import { LiftOverride } from '../ports/IWorkoutLiftOverrideRepository';
 import { ScheduledWorkout } from '../ports/ICycleScheduledWorkoutRepository';
 
@@ -69,6 +75,30 @@ describe('weekForWorkoutNum', () => {
     const s = [spec(0, 'Squat', 1), spec(0, 'Squat', 2), spec(0, 'Squat', 3)];
     expect(weekForWorkoutNum(s, 3, 'a-custom-uuid')).toBe(3);
     expect(weekForWorkoutNum(s, 4, 'a-custom-uuid')).toBeUndefined();
+  });
+});
+
+describe('workoutKeyForWorkoutNum', () => {
+  it('returns the (week, offset) key for a tiled Leangains block', () => {
+    // 1-week block of offsets {0,2} → tiled to 12 weeks = 24 workout days. The offset
+    // (not just the week) is what the no-schedule detail date needs (issue #745).
+    const s = [spec(0, 'Bench Press', 1), spec(2, 'Squat', 1)];
+    expect(workoutKeyForWorkoutNum(s, 1, 'leangains')).toEqual({ week: 1, offset: 0 });
+    expect(workoutKeyForWorkoutNum(s, 2, 'leangains')).toEqual({ week: 1, offset: 2 });
+    expect(workoutKeyForWorkoutNum(s, 3, 'leangains')).toEqual({ week: 2, offset: 0 }); // week-2 day
+    expect(workoutKeyForWorkoutNum(s, 24, 'leangains')).toEqual({ week: 12, offset: 2 });
+  });
+
+  it('returns undefined past the full canonical length', () => {
+    const s = [spec(0, 'Bench Press', 1), spec(2, 'Squat', 1)];
+    expect(workoutKeyForWorkoutNum(s, 25, 'leangains')).toBeUndefined();
+  });
+
+  it('weekForWorkoutNum is exactly its .week projection', () => {
+    const s = [spec(0, 'Squat', 1), spec(3, 'Deadlift', 1), spec(0, 'Squat', 2), spec(3, 'Deadlift', 2)];
+    for (const n of [1, 2, 3, 4, 5]) {
+      expect(weekForWorkoutNum(s, n)).toBe(workoutKeyForWorkoutNum(s, n)?.week);
+    }
   });
 });
 
@@ -176,6 +206,48 @@ describe('toWorkoutResponse with plannedLifts', () => {
     const scheduledDate = new Date('2026-06-02T00:00:00.000Z');
     const result = toWorkoutResponse(program, cycleNum, workoutNum, week, records, undefined, undefined, scheduledDate);
     expect(result.date).toBe(records[0]!.date.toISOString().slice(0, 10));
+  });
+
+  it('no-schedule, unlogged: derives date from cycleStart + (week-1)*7 + offset (issue #745)', () => {
+    // No records, no scheduledDate. Pre-#745 this fell back to today(); now it must
+    // equal the date the Cycle Dashboard card computes for the same (cycleStart,
+    // week, offset) — both route through the shared noScheduleWorkoutDateUTC.
+    const cycleStart = new Date('2026-04-20T00:00:00.000Z');
+    // week 2, offset 0 → 2026-04-20 + 7 = 2026-04-27 (NOT today).
+    const result = toWorkoutResponse(
+      program, cycleNum, 3, 2, [], undefined, ['Squat'], undefined, false, cycleStart, 0,
+    );
+    expect(result.date).toBe('2026-04-27');
+  });
+
+  it('no-schedule week-1 date is cycleStart + offset', () => {
+    const cycleStart = new Date('2026-04-20T00:00:00.000Z');
+    const result = toWorkoutResponse(
+      program, cycleNum, 2, 1, [], undefined, ['Squat'], undefined, false, cycleStart, 2,
+    );
+    expect(result.date).toBe('2026-04-22');
+  });
+
+  it('scheduledDate still wins over the cycleStart-derived no-schedule date', () => {
+    const cycleStart = new Date('2026-04-20T00:00:00.000Z');
+    const scheduledDate = new Date('2026-06-02T00:00:00.000Z');
+    const result = toWorkoutResponse(
+      program, cycleNum, 3, 2, [], undefined, ['Squat'], scheduledDate, false, cycleStart, 0,
+    );
+    expect(result.date).toBe('2026-06-02');
+  });
+
+  it('falls back to today only when cycleStartDate/offset are absent (defensive last resort)', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-15T12:00:00.000Z'));
+    try {
+      // No records, no scheduledDate, and no cycleStart/offset threaded → retains the
+      // pre-#745 today() behavior so a degenerate call (e.g. missing cycle dashboard)
+      // never crashes. The controller always threads them in real no-schedule mode.
+      const result = toWorkoutResponse(program, cycleNum, workoutNum, week, []);
+      expect(result.date).toBe('2026-08-15');
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });
 

--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -7,6 +7,7 @@ import {
   TrainingMaxHistoryEntry,
   expandSpecToLength,
   normalizeAmrap,
+  noScheduleWorkoutDateUTC,
   orderedWorkoutKeys,
   programLengthWeeks,
 } from '@lifting-logbook/core';
@@ -233,29 +234,40 @@ export const isValidWorkoutNum = (n: number): boolean =>
   Number.isInteger(n) && n >= 1;
 
 /**
- * Derives the training week for a global `workoutNum` from the program spec — the
- * no-schedule fallback (a scheduled row's `weekNum` is authoritative when present).
- *
- * The stored spec is one repeating block, so it is first tiled to the program's
- * canonical length ({@link expandSpecToLength} + {@link programLengthWeeks}); the
- * `workoutNum` then indexes into the ordered `(week, offset)` workout days
- * ({@link orderedWorkoutKeys}) — the *same* mapping the web Cycle Dashboard grid
- * (`buildWorkoutDays`) uses, so a card and the workout it opens never disagree.
+ * The `(week, offset)` workout-day key for a global `workoutNum`, or undefined when
+ * `workoutNum` exceeds the program's canonical length. The stored spec is one
+ * repeating block, so it is first tiled to the program's canonical length
+ * ({@link expandSpecToLength} + {@link programLengthWeeks}); the `workoutNum` then
+ * indexes into the ordered `(week, offset)` workout days ({@link orderedWorkoutKeys})
+ * — the *same* mapping the web Cycle Dashboard grid (`buildWorkoutDays`) uses, so a
+ * card and the workout it opens can never disagree on week, offset, or the
+ * spec-relative date derived from them (issues #740, #745). `program` defaults to
+ * the base-spec block length for custom / unregistered programs.
+ */
+export const workoutKeyForWorkoutNum = (
+  spec: LiftingProgramSpec[],
+  workoutNum: number,
+  program = '',
+): { week: WeekNumber; offset: number } | undefined => {
+  const fullSpec = expandSpecToLength(spec, programLengthWeeks(program, spec));
+  return orderedWorkoutKeys(fullSpec)[workoutNum - 1];
+};
+
+/**
+ * The training week for a global `workoutNum` — the no-schedule fallback (a
+ * scheduled row's `weekNum` is authoritative when present). A thin `.week` accessor
+ * over {@link workoutKeyForWorkoutNum}; see it for the tiling contract.
  *
  * Returns undefined only when `workoutNum` exceeds the *full* canonical length
  * (surfaced as 400 by the controller). Before #740 the cap was one block's
  * distinct-offset count, which 400'd every week-2+ workout of a tiled program in
- * no-schedule mode (#680 fixed this only for schedule mode). `program` defaults to
- * the base-spec block length for custom / unregistered programs.
+ * no-schedule mode (#680 fixed this only for schedule mode).
  */
 export const weekForWorkoutNum = (
   spec: LiftingProgramSpec[],
   workoutNum: number,
   program = '',
-): WeekNumber | undefined => {
-  const fullSpec = expandSpecToLength(spec, programLengthWeeks(program, spec));
-  return orderedWorkoutKeys(fullSpec)[workoutNum - 1]?.week;
-};
+): WeekNumber | undefined => workoutKeyForWorkoutNum(spec, workoutNum, program)?.week;
 
 /**
  * Groups a workout's lift records into the WorkoutResponse shape.
@@ -267,6 +279,16 @@ export const weekForWorkoutNum = (
  * `planned: true`. Logged lifts not in the planned list are appended with
  * `planned: false`. When `plannedLifts` is omitted, all logged lifts are emitted
  * in record order with `planned: false` (preserves pre-override behaviour).
+ *
+ * The response `date` is the first logged record's date, else `scheduledDate`
+ * (schedule mode), else — for a no-schedule unlogged workout — the spec-relative
+ * date `cycleStart + (week-1)*7 + offset` derived from `cycleStartDate` + `offset`
+ * (this workout's `(week, offset)` key offset, from `workoutKeyForWorkoutNum`) via
+ * the shared {@link noScheduleWorkoutDateUTC}. That is the SAME date the Cycle
+ * Dashboard card shows (`buildWorkoutDays` calls the same helper), so the card and
+ * this detail page can never diverge (issue #745). Omitting `cycleStartDate` /
+ * `offset` falls back to today only as a defensive last resort (e.g. no cycle
+ * dashboard), which is what the pre-#745 code always did in no-schedule mode.
  */
 export const toWorkoutResponse = (
   program: string,
@@ -278,6 +300,8 @@ export const toWorkoutResponse = (
   plannedLifts?: string[],
   scheduledDate?: Date,
   skipped = false,
+  cycleStartDate?: Date,
+  offset?: number,
 ): WorkoutResponse => {
   const liftMap = new Map<string, SetResponse[]>();
   for (const r of records) {
@@ -318,7 +342,9 @@ export const toWorkoutResponse = (
     ? isoDate(records[0].date)
     : scheduledDate
       ? isoDate(scheduledDate)
-      : isoDate(new Date());
+      : cycleStartDate !== undefined && offset !== undefined
+        ? isoDate(noScheduleWorkoutDateUTC(cycleStartDate, week, offset))
+        : isoDate(new Date());
   return {
     program,
     cycleNum,

--- a/apps/api/src/programs/workouts.controller.spec.ts
+++ b/apps/api/src/programs/workouts.controller.spec.ts
@@ -188,6 +188,31 @@ describe('WorkoutsController', () => {
     expect(result.lifts.every((l) => l.planned)).toBe(true);
   });
 
+  it('sets the no-schedule detail date to the Cycle Dashboard card date, not today (issue #745)', async () => {
+    // Same leangains 2-offset block + cycleStart as the web buildWorkoutDays card
+    // test, so this asserts card date == detail date end-to-end. workout 3 → (week 2,
+    // offset 0) → cycleStart 2026-04-20 + 7 = 2026-04-27. Pre-#745 the no-schedule,
+    // unlogged detail fell back to today() and diverged from the card.
+    dashboardRepo.getCycleDashboard.mockResolvedValue({
+      program: 'leangains',
+      cycleUnit: 'week',
+      cycleNum: 3,
+      cycleDate: new Date('2026-04-20T00:00:00.000Z'),
+      sheetName: '',
+      cycleStartWeekday: Weekday.Monday,
+    });
+    specRepo.getProgramSpec.mockResolvedValue([
+      { week: 1, offset: 0, lift: 'Bench Press', increment: 5, order: 1, sets: 3, reps: 6, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+      { week: 1, offset: 2, lift: 'Squat', increment: 10, order: 1, sets: 3, reps: 6, amrap: true, warmUpPct: '0.4,0.5,0.6', wtDecrementPct: 0.1, activation: 'compound' },
+    ]);
+    workoutRepo.getWorkout.mockResolvedValue([]); // upcoming — no records, no schedule
+
+    const result = await controller.getWorkout('leangains', '3', MOCK_USER);
+
+    expect(result.week).toBe(2);
+    expect(result.date).toBe('2026-04-27');
+  });
+
   it('resolves week from the scheduled row for a tiled week-2+ workout (issue #680)', async () => {
     // A 12-week Leangains schedule tiles a 1-week block, so workoutNum 4 lands in
     // week 2 — beyond the block's 2 distinct offsets. Without sourcing week from

--- a/apps/api/src/programs/workouts.controller.ts
+++ b/apps/api/src/programs/workouts.controller.ts
@@ -16,7 +16,7 @@ import {
   applyLiftOverrides,
   isValidWorkoutNum,
   toWorkoutResponse,
-  weekForWorkoutNum,
+  workoutKeyForWorkoutNum,
 } from './mappers';
 
 @Controller('programs/:program')
@@ -67,12 +67,15 @@ export class WorkoutsController {
     const scheduledDate = scheduledWorkout?.scheduledDate;
 
     // The scheduled row's weekNum is authoritative for the program week. With no
-    // schedule, weekForWorkoutNum tiles the stored block to the program's canonical
-    // length and indexes the global workoutNum into the ordered (week, offset)
-    // workout days — so week-2+ workouts of a tiled program (Leangains 12w, 5-3-1
-    // 12w) resolve in no-schedule mode too, not only schedule mode (#680 completed
-    // by #740). Undefined now means workoutNum is past the *full* canonical length.
-    const week = scheduledWorkout?.weekNum ?? weekForWorkoutNum(spec, workoutNum, program);
+    // schedule, workoutKeyForWorkoutNum tiles the stored block to the program's
+    // canonical length and indexes the global workoutNum into the ordered
+    // (week, offset) workout days — so week-2+ workouts of a tiled program
+    // (Leangains 12w, 5-3-1 12w) resolve in no-schedule mode too, not only schedule
+    // mode (#680 completed by #740). Undefined means workoutNum is past the *full*
+    // canonical length. The key's `offset` also feeds the no-schedule detail date
+    // below, keeping it aligned with the Cycle Dashboard card (issue #745).
+    const workoutKey = workoutKeyForWorkoutNum(spec, workoutNum, program);
+    const week = scheduledWorkout?.weekNum ?? workoutKey?.week;
     if (week === undefined) {
       throw new BadRequestException(
         `workoutNum ${workoutNum} exceeds the program's ${programLengthWeeks(program, spec)}-week schedule`,
@@ -86,6 +89,12 @@ export class WorkoutsController {
     const specLifts = [...new Set(spec.filter((s) => s.week === blockWeek).map((s) => s.lift))];
 
     const plannedLifts = applyLiftOverrides(specLifts, liftOverrides);
+
+    // cycleDate is absent only on the ProgramNotFoundError fallback ({ cycleNum: 1 }),
+    // where the spec is empty so the workoutNum guard above already 400'd. When
+    // present it anchors the no-schedule detail date to the same cycle start the
+    // dashboard card derives its date from (issue #745).
+    const cycleStartDate = 'cycleDate' in dashboard ? dashboard.cycleDate : undefined;
 
     // Apply overrides to logged records so removed/replaced lifts don't
     // re-appear via the "append ad-hoc logged lifts" path in toWorkoutResponse.
@@ -112,6 +121,8 @@ export class WorkoutsController {
       plannedLifts,
       scheduledDate,
       skippedNums.has(workoutNum),
+      cycleStartDate,
+      workoutKey?.offset,
     );
   }
 }

--- a/apps/web/lib/__tests__/workoutPlan.test.ts
+++ b/apps/web/lib/__tests__/workoutPlan.test.ts
@@ -124,6 +124,19 @@ describe('buildWorkoutDays — multi-week grouping and canonical-length expansio
     expect(days[3]?.week).toBe(2);
   });
 
+  it('no-schedule card date is cycleStart + (week-1)*7 + offset — matches the workout-detail date (issue #745)', () => {
+    // Same leangains 2-offset block + cycleStart the API mappers/controller specs use
+    // for the detail page, so this locks card date == detail date. workout 3 →
+    // (week 2, offset 0) → 2026-04-20 + 7 = 2026-04-27 (the API asserts the same).
+    const base = [0, 2].map((offset, i) => makeSpec({ week: 1, offset, lift: `Lift${i}` }));
+
+    const days = buildWorkoutDays(base, '2026-04-20', 'leangains');
+
+    expect(days[2]?.workoutNum).toBe(3);
+    expect(days[2]?.week).toBe(2);
+    expect(days[2]?.date).toBe('2026-04-27');
+  });
+
   it('does not collide a 3-week custom program whose lifts all share offset 0', () => {
     // Every ProgramEditor custom program is a 3-week spec with all lifts at offset 0.
     const specs = [1, 2, 3].flatMap((week) =>

--- a/apps/web/lib/workoutPlan.ts
+++ b/apps/web/lib/workoutPlan.ts
@@ -3,8 +3,8 @@ import {
   PROG_SPEC_WARMUP_PCTS,
   PROG_SPEC_WORK_PCTS,
   WARMUP_BASE_REPS,
-  addDaysUTC,
   expandSpecToLength,
+  noScheduleWorkoutDateUTC,
   orderedWorkoutKeys,
   programLengthWeeks,
 } from '@lifting-logbook/core';
@@ -80,10 +80,10 @@ export function buildWorkoutDays(
     return {
       workoutNum: i + 1,
       week: k.week,
-      // Program weeks are 7 calendar days (distributeWorkouts), so a workout's
-      // absolute offset from the cycle start is (week-1)*7 + its in-week offset.
-      // Week 1 is unchanged from the pre-#740 single-block behavior.
-      date: addDaysUTC(startDate, (k.week - 1) * 7 + k.offset)
+      // cycleStart + (week-1)*7 + offset, via the shared core helper the API's
+      // no-schedule detail fallback (toWorkoutResponse) also calls — so a card's
+      // date can never drift from the workout it opens (issues #740, #745).
+      date: noScheduleWorkoutDateUTC(startDate, k.week, k.offset)
         .toISOString()
         .slice(0, 10),
       lifts,

--- a/packages/core/src/presets/programLengths.test.ts
+++ b/packages/core/src/presets/programLengths.test.ts
@@ -6,6 +6,7 @@ import {
   programLengthWeeks,
   expandSpecToLength,
   orderedWorkoutKeys,
+  noScheduleWorkoutDateUTC,
 } from '.';
 import { LiftingProgramSpec } from '../models/LiftingProgramSpec';
 
@@ -305,5 +306,39 @@ describe('orderedWorkoutKeys', () => {
     expect(keys[0]).toEqual({ week: 1, offset: 0 });
     expect(keys[3]).toEqual({ week: 2, offset: 0 }); // workoutNum 4 → week 2
     expect(keys[35]?.week).toBe(12);
+  });
+});
+
+describe('noScheduleWorkoutDateUTC', () => {
+  const cycleStart = new Date('2026-04-20T00:00:00.000Z'); // a Monday, UTC midnight
+  const iso = (d: Date) => d.toISOString().slice(0, 10);
+
+  it('week 1 is cycleStart + offset (no week term)', () => {
+    expect(iso(noScheduleWorkoutDateUTC(cycleStart, 1, 0))).toBe('2026-04-20');
+    expect(iso(noScheduleWorkoutDateUTC(cycleStart, 1, 2))).toBe('2026-04-22');
+  });
+
+  it('advances a full 7 days per program week: (week-1)*7 + offset', () => {
+    expect(iso(noScheduleWorkoutDateUTC(cycleStart, 2, 0))).toBe('2026-04-27'); // +7
+    expect(iso(noScheduleWorkoutDateUTC(cycleStart, 3, 4))).toBe('2026-05-08'); // +14+4
+    expect(iso(noScheduleWorkoutDateUTC(cycleStart, 12, 0))).toBe('2026-07-06'); // +77
+  });
+
+  it('returns a fresh UTC-midnight Date and does not mutate the input', () => {
+    const out = noScheduleWorkoutDateUTC(cycleStart, 2, 0);
+    expect(out.getUTCHours()).toBe(0);
+    expect(iso(cycleStart)).toBe('2026-04-20'); // input unchanged
+  });
+
+  it('is the date-side companion to orderedWorkoutKeys — one date per tiled workoutNum', () => {
+    // buildWorkoutDays (web card) and toWorkoutResponse (API detail) both resolve a
+    // workoutNum to its (week, offset) via orderedWorkoutKeys(expandSpecToLength(...))
+    // then feed it to this helper, so this is the single contract that keeps a card's
+    // date aligned with the workout it opens (issue #745).
+    const base = PRESET_BASE_SPECS['leangains'] ?? [];
+    const keys = orderedWorkoutKeys(expandSpecToLength(base, 12));
+    expect(keys[3]).toEqual({ week: 2, offset: 0 }); // workoutNum 4 → week 2, offset 0
+    // …and that (week, offset) yields the card/detail date cycleStart + 7.
+    expect(iso(noScheduleWorkoutDateUTC(cycleStart, 2, 0))).toBe('2026-04-27');
   });
 });

--- a/packages/core/src/presets/programLengths.ts
+++ b/packages/core/src/presets/programLengths.ts
@@ -1,4 +1,5 @@
 import { WeekNumber } from '@lifting-logbook/types';
+import { addDaysUTC } from '../utils/jsUtil';
 
 /**
  * How a program's weeks are periodized for plan display.
@@ -150,4 +151,26 @@ export function orderedWorkoutKeys(
     keys.push({ week: row.week, offset: row.offset });
   }
   return keys.sort((a, b) => a.week - b.week || a.offset - b.offset);
+}
+
+/**
+ * The UTC calendar date of a no-schedule workout day, from its `(week, offset)`
+ * key relative to the cycle start: `cycleStart + (week-1)*7 + offset` days.
+ * Program weeks are 7 calendar days (see `distributeWorkouts`), so a workout in
+ * program week W at in-week `offset` lands `(W-1)*7 + offset` days after the
+ * cycle start. Week 1 (`week === 1`) is just `cycleStart + offset`.
+ *
+ * The single source of truth for the spec-relative (no-schedule) workout date,
+ * shared by the web Cycle Dashboard grid (`buildWorkoutDays`) and the API
+ * no-schedule workout-detail fallback (`toWorkoutResponse`) so a card's date and
+ * the detail page it opens can never drift (issue #745). This is the date-side
+ * companion to {@link orderedWorkoutKeys}, which shares the `workoutNum ↔
+ * (week, offset)` mapping the same two callers use (issue #740).
+ */
+export function noScheduleWorkoutDateUTC(
+  cycleStart: Date,
+  week: number,
+  offset: number,
+): Date {
+  return addDaysUTC(cycleStart, (week - 1) * 7 + offset);
 }


### PR DESCRIPTION
## Summary

In **no-schedule mode**, a workout's date on the Cycle Dashboard grid diverged from the workout **detail** page it links to:

- **Dashboard card** (`apps/web/lib/workoutPlan.ts` `buildWorkoutDays`) computed the spec-relative date `cycleStart + (week-1)*7 + offset`.
- **Workout detail** (`apps/api/src/programs/mappers.ts` `toWorkoutResponse`) fell back to `isoDate(new Date())` — **today** — for an unlogged workout with no scheduled row.

So a no-schedule week-2+ card could read e.g. `2026-04-27` while the detail page it opened read today. Pre-existing (it applied to week 1 before #740), but [#740](https://github.com/brownm09/lifting-logbook/pull/743) amplified its surface from one stored block to the full tiled program (leangains 1 → 12 weeks). Surfaced by the PR #743 `/review`.

## Approach

Centralize the no-schedule date derivation in a single shared helper so the card and detail **cannot drift** — mirroring how #740 shared the `workoutNum ↔ (week, offset)` mapping via `orderedWorkoutKeys`.

- **`packages/core` — new `noScheduleWorkoutDateUTC(cycleStart, week, offset)`**: returns `cycleStart + (week-1)*7 + offset` (UTC). The date-side companion to `orderedWorkoutKeys`, co-located with it in `programLengths.ts`.
- **`apps/web` `buildWorkoutDays`**: now calls `noScheduleWorkoutDateUTC` instead of inlining the arithmetic (identical output — existing date tests unchanged).
- **`apps/api` `mappers.ts`**: `toWorkoutResponse` threads `cycleStartDate` + the workout's `offset` and derives the no-schedule fallback via the same shared helper. `isoDate(new Date())` is retained only as a defensive last resort (missing `cycleDate`). Added `workoutKeyForWorkoutNum` (returns the full `(week, offset)` key); `weekForWorkoutNum` is now its thin `.week` projection.
- **`apps/api` `workouts.controller.ts`**: resolves the `(week, offset)` key once via `workoutKeyForWorkoutNum`, narrows `dashboard.cycleDate`, and passes `cycleStartDate` + `offset` into `toWorkoutResponse`.

## Acceptance criteria

- [x] A no-schedule workout's detail-page date matches the Cycle Dashboard card date (both derived from `cycleStart + (week-1)*7 + offset`, via the shared `noScheduleWorkoutDateUTC`).
- [x] The no-schedule date derivation is centralized/shared so the card and detail cannot drift.
- [x] Regression test asserting card date == detail date for a tiled week-2+ no-schedule workout.

## Testing

`npm run build` (6/6 ✓) · `npm run typecheck` (4/4 ✓, blocking CI gate) · `npm test`:

**Tests: 1052 passed, 0 skipped, 0 failed** (core 322, web 232, api 471, api-client 27; eslint-rules node:test 0 skipped/0 todo). Full turbo run ~1m57s. Docker was up, so the API DB E2E suite ran (not skipped).

Regression coverage added (all assert the **same** literal `2026-04-27` for the identical input — leangains 2-offset block, cycleStart `2026-04-20`, workoutNum 3 → week 2 / offset 0 — so card == detail is locked across the boundary):
- `packages/core` `noScheduleWorkoutDateUTC` — formula + tie-in to the tiled-leangains `orderedWorkoutKeys`.
- `apps/api` `mappers.spec.ts` — `toWorkoutResponse` no-schedule date = `cycleStart + (week-1)*7 + offset` (**not today**); `scheduledDate`/record-date precedence preserved; defensive today-fallback (fake timers); `workoutKeyForWorkoutNum` key + `weekForWorkoutNum` projection.
- `apps/api` `workouts.controller.spec.ts` — end-to-end: no-schedule leangains workout 3 → `date: 2026-04-27`.
- `apps/web` `workoutPlan.test.ts` — the card side: same input → `2026-04-27`.

### Pre-PR checks
- Suppression grep — clean. Test-integrity grep — clean (0 skipped). No deleted tests. No coverage-threshold changes. No `package.json` change → lockfile-sync N/A.

### Risk-dimension audit
- **Testing** — covered (above). **Observability** — N/A: read-time date derivation, no new boundary/log/span (no raw SQL, no LLM). **Security** — N/A: no authz/input/secret/PII change; `workoutNum` already validated; `cycleDate` server-derived. **Resilience** — defensive `isoDate(new Date())` retained → no crash when `cycleDate` absent; revert is a pure code change. **Performance** — `workoutKeyForWorkoutNum` = same cost as the prior `weekForWorkoutNum` (one expand + order); no extra fetch/N+1. **Data integrity & migrations** — N/A: read-time only, no schema/DB/stored-data change. **Accessibility** — N/A: no markup/aria change (same rendered value, corrected).

## Review findings disposition

From the [`/review`](https://github.com/brownm09/lifting-logbook/pull/749#issuecomment-4918105364) — **0 blocking, 1 non-blocking**:

- **[maintainability]** `toWorkoutResponse` now has 11 positional parameters with two adjacent `Date?` params (`apps/api/src/programs/mappers.ts`) → **filed #750**. The options-object refactor touches the controller call site + ~7 mapper test call sites, so it's out of scope for this focused bug fix and tracked separately rather than mixed in here.

Closes #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)
