### PR TITLE
[infra] Add gke_deletion_protection var (default false) so GKE teardown doesn't block

### DIFF
--- a/infra/terraform/gke.tf
+++ b/infra/terraform/gke.tf
@@ -13,6 +13,8 @@ resource "google_container_cluster" "main" {
 
   enable_autopilot = true
 
+  deletion_protection = var.gke_deletion_protection
+
   network    = google_compute_network.main.id
   subnetwork = google_compute_subnetwork.main.id
 

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -91,6 +91,22 @@ variable "enable_gke" {
   default     = true
 }
 
+variable "gke_deletion_protection" {
+  description = <<-EOT
+    Terraform-side guard on the GKE Autopilot cluster (google_container_cluster.main).
+    When true, `terraform apply` refuses to destroy the cluster — including the implicit
+    destroy when `enable_gke` flips true → false (count → 0), which then hard-fails with
+    "Cannot destroy cluster because deletion_protection is set to true."
+
+    Defaults to false for this single-user / portfolio context so the ADR-009
+    GKE-vs-Cloud-Run A/B can be torn down cleanly. Set true (e.g. in
+    terraform.tfvars.production) if a future long-lived prod cluster should be protected
+    from an accidental terraform destroy. See issue #862.
+  EOT
+  type        = bool
+  default     = false
+}
+
 variable "cloud_run_min_instances" {
   description = "Minimum Cloud Run instances per service. null = use environment default (1 in production, 0 in staging). Set 0 in production for scale-to-zero (adds ~2s cold start to first request, near-zero idle cost)."
   type        = number


### PR DESCRIPTION
## Summary

`infra/terraform/gke.tf`'s `google_container_cluster.main` never set `deletion_protection`, so with the pinned `hashicorp/google-beta ~> 5.0` provider (locked at 5.45.2) the field **provider-defaulted to `true`** — a Terraform-side guard, not a GCP-level setting. That default blocks `terraform apply` from destroying the cluster whenever `enable_gke` flips `true → false` (`count → 0`):

```
Error: Cannot destroy cluster because deletion_protection is set to true.
```

This surfaced landing #861 (staging GKE retirement); the staging cluster had to be deleted out-of-band via `gcloud container clusters delete`. The gap recurs the next time GKE is re-enabled and later disabled.

## Change

Per the issue's variable option, this adds a **`gke_deletion_protection` bool variable (default `false`)** matching the existing `enable_gke` feature-flag convention, and wires `deletion_protection = var.gke_deletion_protection` into the cluster. A future long-lived prod cluster can opt back into protection by setting the var `true` in `terraform.tfvars.production`.

- `infra/terraform/variables.tf` — new `gke_deletion_protection` variable (heredoc-documented, `type = bool`, `default = false`).
- `infra/terraform/gke.tf` — `deletion_protection = var.gke_deletion_protection` on `google_container_cluster.main`.

**Forward-looking, inert today.** Both `terraform.tfvars.staging` and `terraform.tfvars.production` are currently `enable_gke = false`, so `count = 0` and no cluster exists in any state. This performs no in-place update and no destroy on apply — it simply ensures the *next* cluster created is born with `deletion_protection = false` so a later `enable_gke = false` tears it down cleanly. No `.tfvars` edits (the `false` default already covers both environments).

## Acceptance criteria (from #862)

- [x] `deletion_protection` is explicitly set on `google_container_cluster.main` (no longer provider-defaults to `true`).
- [x] Defaults to `false` for this single-user / portfolio context.
- [x] Exposed as a variable so a future prod cluster can opt back into `true`.
- [x] `terraform validate` + `fmt -check` pass.

## Testing

No JS/TS surface is touched, so `npm test` is **N/A** (config-only change; the coverage table treats these as "None required" and the suite is unchanged). There is no Terraform test suite and no CI `terraform validate`/`fmt` gate, so the applicable verification is the Terraform CLI locally (v1.15.3):

```
$ terraform -chdir=infra/terraform fmt -check      # exit 0 — no formatting changes
$ terraform -chdir=infra/terraform init -backend=false
Terraform has been successfully initialized!
$ terraform -chdir=infra/terraform validate
Success! The configuration is valid.
```

Pre-commit lint hook (`turbo run lint`) also passed: `7 successful, 7 total (FULL TURBO)`.

The advisory `prod-plan-pr.yml` CI job (`terraform plan (production)`, non-blocking) will show **no change** to `google_container_cluster.main` — prod is `enable_gke = false`, so the cluster is absent — confirming the fix is inert for current state.

Closes #862

## Review findings disposition

`/review` (claude-opus-4-8) returned a **clean review — 0 blocking, 0 non-blocking findings**. Nothing to dispose. Premerge checkpoints: `adr_warrant=not-warranted`, `doc_reconciliation=not-applicable`.
