### PR TITLE
[docs] Replace board-move item-list lookups with direct GraphQL query

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Architecture follows hexagonal / Ports & Adapters. `packages/core` has zero infr
 
 All new issues must be added to the **Lifting Logbook** project and assigned an epic before work begins.
 
-**Important:** All `gh project item-list` queries in this file use `--limit 500` to avoid truncation. The project has 327+ items (default limit is 30). If the project grows beyond 500 items, increase this limit accordingly.
+**Board-item lookups use a direct per-issue GraphQL query — no board enumeration, no `--limit` to maintain.** The two board-move steps (Standard Issue Workflow steps 3 & 9) resolve an issue's project-item ID via a `gh api graphql` query keyed on the issue number, so board growth can never truncate them. This replaces the old `gh project item-list --limit N` + client-side `node -e` find, which silently returned "not found" for recent issues once the board outgrew the hardcoded limit (it passed 500 items in July 2026; issues ≥ #837 broke — see [#852](https://github.com/brownm09/lifting-logbook/issues/852), prior art [#632](https://github.com/brownm09/lifting-logbook/issues/632)/[#601](https://github.com/brownm09/lifting-logbook/issues/601)). Note: `gh`'s `--jq` flag is its own built-in filter (gojq) and does **not** require the standalone `jq` binary this repo otherwise lacks.
 
 **Project IDs (needed for CLI commands):**
 - Project number: `2`, owner: `brownm09`
@@ -161,17 +161,19 @@ If `--format json` is not supported by the installed `gh` version, fall back to 
 2. Create a branch: `git checkout -b <type>/issue-<N>-<slug>` (see Branch Naming)
 3. Move the issue to **In Progress** on the project board:
    ```bash
-   TMPFILE="C:/Users/brown/.claude/scratch/tmp_item_<N>.json"
-   gh project item-list 2 --owner brownm09 --limit 500 --format json > "$TMPFILE"
-   ITEM_ID=$(node -e "
-     const d=JSON.parse(require('fs').readFileSync('$TMPFILE','utf8'));
-     const item=d.items.find(i=>i.content&&i.content.number===<N>);
-     console.log(item.id);
-   ")
-   rm -f "$TMPFILE"
+   # Resolve the project-item ID for issue <N> directly — no board enumeration, no --limit.
+   ITEM_ID=$(gh api graphql -f query='
+     query($number: Int!) {
+       repository(owner: "brownm09", name: "lifting-logbook") {
+         issue(number: $number) {
+           projectItems(first: 10) { nodes { id project { number } } }
+         }
+       }
+     }' -F number=<N> \
+     --jq '.data.repository.issue.projectItems.nodes[] | select(.project.number==2) | .id')
    gh project item-edit --project-id PVT_kwHOAjEKvM4BTuEF --id "$ITEM_ID" \
      --field-id PVTSSF_lAHOAjEKvM4BTuEFzhA7F7E \
-     --single-select-option-id 47fc9ee4
+     --single-select-option-id 47fc9ee4   # In Progress
    ```
 4. Implement the changes
 5. Commit with `Closes #<N>` in the message (see Commit Format)
@@ -191,17 +193,19 @@ If `--format json` is not supported by the installed `gh` version, fall back to 
    branch are auto-retargeted to `main` by GitHub when the branch is deleted.
 9. Move the issue to **Done** on the project board:
    ```bash
-   TMPFILE="C:/Users/brown/.claude/scratch/tmp_item_<N>.json"
-   gh project item-list 2 --owner brownm09 --limit 500 --format json > "$TMPFILE"
-   ITEM_ID=$(node -e "
-     const d=JSON.parse(require('fs').readFileSync('$TMPFILE','utf8'));
-     const item=d.items.find(i=>i.content&&i.content.number===<N>);
-     console.log(item.id);
-   ")
-   rm -f "$TMPFILE"
+   # Resolve the project-item ID for issue <N> directly — no board enumeration, no --limit.
+   ITEM_ID=$(gh api graphql -f query='
+     query($number: Int!) {
+       repository(owner: "brownm09", name: "lifting-logbook") {
+         issue(number: $number) {
+           projectItems(first: 10) { nodes { id project { number } } }
+         }
+       }
+     }' -F number=<N> \
+     --jq '.data.repository.issue.projectItems.nodes[] | select(.project.number==2) | .id')
    gh project item-edit --project-id PVT_kwHOAjEKvM4BTuEF --id "$ITEM_ID" \
      --field-id PVTSSF_lAHOAjEKvM4BTuEFzhA7F7E \
-     --single-select-option-id 98236657
+     --single-select-option-id 98236657   # Done
    ```
 10. Pull main: `git checkout main && git pull`
 11. Close the issue if not auto-closed: `gh issue close <N>`


