### PR TITLE
[infra] Deploy the otel-collector sidecar in per-PR staging (api + web)

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -126,6 +126,7 @@ jobs:
       kms_key_name: ${{ steps.tf-outputs.outputs.kms_key_name }}
       api_wi_sa: ${{ steps.tf-outputs.outputs.api_wi_sa }}
       web_workload_sa: ${{ steps.tf-outputs.outputs.web_workload_sa }}
+      otel_mirror_repo: ${{ steps.tf-outputs.outputs.otel_mirror_repo }}
 
     steps:
       - uses: actions/checkout@v5
@@ -175,6 +176,7 @@ jobs:
           echo "kms_key_name=$(terraform output -raw kms_key_name)" >> "$GITHUB_OUTPUT"
           echo "api_wi_sa=$(terraform output -raw cicd_service_account_email)" >> "$GITHUB_OUTPUT"
           echo "web_workload_sa=$(terraform output -raw web_workload_sa)" >> "$GITHUB_OUTPUT"
+          echo "otel_mirror_repo=$(terraform output -raw otel_collector_mirror_repo)" >> "$GITHUB_OUTPUT"
 
   # ── 2. Build and push Docker images ──────────────────────────────────────
   build-images:
@@ -531,7 +533,7 @@ jobs:
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Deploy API to Cloud Run (staging)
+      - name: Deploy API + OTel Collector sidecar to Cloud Run (staging)
         id: deploy-api
         if: steps.clerk-check.outputs.configured == 'true'
         # continue-on-error is retained here (NOT for Cloud SQL flakiness — the
@@ -542,18 +544,59 @@ jobs:
         # docs/runbooks/staging-ci-flakiness.md.
         continue-on-error: true
         run: |
