### PR TITLE
[fix] Redact x-clerk-authorization header to stop Clerk JWT plaintext logging

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -16,10 +16,14 @@ import { UserSettingsModule } from './user-settings/user-settings.module';
 export const pinoHttpOptions: PinoHttpOptions = {
   // Strip auth-bearing headers before they reach Loki. pino-http's default
   // req serializer logs req.headers verbatim, which would otherwise leak
-  // JWTs and session cookies into long-retention log storage.
+  // JWTs and session cookies into long-retention log storage. Server-to-server
+  // calls (apps/web) carry the Clerk JWT in x-clerk-authorization rather than
+  // authorization (see auth.guard.ts) — both header names carry a bearer
+  // token and must be redacted (#767).
   redact: {
     paths: [
       'req.headers.authorization',
+      'req.headers["x-clerk-authorization"]',
       'req.headers.cookie',
       'req.headers["set-cookie"]',
       'res.headers["set-cookie"]',

--- a/apps/api/src/otel-log-redaction.spec.ts
+++ b/apps/api/src/otel-log-redaction.spec.ts
@@ -22,8 +22,9 @@ import { pinoHttpOptions } from './app.module';
 describe('OTel log export does not leak redacted fields', () => {
   const SECRET_TOKEN = 'super-secret-jwt-value';
   const SECRET_COOKIE = 'session=super-secret-cookie-value';
+  const SECRET_CLERK_JWT = 'super-secret-clerk-jwt-value';
 
-  it('keeps Authorization/Cookie values out of both the Pino wire format and the resulting OTel LogRecord', async () => {
+  it('keeps Authorization/Cookie/X-Clerk-Authorization values out of both the Pino wire format and the resulting OTel LogRecord', async () => {
     // 1. Log a request/response pair shaped like pino-http's own serialization,
     // through the app's REAL redact config, and capture the exact line pino
     // would have written to stdout.
@@ -43,6 +44,11 @@ describe('OTel log export does not leak redacted fields', () => {
           headers: {
             authorization: `Bearer ${SECRET_TOKEN}`,
             cookie: SECRET_COOKIE,
+            // Server-to-server calls (apps/web/lib/api.ts) carry the Clerk JWT
+            // here instead of `authorization` — see auth.guard.ts. Regression
+            // coverage for #767: this leaked into GCP Cloud Logging in plaintext
+            // because it wasn't in the original redact.paths list.
+            'x-clerk-authorization': `Bearer ${SECRET_CLERK_JWT}`,
           },
         },
         res: { statusCode: 500 },
@@ -54,6 +60,7 @@ describe('OTel log export does not leak redacted fields', () => {
 
     expect(serializedLine).not.toContain(SECRET_TOKEN);
     expect(serializedLine).not.toContain(SECRET_COOKIE);
+    expect(serializedLine).not.toContain(SECRET_CLERK_JWT);
     // Sanity check: the line is real content, not an empty/broken write.
     expect(serializedLine).toContain('42501');
 
@@ -89,6 +96,7 @@ describe('OTel log export does not leak redacted fields', () => {
 
     expect(serializedRecord).not.toContain(SECRET_TOKEN);
     expect(serializedRecord).not.toContain(SECRET_COOKIE);
+    expect(serializedRecord).not.toContain(SECRET_CLERK_JWT);
 
     await provider.shutdown();
   });


### PR DESCRIPTION
## Summary

Clerk session JWTs were being logged in plaintext in production GCP Cloud Logging. Confirmed live
via a real production log entry containing a full raw bearer JWT under `req.headers["x-clerk-authorization"]`
— the header `apps/web`'s server-to-server calls (`lib/api.ts`) use to carry the Clerk JWT, since
the standard `authorization` header is reserved for the Cloud Run IAM identity token on that path
(see `auth.guard.ts`). `apps/api/src/app.module.ts`'s pino `redact.paths` only covered
`req.headers.authorization`, so this second header sailed through unredacted.

## Changes

- `apps/api/src/app.module.ts`: add `'req.headers["x-clerk-authorization"]'` to `redact.paths`.
- `apps/api/src/otel-log-redaction.spec.ts`: extended the existing end-to-end redaction test
  (which already proves `Authorization`/`Cookie` are stripped from both the raw Pino wire format
  *and* the OTel Logs export pipeline) with the same coverage for `x-clerk-authorization`.

## Testing

- New test: `otel-log-redaction.spec.ts` — **verified as a genuine regression test**: temporarily
  reverted just the `app.module.ts` redact-path addition (keeping the test change) and confirmed
  the test fails (1 failed, 1 total) before re-applying the fix, which passes cleanly.
- `npm run typecheck`: same pre-existing failure as noted in
  [#766](https://github.com/brownm09/lifting-logbook/issues/766)'s PR — `@lifting-logbook/web`
  fails with `TS7016` on `react-dom/server` in 5 test files this branch does not touch (this
  branch only touches `apps/api`). Tracked in
  [#769](https://github.com/brownm09/lifting-logbook/issues/769).
- Suppression grep, test-integrity grep, deleted-test-files check: all clean.
- No `package.json` changes, so the lockfile-sync check is N/A.
- Tests: 1 passed (the new/extended redaction test), 0 skipped, 0 failed — ran directly via
  `npm test -w @lifting-logbook/api -- otel-log-redaction`. Did not run the full `apps/api` suite
  for this PR (2-line, tightly-scoped change; the extended spec is the only coverage this change
  affects).

## Review findings disposition

The `/review` on this PR surfaced **0 blocking / 1 non-blocking** finding:

- **[maintainability]** `apps/api/src/app.module.ts` redaction is a *denylist* — incomplete by
  design. The same class of gap this PR fixes (a forgotten auth-bearing header leaking in
  plaintext) will recur for the next such header until someone remembers to add it.
  → **Filed as [#780](https://github.com/brownm09/lifting-logbook/issues/780)** (out of scope for
  this 2-line targeted fix; it's a broader allowlist-inversion / guard-test hardening change).

## Note

This does not retroactively scrub tokens already sitting in GCP Cloud Logging. Whether that
warrants a Clerk session-revocation discussion is a separate, human call.

Part of #765.

Closes #767
