### PR TITLE
[infra] Enable same-origin enforcement for /api/client-errors (#809 PR 2)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -573,9 +573,10 @@ jobs:
           otel_mirror_repo: ${{ needs.terraform-staging.outputs.otel_mirror_repo }}
           web_sa: ${{ needs.terraform-staging.outputs.web_workload_sa }}
           # Same-origin guard (#809): allowlist = this web service's own Cloud Run URL, derived at
-          # deploy. drop=false = observe-only until staging Tempo validation (PR2 flips to true).
+          # deploy. drop=true = ENFORCING — cross-origin client-error beacons are dropped. Enabled
+          # after staging Tempo validation confirmed legit beacons tag same-origin (#809 PR2).
           client_error_guard: "true"
-          client_error_drop_cross_origin: "false"
+          client_error_drop_cross_origin: "true"
 
       # ── OTel Collector (observability — #474) ──────────────────────────────
       # Deployed LAST in the job, after the Cloud Run app deploys above, so an
@@ -1165,9 +1166,10 @@ jobs:
           otel_mirror_repo: ${{ steps.tf-prod.outputs.otel_mirror_repo }}
           web_sa: ${{ steps.tf-prod.outputs.web_workload_sa }}
           # Same-origin guard (#809): allowlist = this web service's own Cloud Run URL, derived at
-          # deploy. drop=false = observe-only until validated; PR2 flips to true (staging→prod).
+          # deploy. drop=true = ENFORCING — cross-origin beacons dropped. Enabled after staging
+          # validation (#809 PR2); this prod rollout is human-gated at environment: production.
           client_error_guard: "true"
-          client_error_drop_cross_origin: "false"
+          client_error_drop_cross_origin: "true"
 
       # ── Production web served-surface smoke (#490 item 3 / #382 / #407) ────
       # Verify the *live* prod web surface through the real Cloud Run ingress

--- a/docs/adr/ADR-020-tail-based-sampling-policy.md
+++ b/docs/adr/ADR-020-tail-based-sampling-policy.md
@@ -173,8 +173,11 @@ validated and enforcement enabled **before / with #804**.
    `client.origin.check=same-origin` (no false `cross-origin`, no `client.origin.enforce_skipped`), so
    PR 2 set `client_error_drop_cross_origin: "true"` on both callers in
    [`deploy.yml`](../../.github/workflows/deploy.yml): **staging enforces on merge**; the **production**
-   rollout is human-gated at the `environment: production` approval gate. Rollback remains instant and
-   code-free — flip the input back to `"false"` (or unset `CLIENT_ERROR_ALLOWED_ORIGINS`).
+   rollout is human-gated at the `environment: production` approval gate. Instant incident rollback is
+   code-free — override the env var on the live service (`gcloud run services update
+   lifting-logbook-{stg,prod}-web --update-env-vars CLIENT_ERROR_DROP_CROSS_ORIGIN=false`), exactly as
+   the enablement note above describes; reverting the `deploy.yml` input to `"false"` is the durable
+   change that survives the next deploy.
 3. **Span *rate* (scripted / no-`Origin` abuse) — deferred to infra.** The `Origin` guard cannot
    stop a `curl` loop (no browser, no truthful `Origin`). The robust fix is an infra-level rate limit
    on the unauthenticated endpoint (Cloud Armor / ingress / edge), tracked as a follow-up. Until it

--- a/docs/adr/ADR-020-tail-based-sampling-policy.md
+++ b/docs/adr/ADR-020-tail-based-sampling-policy.md
@@ -164,6 +164,17 @@ validated and enforcement enabled **before / with #804**.
    app's public origin(s), confirm in staging Tempo that legitimate beacons tag
    `client.origin.check=same-origin`, then set `CLIENT_ERROR_DROP_CROSS_ORIGIN=true`. Rollback is
    instant — unset the flag (no code deploy).
+
+   **Enforcement enabled — 2026-07-12 ([#809](https://github.com/brownm09/lifting-logbook/issues/809)).**
+   [PR #827](https://github.com/brownm09/lifting-logbook/pull/827) wired `CLIENT_ERROR_ALLOWED_ORIGINS`
+   (derived at deploy from each web service's own Cloud Run URL) into the staging + production web
+   callers of [`deploy-cloud-run-otel-sidecar`](../../.github/actions/deploy-cloud-run-otel-sidecar/action.yml)
+   in **observe mode** (`drop=false`). Staging Tempo validation then confirmed legitimate beacons tag
+   `client.origin.check=same-origin` (no false `cross-origin`, no `client.origin.enforce_skipped`), so
+   PR 2 set `client_error_drop_cross_origin: "true"` on both callers in
+   [`deploy.yml`](../../.github/workflows/deploy.yml): **staging enforces on merge**; the **production**
+   rollout is human-gated at the `environment: production` approval gate. Rollback remains instant and
+   code-free — flip the input back to `"false"` (or unset `CLIENT_ERROR_ALLOWED_ORIGINS`).
 3. **Span *rate* (scripted / no-`Origin` abuse) — deferred to infra.** The `Origin` guard cannot
    stop a `curl` loop (no browser, no truthful `Origin`). The robust fix is an infra-level rate limit
    on the unauthenticated endpoint (Cloud Armor / ingress / edge), tracked as a follow-up. Until it


### PR DESCRIPTION
## Summary

**PR 2 of 2 for #809 — the enforcement flip.** Sets `client_error_drop_cross_origin: "true"` on the **staging** and **production** web `deploy-cloud-run-otel-sidecar` callers, so the #806 same-origin guard on `POST /api/client-errors` now **drops** cross-origin browser beacons instead of only tagging them.

This is unblocked by PR #827 (observe-mode wiring, merged) **and** staging Tempo validation, which confirmed legitimate beacons tag `client.origin.check=same-origin` — the validate-first safety gate #806/#809 exist to preserve. The allowlist itself is still **derived at deploy** from each web service's own Cloud Run `status.url` (from PR #827); this PR changes only the two literal `drop` input values plus the ADR record.

## What changed

- **`.github/workflows/deploy.yml`** — `client_error_drop_cross_origin` flipped `"false"` → `"true"` at both web callers (staging ~L578, production ~L1170); each comment updated to reflect enforcement is now ON.
- **`docs/adr/ADR-020-tail-based-sampling-policy.md`** — the #806 addendum's mitigation 2 gains an **"Enforcement enabled — 2026-07-12 (#809)"** note recording the observe→enforce transition, the validation result, and that prod is human-gated. (ADR-warrant for this change.)

## Deliberately NOT changed

- **`infra/terraform/cloud-run.tf`** — the declared `CLIENT_ERROR_DROP_CROSS_ORIGIN` default stays `"false"`. The web service is `lifecycle.ignore_changes = [template]`, so tf's value never affects the live service after bootstrap; enforcement lives entirely in the deploy step. `drop=false` remains the correct **safe observe-only state a bare `terraform apply` bootstraps** (before any deploy step has derived an allowlist), exactly as framed in PR #827.
- **`CLAUDE.md`** — the Observability "Client-side write errors" note already documents enablement-via-`client_error_drop_cross_origin=true` (added in PR #827); no change needed.

## Validation (the gate this PR clears)

On the persistent staging deploy from PR #827 (observe mode, allowlist derived to `https://lifting-logbook-stg-web-…-uc.a.run.app`), a same-origin beacon was triggered and confirmed in staging Tempo:

- `{ span.client.operation = "origin-guard-staging-validation" }` — the probe span present.
- `{ name = "client.mutation.error" && span.client.origin.check != "same-origin" }` — **zero** legit-traffic results: no false `cross-origin`, no `client.origin.enforce_skipped`.

→ Legitimate beacons classify `same-origin`, so enabling `drop` cannot silently blackhole real client-error telemetry.

## Testing

Config + docs change; no JS/TS/route logic touched (`apps/web/app/api/client-errors/route.ts` and its 20 guard tests, merged in #810, are untouched and remain green). The composite action's derive-`status.url` + env-passthrough bash is unit-covered one layer down by `scripts/test_inject_otel_sidecar.py` (32 tests, incl. the 6 `INGRESS_EXTRA_ENV` cases from PR #827) and exercised end-to-end by this PR's own staging deploy. Pre-commit `turbo run lint` passed (7/7). `deploy.yml` parses clean (`js-yaml` loadAll).

**Pre-PR gates:** suppression grep (ADR-026) clean · test-integrity grep (ADR-029) clean · no deleted tests · no `package.json` change (lockfile gate N/A).

## Risk-dimension audit

- **Testing** — N/A new code; validation is the staging deploy + Tempo check above (recorded in the ADR addendum).
- **Observability** — this *is* the observability control. Enforcement now drops cross-origin beacons; retained-span volume for that abuse class goes down. Legit same-origin telemetry is unaffected (validated). Repo audit items 1–4 (raw SQL / LLM PII / header allowlist / client error-swallow) N/A — no such code touched.
- **Security** — shrinks the unauthenticated retained-ERROR-span abuse surface (the #806 purpose). Allowlist is the service's own URL (no external input). No authz/isolation boundary touched (privilege-restricted-test rule N/A).
- **Resilience / rollback** — instant, code-free rollback: flip the input back to `"false"` (or unset `CLIENT_ERROR_ALLOWED_ORIGINS`) and redeploy. Guard cannot blackout telemetry for same-origin traffic.
- **Performance** — zero request-path change vs PR #827 (same guard, same derive step); a dropped beacon is strictly less collector work.
- **Data integrity / migrations** — N/A (no schema/data change).

## Sequencing

1. **This PR merges** → `deploy.yml` deploys **staging with enforcement on** automatically; **production held at the `environment: production` approval gate**.
2. **Re-confirm** on staging: same-origin beacon still recorded (`origin.check=same-origin`), cross-origin dropped.
3. **Human approves the production deploy** → prod enforces. (I do not self-approve prod.)

Closes #809

---

## Review findings disposition

Review: [comment](https://github.com/brownm09/lifting-logbook/pull/836#issuecomment-4952733664) — `blocking=0 non_blocking=1`.

- **[documentation] ADR-020 rollback wording** — the #809 addendum called reverting the `deploy.yml` input "instant and code-free," but that path requires a PR + CI + redeploy. **Fixed in `5e56759`**: distinguishes the truly instant/code-free incident rollback (override `CLIENT_ERROR_DROP_CROSS_ORIGIN` on the live Cloud Run service) from the durable `deploy.yml` revert.