-          # Cloud Run IAM is intentionally public here (ADR-032): the browser calls this API
-          # directly (ADR-028) and the Clerk JWT is the real auth gate. With --no-allow-
-          # unauthenticated, every PR-staging deploy would re-lock the API and 403 the
-          # browser's CORS preflight before it reaches the app — the ~month-long outage #766
-          # fixed. Kept in sync with the stg/prod API deploys in deploy.yml.
-          gcloud run deploy lifting-logbook-stg-api \
-            --image="${{ needs.build-images.outputs.ar_repo }}/api:${{ needs.build-images.outputs.image_tag }}" \
-            --region="${{ env.REGION }}" \
-            --project="${{ vars.GCP_STAGING_PROJECT_ID }}" \
-            --platform=managed \
-            --allow-unauthenticated \
-            --quiet
+          # Wire the API into Grafana Cloud via a co-located otel-collector sidecar (#768/#813),
+          # matching the post-merge staging + prod deploys in deploy.yml so per-PR staging runs the
+          # SAME 2-container topology it will run once merged — instead of stripping the sidecar back
+          # to a single container on every PR push. Cloud Run has no additive sidecar command and no
+          # ConfigMap volumes, and the api service is lifecycle.ignore_changes = [template]
+          # (Terraform never mutates the running revision), so the whole 2-container topology is
+          # owned here:
+          #   1. Ensure the collector config.yaml secret (non-sensitive; from the repo file; a new
+          #      version only when the content changed, to avoid per-deploy churn). deploy-api and
+          #      deploy-web are SEPARATE PARALLEL jobs in this workflow (unlike deploy.yml's single
+          #      sequential job), so each ensures the secret independently — the block is idempotent
+          #      and the secret already exists from prior post-merge deploys, so describe-or-create
+          #      is a cold-start-only path.
+          #   2. Describe the live service, inject the sidecar (+ the api's OTEL_EXPORTER_OTLP_ENDPOINT;
+          #      minus the unused SYSTEM_DATABASE_URL, #534), and `gcloud run services replace`.
+          # Deriving the manifest from the live service preserves every Terraform-managed field (VPC
+          # connector, scaling, SA, startup probe) verbatim. Crucially `services replace` never touches
+          # the invoker IAM policy, so the api's public posture stays owned solely by Terraform's
+          # allUsers run.invoker binding (google_cloud_run_v2_service_iam_member.api_public, #766/#770)
+          # — this replaces the prior `gcloud run deploy --allow-unauthenticated` (ADR-032) without
+          # re-asserting or fighting that grant, so the browser CORS preflight the #766 outage broke is
+          # unaffected. `--container` was rejected (unresolvable sidecar port catch-22) — see
+          # scripts/inject-otel-sidecar.py. The sidecar shares the api revision's CPU-throttling, so
+          # its batch/export timers are best-effort between requests, not always-on like the GKE
+          # DaemonSet (ADR-018). Grafana OTLP/Loki endpoints come from the single source of truth
+          # (infra/observability/grafana-endpoints.env, #785); sourcing it exports OTEL_OTLP_ENDPOINT /
+          # OTEL_LOKI_ENDPOINT for the injector below.
+          source infra/observability/grafana-endpoints.env
+          source infra/observability/otel-collector-image.env
+          PROJECT="${{ vars.GCP_STAGING_PROJECT_ID }}"
+          CONFIG_SECRET="lifting-logbook-stg-otel-collector-config"
+          gcloud secrets describe "$CONFIG_SECRET" --project="$PROJECT" >/dev/null 2>&1 \
+            || gcloud secrets create "$CONFIG_SECRET" --replication-policy=automatic --project="$PROJECT" --quiet 2>/dev/null || true
+          CURRENT_CFG=$(gcloud secrets versions access latest --secret="$CONFIG_SECRET" --project="$PROJECT" 2>/dev/null || true)
+          if [ "$CURRENT_CFG" != "$(cat infra/cloud-run/otel-collector-config.yaml)" ]; then
+            gcloud secrets versions add "$CONFIG_SECRET" --data-file=infra/cloud-run/otel-collector-config.yaml --project="$PROJECT" --quiet
+            echo "otel-collector config secret: new version published."
+          else
+            echo "otel-collector config secret: unchanged."
+          fi
+          # PyYAML ships pre-installed on GitHub-hosted ubuntu runners; --break-system-packages
+          # keeps the fallback working if it is ever absent on a PEP-668 (externally-managed) runner.
+          python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet --break-system-packages pyyaml
+          gcloud run services describe lifting-logbook-stg-api \
+            --region="${{ env.REGION }}" --project="$PROJECT" --format=export > "$RUNNER_TEMP/stg-api.yaml"
+          API_IMAGE="${{ needs.build-images.outputs.ar_repo }}/api:${{ needs.build-images.outputs.image_tag }}" \
+          OTEL_CONFIG_SECRET="$CONFIG_SECRET" \
+          COLLECTOR_IMAGE="${{ needs.terraform-staging.outputs.otel_mirror_repo }}/${OTEL_COLLECTOR_IMAGE_REPO_PATH}@${OTEL_COLLECTOR_IMAGE_DIGEST}" \
+          OTEL_OTLP_SECRET="lifting-logbook-stg-otel-otlp-auth-header" \
+          OTEL_LOKI_SECRET="lifting-logbook-stg-otel-loki-auth-header" \
+            python3 scripts/inject-otel-sidecar.py "$RUNNER_TEMP/stg-api.yaml" > "$RUNNER_TEMP/stg-api-sidecar.yaml"
+          gcloud run services replace "$RUNNER_TEMP/stg-api-sidecar.yaml" \
+            --region="${{ env.REGION }}" --project="$PROJECT" --quiet
 
       - name: Fetch Cloud Run API logs on failure
         if: steps.deploy-api.outcome == 'failure'
@@ -674,33 +717,77 @@ jobs:
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Deploy web to Cloud Run (staging)
+      - name: Deploy web + OTel Collector sidecar to Cloud Run (staging)
         id: deploy-web
         if: steps.clerk-check.outputs.configured == 'true'
         run: |