### PR DESCRIPTION
## Summary

The board-move lookups in `CLAUDE.md` (Standard Issue Workflow **steps 3 & 9**) resolved an issue's project-item ID by enumerating the whole board with `gh project item-list 2 --owner brownm09 --limit 500 --format json` and finding the matching item client-side via `node -e`. The project passed **500 items in July 2026** (519 at time of writing), so the `--limit 500` page no longer includes recent issues — the lookup returned `undefined` for any issue ≥ **#837**, and the subsequent `gh project item-edit` silently no-opped. Directly observed on #841 (fixed only at `--limit 1000`) and confirmed again on #842.

Each prior fix was a limit bump (300 → 500 → 1000), a treadmill that just fails again. This replaces the enumeration with a **direct, per-issue GraphQL lookup** keyed on the issue number, so board size is irrelevant and there is no `--limit` to keep ahead of:

```bash
ITEM_ID=$(gh api graphql -f query='
  query($number: Int!) {
    repository(owner: "brownm09", name: "lifting-logbook") {
      issue(number: $number) {
        projectItems(first: 10) { nodes { id project { number } } }
      }
    }
  }' -F number=<N> \
  --jq '.data.repository.issue.projectItems.nodes[] | select(.project.number==2) | .id')
```

## What changed (docs only — `CLAUDE.md`)

- **Step 3** (move to *In Progress*) and **Step 9** (move to *Done*) board-move blocks: replaced the `item-list --limit 500` + `TMPFILE` + `node -e` + `rm` dance with the direct GraphQL lookup above. Also drops the temp-file round-trip entirely.
- **Stale caveat** (GitHub Project & Epic Assignment section): the old "*All `gh project item-list` queries use `--limit 500`… the project has 327+ items… increase this limit if it grows beyond 500*" note is replaced with a durable one explaining the direct-GraphQL approach, why the treadmill is retired, and that `gh`'s `--jq` is its own built-in filter (gojq) — so nobody reverts it to `node -e` citing "jq is NOT available."

## Verification

- New command validated end-to-end against **#852** and **#842** (both ≥ #837) — each resolved its item ID directly.
- The new command performed **this issue's own In-Progress board move** (`#852` → In Progress) successfully, exercising the full `graphql → item-edit` path with a real recent issue.

## Testing

Docs-only change — no source code, tests, or build output touched (`git diff --name-only origin/main` → `CLAUDE.md` only). Per the repo Coverage Requirements table ("Refactor / docs only — None required"), the full `npm test` suite (which spins up Docker/Testcontainers for the API DB E2E layer) was not run — there is no code path to exercise. The pre-commit `turbo run lint` gate passed (7/7 tasks, FULL TURBO cache).

## Pre-PR checks

- **Suppression grep** — two matches, both **false positives**: the `!\s*[;,)]` pattern matched `Int!)` inside the documented GraphQL query, where `$number: Int!` is a GraphQL non-null *type*, not a TypeScript non-null assertion. No real suppressions added.
- **Test-integrity grep** — clean.
- **Lockfile drift** — N/A, no `package.json` changed.

## Acceptance criteria (from #852)

- [x] Board-move steps resolve the item ID for any issue regardless of project size (no `--limit` treadmill); verified against an issue ≥ #837 (#852, #842).
- [x] `CLAUDE.md` updated in both board-move locations (steps 3 & 9); stale 500-item caveat removed/updated.

Closes #852
