### PR TITLE
[docs] Document update-branch API stale-snapshot gotcha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -506,12 +506,13 @@ Motivating incident: [PR #604](https://github.com/brownm09/lifting-logbook/pull/
 
 **Diagnosis:** After calling `update-branch`, check the resulting merge commit's second parent directly against `main`'s real tip:
 ```bash
-git log -1 --format="%P" <merge-commit-sha>   # second hash is the merged-in main SHA
+gh pr view <N> --json headRefOid --jq .headRefOid   # PR branch tip after update-branch
+git log -1 --format="%P" <merge-commit-sha>          # second hash is the merged-in main SHA
 git rev-parse origin/main
 ```
 If they don't match, the API used a stale snapshot.
 
-**Fix:** Don't rely on the `update-branch` API for this repo. Instead, manually merge: create a worktree for the PR's branch, `git merge origin/main`, resolve any conflicts, `git push`. This is deterministic and uses the actual current `main` tip.
+**Fix:** Don't rely on the `update-branch` API for this repo. Instead, manually merge: create a worktree for the PR's branch, `git fetch origin` (the merge is only as current as this repo's local `origin/main` tracking ref), `git merge origin/main`, resolve any conflicts, `git push`. This is deterministic and uses the actual current `main` tip.
 
 Motivating incident: [PR #722](https://github.com/brownm09/lifting-logbook/pull/722) merge session, 2026-07-08.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -498,6 +498,23 @@ gh pr view <N> --json mergeable,mergeStateStatus
 
 Motivating incident: [PR #604](https://github.com/brownm09/lifting-logbook/pull/604).
 
+### Stale-branch squash-merge rejection — update-branch API silently uses a stale main
+
+**Pattern:** lifting-logbook has `allow_update_branch: false` in its repo settings (confirmed via `gh api repos/brownm09/lifting-logbook --jq .allow_update_branch`). When a PR's branch falls behind `main` and `gh pr merge --squash` is rejected with "the head branch is not up to date with the base branch", calling `gh api -X PUT repos/brownm09/lifting-logbook/pulls/<N>/update-branch` returns an apparent-success message (`{"message":"Updating pull request branch."}`) but the update can silently apply against a **stale snapshot** of `main` — not the current tip — with no error surfaced. In one observed case, the resulting merge commit's merged-in `main` SHA matched the PR's *original* base ref from when it was first opened, not `main`'s actual current HEAD, even though `main` had moved significantly since. `mergeStateStatus` stayed `BEHIND` for 9+ minutes with no indication anything was wrong.
+
+**Symptom:** `mergeStateStatus` remains `BEHIND` well after `update-branch` reports success, and the eventual merge commit's second parent is not `main`'s actual current tip.
+
+**Diagnosis:** After calling `update-branch`, check the resulting merge commit's second parent directly against `main`'s real tip:
+```bash
+git log -1 --format="%P" <merge-commit-sha>   # second hash is the merged-in main SHA
+git rev-parse origin/main
+```
+If they don't match, the API used a stale snapshot.
+
+**Fix:** Don't rely on the `update-branch` API for this repo. Instead, manually merge: create a worktree for the PR's branch, `git merge origin/main`, resolve any conflicts, `git push`. This is deterministic and uses the actual current `main` tip.
+
+Motivating incident: [PR #722](https://github.com/brownm09/lifting-logbook/pull/722) merge session, 2026-07-08.
+
 ### Staging-deploy queue starvation — cross-PR mutex preemption
 
 **Pattern:** `.github/workflows/staging.yml`'s `deploy-api`/`deploy-web` jobs serialize writes to the one shared staging Cloud Run service / Helm release via job-level concurrency groups (`staging-deploy-mutex-api`, `staging-deploy-mutex-web`, both `cancel-in-progress: false`). These groups are global, not per-PR. GitHub Actions keeps only the most-recently-queued run per concurrency group — when a third PR pushes while a second PR's deploy is already queued behind a first PR's running deploy, the second PR's queued run is silently cancelled and the third takes its place. Under sustained multi-PR throughput this can repeat for an unlucky PR across many cycles.


### PR DESCRIPTION
## Summary

Documents a gotcha discovered during the PR #722 merge session (2026-07-08): on repos with `allow_update_branch: false` (confirmed for this repo), GitHub's `update-branch` REST API can report success while silently merging against a **stale snapshot** of `main`, leaving `mergeStateStatus` stuck at `BEHIND` with no error surfaced. Adds a new troubleshooting entry to `CLAUDE.md`'s `## Testing` section, between the existing "CI not firing" and "Staging-deploy queue starvation" entries, using the same Pattern/Symptom/Diagnosis/Fix structure.

## Acceptance Criteria

- [x] New entry added to `CLAUDE.md`'s `## Testing` section following the existing Pattern/Symptom/Diagnosis/Fix structure
- [x] Entry documents the Pattern (`allow_update_branch: false` + silent stale-snapshot merge)
- [x] Entry documents the Symptom (`mergeStateStatus` stuck at `BEHIND`)
- [x] Entry documents the Diagnosis (compare the merge commit's second parent to `origin/main`'s actual tip)
- [x] Entry documents the Fix (manual worktree merge instead of the API)
- [x] Motivating incident linked (PR #722)

## Testing

Docs-only change — a single entry added to `CLAUDE.md`; no source files touched. Per this repo's own Coverage Requirements table ("Refactor / docs only → None required — existing tests must pass"), no new test coverage applies and the full suite is unaffected. The `.husky/pre-commit` lint hook (`npx turbo run lint`) ran on commit and passed cleanly across all 7 workspaces.

## Review findings disposition

Both non-blocking `[documentation]` findings from the initial review ([comment](https://github.com/brownm09/lifting-logbook/pull/753#issuecomment-4919257702)) were fixed in `4ee898f`:
- Diagnosis block's unexplained `<merge-commit-sha>` placeholder → fixed, now shows `gh pr view <N> --json headRefOid --jq .headRefOid`.
- Fix step's implicit reliance on a current local `origin/main` tracking ref → fixed, now calls out an explicit `git fetch origin` before the merge.

Closes #752
