### PR TITLE
[refactor] Collapse toWorkoutResponse optional tail into an options object

### DIFF
--- a/apps/api/src/programs/mappers.spec.ts
+++ b/apps/api/src/programs/mappers.spec.ts
@@ -169,13 +169,13 @@ describe('toWorkoutResponse with plannedLifts', () => {
 
   it('marks logged lifts as planned:false', () => {
     const records = [record('Squat', 1, 200)];
-    const result = toWorkoutResponse(program, cycleNum, workoutNum, week, records, undefined, ['Squat']);
+    const result = toWorkoutResponse(program, cycleNum, workoutNum, week, records, { plannedLifts: ['Squat'] });
     expect(result.lifts[0]).toMatchObject({ lift: 'Squat', planned: false });
     expect(result.lifts[0]?.sets).toHaveLength(1);
   });
 
   it('marks unlogged planned lifts as planned:true with empty sets', () => {
-    const result = toWorkoutResponse(program, cycleNum, workoutNum, week, [], undefined, ['Squat', 'Bench Press']);
+    const result = toWorkoutResponse(program, cycleNum, workoutNum, week, [], { plannedLifts: ['Squat', 'Bench Press'] });
     expect(result.lifts).toHaveLength(2);
     expect(result.lifts[0]).toMatchObject({ lift: 'Squat', sets: [], planned: true });
     expect(result.lifts[1]).toMatchObject({ lift: 'Bench Press', sets: [], planned: true });
@@ -183,7 +183,7 @@ describe('toWorkoutResponse with plannedLifts', () => {
 
   it('appends logged lifts not in planned list as planned:false', () => {
     const records = [record('Squat', 1, 200), record('Chin-up', 1, 0)];
-    const result = toWorkoutResponse(program, cycleNum, workoutNum, week, records, undefined, ['Squat']);
+    const result = toWorkoutResponse(program, cycleNum, workoutNum, week, records, { plannedLifts: ['Squat'] });
     expect(result.lifts).toHaveLength(2);
     expect(result.lifts[0]).toMatchObject({ lift: 'Squat', planned: false });
     expect(result.lifts[1]).toMatchObject({ lift: 'Chin-up', planned: false });
@@ -197,14 +197,14 @@ describe('toWorkoutResponse with plannedLifts', () => {
 
   it('uses scheduledDate as date when no records exist', () => {
     const scheduledDate = new Date('2026-06-02T00:00:00.000Z');
-    const result = toWorkoutResponse(program, cycleNum, workoutNum, week, [], undefined, undefined, scheduledDate);
+    const result = toWorkoutResponse(program, cycleNum, workoutNum, week, [], { scheduledDate });
     expect(result.date).toBe('2026-06-02');
   });
 
   it('prefers first record date over scheduledDate when records exist', () => {
     const records = [record('Squat', 1, 200)];
     const scheduledDate = new Date('2026-06-02T00:00:00.000Z');
-    const result = toWorkoutResponse(program, cycleNum, workoutNum, week, records, undefined, undefined, scheduledDate);
+    const result = toWorkoutResponse(program, cycleNum, workoutNum, week, records, { scheduledDate });
     expect(result.date).toBe(records[0]!.date.toISOString().slice(0, 10));
   });
 
@@ -214,26 +214,33 @@ describe('toWorkoutResponse with plannedLifts', () => {
     // week, offset) — both route through the shared noScheduleWorkoutDateUTC.
     const cycleStart = new Date('2026-04-20T00:00:00.000Z');
     // week 2, offset 0 → 2026-04-20 + 7 = 2026-04-27 (NOT today).
-    const result = toWorkoutResponse(
-      program, cycleNum, 3, 2, [], undefined, ['Squat'], undefined, false, cycleStart, 0,
-    );
+    const result = toWorkoutResponse(program, cycleNum, 3, 2, [], {
+      plannedLifts: ['Squat'],
+      cycleStartDate: cycleStart,
+      offset: 0,
+    });
     expect(result.date).toBe('2026-04-27');
   });
 
   it('no-schedule week-1 date is cycleStart + offset', () => {
     const cycleStart = new Date('2026-04-20T00:00:00.000Z');
-    const result = toWorkoutResponse(
-      program, cycleNum, 2, 1, [], undefined, ['Squat'], undefined, false, cycleStart, 2,
-    );
+    const result = toWorkoutResponse(program, cycleNum, 2, 1, [], {
+      plannedLifts: ['Squat'],
+      cycleStartDate: cycleStart,
+      offset: 2,
+    });
     expect(result.date).toBe('2026-04-22');
   });
 
   it('scheduledDate still wins over the cycleStart-derived no-schedule date', () => {
     const cycleStart = new Date('2026-04-20T00:00:00.000Z');
     const scheduledDate = new Date('2026-06-02T00:00:00.000Z');
-    const result = toWorkoutResponse(
-      program, cycleNum, 3, 2, [], undefined, ['Squat'], scheduledDate, false, cycleStart, 0,
-    );
+    const result = toWorkoutResponse(program, cycleNum, 3, 2, [], {
+      plannedLifts: ['Squat'],
+      scheduledDate,
+      cycleStartDate: cycleStart,
+      offset: 0,
+    });
     expect(result.date).toBe('2026-06-02');
   });
 

--- a/apps/api/src/programs/mappers.ts
+++ b/apps/api/src/programs/mappers.ts
@@ -270,6 +270,31 @@ export const weekForWorkoutNum = (
 ): WeekNumber | undefined => workoutKeyForWorkoutNum(spec, workoutNum, program)?.week;
 
 /**
+ * Optional inputs to {@link toWorkoutResponse}. Collapsed into an options object
+ * (issue #750) so call sites pass them by name — the two adjacent `Date` fields
+ * (`scheduledDate`, `cycleStartDate`) can no longer be transposed without a
+ * TypeScript error, the silent-wrong-date failure mode #749 fixed.
+ */
+export interface WorkoutResponseOptions {
+  // Each field is `T | undefined` (not just `T?`): the pre-#750 positional params
+  // these replace all accepted `undefined`, and the controller passes values that
+  // may be undefined (`overrideDate ?? undefined`, `scheduledDate`, `cycleStartDate`,
+  // `workoutKey?.offset`). Required under this workspace's `exactOptionalPropertyTypes`.
+  /** User override date for the workout; surfaced as `overrideDate` on the response. */
+  overrideDate?: Date | undefined;
+  /** Spec-derived + override lift list; drives lift ordering and the `planned` flags. */
+  plannedLifts?: string[] | undefined;
+  /** System-assigned scheduled date (schedule mode). */
+  scheduledDate?: Date | undefined;
+  /** Whether the workout is explicitly skipped. */
+  skipped?: boolean | undefined;
+  /** Cycle start date; anchors the no-schedule spec-relative date. */
+  cycleStartDate?: Date | undefined;
+  /** This workout's `(week, offset)` key offset; feeds the no-schedule date. */
+  offset?: number | undefined;
+}
+
+/**
  * Groups a workout's lift records into the WorkoutResponse shape.
  * Caller must validate `workoutNum` with `isValidWorkoutNum` and derive
  * `week` via `weekForWorkoutNum` before invoking.
@@ -296,13 +321,17 @@ export const toWorkoutResponse = (
   workoutNum: number,
   week: WeekNumber,
   records: LiftRecord[],
-  overrideDate?: Date,
-  plannedLifts?: string[],
-  scheduledDate?: Date,
-  skipped = false,
-  cycleStartDate?: Date,
-  offset?: number,
+  options: WorkoutResponseOptions = {},
 ): WorkoutResponse => {
+  const {
+    overrideDate,
+    plannedLifts,
+    scheduledDate,
+    skipped = false,
+    cycleStartDate,
+    offset,
+  } = options;
+
   const liftMap = new Map<string, SetResponse[]>();
   for (const r of records) {
     const set: SetResponse = {

--- a/apps/api/src/programs/workouts.controller.ts
+++ b/apps/api/src/programs/workouts.controller.ts
@@ -111,18 +111,13 @@ export class WorkoutsController {
         return renamed !== undefined ? { ...r, lift: renamed } : r;
       });
 
-    return toWorkoutResponse(
-      program,
-      dashboard.cycleNum,
-      workoutNum,
-      week,
-      adjustedRecords,
-      overrideDate ?? undefined,
+    return toWorkoutResponse(program, dashboard.cycleNum, workoutNum, week, adjustedRecords, {
+      overrideDate: overrideDate ?? undefined,
       plannedLifts,
       scheduledDate,
-      skippedNums.has(workoutNum),
+      skipped: skippedNums.has(workoutNum),
       cycleStartDate,
-      workoutKey?.offset,
-    );
+      offset: workoutKey?.offset,
+    });
   }
 }


### PR DESCRIPTION
## Summary

`toWorkoutResponse` (`apps/api/src/programs/mappers.ts`) took **11 positional parameters**, six optional. The optional tail — `overrideDate?`, `plannedLifts?`, `scheduledDate?`, `skipped`, `cycleStartDate?`, `offset?` — included **two adjacent `Date?` params (`scheduledDate`, `cycleStartDate`) separated only by a boolean**, so a caller could transpose them with no TypeScript error and silently render the wrong workout `date` — the exact class of bug #749 fixed.

This collapses the optional tail into a single `WorkoutResponseOptions` object so call sites are keyed by name. The five required positional args (`program, cycleNum, workoutNum, week, records`) are unchanged.

**Pure refactor, no behavior change:** the mapper body is byte-identical after destructuring the options object; the one production caller (`workouts.controller.ts`) and all `mappers.spec.ts` call sites are updated; existing tests cover the contract.

### Note on `exactOptionalPropertyTypes`

`apps/api` compiles with `exactOptionalPropertyTypes: true`, under which an optional property `overrideDate?: Date` rejects an *explicit* `undefined`. The pre-refactor positional params all accepted `undefined` (the controller passes `overrideDate ?? undefined`, `scheduledDate`/`cycleStartDate` from optional chains, and `workoutKey?.offset`), so each option field is typed `T | undefined` to preserve that contract exactly. This is the compiler's own suggested remedy and keeps call sites clean (no conditional spreads).

## Acceptance Criteria

- [x] `toWorkoutResponse`'s optional parameters are passed by name (options object), eliminating the adjacent-`Date?` transposition hazard.
- [x] `workouts.controller.ts` and all `mappers.spec.ts` call sites updated; `npm test -w @lifting-logbook/api` green.
- [x] No behavior change (pure refactor; existing tests cover the contract).

## Testing

From the worktree on Node 20.11.1 (Windows), Docker up (DB E2E via Testcontainers ran):

- `npm run build` → 6/6 workspaces pass. The api build's `nest build`/`tsc` is the authoritative type gate (ts-jest is transpile-only); it caught the `exactOptionalPropertyTypes` mismatch, now resolved.
- `npm run typecheck` → 4/4 pass.
- `npm test` (full suite) → **Tasks: 12 successful, 12 total; 1,052 passed, 0 skipped, 0 failed**
  - api: `Tests: 471 passed, 471 total` (37 suites, DB E2E included)
  - core: `Tests: 322 passed, 322 total` (39 suites)
  - web: `Tests: 232 passed, 232 total` (39 suites)
  - api-client: `Tests: 27 passed, 27 total`

### Coverage gate
No new behavior — pure refactor. The existing `describe('toWorkoutResponse with plannedLifts')` suite (10 cases, including the no-schedule date-derivation paths that consume `scheduledDate`/`cycleStartDate`/`offset`) fully covers the contract and now exercises the options-object form.

### Suppression / test-integrity greps
Clean. The suppression grep's lone match (`records[0]!.date`) is a pre-existing context line, not an added suppression. No skip markers, deleted tests, or lowered thresholds. No `package.json` change → lockfile-sync check N/A.

> Local-only note: the worktree's initial `npm install` produced an incomplete `jsdom` extraction (the documented Windows artifact, #373), which failed to *load* 34 web suites on the first full run — a broken install, not a code failure. Re-extracting jsdom (`npm install jsdom --no-save`) resolved it; the lockfile was untouched. CI (Linux) is unaffected.

Closes #750
