### PR TITLE
[infra] De-duplicate the 4 Cloud Run OTel sidecar deploy blocks into a composite action

### DIFF
--- a/.github/actions/deploy-cloud-run-otel-sidecar/action.yml
+++ b/.github/actions/deploy-cloud-run-otel-sidecar/action.yml
@@ -81,8 +81,16 @@ runs:
       run: |
         PROJECT="${{ inputs.project }}"
         CONFIG_SECRET="${{ inputs.config_secret }}"
+        # Concurrency-safe create: two invocations racing on a not-yet-existent secret would
+        # both pass `describe` (not-found) and both `create`; the race loser gets ALREADY_EXISTS
+        # (exit 1), which `bash -eo pipefail` would otherwise fail the job on. Re-`describe` after
+        # a failed create so the race loser still succeeds once the winner has created it, while a
+        # genuine create failure (e.g. IAM) still surfaces (the re-describe also fails). This
+        # matters as soon as parallel jobs share this action — e.g. staging's separate
+        # deploy-api / deploy-web jobs — not for deploy.yml's single sequential job.
         gcloud secrets describe "$CONFIG_SECRET" --project="$PROJECT" >/dev/null 2>&1 \
-          || gcloud secrets create "$CONFIG_SECRET" --replication-policy=automatic --project="$PROJECT" --quiet
+          || gcloud secrets create "$CONFIG_SECRET" --replication-policy=automatic --project="$PROJECT" --quiet 2>/dev/null \
+          || gcloud secrets describe "$CONFIG_SECRET" --project="$PROJECT" >/dev/null 2>&1
         CURRENT_CFG=$(gcloud secrets versions access latest --secret="$CONFIG_SECRET" --project="$PROJECT" 2>/dev/null || true)
         if [ "$CURRENT_CFG" != "$(cat infra/cloud-run/otel-collector-config.yaml)" ]; then
           gcloud secrets versions add "$CONFIG_SECRET" --data-file=infra/cloud-run/otel-collector-config.yaml --project="$PROJECT" --quiet

