### PR TITLE
[docs] Document react-dom/server TS7016 as an incomplete-install issue (not a code defect)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -482,6 +482,23 @@ A label of "pre-existing" without an open-issue link is not acceptable. The moti
 
 When a PR adds or modifies a `.catch(() => default)`, `?? default`, or `try { … } catch { return neutral }` in a server component or API boundary, the test coverage for that code path must satisfy one of: (a) a data-level assertion the fallback would not produce, (b) a separate test that fails specifically when the upstream fails, or (c) an inline comment that names the swallowed-fallback source line and explains why structure-only is intentional. See [`docs/standards/error-fallback-test-coverage.md`](docs/standards/error-fallback-test-coverage.md) for the full rule and examples.
 
+### Typecheck TS7016 on `react-dom/server` — incomplete install, not a code defect
+
+**Pattern:** `npm run typecheck` fails on `apps/web` with:
+
+```
+error TS7016: Could not find a declaration file for module 'react-dom/server'.
+'.../apps/web/node_modules/react-dom/server.node.js' implicitly has an 'any' type.
+```
+
+on the five `page.test.tsx` files that `import { renderToStaticMarkup } from 'react-dom/server'`.
+
+**Root cause:** `react-dom@19`'s `package.json` `exports["./server"]` ships only runtime conditions (`node → server.node.js`, `browser`, `default`, …) and **no `types` condition**, so TypeScript cannot source the `react-dom/server` declaration from `react-dom` itself — it resolves the declaration solely from the **`@types/react-dom` devDependency** (whose `exports["./server"].types → server.d.ts`). `react-dom` is a runtime `dependency` while `@types/react-dom` is a `devDependency`, so any install that has deps but not devDeps — `npm install --omit=dev`, a partial/interrupted extract, or a worktree whose `npm install` never completed — leaves `react-dom` present but `@types/react-dom` absent → TS7016 on every `react-dom/server` import. It is **not** a version or `tsconfig` bug: a clean install (`npm ci` in CI, a fresh worktree `npm install`) always resolves it, and `@types/react-dom` resolves whether it sits in `apps/web/node_modules` or is hoisted to the repo-root `node_modules`.
+
+**Symptom that confirms it:** the error names a `server.node.js` runtime file (so `react-dom` IS installed) rather than "Cannot find module" (which would mean `react-dom` itself is missing); the same five files pass under `npm ci` or a completed `npm install`.
+
+**Fix:** run a full install in the worktree — `npm install`, or `rm -rf node_modules && npm ci` — then re-run `npm run typecheck`. `@types/react` and `@types/react-dom` are also declared in the **root** `package.json` devDependencies so they hoist to the root `node_modules` and stay resolvable from `apps/web` even when the workspace-local copy is missing. Motivating incident: [#769](https://github.com/brownm09/lifting-logbook/issues/769).
+
 ### CI not firing — merge conflict silences GitHub Actions
 
 **Pattern:** A PR in `CONFLICTING` (merge conflict) state causes GitHub Actions `pull_request` events to never fire. GitHub cannot create the virtual merge commit at `refs/pull/N/merge`, so the event is silently dropped — no checks are queued, no runs appear.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -497,7 +497,7 @@ on the five `page.test.tsx` files that `import { renderToStaticMarkup } from 're
 
 **Symptom that confirms it:** the error names a `server.node.js` runtime file (so `react-dom` IS installed) rather than "Cannot find module" (which would mean `react-dom` itself is missing); the same five files pass under `npm ci` or a completed `npm install`.
 
-**Fix:** run a full install in the worktree — `npm install`, or `rm -rf node_modules && npm ci` — then re-run `npm run typecheck`. `@types/react` and `@types/react-dom` are also declared in the **root** `package.json` devDependencies so they hoist to the root `node_modules` and stay resolvable from `apps/web` even when the workspace-local copy is missing. Motivating incident: [#769](https://github.com/brownm09/lifting-logbook/issues/769).
+**Fix:** run a full install in the worktree — `npm install`, or `rm -rf node_modules && npm ci` — then re-run `npm run typecheck`. (Root-hoisting `@types/react` + `@types/react-dom` into the **root** `package.json` so they always resolve from `apps/web` even when the workspace-local copy is missing would harden this further, but currently `ERESOLVE`s against `apps/mobile`'s Expo 54 / RN 0.81 `@types/react@19.1.x` pin vs. `@types/react-dom@19.2.3`'s `@types/react@^19.2.0` peer requirement — tracked in [#777](https://github.com/brownm09/lifting-logbook/issues/777).) Motivating incident: [#769](https://github.com/brownm09/lifting-logbook/issues/769).
 
 ### CI not firing — merge conflict silences GitHub Actions
 


### PR DESCRIPTION
## Summary

`apps/web`'s `npm run typecheck` failing with **`TS7016: Could not find a declaration file for module 'react-dom/server'`** (#769) is **not a code defect** — it is an **incomplete-install** symptom. This PR documents the root cause and fix as a `CLAUDE.md` → Testing troubleshooting note. No source, config, or dependency changes.

## Root cause

`react-dom@19`'s `package.json` `exports["./server"]` provides only runtime conditions (`node -> server.node.js`, `browser`, `default`, …) and **no `types` condition**. TypeScript therefore cannot obtain the `react-dom/server` declaration from `react-dom` itself and sources it **solely from the `@types/react-dom` devDependency** (`exports["./server"].types -> server.d.ts`).

- `react-dom` is a runtime **`dependency`**; `@types/react-dom` is a **`devDependency`**.
- Any install with deps but not devDeps — `npm install --omit=dev`, a partial/interrupted extract, or a worktree whose `npm install` never completed — leaves `react-dom` present but `@types/react-dom` **absent** -> `TS7016` on every `react-dom/server` import (all five `page.test.tsx` files that `import { renderToStaticMarkup }`).

**Confirmed by controlled experiment** (throwaway worktree): hiding `apps/web/node_modules/@types/react-dom` reproduces the error byte-for-byte (same `server.node.js` path, all 5 files); restoring it -> clean. `@types/react-dom` resolves whether it sits in `apps/web/node_modules` **or** is hoisted to the repo-root `node_modules`.

**A clean install always passes:**
- PR #770's CI **"Lint & Test"** job (clean `npm ci`, Linux, `turbo run lint typecheck test` incl. `@lifting-logbook/web:typecheck`) = **SUCCESS**.
- The canonical checkout, a fresh worktree `npm install`, and every currently-installed worktree resolve it.

The three hypotheses in the issue are disproven: version drift (`@types/react-dom@19.2.3` vs `react-dom@19.2.4`) isn't it; `tsconfig.typecheck.json`'s `moduleResolution: bundler` / no `types` restriction isn't it; react-dom's missing `./server` `types` export condition is the *mechanism* but is by-design (delegated to `@types/react-dom`, which works when present).

## Why documentation, not a code change

No `tsconfig` / `paths` / `moduleResolution` / version change can conjure declarations that aren't on disk, and a global `declare module 'react-dom/server'` shim would **conflict** with the real `@types/react-dom` types in the normal (clean-install) case. The genuine fix is install-completeness: `npm install`.

A dependency-tree hardening — declaring `@types/react` + `@types/react-dom` in the **root** `package.json` so they hoist to the repo root (resolvable from `apps/web` even when the workspace-local copy is missing) — was attempted and **cannot be installed cleanly**: it `ERESOLVE`s because `apps/mobile` (Expo 54 / RN 0.81) pins `@types/react` to `19.1.x` while `@types/react-dom@19.2.3` peer-requires `@types/react ^19.2.0`. Forcing it (`--legacy-peer-deps` / `overrides`) would violate this repo's dependency hygiene. Filed as follow-up **#777**.

## Change

One troubleshooting note added to `CLAUDE.md` → Testing: `### Typecheck TS7016 on react-dom/server — incomplete install, not a code defect` (Pattern / Root cause / Symptom / Fix), matching the existing troubleshooting-note style (CI-not-firing, staging-queue-starvation).

## Testing

- `npm run typecheck` -> **PASS** (`4 successful, 4 total`; web ran fresh on cache-miss) — the issue's exact command.
- Direct `apps/web` typecheck (`tsc --noEmit -p tsconfig.typecheck.json`, bypasses turbo cache) -> **exit 0**; `@types/react-dom/server.d.ts` present.
- Diff is **documentation-only** (single markdown file, `CLAUDE.md`, +17 lines) — no source/test/config/dependency change, so the test suite is unaffected (Coverage Requirements -> "docs only — none required").
- Suppression grep: clean. Test-integrity grep: clean. No deleted test files. No `package.json` / lockfile change (lockfile-drift obligation N/A).

## Follow-up

- #777 — mobile↔web React version skew that blocks root-hoisting the shared React type deps.

Closes #769
