### PR TITLE
[fix] Staging deploy-api: hard-fail a hollow-green sidecar deploy

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -567,6 +567,57 @@ jobs:
           loki_secret: lifting-logbook-stg-otel-loki-auth-header
           otel_mirror_repo: ${{ needs.terraform-staging.outputs.otel_mirror_repo }}
 
+      # Guard against a HOLLOW GREEN (#823). The deploy step above intentionally
+      # carries continue-on-error: true (#498 — a failed *revision* must still let
+      # the log-fetch step below run and let the integration-test gate, not the
+      # deploy step, fail the run). But since #822 moved that step to
+      # `uses: ./.github/actions/deploy-cloud-run-otel-sidecar`, a composite-action
+      # *load* failure (a manifest/template-validation error — e.g. the
+      # `env.REGION`-in-an-input-description bug on #822's first CI run) is ALSO
+      # swallowed: deploy-api reports outcome=success while NO revision was submitted
+      # and the stale one keeps serving, so the integration tests can pass against
+      # old code and the hollow green propagates undetected.
+      #
+      # This step re-derives ground truth from Cloud Run and hard-fails (no
+      # continue-on-error) when the live service is NOT running the just-built image.
+      # It runs ONLY on the claimed-success path (outcome == 'success') — exactly
+      # where the mask hides — so the outcome == 'failure' runtime-revision case stays
+      # owned, unchanged, by the existing cloud_run_api_deployed gate + the log-fetch
+      # step below. On the non-image-affecting skip-build path the built tag already
+      # equals what serves, so this is a correct no-op, never a false failure. See #823.
+      - name: Verify API revision actually deployed (staging)
+        if: steps.deploy-api.outcome == 'success'
+        run: |
+          SERVICE="lifting-logbook-stg-api"
+          EXPECTED="${{ needs.build-images.outputs.ar_repo }}/api:${{ needs.build-images.outputs.image_tag }}"
+          # The image(s) the latest-applied service spec runs (ingress `api` + the otel
+          # sidecar). On a hollow green nothing was applied, so this is still the PRIOR
+          # revision's image and won't contain the just-built tag.
+          if ! LIVE_IMAGES=$(gcloud run services describe "$SERVICE" \
+                --region="${{ env.REGION }}" \
+                --project="${{ vars.GCP_STAGING_PROJECT_ID }}" \
+                --format='value(spec.template.spec.containers[].image)'); then
+            echo "::error title=Staging API deploy unverifiable::deploy-api reported success but '$SERVICE' could not be described to confirm the deployed image — not trusting this green. See #823 and docs/runbooks/staging-ci-flakiness.md."
+            exit 1
+          fi
+          echo "Expected just-built image: $EXPECTED"
+          echo "Latest-applied image(s):   $LIVE_IMAGES"
+          if printf '%s\n' "$LIVE_IMAGES" | grep -qF "$EXPECTED"; then
+            echo "✓ Live service runs the just-built image — real deploy, not a hollow green."
+            exit 0
+          fi
+          # Tag didn't match — fall back to a digest comparison, in case Cloud Run stored
+          # the image by digest rather than the tag we passed to `services replace`.
+          EXPECTED_DIGEST=$(gcloud artifacts docker images describe "$EXPECTED" \
+            --project="${{ vars.GCP_STAGING_PROJECT_ID }}" \
+            --format='value(image_summary.digest)' 2>/dev/null || true)
+          if [[ -n "$EXPECTED_DIGEST" ]] && printf '%s\n' "$LIVE_IMAGES" | grep -qF "$EXPECTED_DIGEST"; then
+            echo "✓ Live service runs the just-built image by digest ($EXPECTED_DIGEST)."
+            exit 0
+          fi
+          echo "::error title=Staging API deploy is a hollow green::deploy-api reported success but '$SERVICE' is NOT running the just-built image ($EXPECTED${EXPECTED_DIGEST:+ / $EXPECTED_DIGEST}). The OTel-sidecar composite action most likely failed to LOAD (a manifest/template-validation error) and submitted no revision, leaving the stale revision serving. Fix the action manifest — do not trust this green. See #823 and docs/runbooks/staging-ci-flakiness.md."
+          exit 1
+
       - name: Fetch Cloud Run API logs on failure
         if: steps.deploy-api.outcome == 'failure'
         run: |

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -593,13 +593,28 @@ jobs:
           # The image(s) the latest-applied service spec runs (ingress `api` + the otel
           # sidecar). On a hollow green nothing was applied, so this is still the PRIOR
           # revision's image and won't contain the just-built tag.
