### PR TITLE
[fix] Skip/unskip workout: validate cycleNum/workoutNum bounds and program existence

### DIFF
--- a/apps/api/src/programs/programs.e2e.spec.ts
+++ b/apps/api/src/programs/programs.e2e.spec.ts
@@ -1279,6 +1279,79 @@ describe('Programs HTTP (e2e, in-memory adapters)', () => {
       });
       expect(finalDash.json().weeks[0].completed).toBe(true);
     });
+
+    // ---- Bounds / cycle / existence validation (#776; mirrors reschedule #775) ----
+    // Each uses a fresh setupSkipUser whose active cycle is deterministically 1
+    // (it initializes a single cycle), so cycle 2 is reliably non-active. Before
+    // #776 the skip controller never loaded the spec or dashboard, so all three
+    // of these silently wrote a 204 skip the current-cycle read model can't show.
+
+    it('POST skip with unknown program returns 404', async () => {
+      const token = await setupSkipUser('skip-e2e-404-post');
+      const res = await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/no-such-program/cycles/1/workouts/1/skip`,
+        headers: { 'content-type': 'application/json', authorization: token },
+        payload: JSON.stringify({}),
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('POST skip with out-of-range workoutNum returns 400', async () => {
+      const token = await setupSkipUser('skip-e2e-oob-post');
+      // 9999 is a positive integer (passes the old check) but far past the
+      // program's canonical length — a skip there is dead data.
+      const res = await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/cycles/1/workouts/9999/skip`,
+        headers: { 'content-type': 'application/json', authorization: token },
+        payload: JSON.stringify({}),
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('POST skip with non-active cycleNum returns 400', async () => {
+      const token = await setupSkipUser('skip-e2e-nac-post');
+      // The fresh user's active cycle is 1; cycle 2 is not active, so a skip
+      // there could never be read.
+      const res = await app.getHttpAdapter().getInstance().inject({
+        method: 'POST',
+        url: `/programs/${SEED_PROGRAM}/cycles/2/workouts/1/skip`,
+        headers: { 'content-type': 'application/json', authorization: token },
+        payload: JSON.stringify({}),
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('DELETE unskip with unknown program returns 404', async () => {
+      const token = await setupSkipUser('skip-e2e-404-delete');
+      const res = await app.getHttpAdapter().getInstance().inject({
+        method: 'DELETE',
+        url: `/programs/no-such-program/cycles/1/workouts/1/skip`,
+        headers: { authorization: token },
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('DELETE unskip with out-of-range workoutNum returns 400', async () => {
+      const token = await setupSkipUser('skip-e2e-oob-delete');
+      const res = await app.getHttpAdapter().getInstance().inject({
+        method: 'DELETE',
+        url: `/programs/${SEED_PROGRAM}/cycles/1/workouts/9999/skip`,
+        headers: { authorization: token },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('DELETE unskip with non-active cycleNum returns 400', async () => {
+      const token = await setupSkipUser('skip-e2e-nac-delete');
+      const res = await app.getHttpAdapter().getInstance().inject({
+        method: 'DELETE',
+        url: `/programs/${SEED_PROGRAM}/cycles/2/workouts/1/skip`,
+        headers: { authorization: token },
+      });
+      expect(res.statusCode).toBe(400);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/apps/api/src/programs/workout-skip.controller.spec.ts
+++ b/apps/api/src/programs/workout-skip.controller.spec.ts
@@ -182,6 +182,14 @@ describe('WorkoutSkipController', () => {
       expect(skipRepo.unskipWorkout).not.toHaveBeenCalled();
     });
 
+    it('propagates ProgramNotFoundError when the cycle dashboard is missing', async () => {
+      dashboardRepo.getCycleDashboard.mockRejectedValue(new ProgramNotFoundError('5-3-1'));
+      await expect(
+        controller.unskipWorkout('5-3-1', '2', '3', MOCK_USER),
+      ).rejects.toThrow(ProgramNotFoundError);
+      expect(skipRepo.unskipWorkout).not.toHaveBeenCalled();
+    });
+
     it('calls unskipWorkout with parsed params', async () => {
       await controller.unskipWorkout('5-3-1', '2', '3', MOCK_USER);
       expect(skipRepo.unskipWorkout).toHaveBeenCalledWith('5-3-1', 2, 3);

--- a/apps/api/src/programs/workout-skip.controller.spec.ts
+++ b/apps/api/src/programs/workout-skip.controller.spec.ts
@@ -1,15 +1,39 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
+import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
 import { IWorkoutSkipOverrideRepository } from '../ports/IWorkoutSkipOverrideRepository';
 import { IRepositoryFactory } from '../ports/factory';
+import { ProgramNotFoundError } from '../ports/errors';
 import { REPOSITORY_FACTORY } from '../ports/tokens';
 import { WorkoutSkipController } from './workout-skip.controller';
 
 const MOCK_USER = { id: 'u1', email: 'test@example.com', provider: 'dev' };
 
+// A realistic 2-offset week-1 block. `5-3-1` is a registered 12-week program, so
+// workoutKeyForWorkoutNum tiles this block across 12 weeks -> 24 workout days;
+// workoutNum 1..24 resolve to a real day. The controller's new upper-bound check
+// needs a spec that actually resolves the tested workoutNum, not a bare stub.
+const baseSpecFields = {
+  increment: 5,
+  order: 1,
+  sets: 3,
+  reps: 5,
+  amrap: true,
+  warmUpPct: '0.4,0.5,0.6',
+  wtDecrementPct: 0.1,
+  activation: 'compound',
+};
+const STUB_SPEC = [
+  { ...baseSpecFields, offset: 0, lift: 'Squat', week: 1 },
+  { ...baseSpecFields, offset: 3, lift: 'Bench Press', week: 1 },
+] as unknown as Awaited<ReturnType<ILiftingProgramSpecRepository['getProgramSpec']>>;
+
 describe('WorkoutSkipController', () => {
   let controller: WorkoutSkipController;
   let skipRepo: jest.Mocked<IWorkoutSkipOverrideRepository>;
+  let specRepo: jest.Mocked<ILiftingProgramSpecRepository>;
+  let dashboardRepo: jest.Mocked<ICycleDashboardRepository>;
 
   beforeEach(async () => {
     skipRepo = {
@@ -17,8 +41,24 @@ describe('WorkoutSkipController', () => {
       skipWorkout: jest.fn().mockResolvedValue(undefined),
       unskipWorkout: jest.fn().mockResolvedValue(undefined),
     };
+    specRepo = {
+      getProgramSpec: jest.fn().mockResolvedValue(STUB_SPEC),
+      saveProgramSpec: jest.fn(),
+      deleteSpecRows: jest.fn(),
+    } as jest.Mocked<ILiftingProgramSpecRepository>;
+    // Active cycle is 2 — the valid-input tests skip/unskip cycle 2; the
+    // controller's new cycle-match check compares the path cycleNum against this
+    // dashboard cycleNum.
+    dashboardRepo = {
+      getCycleDashboard: jest.fn().mockResolvedValue({ cycleNum: 2 }),
+      saveCycleDashboard: jest.fn(),
+    } as unknown as jest.Mocked<ICycleDashboardRepository>;
     const factory: jest.Mocked<IRepositoryFactory> = {
-      forUser: jest.fn().mockResolvedValue({ workoutSkipOverride: skipRepo }),
+      forUser: jest.fn().mockResolvedValue({
+        workoutSkipOverride: skipRepo,
+        liftingProgramSpec: specRepo,
+        cycleDashboard: dashboardRepo,
+      }),
     };
     const module: TestingModule = await Test.createTestingModule({
       controllers: [WorkoutSkipController],
@@ -50,6 +90,38 @@ describe('WorkoutSkipController', () => {
       await expect(
         controller.skipWorkout('5-3-1', '1', '0', {}, MOCK_USER),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws 404 for an unknown program', async () => {
+      specRepo.getProgramSpec.mockResolvedValue([]);
+      await expect(
+        controller.skipWorkout('no-such-program', '2', '3', {}, MOCK_USER),
+      ).rejects.toThrow(NotFoundException);
+      expect(skipRepo.skipWorkout).not.toHaveBeenCalled();
+    });
+
+    it('throws 400 for a workoutNum beyond the program length', async () => {
+      // 5-3-1 is 12 weeks x 2 offsets = 24 workout days; 9999 maps to no real day.
+      await expect(
+        controller.skipWorkout('5-3-1', '2', '9999', {}, MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+      expect(skipRepo.skipWorkout).not.toHaveBeenCalled();
+    });
+
+    it('throws 400 for a cycleNum that is not the active cycle', async () => {
+      // Active cycle is 2 (dashboard mock); a skip on cycle 7 could never be read.
+      await expect(
+        controller.skipWorkout('5-3-1', '7', '3', {}, MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+      expect(skipRepo.skipWorkout).not.toHaveBeenCalled();
+    });
+
+    it('propagates ProgramNotFoundError when the cycle dashboard is missing', async () => {
+      dashboardRepo.getCycleDashboard.mockRejectedValue(new ProgramNotFoundError('5-3-1'));
+      await expect(
+        controller.skipWorkout('5-3-1', '2', '3', {}, MOCK_USER),
+      ).rejects.toThrow(ProgramNotFoundError);
+      expect(skipRepo.skipWorkout).not.toHaveBeenCalled();
     });
 
     it('calls skipWorkout with parsed params and optional reason', async () => {
@@ -86,6 +158,28 @@ describe('WorkoutSkipController', () => {
       await expect(
         controller.unskipWorkout('5-3-1', '1', '0', MOCK_USER),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws 404 for an unknown program', async () => {
+      specRepo.getProgramSpec.mockResolvedValue([]);
+      await expect(
+        controller.unskipWorkout('no-such-program', '2', '3', MOCK_USER),
+      ).rejects.toThrow(NotFoundException);
+      expect(skipRepo.unskipWorkout).not.toHaveBeenCalled();
+    });
+
+    it('throws 400 for a workoutNum beyond the program length', async () => {
+      await expect(
+        controller.unskipWorkout('5-3-1', '2', '9999', MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+      expect(skipRepo.unskipWorkout).not.toHaveBeenCalled();
+    });
+
+    it('throws 400 for a cycleNum that is not the active cycle', async () => {
+      await expect(
+        controller.unskipWorkout('5-3-1', '7', '3', MOCK_USER),
+      ).rejects.toThrow(BadRequestException);
+      expect(skipRepo.unskipWorkout).not.toHaveBeenCalled();
     });
 
     it('calls unskipWorkout with parsed params', async () => {

--- a/apps/api/src/programs/workout-skip.controller.ts
+++ b/apps/api/src/programs/workout-skip.controller.ts
@@ -6,15 +6,19 @@ import {
   HttpCode,
   HttpStatus,
   Inject,
+  NotFoundException,
   Param,
   Post,
 } from '@nestjs/common';
+import { programLengthWeeks } from '@lifting-logbook/core';
 import { IsOptional, IsString, MaxLength } from 'class-validator';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../ports/auth';
+import { ICycleDashboardRepository } from '../ports/ICycleDashboardRepository';
+import { ILiftingProgramSpecRepository } from '../ports/ILiftingProgramSpecRepository';
 import { IRepositoryFactory } from '../ports/factory';
 import { REPOSITORY_FACTORY } from '../ports/tokens';
-import { isValidWorkoutNum } from './mappers';
+import { isValidWorkoutNum, workoutKeyForWorkoutNum } from './mappers';
 
 class SkipWorkoutDto {
   @IsOptional()
@@ -48,7 +52,15 @@ export class WorkoutSkipController {
       throw new BadRequestException('workoutNum must be a positive integer');
     }
 
-    const { workoutSkipOverride } = await this.factory.forUser(user);
+    const { workoutSkipOverride, liftingProgramSpec, cycleDashboard } =
+      await this.factory.forUser(user);
+    await this.assertActiveInBoundsTarget(
+      program,
+      cycleNum,
+      workoutNum,
+      liftingProgramSpec,
+      cycleDashboard,
+    );
     await workoutSkipOverride.skipWorkout(program, cycleNum, workoutNum, dto.reason);
   }
 
@@ -70,7 +82,58 @@ export class WorkoutSkipController {
       throw new BadRequestException('workoutNum must be a positive integer');
     }
 
-    const { workoutSkipOverride } = await this.factory.forUser(user);
+    const { workoutSkipOverride, liftingProgramSpec, cycleDashboard } =
+      await this.factory.forUser(user);
+    await this.assertActiveInBoundsTarget(
+      program,
+      cycleNum,
+      workoutNum,
+      liftingProgramSpec,
+      cycleDashboard,
+    );
     await workoutSkipOverride.unskipWorkout(program, cycleNum, workoutNum);
+  }
+
+  /**
+   * Rejects a skip/unskip target the current-cycle read model could never
+   * surface, so the endpoint can't silently record dead data (a 204 with no
+   * visible effect — the failure mode #773 flagged). Shared by both skip (POST)
+   * and unskip (DELETE); mirrors the RescheduleController bounds/cycle checks
+   * (#773/#775). Order matters — spec (404) → workoutNum bound (400) → active
+   * cycle (400) — so the cheapest, most-specific failure wins and the dashboard
+   * is only loaded once the workoutNum is known to be in range.
+   */
+  private async assertActiveInBoundsTarget(
+    program: string,
+    cycleNum: number,
+    workoutNum: number,
+    liftingProgramSpec: ILiftingProgramSpecRepository,
+    cycleDashboard: ICycleDashboardRepository,
+  ): Promise<void> {
+    const spec = await liftingProgramSpec.getProgramSpec(program);
+    if (spec.length === 0) {
+      throw new NotFoundException(`Program '${program}' not found`);
+    }
+
+    // Reject a workoutNum past the program's spec-derived canonical length, via
+    // the same workoutKeyForWorkoutNum helper the GET workout endpoint uses.
+    // Without this a skip is recorded for a workoutNum that maps to no real
+    // workout day and is silently never surfaced.
+    if (workoutKeyForWorkoutNum(spec, workoutNum, program) === undefined) {
+      throw new BadRequestException(
+        `workoutNum ${workoutNum} exceeds the program's ${programLengthWeeks(program, spec)}-week schedule`,
+      );
+    }
+
+    // getCycleDashboard throws ProgramNotFoundError when the program has no
+    // cycle. Its cycleNum is the *active* cycle, and the entire read model (GET
+    // workout, cycle dashboard, getSkipsForCycle) reads only that cycle — a skip
+    // written for any other cycleNum is dead data the client can never see.
+    const dashboard = await cycleDashboard.getCycleDashboard(program);
+    if (cycleNum !== dashboard.cycleNum) {
+      throw new BadRequestException(
+        `cycleNum ${cycleNum} is not the active cycle (${dashboard.cycleNum})`,
+      );
+    }
   }
 }


### PR DESCRIPTION
## Summary

Closes #776. Mirrors the reschedule bounds/cycle validation just merged in #775 (issue #773) on **both** the skip (`POST`) and unskip (`DELETE`) workout endpoints (`apps/api/src/programs/workout-skip.controller.ts`).

Before this change the skip controller validated only that `cycleNum` / `workoutNum` are **positive integers** and — unlike reschedule — never loaded the program spec or cycle dashboard at all. So a skip/unskip for a **non-existent program**, an **out-of-range workout**, or a **non-active cycle** was silently written and returned `204`, becoming **dead data the current-cycle read model (GET workout, cycle dashboard, `getSkipsForCycle`) can never surface** — the same silent-no-op failure mode as #773.

A shared **private controller method** `assertActiveInBoundsTarget`, called from both `skipWorkout` and `unskipWorkout` after resolving the user's repository bundle, now:

1. loads the spec and throws **404** (`Program '<p>' not found`) for an unknown program;
2. rejects a `workoutNum` past the program's canonical length with **400** — via the same `workoutKeyForWorkoutNum` helper the GET workout endpoint uses, with the identical message (`workoutNum N exceeds the program's M-week schedule`);
3. loads the cycle dashboard and rejects a `cycleNum` that is not the active cycle with **400**.

Order is spec → workoutNum → cycle, so the cheapest / most-specific failure wins and the dashboard is only loaded once the workoutNum is known to be in range.

### Design note — inline vs. shared cross-file helper

The issue suggested considering a helper shared with reschedule. I used a **private method within the controller** (DRY across skip + unskip) but **not** a cross-file helper shared with `RescheduleController`, because:

- `mappers.ts` is intentionally framework-agnostic (imports only `@lifting-logbook/core` / `types`); moving async repo-loading + `@nestjs/common` exceptions there would be a layering regression, and a pure helper can't throw the HTTP exceptions cleanly.
- Reschedule keeps its copy inline today, and there are only two call sites.

The reschedule↔skip de-duplication (e.g. a shared guard) is filed as a follow-up rather than expanded into this PR.

## Acceptance criteria

- [x] `skipWorkout` and `unskipWorkout` reject an unknown program with `404`.
- [x] Both reject a `workoutNum` beyond the program's canonical length with `400` (consistent with the GET workout endpoint).
- [x] Both reject a `cycleNum` that is not the active cycle with `400`.
- [x] Existing valid skip/unskip (active cycle, in-range workout) continue to return `204`.
- [x] Unit (`workout-skip.controller.spec.ts`) and E2E (`programs.e2e.spec.ts`) coverage for the new `400` / `404` paths.

## Testing

`npm run typecheck` (4 pkgs) ✓ · `npm run build` (api `nest build` type-checks the controller `src`) ✓ · full `npm test`:

| Workspace | Result |
|---|---|
| `@lifting-logbook/core` | 322 passed |
| `@lifting-logbook/api-client` | 27 passed |
| `@lifting-logbook/api` | 494 passed (incl. DB e2e via Testcontainers) |
| `@lifting-logbook/web` | 244 passed |

**Tests: 1087 passed, 0 skipped, 0 failed.** No suppressions, test-integrity violations, or deleted tests in the diff; no `package.json` / lockfile change.

### New coverage

- **Unit:** 4 new cases each on `skipWorkout` / `unskipWorkout` (404 unknown program, 400 out-of-range `workoutNum`, 400 non-active cycle, `ProgramNotFoundError`-propagation — the last added symmetrically to both methods per the `/review` finding below); existing happy-path tests retained (dashboard mock pinned to the active cycle they exercise).
- **E2E:** 6 new cases in the `workout skip override` block (`POST` + `DELETE` × 404 / oob-400 / non-active-400), each using a fresh `setupSkipUser` so the active cycle is deterministically 1 (mirrors the reschedule e2e block's "run before new-cycle writes" precondition).

## Risk audit

- **Security:** no authz change; per-user repository-factory isolation intact; no PII. Defense-in-depth against dead-data writes.
- **Resilience / failure modes:** `getCycleDashboard` may throw `ProgramNotFoundError` (→ 404), mirroring reschedule; covered by a unit test on both call sites.
- **Performance:** adds two reads (spec + dashboard) per skip/unskip, mirroring reschedule; not a hot path.
- **Observability:** standard Nest exceptions; `nestjs-pino` auto-logs the error responses carrying `trace_id` / `span_id`. No new logging.
- **Data integrity & migrations:** prevents dead-data skip writes; no schema / migration change.

Precedent: #773 (gap analysis) / #775 (reschedule fix).

## Review findings disposition

[`/review`](https://github.com/brownm09/lifting-logbook/pull/779#issuecomment-4929761001) posted 1 non-blocking finding, 0 blocking:

- **[maintainability]** `workout-skip.controller.spec.ts` — `unskipWorkout`'s describe block was missing the `ProgramNotFoundError`-propagation test that `skipWorkout`'s had, despite both sharing the same `assertActiveInBoundsTarget` method. **Fixed in `e35c46f`** — added the mirror test; full suite re-run green (1087 passed).
