### PR TITLE
[chore] Skip <ClerkProvider> in dev-auth mode to silence benign ClerkJS console error

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ API_URL=http://localhost:3004
 PUBLIC_API_URL=http://localhost:3004
 DEFAULT_PROGRAM=5-3-1
 DEV_AUTH_TOKEN=dev-user
-# Required even in dev-auth mode — <ClerkProvider> throws "Missing publishableKey"
-# at startup without it. Clerk's public example key (not a secret); see
-# apps/web/.env.example and apps/web/README.md for details.
-CLERK_PUBLISHABLE_KEY=pk_test_ZXhhbXBsZS5jbGVyay5hY2NvdW50cy5kZXYk
+# No Clerk key is needed in dev-auth mode: the root layout skips <ClerkProvider>
+# when DEV_AUTH_TOKEN is set. For a real Clerk sign-in flow, unset DEV_AUTH_TOKEN and
+# set CLERK_PUBLISHABLE_KEY + CLERK_SECRET_KEY — see apps/web/.env.example and
+# apps/web/README.md for details.
 ```
 
 ```sh

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -21,29 +21,18 @@ DEFAULT_PROGRAM=5-3-1
 DEV_AUTH_TOKEN=dev-user
 
 # ── Clerk auth ────────────────────────────────────────────────────────────────
-# CLERK_PUBLISHABLE_KEY is REQUIRED even for local dev-auth mode. The root layout
-# (app/layout.tsx) renders <ClerkProvider publishableKey={...}> unconditionally, and
-# @clerk/nextjs throws "Missing publishableKey" at startup when the key is empty — so
-# `next dev` will not boot without it, even though DEV_AUTH_TOKEN (above) makes Clerk
-# inert for actual auth. (No NEXT_PUBLIC_ prefix: the layout reads it at request time.)
+# NEITHER Clerk key is needed for local dev-auth mode. When DEV_AUTH_TOKEN (above) is
+# set, the root layout (app/layout.tsx) skips <ClerkProvider> entirely and middleware.ts
+# bypasses clerkMiddleware(), so Clerk is fully inert — `next dev` boots with no Clerk key
+# and ClerkJS never initializes in the browser (so there is no console noise). Leave both
+# keys unset locally.
 #
