### PR TITLE
[config] Enforce LF line endings by construction for shell/env files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,22 @@
-# Files that are `source`d by bash on the Linux CI runner must stay LF-only, so a
-# sourced value never carries a trailing CR. A CRLF grafana-endpoints.env would
-# append "\r" to each endpoint URL and silently break telemetry — the same
-# no-telemetry failure class as #781 that #785 exists to prevent.
-infra/observability/grafana-endpoints.env text eol=lf
+# ── Line-ending policy ───────────────────────────────────────────────────────
+# Enforce line endings by construction, not by each contributor's core.autocrlf
+# (the Windows default — a clone with autocrlf=false, or input misconfigured,
+# could otherwise commit CRLF). All text files are normalized to LF in the git
+# blob; git auto-detects text vs binary and leaves binaries untouched.
+* text=auto
+
+# Files run or `source`d by bash on Linux — the CI runner and the prod containers —
+# must be LF in the working-tree checkout too, not just in the blob. A CRLF copy
+# breaks execution on Linux: `/bin/bash^M: bad interpreter`, or a trailing CR on a
+# sourced value (a CRLF grafana-endpoints.env would append "\r" to each Grafana
+# endpoint URL and silently break telemetry — the #781 no-telemetry failure class
+# that #785/#790 fixed for that one file; #792 generalizes it to every such file).
+*.sh   text eol=lf
+*.bash text eol=lf
+*.env  text eol=lf
+
+# Binaries: mark explicitly so `* text=auto` can never misdetect and line-ending-
+# mangle them. Git's content detection already handles these, but an explicit rule
+# is robust against detection edge cases and future files. (Only *.png is present
+# today — the apps/mobile assets.)
+*.png binary


### PR DESCRIPTION
## Summary

Follow-up to #790 (#785). PR #790 pinned **only** `infra/observability/grafana-endpoints.env` to LF, because it is `source`d by bash on the Linux CI runner and a CRLF commit would append `\r` to each endpoint URL (the #781 no-telemetry class). This generalizes that protection to every bash-run/sourced file, so line endings are enforced **by construction**, not by each contributor's `core.autocrlf`.

## What changed

`.gitattributes`:
- `* text=auto` — all text files are normalized to LF in the git blob; a contributor with `core.autocrlf=false` (or `input` misconfigured) can no longer commit CRLF for a text file.
- `*.sh`, `*.bash`, `*.env` → `text eol=lf` — files run or `source`d by bash on Linux (CI runner + prod containers) are LF in the working-tree checkout too, so they never break on Linux (`/bin/bash^M: bad interpreter`, or a trailing CR on a sourced value). Covers the previously-unprotected `scripts/observability/mimir-query-env.sh`, `mimir-setup.sh`, `scripts/bootstrap-otel-secrets.sh`, `scripts/smoke-test-observability.sh`, and the rest of `scripts/**`.
- `*.png binary` — the only binary type present (apps/mobile assets); marked explicitly so `* text=auto` can never misdetect and line-ending-mangle it.
- The standalone `grafana-endpoints.env` line from #790 is folded into `*.env` (still resolves to `eol=lf` — verified with `git check-attr`).

## Verification (config-only change — no runtime/test surface)

- **`git add --renormalize .` stages nothing but `.gitattributes`** — all tracked blobs were already LF (historical `core.autocrlf=true`), so there are **zero file-content changes** and no binary corruption. Confirmed `git ls-files --eol` reports `i/crlf` on 0 files.
- `git check-attr` confirms: `.sh`/`.env` → `text=set, eol=lf`; `.ts`/`.ps1`/`package.json` → `text=auto`; `.png` → binary; `grafana-endpoints.env` → `eol=lf` (the #785 protection is preserved).
- No `package.json` change (lockfile policy N/A). No suppressions, no test changes.

## Risk audit
- **Resilience / failure modes:** the whole point — removes a latent CRLF-on-Linux foot-gun for every bash-sourced/executed script. Revert restores the #790-only pin. Zero blob changes ⇒ no behavioral risk to existing files.
- **Data integrity:** `*.png binary` + the clean renormalize confirm no binary is mangled.
- **Testing / Security / Observability / Performance:** N/A — repo-config only, no code or runtime surface.

Closes #792