-          # Capture gcloud output so we can parse the canonical "Service URL:" line.
-          # gcloud run services describe --format="value(status.url)" returns the legacy
-          # *.a.run.app URL which may no longer be routed to the current service instance;
-          # the "Service URL:" line from gcloud run deploy is always the live canonical URL.
-          # Runtime public-config injection (#396 / ADR-028): PUBLIC_API_URL == API_URL on
-          # Cloud Run; CLERK_PUBLISHABLE_KEY is a runtime secret env consumed by the root
-          # layout and passed to <ClerkProvider> as a prop.
-          # Use --set-env-vars (replace), matching deploy.yml: the deploy command is the single
-          # source of truth for the env set, so a var removed here can't linger on the revision
-          # via merge semantics. (Secrets use --update-secrets — a separate namespace.)
-          DEPLOY_OUT=$(gcloud run deploy lifting-logbook-stg-web \
-            --image="${{ needs.build-images.outputs.ar_repo }}/web:${{ needs.build-images.outputs.image_tag }}" \
-            --region="${{ env.REGION }}" \
-            --project="${{ vars.GCP_STAGING_PROJECT_ID }}" \
-            --platform=managed \
-            --allow-unauthenticated \
-            --service-account="${{ needs.terraform-staging.outputs.web_workload_sa }}" \
-            --set-env-vars="API_URL=${{ needs.terraform-staging.outputs.cloud_run_api_url }},PUBLIC_API_URL=${{ needs.terraform-staging.outputs.cloud_run_api_url }}" \
-            --update-secrets="CLERK_SECRET_KEY=lifting-logbook-stg-clerk-secret-key:latest,CLERK_PUBLISHABLE_KEY=lifting-logbook-stg-clerk-publishable-key:latest" \
-            --quiet 2>&1)
-          echo "$DEPLOY_OUT"
-          WEB_URL=$(echo "$DEPLOY_OUT" | grep "Service URL:" | awk '{print $NF}')
-          echo "url=${WEB_URL}" >> "$GITHUB_OUTPUT"
+          # Wire the web SERVER runtime into Grafana Cloud via a co-located otel-collector sidecar
+          # (#804/#813), mirroring the api step above and the post-merge web deploy in deploy.yml so
+          # per-PR staging runs the SAME 2-container topology it will run once merged. @vercel/otel
+          # (apps/web/instrumentation.ts) exports OTLP to localhost:4318, so without a sidecar in the
+          # web instance every web-server span is dropped — the #206 request traces AND the #798
+          # client.mutation.error spans. Same describe → inject → `services replace` mechanism and the
+          # SAME collector config + Grafana endpoints/auth-header secrets as the api step; only the
+          # ingress container name (web) and image differ.
+          #
+          # Dropping the old --set-env-vars / --update-secrets / --service-account /
+          # --allow-unauthenticated flags is deliberate and matches deploy.yml: the web service's
+          # env/secrets (NODE_ENV, API_URL, PUBLIC_API_URL, CLERK_*) and its service account are
+          # Terraform-managed (lifecycle.ignore_changes = [template]) and preserved verbatim by
+          # describe, and its public posture is owned by Terraform's allUsers run.invoker binding
+          # (google_cloud_run_v2_service_iam_member.web_public) — `services replace` never touches
+          # invoker IAM. deploy-api and deploy-web run as SEPARATE PARALLEL jobs here, so this job
+          # ensures the collector config secret independently (idempotent; already exists from prior
+          # post-merge deploys).
+          #
+          # IAM (#804): the web sidecar runs as the WEB workload SA, which — unlike the api SA's
+          # project-level secretmanager.secretAccessor — only has per-secret grants for the two Clerk
+          # secrets. Grant it read on exactly the three otel secrets it needs (config + the two Grafana
+          # auth headers): least-privilege, so the internet-facing web SA never gains the api SA's broad
+          # access to DATABASE_URL / migrator creds. Idempotent, runs as the staging CI/CD SA. (First-
+          # ever deploy only: a few seconds of IAM propagation may be needed before the sidecar can read
+          # them; a failed replace leaves the prior web revision serving and self-heals on re-run.)
+          source infra/observability/grafana-endpoints.env
+          source infra/observability/otel-collector-image.env
+          PROJECT="${{ vars.GCP_STAGING_PROJECT_ID }}"
+          CONFIG_SECRET="lifting-logbook-stg-otel-collector-config"
+          WEB_SA="${{ needs.terraform-staging.outputs.web_workload_sa }}"
+          gcloud secrets describe "$CONFIG_SECRET" --project="$PROJECT" >/dev/null 2>&1 \
+            || gcloud secrets create "$CONFIG_SECRET" --replication-policy=automatic --project="$PROJECT" --quiet 2>/dev/null || true
+          CURRENT_CFG=$(gcloud secrets versions access latest --secret="$CONFIG_SECRET" --project="$PROJECT" 2>/dev/null || true)
+          if [ "$CURRENT_CFG" != "$(cat infra/cloud-run/otel-collector-config.yaml)" ]; then
+            gcloud secrets versions add "$CONFIG_SECRET" --data-file=infra/cloud-run/otel-collector-config.yaml --project="$PROJECT" --quiet
+            echo "otel-collector config secret: new version published."
+          else
+            echo "otel-collector config secret: unchanged."
+          fi
+          for SECRET in "$CONFIG_SECRET" \
+                        "lifting-logbook-stg-otel-otlp-auth-header" \
+                        "lifting-logbook-stg-otel-loki-auth-header"; do
+            gcloud secrets add-iam-policy-binding "$SECRET" \
+              --member="serviceAccount:${WEB_SA}" \
+              --role="roles/secretmanager.secretAccessor" \
+              --project="$PROJECT" --quiet >/dev/null
+          done
+          # PyYAML ships pre-installed on GitHub-hosted ubuntu runners; --break-system-packages
+          # keeps the fallback working if it is ever absent on a PEP-668 (externally-managed) runner.
+          python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet --break-system-packages pyyaml
+          gcloud run services describe lifting-logbook-stg-web \
+            --region="${{ env.REGION }}" --project="$PROJECT" --format=export > "$RUNNER_TEMP/stg-web.yaml"
+          INGRESS_CONTAINER_NAME=web \
+          INGRESS_IMAGE="${{ needs.build-images.outputs.ar_repo }}/web:${{ needs.build-images.outputs.image_tag }}" \
+          OTEL_CONFIG_SECRET="$CONFIG_SECRET" \
+          COLLECTOR_IMAGE="${{ needs.terraform-staging.outputs.otel_mirror_repo }}/${OTEL_COLLECTOR_IMAGE_REPO_PATH}@${OTEL_COLLECTOR_IMAGE_DIGEST}" \
+          OTEL_OTLP_SECRET="lifting-logbook-stg-otel-otlp-auth-header" \
+          OTEL_LOKI_SECRET="lifting-logbook-stg-otel-loki-auth-header" \
+            python3 scripts/inject-otel-sidecar.py "$RUNNER_TEMP/stg-web.yaml" > "$RUNNER_TEMP/stg-web-sidecar.yaml"
+          gcloud run services replace "$RUNNER_TEMP/stg-web-sidecar.yaml" \
+            --region="${{ env.REGION }}" --project="$PROJECT" --quiet
+          # web_url for the integration-test + report-status jobs. `services replace` (unlike
+          # `gcloud run deploy`) emits no "Service URL:" line, so source the canonical service URL from
+          # the Terraform output (the same value deploy.yml's smoke test probes). Emitted only after a
+          # successful replace, preserving the prior "url set ⇒ deploy succeeded" semantics.
+          echo "url=${{ needs.terraform-staging.outputs.cloud_run_web_url }}" >> "$GITHUB_OUTPUT"
 
   # ── 4. Staging integration tests ─────────────────────────────────────────
   staging-integration-tests:


### PR DESCRIPTION
## Summary

Per-PR staging (`staging.yml`) deployed both `lifting-logbook-stg-api` and `lifting-logbook-stg-web` via plain single-container `gcloud run deploy`, **stripping** the otel-collector sidecar that `deploy.yml` injects post-merge. Every PR push therefore flapped the shared staging Cloud Run service 2-container → 1-container → 2-container across each PR/merge cycle, and left the #804 "verify in Tempo (staging)" window narrow.

This mirrors `deploy.yml`'s `describe → inject → gcloud run services replace` sidecar pattern into `staging.yml` for **both** the api and web deploys, so per-PR staging runs the **same 2-container topology** it will run once merged.

**Decision (per issue #813's open question):** wire the sidecar into per-PR staging rather than intentionally stay single-container. Rationale: the staging service is already 2-container as its post-merge steady state, so this stops the per-PR/merge flap rather than adding steady-state cost; it catches sidecar-injection regressions at PR time instead of post-merge; and the marginal Grafana spend is small (telemetry only during the brief integration-test window on a service whose only staging traffic is the Playwright suite).

## Changes (`.github/workflows/staging.yml` only)

- **`deploy-api`** → replaces the plain `gcloud run deploy` with `describe → inject → services replace` (`API_IMAGE` back-compat; floating `image_tag`, not `github.sha`).
- **`deploy-web`** → same pattern with `INGRESS_CONTAINER_NAME=web` / `INGRESS_IMAGE`, **plus** a least-privilege grant of `roles/secretmanager.secretAccessor` to the web workload SA on exactly the 3 otel secrets (config + 2 Grafana auth headers), mirroring `deploy.yml`. `web_url` now comes from the `terraform` `cloud_run_web_url` output, since `services replace` emits no `Service URL:` line to parse.
- **`terraform-staging`** → exposes the `otel_mirror_repo` output for the injector's collector image.
- Both deploy jobs ensure the collector config secret **independently** — unlike `deploy.yml`'s single sequential job, `deploy-api`/`deploy-web` run as **parallel** jobs here with no ordering guarantee (idempotent; the secret already exists from prior post-merge deploys).
- Drops `--allow-unauthenticated`: `services replace` never touches invoker IAM, so the api/web public posture stays owned by Terraform's `allUsers` binding — no re-lock of the #766 CORS path.

## ✅ #814 landed — rebased; diff is now `staging.yml`-only

#814 (`infra/issue-804-web-otel-sidecar`, which generalized `scripts/inject-otel-sidecar.py` with the `INGRESS_CONTAINER_NAME` / `INGRESS_IMAGE` params this PR reuses) **merged on 2026-07-11** (squash `c6fc0de`). This branch has since been **rebased onto current `main`**, dropping #814's now-merged commit — the diff is a single file, `.github/workflows/staging.yml` (+124/−37), and CI re-fired on the clean base. The reused injector on `main` carries the `INGRESS_CONTAINER_NAME`/`INGRESS_IMAGE` generalization the web step depends on (verified), so the #813→#814 dependency is satisfied.

## Testing

CI-workflow-only change — no application / library / test code touched, so `npm test` and `npm run typecheck` are not exercised by it (Refactor/config tier). Verified:

- **`scripts/test_inject_otel_sidecar.py`** (the test for the script this workflow calls): `Tests: 25 passed, 0 skipped, 0 failed (1.3s)` via `python -m unittest`.
- **Local inject dry-runs** against `scripts/testdata/cloud-run-{api,web}-export.yaml` with this PR's exact env-var invocation → both produce a valid 2-container manifest: ingress container correctly named (`api`/`web`) with its image set, `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318` added, `SYSTEM_DATABASE_URL` dropped, and the Terraform-managed env **preserved** (api: `DATABASE_URL`; web: `API_URL` / `PUBLIC_API_URL` / `CLERK_SECRET_KEY`) — de-risking the describe-preserves-env assumption on the as-yet-unexercised web path.
- **CI sync guards** all green: `check-grafana-endpoint-sources.mjs` (the step `source`s the single-source env, no hardcoded endpoint), `check-otel-config-sync.mjs`, `check-turbo-version-sync.mjs`.
- **Cross-references verified against current `main`** (post-rebase): `terraform output -raw otel_collector_mirror_repo` is a defined output (#795) and `needs.terraform-staging.outputs.cloud_run_web_url` is a pre-existing `terraform-staging` output — both resolve, and `deploy.yml` on `main` sources them identically.
- **YAML** parses; job structure verified (`otel_mirror_repo` output present, `web_url` output wired, both sidecar steps present).
- **Definitive check:** this PR's own staging integration run deploys the 2-container api+web and runs the Playwright staging suite against it (dogfood).

Suppression grep and test-integrity grep against the net diff: both clean (YAML-only).

## Risk audit

- **Observability** — this *restores* per-PR staging telemetry; config drift guarded by `check-otel-config-sync.mjs` (#788); telemetry never gates serving (a failed `services replace` leaves the prior revision serving, self-heals on re-run).
- **Security** — web SA gets least-privilege read on exactly 3 otel secrets; api uses its existing project-level `secretAccessor`; no secrets echoed (bindings `--quiet >/dev/null`; auth headers only via `secretKeyRef`).
- **Resilience** — `continue-on-error` retained on `deploy-api`; prior revision serves on a failed replace.
- **Performance** — +1 `describe`/+1 `replace` per deploy job (negligible); the 2nd container is the intended cost per the decision above.
- **Data/migrations** — migrate step untouched; specs derived from the live service preserve all Terraform-managed fields. Accessibility — N/A (CI change).

## Review findings disposition

Per the [`/review` of this PR](https://github.com/brownm09/lifting-logbook/pull/816#issuecomment-4942399914): **0 blocking, 1 non-blocking.**

- **[maintainability] Sidecar-injection block duplicated across `deploy-api`/`deploy-web` here (and the four copies in `deploy.yml`)** → **filed [#817](https://github.com/brownm09/lifting-logbook/issues/817)** (item 1: extract a composite action). Dedup deliberately deferred to keep this PR scoped to the `staging.yml` mirror; #817 [extended](https://github.com/brownm09/lifting-logbook/issues/817#issuecomment-4942404001) to note the block count is now six with `staging.yml` included.

Closes #813