-          if ! LIVE_IMAGES=$(gcloud run services describe "$SERVICE" \
-                --region="${{ env.REGION }}" \
-                --project="${{ vars.GCP_STAGING_PROJECT_ID }}" \
-                --format='value(spec.template.spec.containers[].image)'); then
-            echo "::error title=Staging API deploy unverifiable::deploy-api reported success but '$SERVICE' could not be described to confirm the deployed image — not trusting this green. See #823 and docs/runbooks/staging-ci-flakiness.md."
+          # Bounded retry so a transient Cloud Run API blip on this READ doesn't red an
+          # otherwise-successful deploy — mirrors the migrate (3-attempt) / terraform apply
+          # (2-attempt) / build-push (wretry) pattern this workflow already uses, and the
+          # reason its companion runbook (staging-ci-flakiness.md) exists: transients must
+          # not produce "re-run goes green" false reds. Only the read is retried; a genuine
+          # hollow green (image mismatch) still hard-fails below with no retry.
+          LIVE_IMAGES=""
+          for attempt in 1 2 3; do
+            if LIVE_IMAGES=$(gcloud run services describe "$SERVICE" \
+                  --region="${{ env.REGION }}" \
+                  --project="${{ vars.GCP_STAGING_PROJECT_ID }}" \
+                  --format='value(spec.template.spec.containers[].image)'); then
+              break
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "describe attempt $attempt failed; retrying in $((attempt * 5))s..."
+              sleep $((attempt * 5))
+              continue
+            fi
+            echo "::error title=Staging API deploy unverifiable::deploy-api reported success but '$SERVICE' could not be described after 3 attempts to confirm the deployed image — not trusting this green. See #823 and docs/runbooks/staging-ci-flakiness.md."
             exit 1
-          fi
+          done
           echo "Expected just-built image: $EXPECTED"
           echo "Latest-applied image(s):   $LIVE_IMAGES"
           if printf '%s\n' "$LIVE_IMAGES" | grep -qF "$EXPECTED"; then

--- a/docs/runbooks/staging-ci-flakiness.md
+++ b/docs/runbooks/staging-ci-flakiness.md
@@ -108,6 +108,41 @@ it (or someone force-cancels it manually).
 job (then with no `timeout-minutes`) wedged on the Playwright `--with-deps` install and ran 3+
 hours before being force-cancelled.
 
