### PR TITLE
[fix] Reschedule: bounds-check cycleNum/workoutNum and add shared request type

### DIFF
--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -184,6 +184,26 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
       expect(res.statusCode).toBe(400);
     });
 
+    it('PATCH reschedule with out-of-range workoutNum returns 400', async () => {
+      // 9999 is a positive integer (passes the old check) but far past the
+      // program's canonical length — an override there is dead data.
+      const res = await patchJson(
+        `/programs/${SEED_PROGRAM}/cycles/1/workouts/9999/reschedule`,
+        { newDate: '2026-06-01' },
+      );
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('PATCH reschedule with non-active cycleNum returns 400', async () => {
+      // Seed's active cycle is 1 (these tests run before any new-cycle writes).
+      // Cycle 2 is not the active cycle, so an override there could never be read.
+      const res = await patchJson(
+        `/programs/${SEED_PROGRAM}/cycles/2/workouts/1/reschedule`,
+        { newDate: '2026-06-01' },
+      );
+      expect(res.statusCode).toBe(400);
+    });
+
     it('PATCH reschedule requires auth', async () => {
       const injectRaw = app.getHttpAdapter().getInstance().inject.bind(
         app.getHttpAdapter().getInstance(),

--- a/apps/api/src/programs/reschedule.controller.spec.ts
+++ b/apps/api/src/programs/reschedule.controller.spec.ts
@@ -11,7 +11,24 @@ import { RescheduleController } from './reschedule.controller';
 const MOCK_USER_A = { id: 'user-a', email: 'a@example.com', provider: 'dev' };
 const _MOCK_USER_B = { id: 'user-b', email: 'b@example.com', provider: 'dev' };
 
-const STUB_SPEC = [{ lift: 'Squat' }] as unknown as Awaited<ReturnType<ILiftingProgramSpecRepository['getProgramSpec']>>;
+// A realistic 2-offset week-1 block. `5-3-1` is a registered 12-week program, so
+// workoutKeyForWorkoutNum tiles this block across 12 weeks → 24 workout days;
+// workoutNum 1..24 resolve to a real day. The controller's new upper-bound check
+// needs a spec that actually resolves the tested workoutNum, not a bare stub.
+const baseSpecFields = {
+  increment: 5,
+  order: 1,
+  sets: 3,
+  reps: 5,
+  amrap: true,
+  warmUpPct: '0.4,0.5,0.6',
+  wtDecrementPct: 0.1,
+  activation: 'compound',
+};
+const STUB_SPEC = [
+  { ...baseSpecFields, offset: 0, lift: 'Squat', week: 1 },
+  { ...baseSpecFields, offset: 3, lift: 'Bench Press', week: 1 },
+] as unknown as Awaited<ReturnType<ILiftingProgramSpecRepository['getProgramSpec']>>;
 
 describe('RescheduleController', () => {
   let controller: RescheduleController;
@@ -34,8 +51,10 @@ describe('RescheduleController', () => {
     };
     specRepoA = { getProgramSpec: jest.fn().mockResolvedValue(STUB_SPEC), saveProgramSpec: jest.fn(), deleteSpecRows: jest.fn() } as jest.Mocked<ILiftingProgramSpecRepository>;
     specRepoB = { getProgramSpec: jest.fn().mockResolvedValue(STUB_SPEC), saveProgramSpec: jest.fn(), deleteSpecRows: jest.fn() } as jest.Mocked<ILiftingProgramSpecRepository>;
-    dashboardRepoA = { getCycleDashboard: jest.fn().mockResolvedValue({}), saveCycleDashboard: jest.fn() } as unknown as jest.Mocked<ICycleDashboardRepository>;
-    dashboardRepoB = { getCycleDashboard: jest.fn().mockResolvedValue({}), saveCycleDashboard: jest.fn() } as unknown as jest.Mocked<ICycleDashboardRepository>;
+    // Active cycle is 3 — the valid-input tests reschedule cycle 3; the controller's
+    // new cycle-match check compares the path cycleNum against this dashboard cycleNum.
+    dashboardRepoA = { getCycleDashboard: jest.fn().mockResolvedValue({ cycleNum: 3 }), saveCycleDashboard: jest.fn() } as unknown as jest.Mocked<ICycleDashboardRepository>;
+    dashboardRepoB = { getCycleDashboard: jest.fn().mockResolvedValue({ cycleNum: 3 }), saveCycleDashboard: jest.fn() } as unknown as jest.Mocked<ICycleDashboardRepository>;
     factory = {
       forUser: jest.fn().mockImplementation(async (user) =>
         user.id === MOCK_USER_A.id
@@ -117,6 +136,24 @@ describe('RescheduleController', () => {
     await expect(
       controller.reschedule('5-3-1', '3', '2', { newDate: '2026-05-15' }, MOCK_USER_A),
     ).rejects.toBeInstanceOf(ProgramNotFoundError);
+    expect(overrideRepoA.upsertOverride).not.toHaveBeenCalled();
+  });
+
+  it('rejects a workoutNum beyond the program length with 400', async () => {
+    // 5-3-1 is 12 weeks × 2 offsets = 24 workout days; 9999 maps to no real day, so
+    // the override would be dead data. Reject rather than 204-with-no-effect.
+    await expect(
+      controller.reschedule('5-3-1', '3', '9999', { newDate: '2026-05-15' }, MOCK_USER_A),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(overrideRepoA.upsertOverride).not.toHaveBeenCalled();
+  });
+
+  it('rejects a cycleNum that is not the active cycle with 400', async () => {
+    // Active cycle is 3 (dashboard mock); rescheduling cycle 7 would write an
+    // override the current-cycle read model can never surface — reject it.
+    await expect(
+      controller.reschedule('5-3-1', '7', '2', { newDate: '2026-05-15' }, MOCK_USER_A),
+    ).rejects.toBeInstanceOf(BadRequestException);
     expect(overrideRepoA.upsertOverride).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/programs/reschedule.controller.ts
+++ b/apps/api/src/programs/reschedule.controller.ts
@@ -9,11 +9,12 @@ import {
   Param,
   Patch,
 } from '@nestjs/common';
+import { programLengthWeeks } from '@lifting-logbook/core';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../ports/auth';
 import { IRepositoryFactory } from '../ports/factory';
 import { REPOSITORY_FACTORY } from '../ports/tokens';
-import { isValidWorkoutNum } from './mappers';
+import { isValidWorkoutNum, workoutKeyForWorkoutNum } from './mappers';
 import { RescheduleDto } from './reschedule.dto';
 
 @Controller('programs/:program')
@@ -48,7 +49,27 @@ export class RescheduleController {
       throw new NotFoundException(`Program '${program}' not found`);
     }
 
-    await cycleDashboard.getCycleDashboard(program);
+    // Reject a workoutNum past the program's canonical length — the same bound the
+    // GET workout endpoint enforces (workouts.controller.ts, via workoutKeyForWorkoutNum).
+    // Without it an override is upserted for a workoutNum that maps to no real workout
+    // day and is silently never surfaced (204 success, no visible effect).
+    if (workoutKeyForWorkoutNum(spec, workoutNum, program) === undefined) {
+      throw new BadRequestException(
+        `workoutNum ${workoutNum} exceeds the program's ${programLengthWeeks(program, spec)}-week schedule`,
+      );
+    }
+
+    // getCycleDashboard throws ProgramNotFoundError when the program has no cycle.
+    // Its cycleNum is the *active* cycle, and the entire read model (GET workout,
+    // cycle dashboard, getOverride) reads only that cycle — an override written for
+    // any other cycleNum is dead data the client can never see. Reject a non-active
+    // cycleNum rather than accept a 204-with-no-effect reschedule.
+    const dashboard = await cycleDashboard.getCycleDashboard(program);
+    if (cycleNum !== dashboard.cycleNum) {
+      throw new BadRequestException(
+        `cycleNum ${cycleNum} is not the active cycle (${dashboard.cycleNum})`,
+      );
+    }
 
     // Append explicit UTC midnight so the YYYY-MM-DD string is stored as the correct calendar day
     // regardless of the server's local timezone.

--- a/apps/api/src/programs/reschedule.controller.ts
+++ b/apps/api/src/programs/reschedule.controller.ts
@@ -49,9 +49,11 @@ export class RescheduleController {
       throw new NotFoundException(`Program '${program}' not found`);
     }
 
-    // Reject a workoutNum past the program's canonical length — the same bound the
-    // GET workout endpoint enforces (workouts.controller.ts, via workoutKeyForWorkoutNum).
-    // Without it an override is upserted for a workoutNum that maps to no real workout
+    // Reject a workoutNum past the program's spec-derived canonical length, via the
+    // same workoutKeyForWorkoutNum helper the GET workout endpoint uses. (GET also
+    // honors a scheduled row's weekNum, so its effective bound is marginally looser;
+    // the two align because schedules are never generated beyond the canonical length.)
+    // Without this an override is upserted for a workoutNum that maps to no real workout
     // day and is silently never surfaced (204 success, no visible effect).
     if (workoutKeyForWorkoutNum(spec, workoutNum, program) === undefined) {
       throw new BadRequestException(

--- a/apps/api/src/programs/reschedule.dto.ts
+++ b/apps/api/src/programs/reschedule.dto.ts
@@ -1,6 +1,10 @@
 import { IsString, Matches } from 'class-validator';
+import { RescheduleRequest } from '@lifting-logbook/types';
 
-export class RescheduleDto {
+// `implements RescheduleRequest` ties this validated DTO to the shared request
+// contract in @lifting-logbook/types: if the contract's shape changes, this
+// class fails to compile until the validation is updated to match.
+export class RescheduleDto implements RescheduleRequest {
   /** Calendar date in YYYY-MM-DD format. Time and timezone components are not accepted. */
   @IsString()
   @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'newDate must be a calendar date in YYYY-MM-DD format' })

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -18,6 +18,7 @@ import type {
   LiftRecordResponse,
   PatchLiftMetadataRequest,
   RecordBodyWeightRequest,
+  RescheduleRequest,
   StrengthGoalResponse,
   SwitchProgramResponse,
   TrainingMaxHistoryResponse,
@@ -278,9 +279,12 @@ export function createApiClient(config: ApiClientConfig) {
       workoutNum: number,
       newDate: string,
     ): Promise<void> {
+      // Typed against the shared contract so a change to RescheduleRequest surfaces
+      // here at compile time rather than as a silently malformed request body.
+      const body: RescheduleRequest = { newDate };
       return request(
         `/programs/${enc(program)}/cycles/${cycleNum}/workouts/${workoutNum}/reschedule`,
-        { method: 'PATCH', headers: JSON_HEADERS, body: JSON.stringify({ newDate }), cache: 'no-store' },
+        { method: 'PATCH', headers: JSON_HEADERS, body: JSON.stringify(body), cache: 'no-store' },
       );
     },
     skipWorkout(

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -97,6 +97,22 @@ export interface WorkoutResponse {
   bodyWeightEntry?: Pick<BodyWeightEntry, 'weight' | 'unit'>;
 }
 
+/**
+ * Request body for PATCH
+ * /programs/:program/cycles/:cycleNum/workouts/:workoutNum/reschedule.
+ *
+ * Shared contract for the reschedule request shape: the backend `RescheduleDto`
+ * (`apps/api`) implements this interface and the api-client builds its request
+ * body as this type, so the two cannot drift. The endpoint returns 204 No
+ * Content, so there is no corresponding response type — the reschedule result is
+ * surfaced on the read side via `WorkoutResponse.overrideDate` and
+ * `CycleDashboardResponse.dateOverrides`.
+ */
+export interface RescheduleRequest {
+  /** Target calendar date in `YYYY-MM-DD` format (no time or timezone component). */
+  newDate: string;
+}
+
 // ---------------------------------------------------------------------------
 // Lift Records
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two minor, pre-existing hardening gaps in the reschedule-workout endpoint (`PATCH /programs/:program/cycles/:cycleNum/workouts/:workoutNum/reschedule`), surfaced in passing during the production-reschedule investigation (#765; production fixes landed in #770/#771). Neither caused a current failure.

Closes #773.

### Gap 1 — Bounds validation (the real defect)

The controller validated only that `cycleNum`/`workoutNum` were **positive integers**. It never checked `workoutNum` against the program's actual length, and it fetched `getCycleDashboard(program)` purely for its throwing side-effect while **discarding** the returned `cycleNum`. Because the entire read model (GET workout, cycle dashboard, `getOverride`) reads **only the active cycle**, an override upserted for a non-active cycle or an out-of-range workout is **dead data the client can never see** — a `204` "success" with no visible effect, reportable as "reschedule failed".

- Reject a `workoutNum` past the program's canonical length → `400`, using `workoutKeyForWorkoutNum` — the *same* bound the GET workout endpoint already enforces.
- Reject a `cycleNum` that is not the active cycle → `400`, reusing the dashboard the controller **already fetched** (zero new queries — the return value was previously discarded).

### Gap 2 — Shared request type

Added `RescheduleRequest` to `packages/types`. `RescheduleDto implements RescheduleRequest` (keeps its `class-validator` decorators) and the api-client types its request body as `RescheduleRequest`, so the request contract can no longer drift between backend and client. No `RescheduleResponse` — the endpoint returns `204 No Content`; the result is surfaced on the read side via `WorkoutResponse.overrideDate`.

## Acceptance Criteria

- [x] Reschedule rejects a `workoutNum` beyond the program's canonical length with `400` (consistent with the GET workout endpoint).
- [x] Reschedule rejects a `cycleNum` that is not the active cycle with `400`, reusing the already-fetched dashboard (no added queries).
- [x] Existing valid reschedules (active cycle, in-range workout) continue to return `204`.
- [x] Shared `RescheduleRequest` type in `packages/types`, referenced by both `reschedule.dto.ts` (via `implements`) and the api-client, with a compile-time link.
- [x] Unit + E2E coverage for both new `400` paths.
- [x] `skip`-endpoint hardening captured as a follow-up (identical positive-integer-only gap; see below).

## Testing

`npm run build` (types touched) + `npm run typecheck` (blocking gate — validates the `implements` link) + `npm test`, all from the repo root. Docker was up, so the api DB E2E suite ran against a real Testcontainers Postgres (no skip escape hatch used).

**Tests: 1073 passed, 0 skipped, 0 failed**

- `@lifting-logbook/api`: 480 passed / 37 suites — incl. `reschedule.controller.spec.ts`, `programs.e2e.spec.ts`, `programs.db.e2e.spec.ts`
- `@lifting-logbook/web`: 244 passed / 40 suites
- `@lifting-logbook/core`: 322 passed / 39 suites
- `@lifting-logbook/api-client`: 27 passed / 1 suite
- `@lifting-logbook/types`: type-only (no runtime test suite; covered by typecheck)

New coverage:
- **Unit** (`reschedule.controller.spec.ts`): rejects a `workoutNum` beyond program length (`400`); rejects a non-active `cycleNum` (`400`); existing valid-input and `ProgramNotFoundError` tests updated to a realistic spec + active-cycle dashboard.
- **E2E** (`programs.e2e.spec.ts`): out-of-range `workoutNum` (`9999`) → `400`; non-active `cycleNum` (`2`, active is `1`) → `400`.

Pre-PR **suppression** and **test-integrity** greps: both clean. No test files deleted, no thresholds lowered, no `package.json`/lockfile change.

## Risk audit (Plan-then-optimize → Pass 3)

- **Testing** — unit + E2E for both new `400` paths (above).
- **Observability** — the two new validation failures return `400` via Nest's exception layer and are auto-logged by `nestjs-pino` with `trace_id`/`span_id` correlation, identical to the sibling validators. No new instrumentation needed; no raw SQL, no LLM call site touched.
- **Security** — a hardening change: prevents writing override rows addressed by an arbitrary cycle/workout number. Per-user isolation (`factory.forUser`) unchanged; no authz surface added.
- **Resilience** — pure input validation before the write; no new failure modes. `getCycleDashboard`'s existing `ProgramNotFoundError` behavior is preserved. Revert is a pure code change.
- **Performance** — **zero added queries**: reuses the already-loaded spec and the dashboard that was previously fetched-and-discarded.
- **Data integrity & migrations** — prevents orphan/dead override rows; no schema change, no migration.
- **Accessibility** — N/A (API only; `RescheduleForm.tsx` and other web code unchanged).

## Follow-up

The `skip` endpoint (`workout-skip.controller.ts`) has the identical positive-integer-only validation and additionally never loads the spec or dashboard (no program-existence or cycle check at all). Deliberately out of scope here to keep this PR focused; captured as a separate follow-up.

## Review findings disposition

- **[maintainability] comment precision** (`reschedule.controller.ts` workoutNum-bound comment) — **fixed in 611ff2a**: reworded to state the check uses the program's spec-derived canonical length via `workoutKeyForWorkoutNum`, and that GET's effective bound is marginally looser (it also honors a scheduled row's `weekNum`); the two align because schedules are never generated beyond the canonical length.
- **Question — 400 vs 404 for a non-active `cycleNum`** — **no change, deliberate**: 400 chosen for consistency with the sibling `workoutNum` guard and the GET workout endpoint's bound message.

Review: https://github.com/brownm09/lifting-logbook/pull/775#issuecomment-4929022779