-# The value below is Clerk's well-known PUBLIC example publishable key (it decodes to
-# "example.clerk.accounts.dev$"). It is not a secret, grants no access, and performs no
-# real sign-in; it only satisfies ClerkProvider's startup validation. It is the same
-# placeholder used by apps/web/playwright.config.ts for the E2E suite.
-#
-# NOTE: because this example key points at a non-real Clerk instance, ClerkJS logs a
-# BENIGN browser-console message in dev-auth mode ("...unable to attribute this request
-# to an instance..."). The page still renders and dev-auth is unaffected. Replace it with
-# your own Clerk dev key (see below) to silence that message and enable real sign-in.
-CLERK_PUBLISHABLE_KEY=pk_test_ZXhhbXBsZS5jbGVyay5hY2NvdW50cy5kZXYk
-#
-# CLERK_SECRET_KEY is NOT needed for local dev-auth mode: middleware.ts bypasses
-# clerkMiddleware() entirely when DEV_AUTH_TOKEN is set, so no server-side Clerk call is
-# made. Leave it unset locally. For a REAL Clerk sign-in flow (or staging / production),
-# replace the publishable key above with your instance's real pk_ key AND set the secret
-# key below, both from your Clerk dashboard (https://dashboard.clerk.com -> API Keys).
-# Never commit a real secret key — .env / .env*.local are gitignored for this reason.
+# For a REAL Clerk sign-in flow (or staging / production), unset DEV_AUTH_TOKEN (above) to
+# switch into real-Clerk mode and set BOTH keys below from your Clerk dashboard
+# (https://dashboard.clerk.com -> API Keys). No NEXT_PUBLIC_ prefix on the publishable key:
+# the layout reads it at request time and passes it to <ClerkProvider>. Never commit a real
+# secret key — .env / .env*.local are gitignored for this reason.
+# CLERK_PUBLISHABLE_KEY=pk_test_...   # browser SDK key, passed to <ClerkProvider>
 # CLERK_SECRET_KEY=sk_test_...        # server-side SDK secret
 
 # ── OpenTelemetry ─────────────────────────────────────────────────────────────

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -29,18 +29,16 @@ The template ([`.env.example`](.env.example)) already points the web app at the 
 API (`API_URL` / `PUBLIC_API_URL = http://localhost:3004`) and sets `DEV_AUTH_TOKEN`,
 which enables **dev-auth mode** (see [Authentication](#authentication) below).
 
-> **Why a Clerk key is in the template:** the root layout renders `<ClerkProvider>`
-> unconditionally, and `@clerk/nextjs` throws `Missing publishableKey` at startup when the
-> key is empty — so `next dev` will not boot without one, even in dev-auth mode. The
-> template ships Clerk's public example key (`pk_test_…`) to satisfy that check; it is not a
-> secret and performs no real sign-in. This is the error tracked in
-> [#828](https://github.com/brownm09/lifting-logbook/issues/828).
->
-> **Expected benign console message:** because the example key points at a non-real Clerk
-> instance, ClerkJS logs a harmless browser-console error in dev-auth mode — *"Something
-> went wrong initializing Clerk … unable to attribute this request to an instance."* The
-> page renders and dev-auth works regardless; supply your own Clerk dev key (below) to
-> silence it.
+> **No Clerk key is needed for dev-auth mode.** When `DEV_AUTH_TOKEN` is set, the root
+> layout ([`app/layout.tsx`](app/layout.tsx)) skips `<ClerkProvider>` entirely and
+> [`middleware.ts`](middleware.ts) bypasses `clerkMiddleware()`, so Clerk is fully inert —
+> `next dev` boots with no Clerk key and ClerkJS never initializes in the browser, so the
+> console stays clean. (The template used to ship Clerk's public example key to satisfy a
+> `<ClerkProvider>` startup check, which logged a benign *"unable to attribute this request
+> to an instance"* console error; skipping the provider resolved both —
+> [#828](https://github.com/brownm09/lifting-logbook/issues/828) /
+> [#834](https://github.com/brownm09/lifting-logbook/issues/834).) Supply your own Clerk
+> keys (below) only for a real sign-in flow.
 
 ### 3. Run the dev servers
 
@@ -73,11 +71,12 @@ Two modes, selected by whether `DEV_AUTH_TOKEN` is set:
 | Trigger | `DEV_AUTH_TOKEN` set | `DEV_AUTH_TOKEN` unset |
 | Middleware | `clerkMiddleware()` bypassed in [`middleware.ts`](middleware.ts) | Clerk protects all non-public routes |
 | API auth | any `Bearer <token>` accepted as the user id (`DevAuthProvider`) | real Clerk session token |
-| `CLERK_PUBLISHABLE_KEY` | **required** (ClerkProvider startup) — dummy key is fine | **required** — real `pk_` key |
+| `<ClerkProvider>` | not rendered (root layout skips it) | wraps the app |
+| `CLERK_PUBLISHABLE_KEY` | not needed (`<ClerkProvider>` skipped) | **required** — real `pk_` key |
 | `CLERK_SECRET_KEY` | not needed (middleware bypassed) | **required** — real `sk_` secret |
 
-For a real Clerk sign-in flow locally, replace the dummy publishable key in `.env.local`
-with your instance's real `pk_` key and set `CLERK_SECRET_KEY`, both from your
+For a real Clerk sign-in flow locally, unset `DEV_AUTH_TOKEN` and set your instance's real
+`pk_` publishable key and `CLERK_SECRET_KEY` in `.env.local`, both from your
 [Clerk dashboard](https://dashboard.clerk.com) → API Keys. Never commit real keys —
 `.env` and `.env*.local` are gitignored.
 
@@ -95,7 +94,7 @@ and [#396](https://github.com/brownm09/lifting-logbook/issues/396).
 | `PUBLIC_API_URL` | yes (has fallback) | `http://localhost:3004` | Browser-facing API base URL (injected at runtime) |
 | `DEFAULT_PROGRAM` | no | `5-3-1` | Program slug used as the `:program` path param |
 | `DEV_AUTH_TOKEN` | local only | `dev-user` | Enables dev-auth mode; sent as the bearer token |
-| `CLERK_PUBLISHABLE_KEY` | **yes** | *(dummy in template)* | Passed to `<ClerkProvider>`; required for startup |
+| `CLERK_PUBLISHABLE_KEY` | no (dev-auth) | *(unset)* | Passed to `<ClerkProvider>`; required only for real-Clerk mode |
 | `CLERK_SECRET_KEY` | no (dev-auth) | *(unset)* | Server-side Clerk SDK; only for real Clerk auth |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | no | *(unset)* | OTLP trace export endpoint |
 

--- a/apps/web/app/layout.test.tsx
+++ b/apps/web/app/layout.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+
+// The root layout imports global (non-module) CSS. The web jest config only maps
+// `.module.css`, and ts-jest only transforms `.tsx?`, so a real `./globals.css` import
+// would reach jest untransformed and throw. Stub it — this suite asserts on the returned
+// element tree, not styling.
+jest.mock('./globals.css', () => ({}));
+
+// Mock the Clerk client surface and the API initializer so we can assert on stable
+// component identities without importing the real (browser-oriented) Clerk SDK. The
+// layout is never rendered here (we inspect the returned element tree structurally, the
+// same approach as (authed)/layout.test.tsx), so the stub bodies are never invoked.
+jest.mock('@clerk/nextjs', () => ({
+  ClerkProvider: function ClerkProvider() {
+    return null;
+  },
+  SignedIn: function SignedIn() {
+    return null;
+  },
+  UserButton: function UserButton() {
+    return null;
+  },
+}));
+
+jest.mock('@/components/ClerkApiInitializer', () => ({
+  ClerkApiInitializer: function ClerkApiInitializer() {
+    return null;
+  },
+}));
+
+import RootLayout from './layout';
+import { ClerkProvider, SignedIn } from '@clerk/nextjs';
+import { ClerkApiInitializer } from '@/components/ClerkApiInitializer';
+
+/** Recursively true if any element in the tree has `.type === type`. */
+function containsType(node: React.ReactNode, type: React.ElementType): boolean {
+  if (!node || typeof node !== 'object') return false;
+  if (Array.isArray(node)) return node.some((child) => containsType(child, type));
+  const element = node as React.ReactElement;
+  if (element.type === type) return true;
+  const children = (element.props as { children?: React.ReactNode }).children;
+  return containsType(children, type);
+}
+
+/** Recursively true if the exact `target` node instance appears anywhere in the tree. */
+function containsNode(node: React.ReactNode, target: React.ReactNode): boolean {
+  if (node === target) return true;
+  if (!node || typeof node !== 'object') return false;
+  if (Array.isArray(node)) return node.some((child) => containsNode(child, target));
+  const element = node as React.ReactElement;
+  const children = (element.props as { children?: React.ReactNode }).children;
+  return containsNode(children, target);
+}
+
+const CHILDREN = React.createElement('main', { 'data-testid': 'children' });
+
+describe('root layout — Clerk client tree gated on dev-auth mode (#834)', () => {
+  const originalDevToken = process.env.DEV_AUTH_TOKEN;
+  const originalKey = process.env.CLERK_PUBLISHABLE_KEY;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.DEV_AUTH_TOKEN;
+    delete process.env.CLERK_PUBLISHABLE_KEY;
+    // readServerPublicConfig / readServerClerkPublishableKey only throw in a deployed
+    // runtime (NODE_ENV === 'production'); keep each test on the non-deployed path.
+    (process.env as Record<string, string>).NODE_ENV = 'test';
+  });
+
+  afterAll(() => {
+    if (originalDevToken === undefined) delete process.env.DEV_AUTH_TOKEN;
+    else process.env.DEV_AUTH_TOKEN = originalDevToken;
+    if (originalKey === undefined) delete process.env.CLERK_PUBLISHABLE_KEY;
+    else process.env.CLERK_PUBLISHABLE_KEY = originalKey;
+    (process.env as Record<string, string | undefined>).NODE_ENV = originalNodeEnv;
+  });
+
+  it('dev-auth mode: returns the <html> shell with no Clerk client tree, children preserved', () => {
+    process.env.DEV_AUTH_TOKEN = 'dev-user';
+    // Even with a publishable key present, dev-auth mode must skip the Clerk client tree
+    // (this is what silences the #834 console error — ClerkJS never initializes).
+    process.env.CLERK_PUBLISHABLE_KEY = 'pk_test_ZXhhbXBsZQ';
+
+    const element = RootLayout({ children: CHILDREN }) as React.ReactElement;
+
+    // Top-level element is the raw <html>, not a <ClerkProvider> wrapper.
+    expect(element.type).toBe('html');
+    expect(containsType(element, ClerkProvider)).toBe(false);
+    expect(containsType(element, ClerkApiInitializer)).toBe(false);
+    expect(containsType(element, SignedIn)).toBe(false);
+    // Page content still passes through verbatim.
+    expect(containsNode(element, CHILDREN)).toBe(true);
+  });
+
+  it('real-Clerk mode: wraps in <ClerkProvider> with the publishable key and mounts the Clerk client tree', () => {
+    // DEV_AUTH_TOKEN stays unset (cleared in beforeEach).
+    process.env.CLERK_PUBLISHABLE_KEY = 'pk_test_real_instance';
+
+    const element = RootLayout({ children: CHILDREN }) as React.ReactElement;
+
+    expect(element.type).toBe(ClerkProvider);
+    expect((element.props as { publishableKey?: string }).publishableKey).toBe(
+      'pk_test_real_instance',
+    );
+    // The single child of <ClerkProvider> is the shared <html> shell.
+    const shell = (element.props as { children: React.ReactElement }).children;
+    expect(shell.type).toBe('html');
+    // The Clerk client tree is mounted in this mode.
+    expect(containsType(element, ClerkApiInitializer)).toBe(true);
+    expect(containsType(element, SignedIn)).toBe(true);
+    expect(containsNode(element, CHILDREN)).toBe(true);
+  });
+});

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -36,9 +36,20 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   // When DEV_AUTH_TOKEN is set (Playwright CI, local dev-auth mode), the
-  // middleware bypasses clerkMiddleware() entirely. Rendering <SignedIn> in
-  // that mode would call auth() server-side without middleware having run,
-  // which throws and crashes the page tree. Skip the Clerk UI in that mode.
+  // middleware bypasses clerkMiddleware() entirely and the browser authenticates
+  // with the dev bearer token (window.__PUBLIC_CONFIG__.devAuthToken) rather than a
+  // Clerk session — so Clerk is inert for auth. The whole Clerk *client* tree is
+  // therefore skipped in this mode:
+  //   • <ClerkProvider> — mounting it would still initialize ClerkJS in the browser
+  //     against the non-real example publishable key and log a benign but noisy
+  //     "unable to attribute this request to an instance" console error (#834).
+  //   • <ClerkApiInitializer> — calls useAuth(), which requires a <ClerkProvider>
+  //     ancestor; it is unused here anyway (getClientAuthHeaders in lib/client-api.ts
+  //     uses the dev token first and never calls Clerk's getToken).
+  //   • <SignedIn>/<UserButton> — <SignedIn> would call auth() server-side without
+  //     middleware having run, which throws and crashes the page tree.
+  // The sign-in page carries the same DEV_AUTH_TOKEN guard so /sign-in does not render
+  // a <ClerkProvider>-less <SignIn/> in this mode (#834). Real-Clerk mode is unchanged.
   const devAuthMode = Boolean(process.env.DEV_AUTH_TOKEN);
 
   // Public config is read here at request time (this is a Server Component) and
@@ -51,38 +62,51 @@ export default function RootLayout({
   // Fail loud in a deployed runtime if the Clerk publishable key is missing, rather than
   // rendering <ClerkProvider> with an undefined key (auth would break silently in the
   // browser). Matches the API-side guard in apps/api/src/auth/auth.module.ts. See #687.
+  // Consumed only in the real-Clerk branch below; in dev-auth mode <ClerkProvider> is
+  // not rendered, so the key is legitimately absent and unused.
   const clerkPublishableKey = readServerClerkPublishableKey();
 
+  // The HTML shell is identical in both modes; only the <ClerkProvider> wrapper and the
+  // Clerk client children differ (both gated on devAuthMode).
+  const shell = (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{ __html: publicConfigScript(publicConfig) }}
+        />
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
+      <body>
+        <PublicConfigProvider config={publicConfig}>
+          {!devAuthMode && <ClerkApiInitializer />}
+          {!devAuthMode && (
+            <SignedIn>
+              <div
+                style={{
+                  position: 'fixed',
+                  top: '1rem',
+                  right: '1rem',
+                  zIndex: 50,
+                }}
+              >
+                <UserButton afterSignOutUrl="/sign-in" />
+              </div>
+            </SignedIn>
+          )}
+          {children}
+        </PublicConfigProvider>
+      </body>
+    </html>
+  );
+
+  // Dev-auth mode: return the shell WITHOUT <ClerkProvider> so ClerkJS never initializes
+  // in the browser (silences the #834 console error). Real-Clerk mode (staging/production
+  // or a real local pk_ key): wrap in <ClerkProvider> exactly as before.
+  if (devAuthMode) {
+    return shell;
+  }
+
   return (
-    <ClerkProvider publishableKey={clerkPublishableKey}>
-      <html lang="en" suppressHydrationWarning>
-        <head>
-          <script
-            dangerouslySetInnerHTML={{ __html: publicConfigScript(publicConfig) }}
-          />
-          <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
-        </head>
-        <body>
-          <PublicConfigProvider config={publicConfig}>
-            <ClerkApiInitializer />
-            {!devAuthMode && (
-              <SignedIn>
-                <div
-                  style={{
-                    position: 'fixed',
-                    top: '1rem',
-                    right: '1rem',
-                    zIndex: 50,
-                  }}
-                >
-                  <UserButton afterSignOutUrl="/sign-in" />
-                </div>
-              </SignedIn>
-            )}
-            {children}
-          </PublicConfigProvider>
-        </body>
-      </html>
-    </ClerkProvider>
+    <ClerkProvider publishableKey={clerkPublishableKey}>{shell}</ClerkProvider>
   );
 }

--- a/apps/web/app/sign-in/[[...sign-in]]/page.test.tsx
+++ b/apps/web/app/sign-in/[[...sign-in]]/page.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+// Mock the Clerk client surface so we can assert on a stable component identity
+// without importing the real (browser-oriented) Clerk SDK. The page is never rendered
+// here — we inspect the returned element tree structurally, matching app/layout.test.tsx.
+jest.mock('@clerk/nextjs', () => ({
+  SignIn: function SignIn() {
+    return null;
+  },
+}));
+
+import Page from './page';
+import { SignIn } from '@clerk/nextjs';
+
+/** Recursively true if any element in the tree has `.type === type`. */
+function containsType(node: React.ReactNode, type: React.ElementType): boolean {
+  if (!node || typeof node !== 'object') return false;
+  if (Array.isArray(node)) return node.some((child) => containsType(child, type));
+  const element = node as React.ReactElement;
+  if (element.type === type) return true;
+  const children = (element.props as { children?: React.ReactNode }).children;
+  return containsType(children, type);
+}
+
+/** Recursively concatenate all plain-string text nodes in the tree. */
+function textOf(node: React.ReactNode): string {
+  if (typeof node === 'string') return node;
+  if (!node || typeof node !== 'object') return '';
+  if (Array.isArray(node)) return node.map(textOf).join('');
+  const element = node as React.ReactElement;
+  const children = (element.props as { children?: React.ReactNode }).children;
+  return textOf(children);
+}
+
+describe('sign-in page — dev-auth guard (#834)', () => {
+  const originalDevToken = process.env.DEV_AUTH_TOKEN;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.DEV_AUTH_TOKEN;
+  });
+
+  afterAll(() => {
+    if (originalDevToken === undefined) delete process.env.DEV_AUTH_TOKEN;
+    else process.env.DEV_AUTH_TOKEN = originalDevToken;
+  });
+
+  it('dev-auth mode: renders the bypass notice, not <SignIn/> (which needs a <ClerkProvider> the layout skips)', () => {
+    process.env.DEV_AUTH_TOKEN = 'dev-user';
+
+    const element = Page() as React.ReactElement;
+
+    expect(containsType(element, SignIn)).toBe(false);
+    expect(textOf(element)).toMatch(/dev-auth mode is active/i);
+  });
+
+  it('real-Clerk mode: renders <SignIn/>', () => {
+    // DEV_AUTH_TOKEN stays unset (cleared in beforeEach).
+    const element = Page() as React.ReactElement;
+
+    expect(containsType(element, SignIn)).toBe(true);
+  });
+});

--- a/apps/web/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/web/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,6 +1,27 @@
 import { SignIn } from '@clerk/nextjs';
 
+// In dev-auth mode (DEV_AUTH_TOKEN set) the root layout intentionally does NOT mount
+// <ClerkProvider> (#834), so <SignIn/> — a Clerk client component that requires a
+// <ClerkProvider> ancestor — would throw and crash this route. /sign-in is a dead route
+// in that mode anyway: middleware.ts bypasses clerkMiddleware() (never redirecting here)
+// and app/page.tsx skips its auth() redirect, so nothing routes a user to it. Render a
+// short notice instead of crashing. The DEV_AUTH_TOKEN read mirrors the root layout's
+// guard and is dynamic (the root layout forces dynamic rendering for the whole tree, so
+// this is evaluated per request, not inlined at build time). Real-Clerk mode
+// (staging/production or a real local pk_ key) renders <SignIn/> exactly as before.
 export default function Page() {
+  if (process.env.DEV_AUTH_TOKEN) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', paddingTop: '4rem' }}>
+        <p style={{ maxWidth: '32rem', textAlign: 'center' }}>
+          Dev-auth mode is active (<code>DEV_AUTH_TOKEN</code> is set), so Clerk sign-in is
+          bypassed and this page is not used. Unset <code>DEV_AUTH_TOKEN</code> and configure
+          a real Clerk publishable key to use the sign-in flow.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div style={{ display: 'flex', justifyContent: 'center', paddingTop: '4rem' }}>
       <SignIn />


### PR DESCRIPTION
## Summary

In dev-auth mode (`DEV_AUTH_TOKEN` set), the root layout rendered `<ClerkProvider>` unconditionally, so ClerkJS initialized in the browser against the example publishable key and logged a benign but noisy console error — *"Something went wrong initializing Clerk … unable to attribute this request to an instance."* It also polluted the Playwright E2E console (same example key). Middleware already bypasses `clerkMiddleware()` in this mode and the browser auth path (`getClientAuthHeaders`) uses the dev bearer token first, so the Clerk **client** tree is inert here.

This gates the Clerk client tree on dev-auth mode so ClerkJS never initializes in the browser — a clean console is now the default local (and E2E) experience. **Real-Clerk mode (staging/production or a real local `pk_` key) is unchanged** — `<ClerkProvider>` initializes normally.

Follow-up to #832 / #828. Closes #834.

## Acceptance criteria

- [x] Console noise silenced in dev-auth mode (clean console is the default local experience)
- [x] Playwright E2E console also quieted (it uses the same example key)
- [x] **Does not** affect real-Clerk mode — `<ClerkProvider>` still initializes normally
- [x] Test added covering both branches

## Changes

- **`app/layout.tsx`** — gate `<ClerkProvider>` and `<ClerkApiInitializer>` on `!devAuthMode`; return the shared `<html>` shell directly in dev-auth mode, wrap it in `<ClerkProvider>` in real-Clerk mode. (`<SignedIn>`/`<UserButton>` were already gated.) The `readServerClerkPublishableKey()` fail-loud deployed-runtime guard is preserved (still consumed in the real-Clerk branch).
- **`app/sign-in/[[...sign-in]]/page.tsx`** — guard `<SignIn/>` for dev-auth mode. Without a `<ClerkProvider>` ancestor `<SignIn/>` would throw; `/sign-in` is a dead route in dev-auth mode (middleware never redirects there, `app/page.tsx` skips its `auth()` redirect), so it renders a short bypass notice instead of crashing. Gated on the same `DEV_AUTH_TOKEN` condition as the layout, keeping the two in lockstep.
- **`.env.example` / `README.md`** — a Clerk key is no longer required to boot dev-auth mode (no `<ClerkProvider>` → no "Missing publishableKey" throw) and the benign console error is gone; docs now describe the Clerk keys as real-Clerk-mode only.
- **`app/layout.test.tsx`** (new) — structural test (same approach as `(authed)/layout.test.tsx` — call the layout fn and inspect the returned element tree): dev-auth mode returns the `<html>` shell with no `<ClerkProvider>`/`<ClerkApiInitializer>`/`<SignedIn>`; real-Clerk mode wraps in `<ClerkProvider>` with the publishable key and mounts the Clerk client tree.

Not touched: `playwright.config.ts` (its keys guard a `@clerk/testing` harness throw, not `next dev`; they become inert but harmless — the E2E console benefit comes for free from `<ClerkProvider>` not initializing).

## Testing

`npm test -w @lifting-logbook/web`

```
Tests: 280 passed, 0 skipped, 0 failed (45 suites, ~29s)
```

`npm run typecheck -w @lifting-logbook/web` — clean.

Pre-PR gates:
- Suppression grep — clean.
- Test-integrity grep — clean; skipped count is 0.
- No deleted test files; no `package.json` change (lockfile drift gate N/A).
- Coverage gate: new behavior covered by `app/layout.test.tsx`.

**Verified live** — web `next dev` in dev-auth mode with an `.env.local` that has **no** `CLERK_PUBLISHABLE_KEY`:
- Server booted (`✓ Ready in 22.8s`, loading `.env.local`) with no Clerk key — confirms the doc claim that no key is needed to boot dev-auth mode.
- Home page renders; console shows only React DevTools info + `[HMR] connected` — **no ClerkJS init error**.
- `/sign-in` renders the dev-auth bypass notice (no crash, no console errors).

## Risk-dimension audit

- **Security** — the must-not-break-real-Clerk requirement is met: gated on `DEV_AUTH_TOKEN`, which is never set in deployed environments, so staging/production always mount `<ClerkProvider>`; middleware auth enforcement is unchanged. No secret handling changes (removes a dummy key from being rendered).
- **Resilience** — the one new failure mode (a `<ClerkProvider>`-less `/sign-in` crash) is mitigated by the sign-in guard; the deployed-runtime fail-loud key guard is preserved; rollback = revert the diff.
- **Observability / Data / Performance / Accessibility** — N/A: removes a browser console error; no logging/tracing, schema, hot-path, or authed-UI change.

## Review findings disposition

`/review` found 1 blocking + 1 non-blocking finding; both fixed in this PR (commit `4325c1b`):

- **[documentation, blocking]** Root `README.md`'s `apps/web/.env` onboarding block still marked `CLERK_PUBLISHABLE_KEY` "required even in dev-auth mode" (added in #832) — **fixed in `4325c1b`**: reframed to state no Clerk key is needed in dev-auth mode, pointing at `apps/web/.env.example` for real-Clerk setup.
- **[correctness, non-blocking]** The sign-in dev-auth guard had no unit test (only live verification) — **fixed in `4325c1b`**: added `app/sign-in/[[...sign-in]]/page.test.tsx` covering both branches.

Post-fix gates: web suite **282 passed / 0 skipped / 0 failed**; `typecheck` clean; suppression + test-integrity greps clean; no `package.json`/lockfile change.