+## Hollow green — deploy-api reports success but nothing deployed
+
+A failure class specific to the `deploy-api` Cloud Run sidecar deploy. That step carries
+`continue-on-error: true` on purpose ([#498](https://github.com/brownm09/lifting-logbook/issues/498)):
+a *revision* that fails to start must still let the `Fetch Cloud Run API logs on failure` step run,
+and the integration-test gate — not the deploy step — fails the run. Since
+[#822](https://github.com/brownm09/lifting-logbook/pull/822) moved the deploy to
+`uses: ./.github/actions/deploy-cloud-run-otel-sidecar`, a new outcome became maskable: the
+composite action can fail to **load** (a manifest/template-validation error), which
+`continue-on-error` also swallows — so `deploy-api` shows a green ✓ while **no revision was
+submitted** and the stale revision keeps serving. Integration tests then run against old code and
+the green propagates undetected ([#823](https://github.com/brownm09/lifting-logbook/issues/823); it
+happened on #822's first CI run, an `env.REGION`-in-an-input-description bug in `action.yml`).
+
+- **Symptom:** the `Verify API revision actually deployed (staging)` step in `Deploy API (staging)`
+  errors with `::error title=Staging API deploy is a hollow green::…` (or `…unverifiable…`). That
+  step is the mitigation: it runs only when the deploy claimed success (`outcome == 'success'`),
+  re-derives the live service's image from Cloud Run, and hard-fails when it is **not** the
+  just-built `…/api:<image_tag>`. So a hollow green now reds `deploy-api` directly instead of
+  slipping through to a stale-image test pass.
+- **Cause:** a structural error in `.github/actions/deploy-cloud-run-otel-sidecar/action.yml` (the
+  manifest fails template validation, so none of the action's steps run) — **not** GCP flakiness.
+  The classic trigger is a `${{ … }}` expression in an input *description* (GitHub evaluates those
+  at action-load time, where `env`/`secrets`/`needs` are not available named-values).
+- **Diagnosis:** open the failing step's log — it prints the expected vs. the live image. Then
+  validate the action manifest locally:
+  ```bash
+  python3 -c "import yaml,sys; yaml.safe_load(open('.github/actions/deploy-cloud-run-otel-sidecar/action.yml')); print('action.yml parses')"
+  # and confirm no ${{ }} appears inside any input description:
+  grep -nE '^\s+description:.*\$\{\{' .github/actions/deploy-cloud-run-otel-sidecar/action.yml
+  ```
+- **Fix:** correct the `action.yml` manifest (remove the offending expression / structural error),
+  push, and re-run. This is a **genuine failure** — do not blindly re-run without fixing the
+  manifest; the same load error recurs every run until the file is fixed.
+
 ## Escalation
 
 - Sustained (non-transient) Artifact Registry failures → GCP support / status page; this is


### PR DESCRIPTION
## Summary

`staging.yml`'s `deploy-api` job runs its Cloud Run OTel-sidecar deploy with `continue-on-error: true`. That's intentional (#498): a *revision* that fails to start must still let the `Fetch Cloud Run API logs on failure` step run, with the integration-test gate — not the deploy step — failing the run. But since #822 moved that step to `uses: ./.github/actions/deploy-cloud-run-otel-sidecar`, a composite-action **load** failure (a manifest/template-validation error) became a *maskable* outcome: `continue-on-error` swallows it too, so `deploy-api` reports success while **no revision was submitted** and the stale revision keeps serving. Integration tests then pass against old code and the hollow green propagates undetected.

Observed on #822's first CI run (an `env.REGION`-in-an-input-description bug in `action.yml`); that bug was fixed in #822 / `11d26fc` — **this PR fixes the masking that hid it.**

## Fix

Add a `Verify API revision actually deployed (staging)` step to `deploy-api`, gated on `steps.deploy-api.outcome == 'success'` with **no** `continue-on-error`:

- Re-derives ground truth from Cloud Run (`gcloud run services describe … --format='value(spec.template.spec.containers[].image)'`) and hard-fails when the live service is **not** running the just-built `…/api:<image_tag>` (tag match, digest fallback).
- Gating on the **claimed-success path** is the whole point — it scrutinizes exactly where the mask hides. The `outcome == 'failure'` runtime-revision case stays owned, unchanged, by the existing `cloud_run_api_deployed` gate + the log-fetch step, so the #498 intent is preserved verbatim.
- On the non-image-affecting **skip-build** path the built tag already equals what serves → correct no-op, never a false failure.
- Scoped to `deploy-api`; `deploy-web` uses the same action but already fail-fasts (no `continue-on-error`).

This implements the issue's option C ("assert post-deploy that the live revision's image tag == the built image_tag"), reconciled with option A ("the deploy actually submitted a new revision") by comparing against the externally-known built image rather than any Cloud Run-internal revision-consistency signal (which can't tell "nothing deployed" from "old revision still healthy").

### Why not just remove `continue-on-error`

That re-breaks #498: a failed *revision* must still capture crash logs and fail via the integration gate, not red the deploy step directly. This PR distinguishes **"nothing was submitted (load failure)"** — now hard-fails — from **"a revision was submitted but failed to start"** — still swallowed for log capture — exactly as the issue asks.

### Behavior matrix

| Scenario | `deploy-api` outcome | New verify step | Result |
|---|---|---|---|
| Real success | success | image matches → pass | ✅ deploy is real |
| Action **load** failure (the bug) | success (masked) | stale image → **hard-fail** | ❌ caught (was: hollow green) |
| Revision submitted, fails to start | failure | skipped (gated) | ❌ caught by existing gate + log-fetch (unchanged) |
| Skip-build (non-image-affecting diff) | success | built tag already serving → pass | ✅ no-op |

## Testing

Workflow + docs only — no app/package/test code is touched, so the app Jest/Playwright suites are not the relevant gate (and don't exercise workflow YAML). Verification performed:

- **Structural validation** — `staging.yml` parses as YAML; the new step sits between the deploy step (idx 11) and the log-fetch step (idx 13), carries `if: steps.deploy-api.outcome == 'success'`, has **no** `continue-on-error`, and is a `run:` step; the deploy step still keeps `continue-on-error: true` + `uses:` the action; the `cloud_run_api_deployed` job output is unchanged. **All assertions passed.**
- **Pre-commit lint** (`npx turbo run lint`): **7/7 tasks passed** (FULL TURBO).
- **Suppression grep** (ADR-026): clean (none).
- **Test-integrity grep** (ADR-029): clean (none).
- **Lockfile gate**: N/A (no `package.json` change).
- **End-to-end:** `.github/**` is image-affecting per the `paths-filter`, so **this PR's own `staging.yml` run executes the modified `deploy-api` against real staging** — the new verify step runs for real. On a healthy deploy it logs `✓ Live service runs the just-built image` and passes; a false-fail here would red this PR before merge.

`Tests: n/a — no automated suite exercises a CI-workflow YAML change; see the verification performed above.`

### Coverage deferral

The new logic is a gcloud-dependent shell assertion inside a GitHub Actions step; the repo has no local gcloud mock harness to unit-test it against. Coverage is the structural validation above plus the PR's own staging CI run exercising the step end-to-end — the same way the rest of `staging.yml`'s gcloud steps are verified.

## Observability

The new step is itself an observability win: it converts a previously-silent failure (hollow green) into a titled, actionable `::error::` in the `Deploy API (staging)` job log, naming expected vs. live image and pointing at #823 + the runbook. `docs/runbooks/staging-ci-flakiness.md` gains a **"Hollow green — deploy-api reports success but nothing deployed"** section (symptom, cause, diagnosis, fix).

## Risk audit (Pass 3)

- **Security** — N/A: reads only non-sensitive Cloud Run image refs under the already-authenticated staging SA; no new secrets/inputs.
- **Resilience / failure modes** — fails **closed** on a detected hollow green and on a `describe` error (can't verify → don't trust the green); introduces no new flakiness (genuine success passes; skip-build is a no-op). Rollback = revert the one-step addition.
- **Performance** — one extra `gcloud run services describe` (+ rarely one `artifacts docker images describe`) per successful API deploy — a few seconds, off the hot path.
- **Data integrity / migrations, Accessibility** — N/A (no schema/data/UI change).
- **ADR warrant** — none: a small reliability guard; rationale captured in the step comment, this PR, #823, and the runbook.

Closes #823

---

## Review findings disposition

`/review` (self, `claude-opus-4-8`) surfaced **0 blocking, 1 non-blocking** finding — fixed in-PR, not left as-is (ADR-028):

- **[reliability] Missing bounded retry on the new `gcloud run services describe`** — **fixed in `1c59646`.** Wrapped the verification read in a 3-attempt bounded retry (mirroring this workflow's migrate/terraform/build retry convention) so a transient Cloud Run API blip on the read can't red an otherwise-successful deploy; only the read retries, a genuine image mismatch still hard-fails.

Review comment: https://github.com/brownm09/lifting-logbook/pull/824#issuecomment-4947544490