--- a/.github/actions/deploy-cloud-run-otel-sidecar/action.yml
+++ b/.github/actions/deploy-cloud-run-otel-sidecar/action.yml
@@ -1,0 +1,156 @@
+name: Deploy Cloud Run service with OTel Collector sidecar
+description: >-
+  Inject the co-located otel-collector sidecar into a Cloud Run service and
+  `gcloud run services replace` it, deriving the manifest from the LIVE service
+  (`describe --format=export`) so every Terraform-managed field (VPC connector,
+  scaling, service account, startup probe, env/secrets) is preserved verbatim.
+  Factored out of .github/workflows/deploy.yml (#817) so the api + web × staging +
+  production deploy steps share ONE implementation instead of four near-identical
+  inline blocks (#768 / #804) that had to stay byte-identical or drift silently.
+  See scripts/inject-otel-sidecar.py for why `services replace` (not `--container`)
+  and why the manifest is derived from the live service rather than a static template.
+
+inputs:
+  service:
+    description: Cloud Run service name, e.g. lifting-logbook-prod-api.
+    required: true
+  image:
+    description: >-
+      Full ingress-app image ref (registry/<api|web>:<sha>) — passed to the
+      injector as INGRESS_IMAGE and set on the ingress container.
+    required: true
+  ingress_container_name:
+    description: >-
+      Name for the ingress container in the rendered manifest — 'api' or 'web'.
+      Cosmetic in Cloud Run, but keeps per-container logs and metrics labelled.
+    required: false
+    default: api
+  project:
+    description: GCP project ID that owns the service and its secrets.
+    required: true
+  region:
+    description: Cloud Run region — pass the workflow's ${{ env.REGION }}.
+    required: true
+  config_secret:
+    description: Secret Manager secret holding the collector config.yaml (mounted as a file).
+    required: true
+  otlp_secret:
+    description: Secret Manager secret name for the Grafana Cloud OTLP auth header.
+    required: true
+  loki_secret:
+    description: Secret Manager secret name for the Grafana Cloud Loki auth header.
+    required: true
+  otel_mirror_repo:
+    description: >-
+      Per-environment Artifact Registry Docker Hub pull-through mirror repo for the
+      collector image (terraform output `otel_collector_mirror_repo`, #795). Composed
+      with the repo path + digest from infra/observability/otel-collector-image.env.
+    required: true
+  web_sa:
+    description: >-
+      When set, grant this service account roles/secretmanager.secretAccessor on
+      exactly the three otel secrets (config + the two Grafana auth headers) —
+      least-privilege for the web workload SA, which (unlike the api SA's
+      project-level accessor) has only per-secret Clerk grants. Leave empty for the
+      api service, whose SA already holds project-level access.
+    required: false
+    default: ""
+  ensure_config:
+    description: >-
+      When 'true' (default) ensure config_secret exists and publish a new version
+      only when the repo's otel-collector-config.yaml content changed. Idempotent +
+      content-diff-guarded, so every invocation is self-contained rather than relying
+      on an earlier step in the same job having created the secret (#817 item 2).
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    # Ensure the collector config.yaml secret (non-sensitive; from the repo file; a
+    # new version only when the content changed, to avoid per-deploy churn). Because
+    # this is idempotent + content-diff-guarded, running it for both the api and web
+    # services in the same job is a no-op the second time — which is exactly what makes
+    # the web step self-contained instead of relying on the api step having created it
+    # (#817 item 2). Runs BEFORE the web-SA grant below so the config secret is
+    # guaranteed to exist when that grant references it, even if the api step is
+    # skipped, reordered, or run in parallel.
+    - name: Ensure otel-collector config secret
+      if: ${{ inputs.ensure_config == 'true' }}
+      shell: bash
+      run: |
+        PROJECT="${{ inputs.project }}"
+        CONFIG_SECRET="${{ inputs.config_secret }}"
+        gcloud secrets describe "$CONFIG_SECRET" --project="$PROJECT" >/dev/null 2>&1 \
+          || gcloud secrets create "$CONFIG_SECRET" --replication-policy=automatic --project="$PROJECT" --quiet
+        CURRENT_CFG=$(gcloud secrets versions access latest --secret="$CONFIG_SECRET" --project="$PROJECT" 2>/dev/null || true)
+        if [ "$CURRENT_CFG" != "$(cat infra/cloud-run/otel-collector-config.yaml)" ]; then
+          gcloud secrets versions add "$CONFIG_SECRET" --data-file=infra/cloud-run/otel-collector-config.yaml --project="$PROJECT" --quiet
+          echo "otel-collector config secret: new version published."
+        else
+          echo "otel-collector config secret: unchanged."
+        fi
+
+    # IAM (#804): the web sidecar runs as the WEB workload SA, which — unlike the api
+    # SA's project-level secretmanager.secretAccessor — has only per-secret grants for
+    # the two Clerk secrets. Grant it read on exactly the three otel secrets the
+    # sidecar needs (config + the two Grafana auth headers): least-privilege, so the
+    # internet-facing web SA never gains the api SA's broad access to DATABASE_URL /
+    # migrator creds. Idempotent; runs as the cicd SA (roles/owner). Kept in the
+    # pipeline, not Terraform, because all three secrets are pipeline/operator-managed
+    # out-of-band and the config secret does not exist at `terraform apply` time (the
+    # ensure step above creates it first, so this grant never races its creation). Only
+    # the config secret is pipeline-created; the two auth-header secrets are seeded
+    # out-of-band by scripts/bootstrap-otel-secrets.sh (docs/deploy.md) and pre-exist.
+    # (First-ever deploy only: a few seconds of IAM propagation may be needed before
+    # the sidecar can read them; a failed replace leaves the prior revision serving
+    # and self-heals on re-run.)
+    - name: Grant web SA read on the otel secrets
+      if: ${{ inputs.web_sa != '' }}
+      shell: bash
+      run: |
+        for SECRET in "${{ inputs.config_secret }}" \
+                      "${{ inputs.otlp_secret }}" \
+                      "${{ inputs.loki_secret }}"; do
+          gcloud secrets add-iam-policy-binding "$SECRET" \
+            --member="serviceAccount:${{ inputs.web_sa }}" \
+            --role="roles/secretmanager.secretAccessor" \
+            --project="${{ inputs.project }}" --quiet >/dev/null
+        done
+
+    # Describe the live service, inject the sidecar (the injector also adds the ingress
+    # container's OTEL_EXPORTER_OTLP_ENDPOINT and drops the unused SYSTEM_DATABASE_URL
+    # on api, #534), and `gcloud run services replace`. Deriving the manifest from the
+    # live service preserves every Terraform-managed field verbatim. `services replace`
+    # deliberately never touches the invoker IAM policy, so the service's public posture
+    # stays owned solely by Terraform's allUsers run.invoker binding (#766/#770) — it
+    # neither re-asserts nor fights that grant. The sidecar shares the revision's
+    # CPU-throttling, so its batch/export timers are best-effort between requests, not
+    # always-on like the GKE DaemonSet (see ADR-018).
+    #
+    # Grafana OTLP/Loki endpoints and the collector image come from their single sources
+    # of truth (infra/observability/grafana-endpoints.env #785, otel-collector-image.env
+    # #795); sourcing them exports OTEL_OTLP_ENDPOINT / OTEL_LOKI_ENDPOINT and the
+    # OTEL_COLLECTOR_IMAGE_* parts for the injector below.
+    - name: Inject OTel sidecar and replace service
+      shell: bash
+      run: |
+        source infra/observability/grafana-endpoints.env
+        source infra/observability/otel-collector-image.env
+        PROJECT="${{ inputs.project }}"
+        SRC="$RUNNER_TEMP/${{ inputs.service }}.yaml"
+        RENDERED="$RUNNER_TEMP/${{ inputs.service }}-sidecar.yaml"
+        # PyYAML ships pre-installed on GitHub-hosted ubuntu runners; --break-system-packages
+        # keeps the fallback working if it is ever absent on a PEP-668 (externally-managed) runner.
+        python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet --break-system-packages pyyaml
+        gcloud run services describe "${{ inputs.service }}" \
+          --region="${{ inputs.region }}" --project="$PROJECT" --format=export > "$SRC"
+        INGRESS_CONTAINER_NAME="${{ inputs.ingress_container_name }}" \
+        INGRESS_IMAGE="${{ inputs.image }}" \
+        OTEL_CONFIG_SECRET="${{ inputs.config_secret }}" \
+        COLLECTOR_IMAGE="${{ inputs.otel_mirror_repo }}/${OTEL_COLLECTOR_IMAGE_REPO_PATH}@${OTEL_COLLECTOR_IMAGE_DIGEST}" \
+        OTEL_OTLP_SECRET="${{ inputs.otlp_secret }}" \
+        OTEL_LOKI_SECRET="${{ inputs.loki_secret }}" \
+          python3 scripts/inject-otel-sidecar.py "$SRC" > "$RENDERED"
+        gcloud run services replace "$RENDERED" \
+          --region="${{ inputs.region }}" --project="$PROJECT" --quiet

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -537,114 +537,41 @@ jobs:
             --wait --timeout=10m
 
       # Cloud Run: A/B comparison target (10% traffic — ADR-009)
+      # Cloud Run sidecar deploys via the shared composite action
+      # (.github/actions/deploy-cloud-run-otel-sidecar, #817): derive the manifest from
+      # the live service, ensure the config secret, inject the otel-collector sidecar,
+      # `services replace`. Full rationale (why `services replace`, live-manifest
+      # derivation, CPU-throttling + invoker-IAM invariants) lives in that action.
       - name: Deploy API + OTel Collector sidecar to Cloud Run (staging)
-        run: |
-          # Wire the API into Grafana Cloud via a co-located otel-collector sidecar (#768).
-          # Cloud Run has no additive sidecar command and no ConfigMap volumes, and the api
-          # service is lifecycle.ignore_changes = [template] (Terraform never mutates the
-          # running revision), so the whole 2-container topology is owned here:
-          #   1. Ensure the collector config.yaml secret (non-sensitive; from the repo file;
-          #      a new version only when the content changed, to avoid per-deploy churn).
-          #   2. Describe the live service, inject the sidecar (+ the api's
-          #      OTEL_EXPORTER_OTLP_ENDPOINT; minus the unused SYSTEM_DATABASE_URL, #534), and
-          #      `gcloud run services replace`.
-          # Deriving the manifest from the live service preserves every Terraform-managed
-          # field (VPC connector, scaling, SA, startup probe) verbatim. `services replace`
-          # deliberately never touches the invoker IAM policy, so the api's public posture
-          # stays owned solely by Terraform's allUsers run.invoker binding
-          # (google_cloud_run_v2_service_iam_member.api_public, #766/#770) — unlike the prior
-          # `gcloud run deploy --allow-unauthenticated`, this neither re-asserts nor fights
-          # that grant. `--container` was rejected (unresolvable sidecar port catch-22) — see
-          # scripts/inject-otel-sidecar.py. The sidecar shares the api revision's CPU-throttling,
-          # so its batch/export timers are best-effort between requests, not always-on like the
-          # GKE DaemonSet (see ADR-018).
-          # Grafana OTLP/Loki endpoints come from the single source of truth
-          # (infra/observability/grafana-endpoints.env, #785); sourcing it exports
-          # OTEL_OTLP_ENDPOINT / OTEL_LOKI_ENDPOINT for the injector below.
-          source infra/observability/grafana-endpoints.env
-          source infra/observability/otel-collector-image.env
-          PROJECT="${{ vars.GCP_STAGING_PROJECT_ID }}"
-          CONFIG_SECRET="lifting-logbook-stg-otel-collector-config"
-          gcloud secrets describe "$CONFIG_SECRET" --project="$PROJECT" >/dev/null 2>&1 \
-            || gcloud secrets create "$CONFIG_SECRET" --replication-policy=automatic --project="$PROJECT" --quiet
-          CURRENT_CFG=$(gcloud secrets versions access latest --secret="$CONFIG_SECRET" --project="$PROJECT" 2>/dev/null || true)
-          if [ "$CURRENT_CFG" != "$(cat infra/cloud-run/otel-collector-config.yaml)" ]; then
-            gcloud secrets versions add "$CONFIG_SECRET" --data-file=infra/cloud-run/otel-collector-config.yaml --project="$PROJECT" --quiet
-            echo "otel-collector config secret: new version published."
-          else
-            echo "otel-collector config secret: unchanged."
-          fi
-          # PyYAML ships pre-installed on GitHub-hosted ubuntu runners; --break-system-packages
-          # keeps the fallback working if it is ever absent on a PEP-668 (externally-managed) runner.
-          python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet --break-system-packages pyyaml
-          gcloud run services describe lifting-logbook-stg-api \
-            --region="${{ env.REGION }}" --project="$PROJECT" --format=export > "$RUNNER_TEMP/stg-api.yaml"
-          API_IMAGE="${{ needs.build-images.outputs.ar_repo }}/api:${{ github.sha }}" \
-          OTEL_CONFIG_SECRET="$CONFIG_SECRET" \
-          COLLECTOR_IMAGE="${{ needs.terraform-staging.outputs.otel_mirror_repo }}/${OTEL_COLLECTOR_IMAGE_REPO_PATH}@${OTEL_COLLECTOR_IMAGE_DIGEST}" \
-          OTEL_OTLP_SECRET="lifting-logbook-stg-otel-otlp-auth-header" \
-          OTEL_LOKI_SECRET="lifting-logbook-stg-otel-loki-auth-header" \
-            python3 scripts/inject-otel-sidecar.py "$RUNNER_TEMP/stg-api.yaml" > "$RUNNER_TEMP/stg-api-sidecar.yaml"
-          gcloud run services replace "$RUNNER_TEMP/stg-api-sidecar.yaml" \
-            --region="${{ env.REGION }}" --project="$PROJECT" --quiet
+        uses: ./.github/actions/deploy-cloud-run-otel-sidecar
+        with:
+          service: lifting-logbook-stg-api
+          ingress_container_name: api
+          image: ${{ needs.build-images.outputs.ar_repo }}/api:${{ github.sha }}
+          project: ${{ vars.GCP_STAGING_PROJECT_ID }}
+          region: ${{ env.REGION }}
+          config_secret: lifting-logbook-stg-otel-collector-config
+          otlp_secret: lifting-logbook-stg-otel-otlp-auth-header
+          loki_secret: lifting-logbook-stg-otel-loki-auth-header
+          otel_mirror_repo: ${{ needs.terraform-staging.outputs.otel_mirror_repo }}
 
+      # web sidecar via the shared composite action (see the api step above). web_sa
+      # triggers the least-privilege grant of the three otel secrets to the web workload
+      # SA; the action's per-invocation config-secret ensure makes this step self-contained
+      # rather than depending on the api step having created the secret (#817 item 2).
       - name: Deploy web + OTel Collector sidecar to Cloud Run (staging)
-        run: |
-          # Wire the web SERVER runtime into Grafana Cloud via a co-located otel-collector
-          # sidecar (#804), mirroring the api step above. @vercel/otel
-          # (apps/web/instrumentation.ts) exports OTLP to localhost:4318, so without a sidecar in
-          # the web instance every web-server span is dropped in prod — the #206 request traces
-          # AND the #798 client.mutation.error spans. Same describe → inject → `services replace`
-          # mechanism and the SAME collector config + Grafana endpoints/auth-header secrets as the
-          # api sidecar; only the ingress container name (web) and image differ.
-          #
-          # Dropping the old --set-env-vars / --update-secrets / --service-account /
-          # --allow-unauthenticated flags is deliberate and matches the api step: the web
-          # service's env/secrets (NODE_ENV, API_URL, PUBLIC_API_URL, CLERK_*) and its service
-          # account are Terraform-managed (lifecycle.ignore_changes = [template]) and preserved
-          # verbatim by describe, and its public posture is owned by Terraform's allUsers
-          # run.invoker binding (google_cloud_run_v2_service_iam_member.web_public) — `services
-          # replace` never touches invoker IAM. The collector config.yaml secret is the one the
-          # api step (which always runs first in this job) already ensured/versioned; we reference
-          # the same secret here.
-          #
-          # IAM (#804): the web sidecar runs as the WEB workload SA, which — unlike the api SA's
-          # project-level secretmanager.secretAccessor — only has per-secret grants for the two
-          # Clerk secrets. Grant it read on exactly the three otel secrets it needs (config + the
-          # two Grafana auth headers): least-privilege, so the internet-facing web SA never gains
-          # the api SA's broad access to DATABASE_URL / migrator creds. Idempotent, and runs as
-          # the cicd SA (roles/owner). Kept in the pipeline, not Terraform, because all three
-          # secrets are pipeline/operator-managed out-of-band and the config secret does not exist
-          # at `terraform apply` time. (First-ever deploy only: a few seconds of IAM propagation
-          # may be needed before the sidecar can read them; a failed replace leaves the prior web
-          # revision serving and self-heals on re-run.)
-          source infra/observability/grafana-endpoints.env
-          source infra/observability/otel-collector-image.env
-          PROJECT="${{ vars.GCP_STAGING_PROJECT_ID }}"
-          CONFIG_SECRET="lifting-logbook-stg-otel-collector-config"
-          WEB_SA="${{ needs.terraform-staging.outputs.web_workload_sa }}"
-          for SECRET in "$CONFIG_SECRET" \
-                        "lifting-logbook-stg-otel-otlp-auth-header" \
-                        "lifting-logbook-stg-otel-loki-auth-header"; do
-            gcloud secrets add-iam-policy-binding "$SECRET" \
-              --member="serviceAccount:${WEB_SA}" \
-              --role="roles/secretmanager.secretAccessor" \
-              --project="$PROJECT" --quiet >/dev/null
-          done
-          # PyYAML ships pre-installed on GitHub-hosted ubuntu runners; --break-system-packages
-          # keeps the fallback working if it is ever absent on a PEP-668 (externally-managed) runner.
-          python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet --break-system-packages pyyaml
-          gcloud run services describe lifting-logbook-stg-web \
-            --region="${{ env.REGION }}" --project="$PROJECT" --format=export > "$RUNNER_TEMP/stg-web.yaml"
-          INGRESS_CONTAINER_NAME=web \
-          INGRESS_IMAGE="${{ needs.build-images.outputs.ar_repo }}/web:${{ github.sha }}" \
-          OTEL_CONFIG_SECRET="$CONFIG_SECRET" \
-          COLLECTOR_IMAGE="${{ needs.terraform-staging.outputs.otel_mirror_repo }}/${OTEL_COLLECTOR_IMAGE_REPO_PATH}@${OTEL_COLLECTOR_IMAGE_DIGEST}" \
-          OTEL_OTLP_SECRET="lifting-logbook-stg-otel-otlp-auth-header" \
-          OTEL_LOKI_SECRET="lifting-logbook-stg-otel-loki-auth-header" \
-            python3 scripts/inject-otel-sidecar.py "$RUNNER_TEMP/stg-web.yaml" > "$RUNNER_TEMP/stg-web-sidecar.yaml"
-          gcloud run services replace "$RUNNER_TEMP/stg-web-sidecar.yaml" \
-            --region="${{ env.REGION }}" --project="$PROJECT" --quiet
+        uses: ./.github/actions/deploy-cloud-run-otel-sidecar
+        with:
+          service: lifting-logbook-stg-web
+          ingress_container_name: web
+          image: ${{ needs.build-images.outputs.ar_repo }}/web:${{ github.sha }}
+          project: ${{ vars.GCP_STAGING_PROJECT_ID }}
+          region: ${{ env.REGION }}
+          config_secret: lifting-logbook-stg-otel-collector-config
+          otlp_secret: lifting-logbook-stg-otel-otlp-auth-header
+          loki_secret: lifting-logbook-stg-otel-loki-auth-header
+          otel_mirror_repo: ${{ needs.terraform-staging.outputs.otel_mirror_repo }}
+          web_sa: ${{ needs.terraform-staging.outputs.web_workload_sa }}
 
       # ── OTel Collector (observability — #474) ──────────────────────────────
       # Deployed LAST in the job, after the Cloud Run app deploys above, so an
@@ -1166,46 +1093,21 @@ jobs:
             --set env.PUBLIC_API_URL="${{ steps.tf-prod.outputs.cloud_run_api_url }}" \
             --wait --timeout=5m
 
+      # Cloud Run sidecar deploys via the shared composite action
+      # (.github/actions/deploy-cloud-run-otel-sidecar, #817), mirroring deploy-staging.
+      # Full rationale lives in that action.
       - name: Deploy API + OTel Collector sidecar to Cloud Run (production)
-        run: |
-          # Mirror of the staging step (see deploy-staging for the full rationale): wire the
-          # API into Grafana Cloud via a co-located otel-collector sidecar (#768) by ensuring
-          # the config.yaml secret, then describe → inject sidecar → `services replace`.
-          # Deriving the manifest from the live service preserves every Terraform-managed
-          # field verbatim. `services replace` never touches the invoker IAM policy, so the
-          # api's public posture stays owned by Terraform's allUsers binding
-          # (google_cloud_run_v2_service_iam_member.api_public, #766/#770), not re-asserted here.
-          # The unused SYSTEM_DATABASE_URL (#534) is dropped by the injector. The sidecar shares
-          # the api revision's CPU-throttling (best-effort flush between requests, not always-on
-          # — see ADR-018). Grafana OTLP/Loki endpoints come from the single source
-          # of truth (infra/observability/grafana-endpoints.env, #785); sourcing it
-          # exports OTEL_OTLP_ENDPOINT / OTEL_LOKI_ENDPOINT for the injector below.
-          source infra/observability/grafana-endpoints.env
-          source infra/observability/otel-collector-image.env
-          PROJECT="${{ vars.GCP_PROD_PROJECT_ID }}"
-          CONFIG_SECRET="lifting-logbook-prod-otel-collector-config"
-          gcloud secrets describe "$CONFIG_SECRET" --project="$PROJECT" >/dev/null 2>&1 \
-            || gcloud secrets create "$CONFIG_SECRET" --replication-policy=automatic --project="$PROJECT" --quiet
-          CURRENT_CFG=$(gcloud secrets versions access latest --secret="$CONFIG_SECRET" --project="$PROJECT" 2>/dev/null || true)
-          if [ "$CURRENT_CFG" != "$(cat infra/cloud-run/otel-collector-config.yaml)" ]; then
-            gcloud secrets versions add "$CONFIG_SECRET" --data-file=infra/cloud-run/otel-collector-config.yaml --project="$PROJECT" --quiet
-            echo "otel-collector config secret: new version published."
-          else
-            echo "otel-collector config secret: unchanged."
-          fi
-          # PyYAML ships pre-installed on GitHub-hosted ubuntu runners; --break-system-packages
-          # keeps the fallback working if it is ever absent on a PEP-668 (externally-managed) runner.
-          python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet --break-system-packages pyyaml
-          gcloud run services describe lifting-logbook-prod-api \
-            --region="${{ env.REGION }}" --project="$PROJECT" --format=export > "$RUNNER_TEMP/prod-api.yaml"
-          API_IMAGE="${{ steps.tf-prod.outputs.ar_repo }}/api:${{ github.sha }}" \
-          OTEL_CONFIG_SECRET="$CONFIG_SECRET" \
-          COLLECTOR_IMAGE="${{ steps.tf-prod.outputs.otel_mirror_repo }}/${OTEL_COLLECTOR_IMAGE_REPO_PATH}@${OTEL_COLLECTOR_IMAGE_DIGEST}" \
-          OTEL_OTLP_SECRET="lifting-logbook-prod-otel-otlp-auth-header" \
-          OTEL_LOKI_SECRET="lifting-logbook-prod-otel-loki-auth-header" \
-            python3 scripts/inject-otel-sidecar.py "$RUNNER_TEMP/prod-api.yaml" > "$RUNNER_TEMP/prod-api-sidecar.yaml"
-          gcloud run services replace "$RUNNER_TEMP/prod-api-sidecar.yaml" \
-            --region="${{ env.REGION }}" --project="$PROJECT" --quiet
+        uses: ./.github/actions/deploy-cloud-run-otel-sidecar
+        with:
+          service: lifting-logbook-prod-api
+          ingress_container_name: api
+          image: ${{ steps.tf-prod.outputs.ar_repo }}/api:${{ github.sha }}
+          project: ${{ vars.GCP_PROD_PROJECT_ID }}
+          region: ${{ env.REGION }}
+          config_secret: lifting-logbook-prod-otel-collector-config
+          otlp_secret: lifting-logbook-prod-otel-otlp-auth-header
+          loki_secret: lifting-logbook-prod-otel-loki-auth-header
+          otel_mirror_repo: ${{ steps.tf-prod.outputs.otel_mirror_repo }}
 
       # ── Production DB-backed smoke test (#460) ─────────────────────────────
       # The migrate guard above prevents shipping against an unmigrated schema;
@@ -1241,51 +1143,23 @@ jobs:
           done
           echo "Production /readyz smoke FAILED — API is up but cannot serve DB-backed requests (check migrations, Cloud SQL connectivity, DATABASE_URL). Roll back the API revision per docs/deploy.md." && exit 1
 
+      # web sidecar via the shared composite action (see the api step above). web_sa
+      # triggers the least-privilege grant of the three otel secrets to the web workload
+      # SA; the action's per-invocation config-secret ensure makes this step self-contained
+      # rather than depending on the api step having created the secret (#817 item 2).
       - name: Deploy web + OTel Collector sidecar to Cloud Run (production)
-        run: |
-          # Mirror of the staging web step (see deploy-staging for the full rationale) and of the
-          # production api sidecar step above: wire the web SERVER runtime into Grafana Cloud via a
-          # co-located otel-collector sidecar (#804) by describe → inject sidecar → `services
-          # replace`. Deriving from the live service preserves every Terraform-managed field
-          # (NODE_ENV, API_URL, PUBLIC_API_URL, CLERK_*, service account) verbatim, and `services
-          # replace` never touches the invoker IAM policy, so the web service's public posture
-          # stays owned by Terraform's allUsers binding
-          # (google_cloud_run_v2_service_iam_member.web_public), not re-asserted here — which is
-          # why the old --set-env-vars / --update-secrets / --allow-unauthenticated flags are gone.
-          # The collector config.yaml secret was already ensured/versioned by the api step above.
-          #
-          # IAM (#804): grant the WEB workload SA read on exactly the three otel secrets the
-          # sidecar needs (config + the two Grafana auth headers) — least-privilege, so the
-          # internet-facing web SA never gains the api SA's broad DATABASE_URL / migrator access.
-          # Idempotent; runs as the cicd SA (roles/owner); kept in the pipeline because all three
-          # secrets are pipeline/operator-managed out-of-band.
-          source infra/observability/grafana-endpoints.env
-          source infra/observability/otel-collector-image.env
-          PROJECT="${{ vars.GCP_PROD_PROJECT_ID }}"
-          CONFIG_SECRET="lifting-logbook-prod-otel-collector-config"
-          WEB_SA="${{ steps.tf-prod.outputs.web_workload_sa }}"
-          for SECRET in "$CONFIG_SECRET" \
-                        "lifting-logbook-prod-otel-otlp-auth-header" \
-                        "lifting-logbook-prod-otel-loki-auth-header"; do
-            gcloud secrets add-iam-policy-binding "$SECRET" \
-              --member="serviceAccount:${WEB_SA}" \
-              --role="roles/secretmanager.secretAccessor" \
-              --project="$PROJECT" --quiet >/dev/null
-          done
-          # PyYAML ships pre-installed on GitHub-hosted ubuntu runners; --break-system-packages
-          # keeps the fallback working if it is ever absent on a PEP-668 (externally-managed) runner.
-          python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet --break-system-packages pyyaml
-          gcloud run services describe lifting-logbook-prod-web \
-            --region="${{ env.REGION }}" --project="$PROJECT" --format=export > "$RUNNER_TEMP/prod-web.yaml"
-          INGRESS_CONTAINER_NAME=web \
-          INGRESS_IMAGE="${{ steps.tf-prod.outputs.ar_repo }}/web:${{ github.sha }}" \
-          OTEL_CONFIG_SECRET="$CONFIG_SECRET" \
-          COLLECTOR_IMAGE="${{ steps.tf-prod.outputs.otel_mirror_repo }}/${OTEL_COLLECTOR_IMAGE_REPO_PATH}@${OTEL_COLLECTOR_IMAGE_DIGEST}" \
-          OTEL_OTLP_SECRET="lifting-logbook-prod-otel-otlp-auth-header" \
-          OTEL_LOKI_SECRET="lifting-logbook-prod-otel-loki-auth-header" \
-            python3 scripts/inject-otel-sidecar.py "$RUNNER_TEMP/prod-web.yaml" > "$RUNNER_TEMP/prod-web-sidecar.yaml"
-          gcloud run services replace "$RUNNER_TEMP/prod-web-sidecar.yaml" \
-            --region="${{ env.REGION }}" --project="$PROJECT" --quiet
+        uses: ./.github/actions/deploy-cloud-run-otel-sidecar
+        with:
+          service: lifting-logbook-prod-web
+          ingress_container_name: web
+          image: ${{ steps.tf-prod.outputs.ar_repo }}/web:${{ github.sha }}
+          project: ${{ vars.GCP_PROD_PROJECT_ID }}
+          region: ${{ env.REGION }}
+          config_secret: lifting-logbook-prod-otel-collector-config
+          otlp_secret: lifting-logbook-prod-otel-otlp-auth-header
+          loki_secret: lifting-logbook-prod-otel-loki-auth-header
+          otel_mirror_repo: ${{ steps.tf-prod.outputs.otel_mirror_repo }}
+          web_sa: ${{ steps.tf-prod.outputs.web_workload_sa }}
 
       # ── Production web served-surface smoke (#490 item 3 / #382 / #407) ────
       # Verify the *live* prod web surface through the real Cloud Run ingress


### PR DESCRIPTION
## Summary

Fast-follow from the `/review` of #804 / PR #814. De-duplicates the four near-identical Cloud Run OTel-sidecar deploy blocks (api/web × staging/prod, ~190 lines) in `.github/workflows/deploy.yml` into a shared composite action, and makes the web deploy self-contained w.r.t. the collector config secret.

**This PR does issue #817 items (1) and (2). Item (3) is deferred — see below.**

### (1) Composite action — `.github/actions/deploy-cloud-run-otel-sidecar`

Replaces the four inline `source envs → ensure config secret → pyyaml → describe --format=export → inject-otel-sidecar.py → services replace` blocks with one composite action (net **−126 lines** in `deploy.yml`). Steps: ensure config secret (idempotent, content-diff-guarded) → optional least-privilege web-SA grant on the three otel secrets → describe / inject / `services replace`. Inputs: `service, image, ingress_container_name (=api), project, region, config_secret, otlp_secret, loki_secret, otel_mirror_repo, web_sa (opt), ensure_config (=true)`. The staging (`needs.*`) vs prod (`steps.*`) output split is handled at the call sites, which pass fully-resolved values — the action never references `needs`/`steps`.

### (2) Web deploy self-contained re: the config secret

The action's `ensure_config` step runs on **every** invocation (default `true`), and now runs **before** the web-SA grant, so the web deploy ensures the `…-otel-collector-config` secret itself instead of relying on the api step (earlier in the same job) having created it. Closes the latent trap if api/web are ever parallelized or reordered. Idempotent + content-diff-guarded, so the second run in a job is a no-op.

### (3) Retire the `API_IMAGE` fallback — DEFERRED (gated)

Item (3) is explicitly gated on the #814 web sidecar being **confirmed live in prod** (a `service.name="lifting-logbook-web"` span in Grafana Tempo). That has not happened: prod deploy is a manual-approval gate, and #814's Deploy run was still in flight when this branch was cut, so the web sidecar has not reached prod. Removing the safety fallback now would violate the gate.

The composite action already passes the image as **`INGRESS_IMAGE`** for all four callers (the api steps no longer set `API_IMAGE`), so the script's `API_IMAGE` fallback is now unused by every caller but remains in place (and remains covered by `test_api_image_fallback_still_works`). Once the prod span is confirmed, retiring it is a trivial no-op cleanup — #817 is kept open to track it.

`scripts/inject-otel-sidecar.py` and `scripts/test_inject_otel_sidecar.py` are **unchanged** in this PR.

## Testing

CI-configuration-only change (`.github/` workflow + composite action YAML); no application/package/app source is touched, so the workspace test suites cannot be affected (existing tests unchanged — per the coverage table's "Refactor / docs only — existing tests must pass"). Targeted validations run locally:

- `python scripts/test_inject_otel_sidecar.py` → **Tests: 26 passed, 0 skipped, 0 failed (1.8s)** (injector unchanged)
- `node scripts/check-grafana-endpoint-sources.mjs` → OK (the action `source`s the single-source endpoint env file; no hardcoded literal)
- `node scripts/check-otel-config-sync.mjs` → OK
- `yaml.safe_load` on both `deploy.yml` and `action.yml` → parse OK; composite step order asserted (ensure → grant → inject)
- Pre-commit `turbo run lint` → 7/7 successful
- Suppression + test-integrity greps → clean

The composite action's runtime behavior is a faithful extraction of the previously-shipping inline blocks (identical command sequences, env vars, and secret names); the only behavioral deltas are additive/no-op (`INGRESS_IMAGE` feeds the same injector variable as `API_IMAGE`; web now ensures the config secret; ensure-before-grant ordering). It is exercised end-to-end by the next Deploy run on `main` (staging before the prod gate).

## Acceptance criteria (#817)

- [x] (1) Four sidecar-deploy blocks → composite action
- [x] (2) Web deploy self-contained re: the config secret
- [ ] (3) Retire the `API_IMAGE` fallback — deferred, gated on the #814 web sidecar confirmed live in prod

Part of #817

---

## Update — post-review (rebased + concurrency fix)

- **Rebased onto current `origin/main`.** The branch was one commit behind #816 ("Deploy the otel-collector sidecar in per-PR staging"), which merged concurrently and added two *new* inline sidecar blocks to `staging.yml`. Rebasing removes the phantom `staging.yml` diff a pre-rebase compare showed and lets CI run against current main.
- **Concurrency-safe config-secret create (`b789a64`).** Review found the ensure-config `create` would fail on `ALREADY_EXISTS` if two invocations race (both pass `describe`, both `create`). Fixed by re-`describe`-after-create — makes the action safe for `staging.yml`'s parallel `deploy-api`/`deploy-web` jobs.
- **Follow-up filed:** #820 — migrate `staging.yml`'s two inline blocks onto this action (completes the de-dup across all six call sites).

## Review findings disposition
- **[reliability] ensure-config `create` not concurrency-safe** — fixed in `b789a64`.
- **[maintainability] incomplete de-dup (`staging.yml` still inline after #816)** — filed #820; branch rebased onto current main; action made concurrency-safe for that migration.
