### PR TITLE
[docs] Add git fetch origin to "CI not firing" entry's Fix step

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -494,7 +494,7 @@ gh pr view <N> --json mergeable,mergeStateStatus
 # mergeable: "CONFLICTING" — direct conflict indicator; mergeStateStatus will also be "DIRTY"
 ```
 
-**Fix:** Rebase (or squash-rebase) the branch onto `origin/main` and force-push. Once the conflict is resolved, GitHub recreates the merge ref and CI fires normally on the next push.
+**Fix:** `git fetch origin` first (the rebase target is only as current as this repo's local `origin/main` tracking ref — a stale ref means the rebase resolves against outdated content and doesn't actually clear the conflict against the real current `main`). Then rebase (or squash-rebase) the branch onto `origin/main` and force-push. Once the conflict is resolved, GitHub recreates the merge ref and CI fires normally on the next push.
 
 Motivating incident: [PR #604](https://github.com/brownm09/lifting-logbook/pull/604).
 


### PR DESCRIPTION
## Summary

The "CI not firing — merge conflict silences GitHub Actions" entry in `CLAUDE.md`'s `## Testing` section had a Fix step that implicitly assumed the local `origin/main` remote-tracking ref was already current before rebasing. If stale, the rebase resolves against outdated content and doesn't actually clear the conflict against the real current `main`.

This mirrors the same gap just fixed in the neighboring "Stale-branch squash-merge rejection" entry (added in #753 via review findings), which now explicitly calls out `git fetch origin` before merging for exactly this reason.

- Added an explicit `git fetch origin` step to the "CI not firing" entry's Fix, with phrasing mirroring the neighboring entry ("the rebase target is only as current as this repo's local `origin/main` tracking ref").

Docs-only change; no code touched.

## Test plan

- [x] N/A — docs-only change, no automated tests per the repo's Coverage Requirements table (Refactor / docs only → None required)
- [x] `/review` to be run before merge per this repo's Review Gate check

Closes #756