### PR TITLE
[infra] Add Docker Hub pull-through mirror for otel-collector image (1/2)

### DIFF
--- a/docs/adr/ADR-029-per-env-artifact-registry-push.md
+++ b/docs/adr/ADR-029-per-env-artifact-registry-push.md
@@ -126,6 +126,28 @@ the existing pattern wins.
   to **both** ARs, and `deploy-production` pulls the prod AR with **no** cross-project access. This
   cannot be exercised from a feature branch (the deploy jobs gate on `main`).
 
+## Addendum — 2026-07-10 (#795): same-project pull-through mirror reader
+
+This ADR removed the module's one **cross-project** `artifactregistry.reader` grant (the prod SA
+reading the staging AR). [#795](https://github.com/brownm09/lifting-logbook/issues/795) then adds the
+module's first **same-project** AR reader grant, and the two do not conflict.
+
+A `REMOTE_REPOSITORY` Docker Hub pull-through repo `${var.app_name}-dockerhub`
+(`google_artifact_registry_repository.dockerhub_mirror`, `main.tf`) was added so the otel-collector
+image is served from Artifact Registry rather than Docker Hub on the request path — Docker Hub's
+mutable tag exposes new production instances to a rate-limit (100 pulls/6h per IP) or outage on every
+cold-start / node pull ([#788](https://github.com/brownm09/lifting-logbook/issues/788)). Pulling
+*through* a remote repo requires `artifactregistry.reader` **on that repo**, so
+`google_artifact_registry_repository_iam_member.dockerhub_mirror_readers` grants it — scoped to the
+mirror repo, inside each environment's **own** project — to the two image-pull identities: the Cloud
+Run **service agent** (`serverless-robot`) and the default **Compute SA** (GKE Autopilot node pulls).
+
+This is consistent with ADR-029's least-privilege stance: the grant is same-project (never
+cross-project), repo-scoped (not project-wide), and given only to identities that pull images. The
+standard `images` repo keeps relying on Google's implicit project-level reader; the grant is explicit
+here because a remote repo's first pull-through is exercised only on the production/staging
+`deploy.yml` run (`push: main`), which PR CI does not execute.
+
 ## References
 
 - [Google Cloud — Artifact Registry: push and pull images](https://cloud.google.com/artifact-registry/docs/docker/pushing-and-pulling) —

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -374,6 +374,55 @@ resource "google_artifact_registry_repository" "images" {
 # `external_ar_reader_service_accounts` variable were removed; applying this
 # revokes the standing cross-project grant.
 
+# ─── Artifact Registry — Docker Hub pull-through mirror (#795) ────────────────
+
+# The otel-collector image (otel/opentelemetry-collector-contrib) is pulled from
+# Docker Hub by a mutable tag on every Cloud Run cold-start / GKE node pull, so a
+# Docker Hub rate-limit (100 pulls/6h per IP) or outage can fail new production
+# request-path instances, and a re-pushed tag breaks reproducibility (#788/#795).
+# This REMOTE repository proxies Docker Hub through Artifact Registry: the first
+# pull of a given digest fetches upstream and caches it in-project; every later
+# request-path pull is served from AR (in-GCP, no Docker Hub dependency).
+# Consumers reference it by digest — wired in the #795 follow-up PR.
+resource "google_artifact_registry_repository" "dockerhub_mirror" {
+  repository_id = "${var.app_name}-dockerhub"
+  location      = var.artifact_registry_region
+  format        = "DOCKER"
+  mode          = "REMOTE_REPOSITORY"
+  description   = "Docker Hub pull-through cache for ${var.app_name} (otel-collector, #795)"
+
+  remote_repository_config {
+    description = "Docker Hub"
+    docker_repository {
+      public_repository = "DOCKER_HUB"
+    }
+  }
+
+  depends_on = [google_project_service.required_apis]
+}
+
+# Project number for the image-pull identities' service-account emails.
+data "google_project" "current" {}
+
+# Explicit reader on the mirror for the two identities that pull container images.
+# Pulls from the STANDARD `images` repo above rely on Google's implicit project-
+# level grant, but the first-ever pull-through of this REMOTE repo happens on a
+# production/staging deploy that PR CI does not exercise (staging.yml deploys the
+# api without the sidecar; the collector ships only via deploy.yml on push:main),
+# so grant reader explicitly rather than depend on the implicit bind:
+#   * Cloud Run pulls the sidecar image via its service agent (serverless-robot).
+#   * GKE Autopilot nodes pull the DaemonSet image via the default Compute SA.
+resource "google_artifact_registry_repository_iam_member" "dockerhub_mirror_readers" {
+  for_each = toset([
+    "serviceAccount:service-${data.google_project.current.number}@serverless-robot-prod.iam.gserviceaccount.com",
+    "serviceAccount:${data.google_project.current.number}-compute@developer.gserviceaccount.com",
+  ])
+  location   = google_artifact_registry_repository.dockerhub_mirror.location
+  repository = google_artifact_registry_repository.dockerhub_mirror.name
+  role       = "roles/artifactregistry.reader"
+  member     = each.value
+}
+
 # ─── IAM — CI/CD service account ─────────────────────────────────────────────
 
 resource "google_service_account" "cicd" {

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -33,6 +33,11 @@ output "artifact_registry_repo" {
   value       = "${var.artifact_registry_region}-docker.pkg.dev/${var.project_id}/${var.app_name}"
 }
 
+output "otel_collector_mirror_repo" {
+  description = "Docker Hub pull-through mirror base path (#795); append /otel/opentelemetry-collector-contrib@<digest>"
+  value       = "${var.artifact_registry_region}-docker.pkg.dev/${var.project_id}/${var.app_name}-dockerhub"
+}
+
 output "cicd_service_account_email" {
   description = "CI/CD service account email (referenced in GitHub Actions secrets)"
   value       = google_service_account.cicd.email


### PR DESCRIPTION
## Summary

**PR 1 of 2 for #795** (which is item 1 of #788). Part of #795 — the follow-up PR closes it.

The otel-collector image (`otel/opentelemetry-collector-contrib`) is pulled from **Docker Hub by a mutable tag** on every Cloud Run cold-start / GKE node pull, so a Docker Hub rate-limit (100 pulls/6h per IP) or outage can fail new production request-path instances, and a re-pushed tag breaks reproducibility.

This PR adds the **Artifact Registry mirror** (a `REMOTE_REPOSITORY` pull-through cache of Docker Hub) plus reader IAM. It is **additive only** — no consumer references it yet. The `#795` follow-up PR switches the collector image refs to it **by digest**.

**Why split** (per the plan): the mirror lands and is verified first — the deploy pipeline stays on the old Docker Hub ref, so `terraform apply` proves the repo + IAM create cleanly before anything depends on them. It also keeps each review small.

## What changed (`infra/terraform/`)

- **`main.tf`** — `google_artifact_registry_repository.dockerhub_mirror` (`mode = "REMOTE_REPOSITORY"`, `remote_repository_config.docker_repository.public_repository = "DOCKER_HUB"`); a `data "google_project" "current"` for the project number; and `google_artifact_registry_repository_iam_member.dockerhub_mirror_readers` granting `roles/artifactregistry.reader` on the mirror to the two image-pull identities — the Cloud Run **service agent** (`serverless-robot`) and the default **Compute SA** (GKE Autopilot node pulls).
- **`outputs.tf`** — `otel_collector_mirror_repo` (the mirror base path; the follow-up PR appends `/otel/opentelemetry-collector-contrib@<digest>`).

**On the explicit reader IAM:** pulls from the standard `images` repo rely on Google's implicit project-level grant, but the first-ever pull-through of this *remote* repo happens on the production/staging deploy, which PR CI does not exercise (staging.yml deploys the api without the sidecar; the collector ships only via `deploy.yml` on `push: main`). Granting reader explicitly removes that unverified dependency.

## Testing

- `terraform fmt -check` → clean; `terraform validate` → **Success! The configuration is valid.** (validates the `REMOTE_REPOSITORY` schema, `remote_repository_config`, `data.google_project`, and the IAM member).
- **`staging.yml` runs `terraform apply` on this PR**, so the mirror repo + reader IAM are actually created in the staging project during CI — an apply-time error (bad IAM/enum/schema) fails the required "Terraform (staging)" check before merge.
- No workspace source (`packages/*`, `apps/*`) or TypeScript touched → `npm test` / `npm run typecheck` not applicable. Suppression/integrity greps clean; no `package.json` change (lockfile gate N/A). This repo has no terraform unit-test framework; `terraform validate` + the staging apply are the checks.

## Coverage

Infra-only; no application behavior. The staging `terraform apply` is the end-to-end verification that the resources create.
