### PR TITLE
[feat] Persist in-progress set inputs so a crash doesn't lose them

### DIFF
--- a/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.test.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.test.tsx
@@ -4,6 +4,7 @@ import type { LiftRecordResponse } from '@lifting-logbook/types';
 import WorkoutLogger from './WorkoutLogger';
 import type { LiftData, WorkoutLoggerProps } from './types';
 import { createLiftRecord, recordBodyWeight } from '@/lib/client-api';
+import { buildDraftKey } from './workoutDraftStorage';
 
 // jest.mock is hoisted above the imports, so `createLiftRecord`/`recordBodyWeight`
 // resolve to the jest.fn() mocks below.
@@ -61,6 +62,9 @@ const LOGGED: LiftRecordResponse = {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  // Several tests below share the default program/cycle/workout/lift/set identity
+  // from makeProps()/makeLift() and would otherwise leak drafts across tests.
+  window.localStorage.clear();
 });
 
 describe('WorkoutLogger — weight-unit display preference', () => {
@@ -221,5 +225,86 @@ describe('WorkoutLogger — mutation failure logging (#783)', () => {
       expect.objectContaining({ program: '5-3-1', lift: 'Back Squat', setNum: 1 }),
     );
     errorSpy.mockRestore();
+  });
+});
+
+describe('WorkoutLogger — in-progress set draft persistence (#878)', () => {
+  // Matches makeProps()/makeLift()'s defaults: program '5-3-1', cycleNum 1, workoutNum 1,
+  // lift 'Back Squat', setNum 1.
+  const DRAFT_KEY = buildDraftKey('5-3-1', 1, 1, 'Back Squat', 1);
+
+  it('persists an in-progress (unsubmitted) set to localStorage as the user types', async () => {
+    const user = userEvent.setup();
+    render(<WorkoutLogger {...makeProps()} />);
+
+    await user.clear(screen.getByLabelText('Weight in lbs'));
+    await user.type(screen.getByLabelText('Weight in lbs'), '225');
+
+    const raw = window.localStorage.getItem(DRAFT_KEY);
+    if (raw === null) throw new Error('expected a draft to be persisted');
+    expect(JSON.parse(raw)).toEqual({ weight: '225', reps: '5', notes: '' });
+  });
+
+  it('restores an in-progress set after a full remount (simulating a reload)', async () => {
+    const user = userEvent.setup();
+    const props = makeProps();
+    const { unmount } = render(<WorkoutLogger {...props} />);
+
+    await user.clear(screen.getByLabelText('Weight in lbs'));
+    await user.type(screen.getByLabelText('Weight in lbs'), '225');
+    await user.type(screen.getByPlaceholderText('Notes (optional)'), 'felt heavy');
+    unmount();
+
+    render(<WorkoutLogger {...props} />);
+    expect(screen.getByLabelText('Weight in lbs')).toHaveValue(225);
+    expect(screen.getByPlaceholderText('Notes (optional)')).toHaveValue('felt heavy');
+  });
+
+  it('clears the persisted draft after a successful log submission', async () => {
+    const user = userEvent.setup();
+    mockCreateLiftRecord.mockResolvedValue(LOGGED);
+    render(<WorkoutLogger {...makeProps()} />);
+
+    await user.clear(screen.getByLabelText('Weight in lbs'));
+    await user.type(screen.getByLabelText('Weight in lbs'), '225');
+    expect(window.localStorage.getItem(DRAFT_KEY)).not.toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Log' }));
+    await waitFor(() => expect(mockCreateLiftRecord).toHaveBeenCalledTimes(1));
+
+    expect(window.localStorage.getItem(DRAFT_KEY)).toBeNull();
+  });
+
+  it('ignores a stale leftover draft when editing an already-logged set', async () => {
+    const user = userEvent.setup();
+    // Simulate a draft typed before this set was logged elsewhere (e.g. a different
+    // tab) — it must never leak into the edit form, which should reflect the real
+    // logged record instead.
+    window.localStorage.setItem(
+      DRAFT_KEY,
+      JSON.stringify({ weight: '999', reps: '99', notes: 'stale' }),
+    );
+
+    render(
+      <WorkoutLogger
+        {...makeProps({
+          lifts: [
+            makeLift({
+              workingSets: [{ setNum: 1, totalLoad: 100, reps: 5, amrap: false, existing: LOGGED }],
+            }),
+          ],
+        })}
+      />,
+    );
+
+    // Read-only summary reflects the real logged record, never the stale draft.
+    expect(screen.getByText(/225 lbs/)).toBeInTheDocument();
+    expect(screen.queryByText(/999/)).not.toBeInTheDocument();
+
+    // Entering edit mode also must not pick up the stray draft.
+    await user.click(screen.getByRole('button', { name: 'Edit set 1' }));
+    expect(screen.getByLabelText('Weight in lbs')).toHaveValue(225);
+    expect(screen.getByLabelText('Reps')).toHaveValue(5);
+    expect(screen.getByPlaceholderText('Notes (optional)')).toHaveValue('');
   });
 });

--- a/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
@@ -210,14 +210,13 @@ function WorkingSetRow({
   const draftStorageKey = buildDraftKey(program, cycleNum, workoutNum, lift, set.setNum);
 
   const [weightInput, setWeightInput] = useState(() => {
-    if (loggedRecord) {
-      return String(formatWorkingWeight(loggedRecord.weight, null, false, unit).value);
-    }
     if (shouldDraft) {
       const draft = readDraft(draftStorageKey);
       if (draft) return draft.weight;
     }
-    return String(defaultWeight);
+    return loggedRecord
+      ? String(formatWorkingWeight(loggedRecord.weight, null, false, unit).value)
+      : String(defaultWeight);
   });
   const [repsInput, setRepsInput] = useState(() => {
     if (shouldDraft) {

--- a/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/WorkoutLogger.tsx
@@ -13,6 +13,7 @@ import {
 import { logClientError } from '@/lib/log-client-error';
 import styles from './WorkoutLogger.module.css';
 import type { LiftData, WorkingSetData, WorkoutLoggerProps } from './types';
+import { buildDraftKey, clearDraft, readDraft, writeDraft } from './workoutDraftStorage';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -197,17 +198,58 @@ function WorkingSetRow({
   // Pre-fill from the logged record when entering edit mode; fall back to plan defaults for new logs.
   // The pre-filled value is always the native lbs number — the input and everything submitted stay
   // in lbs (lift records have no per-record unit); `unit` only drives the read-only ≈ hint below.
-  const [weightInput, setWeightInput] = useState(
-    loggedRecord
-      ? String(formatWorkingWeight(loggedRecord.weight, null, false, unit).value)
-      : String(defaultWeight),
-  );
-  const [repsInput, setRepsInput] = useState(String(loggedRecord?.reps ?? set.reps));
-  const [notesInput, setNotesInput] = useState(loggedRecord?.notes ?? '');
+  //
+  // Drafts only ever apply to the fresh "Log" form — never a read-only workout, and never an
+  // edit-in-progress (editingSet resets to null on reload, so a drafted edit has no restoration
+  // path). Gating on isReadOnly matters even though isReadOnly implies loggedRecord in practice
+  // (page.tsx only sets it once every set is logged): WorkingSetRow doesn't itself enforce that
+  // invariant, and hooks run unconditionally before the isReadOnly early-return below, so without
+  // this guard an isReadOnly + unlogged row (exercised directly by the isReadOnly test in
+  // WorkoutLogger.test.tsx) would still read a stray draft into unused state.
+  const shouldDraft = !loggedRecord && !isReadOnly;
+  const draftStorageKey = buildDraftKey(program, cycleNum, workoutNum, lift, set.setNum);
+
+  const [weightInput, setWeightInput] = useState(() => {
+    if (loggedRecord) {
+      return String(formatWorkingWeight(loggedRecord.weight, null, false, unit).value);
+    }
+    if (shouldDraft) {
+      const draft = readDraft(draftStorageKey);
+      if (draft) return draft.weight;
+    }
+    return String(defaultWeight);
+  });
+  const [repsInput, setRepsInput] = useState(() => {
+    if (shouldDraft) {
+      const draft = readDraft(draftStorageKey);
+      if (draft) return draft.reps;
+    }
+    return String(loggedRecord?.reps ?? set.reps);
+  });
+  const [notesInput, setNotesInput] = useState(() => {
+    if (shouldDraft) {
+      const draft = readDraft(draftStorageKey);
+      if (draft) return draft.notes;
+    }
+    return loggedRecord?.notes ?? '';
+  });
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const isLogged = !!loggedRecord && !isEditing;
+
+  function handleWeightInputChange(value: string) {
+    setWeightInput(value);
+    if (shouldDraft) writeDraft(draftStorageKey, { weight: value, reps: repsInput, notes: notesInput });
+  }
+  function handleRepsInputChange(value: string) {
+    setRepsInput(value);
+    if (shouldDraft) writeDraft(draftStorageKey, { weight: weightInput, reps: value, notes: notesInput });
+  }
+  function handleNotesInputChange(value: string) {
+    setNotesInput(value);
+    if (shouldDraft) writeDraft(draftStorageKey, { weight: weightInput, reps: repsInput, notes: value });
+  }
 
   async function handleLog(e: React.FormEvent) {
     e.preventDefault();
@@ -231,6 +273,7 @@ function WorkingSetRow({
         reps,
         notes: notesInput || undefined,
       });
+      clearDraft(draftStorageKey);
       onLogged(record);
     } catch (err) {
       logClientError('createLiftRecord', err, {
@@ -320,7 +363,7 @@ function WorkingSetRow({
           min="0"
           step="2.5"
           value={weightInput}
-          onChange={(e) => setWeightInput(e.target.value)}
+          onChange={(e) => handleWeightInputChange(e.target.value)}
           disabled={submitting}
           aria-label="Weight in lbs"
         />
@@ -335,7 +378,7 @@ function WorkingSetRow({
           min="0"
           step="1"
           value={repsInput}
-          onChange={(e) => setRepsInput(e.target.value)}
+          onChange={(e) => handleRepsInputChange(e.target.value)}
           disabled={submitting}
           aria-label="Reps"
         />
@@ -348,7 +391,7 @@ function WorkingSetRow({
           type="text"
           placeholder="Notes (optional)"
           value={notesInput}
-          onChange={(e) => setNotesInput(e.target.value)}
+          onChange={(e) => handleNotesInputChange(e.target.value)}
           disabled={submitting}
         />
         {error && <p className={styles.setError}>{error}</p>}
@@ -588,6 +631,18 @@ export default function WorkoutLogger({
   const totalSets = lifts.reduce((n, l) => n + l.workingSets.length, 0);
   const allLogged = loggedSets.size === totalSets && totalSets > 0;
 
+  // Per-set clearDraft (in WorkingSetRow's handleLog) can't reach a draft written on a
+  // different tab/device than the one that logged the set — sweep the whole workout's
+  // drafts here as a backstop before leaving the page.
+  function handleFinishWorkout() {
+    for (const l of lifts) {
+      for (const ws of l.workingSets) {
+        clearDraft(buildDraftKey(program, cycleNum, workoutNum, l.lift, ws.setNum));
+      }
+    }
+    router.push(`/cycle/${cycleNum}`);
+  }
+
   // Body weight gate
   if (!bodyWeightDone) {
     return <BodyWeightGate onSubmit={handleBodyWeightSubmit} unit={unit} />;
@@ -630,7 +685,7 @@ export default function WorkoutLogger({
           <button
             className={styles.finishBtn}
             type="button"
-            onClick={() => router.push(`/cycle/${cycleNum}`)}
+            onClick={handleFinishWorkout}
           >
             Finish workout
           </button>
@@ -747,7 +802,7 @@ export default function WorkoutLogger({
           <button
             className={styles.finishBtn}
             type="button"
-            onClick={() => router.push(`/cycle/${cycleNum}`)}
+            onClick={handleFinishWorkout}
           >
             Finish workout
           </button>

--- a/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/workoutDraftStorage.test.ts
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/workoutDraftStorage.test.ts
@@ -1,0 +1,62 @@
+import { buildDraftKey, clearDraft, readDraft, writeDraft } from './workoutDraftStorage';
+
+beforeEach(() => {
+  window.localStorage.clear();
+  jest.restoreAllMocks();
+});
+
+it('builds a namespaced key from program/cycle/workout/lift/set', () => {
+  expect(buildDraftKey('5-3-1', 2, 3, 'Back Squat', 1)).toBe('workout-draft:5-3-1:2:3:Back Squat:1');
+});
+
+it('round-trips a draft through write then read', () => {
+  writeDraft('k', { weight: '225', reps: '5', notes: 'felt heavy' });
+  expect(readDraft('k')).toEqual({ weight: '225', reps: '5', notes: 'felt heavy' });
+});
+
+it('clearDraft removes a previously written draft', () => {
+  writeDraft('k', { weight: '225', reps: '5', notes: '' });
+  clearDraft('k');
+  expect(readDraft('k')).toBeNull();
+});
+
+it('readDraft returns null when no draft has been written for the key', () => {
+  expect(readDraft('never-written')).toBeNull();
+});
+
+it('readDraft returns null for corrupted JSON instead of throwing', () => {
+  window.localStorage.setItem('bad-json', 'not-json{{{');
+  expect(readDraft('bad-json')).toBeNull();
+});
+
+it('readDraft returns null for well-formed JSON with the wrong shape', () => {
+  // weight is a number, not a string, and reps/notes are missing entirely.
+  window.localStorage.setItem('bad-shape', JSON.stringify({ weight: 225 }));
+  expect(readDraft('bad-shape')).toBeNull();
+});
+
+it('writeDraft silently no-ops when localStorage.setItem throws (e.g. quota exceeded)', () => {
+  jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+    throw new DOMException('The quota has been exceeded.', 'QuotaExceededError');
+  });
+  expect(() => writeDraft('k', { weight: '1', reps: '1', notes: '' })).not.toThrow();
+});
+
+it('readDraft silently returns null when localStorage.getItem throws', () => {
+  jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+    throw new DOMException('The operation is insecure.', 'SecurityError');
+  });
+  expect(readDraft('k')).toBeNull();
+});
+
+it('clearDraft silently no-ops when localStorage.removeItem throws', () => {
+  jest.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+    throw new DOMException('The operation is insecure.', 'SecurityError');
+  });
+  expect(() => clearDraft('k')).not.toThrow();
+});
+
+// The SSR guard (typeof window === 'undefined') is not exercised here: jsdom always
+// defines `window`, and reliably faking its absence needs a suppression-policy-flagged
+// cast on the delete. It's implicitly proven correct on every production server
+// render — if it were broken, apps/web's workout page couldn't render at all.

--- a/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/workoutDraftStorage.ts
+++ b/apps/web/app/(authed)/cycle/[cycleNum]/workout/[workoutNum]/workoutDraftStorage.ts
@@ -1,0 +1,76 @@
+// Lightweight, best-effort localStorage cache for the ONE set currently being typed
+// but not yet submitted. Every CONFIRMED set already survives a crash via its own
+// immediate POST/PATCH (see WorkoutLogger.tsx handleLog/handleSave) — this module
+// exists solely to protect whatever is mid-keystroke in an unlogged WorkingSetRow.
+// Deliberately tiny: no TTL, no cross-tab sync, no retry queue. A lost or stale
+// draft degrades to "no draft" (falls back to plan defaults) — never a data-loss or
+// correctness bug, since the source of truth is always the server record.
+//
+// Storage failures (quota exceeded, disabled storage, corrupted JSON) are handled by
+// failing open silently rather than through logClientError — that helper is scoped to
+// API mutation failures (see apps/web/lib/log-client-error.ts) and beacons every call;
+// routing a per-keystroke local write failure through it would spam a telemetry beacon
+// for a benign, expected browser condition rather than a production incident.
+
+export interface WorkoutSetDraft {
+  weight: string;
+  reps: string;
+  notes: string;
+}
+
+const KEY_PREFIX = 'workout-draft';
+
+export function buildDraftKey(
+  program: string,
+  cycleNum: number,
+  workoutNum: number,
+  lift: string,
+  setNum: number,
+): string {
+  return `${KEY_PREFIX}:${program}:${cycleNum}:${workoutNum}:${lift}:${setNum}`;
+}
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined';
+}
+
+// Real runtime narrowing (not a suppression) — validates JSON.parse's `unknown` result
+// before trusting its shape, so callers never need an unsafe `as WorkoutSetDraft` cast.
+function isDraftShape(value: unknown): value is WorkoutSetDraft {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.weight === 'string' && typeof v.reps === 'string' && typeof v.notes === 'string';
+}
+
+export function readDraft(key: string): WorkoutSetDraft | null {
+  if (!isBrowser()) return null;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (raw === null) return null;
+    const parsed: unknown = JSON.parse(raw);
+    return isDraftShape(parsed) ? parsed : null;
+  } catch {
+    // Corrupted JSON, or localStorage access itself throwing (e.g. SecurityError in a
+    // locked-down browser context). Fail open — see module doc comment above.
+    return null;
+  }
+}
+
+export function writeDraft(key: string, draft: WorkoutSetDraft): void {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(draft));
+  } catch {
+    // QuotaExceededError or a SecurityError when storage is disabled. Best-effort:
+    // proceed without persisting rather than disrupt typing.
+  }
+}
+
+export function clearDraft(key: string): void {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // Same rationale as writeDraft.
+  }
+}


### PR DESCRIPTION
## Summary

Every already-logged set is already crash-safe: "Log"/"Save" writes immediately via its own `POST`/`PATCH` to `/lift-records`, and there's no batch "submit the whole workout" step to lose. The one real gap: whatever is typed into the set a user is actively filling in — but hasn't submitted yet — lived only in transient React state (`WorkingSetRow`) and was lost on a crash/reload.

This adds a small, scoped localStorage draft cache for exactly that gap:

- New `workoutDraftStorage.ts`: `buildDraftKey`/`readDraft`/`writeDraft`/`clearDraft`, SSR-guarded, fails open silently on any storage error (never blocks typing/logging), with runtime shape validation on read (no unsafe cast).
- `WorkingSetRow` reads a draft on mount and writes on every keystroke — **only** when a set is neither logged nor read-only (`shouldDraft = !loggedRecord && !isReadOnly`). Writes are imperative (in the `onChange` handlers), not a reactive `useEffect`, so nothing is ever written on mere mount/navigation — only on genuine typing.
- The draft clears on a successful "Log". A consolidated `handleFinishWorkout` (replacing two duplicated `router.push` call sites) also sweeps any stray per-set drafts for the whole workout as a backstop for a set logged from a different tab/device than the one holding the draft.

Deliberately out of scope (see issue for full rationale): editing-in-progress on an already-logged set, the body-weight gate, mobile (no logging screen exists there yet), cross-tab sync, offline queue, and draft TTL.

## Note on the `isReadOnly` half of the gate

While implementing, I found the `!isReadOnly` half of `shouldDraft` has no way to fail its own dedicated unit test: `isReadOnly` only ever matters when a row has no `loggedRecord`, and in that combination the component always takes the read-only early-return branch regardless — so no `useState`/render ever surfaces the difference. It's still correct, cheap defense-in-depth against relying on `page.tsx`'s "isReadOnly implies every set is logged" invariant holding forever (rather than WorkingSetRow enforcing it itself), and it's covered by a code comment explaining exactly this — but I did not add a test claiming to catch it, since that would be a false-green test under this repo's own Test Integrity Policy (a test that can't fail under the "before" state isn't a regression test). The `!loggedRecord` half **is** independently meaningful and **is** covered (see "ignores a stale leftover draft when editing an already-logged set").

## Testing

- `npm run typecheck` — pass
- `npm run lint` — pass (confirms `no-uncovered-error-fallback` doesn't flag the new module's plain `try{}catch{return null}` pattern, which matches neither of the rule's two detected shapes)
- `npm test` (full monorepo) — Tests: 806 passed, 0 skipped, 0 failed (in ~30s per workspace; web workspace alone: 295 passed)
- **Manual verification in a real browser** (dev server + the existing Playwright e2e mock API, DEV_AUTH_TOKEN bypass — see `apps/web/e2e/mock-api.mjs` / `playwright.config.ts` for the same setup): typed weight/reps/notes into an unlogged set, confirmed the `workout-draft:...` key appeared in localStorage with the exact typed values, hard-reloaded the page, confirmed the same values were restored into that set's inputs (and only that set — sibling sets stayed at plan defaults), clicked "Log", and confirmed both that the set now shows as logged with those exact values and that the localStorage key was removed.

New/changed test coverage:
- `workoutDraftStorage.test.ts` (new): key building, round-trip, clear, corrupted JSON → null, wrong-shape JSON → null, `setItem`/`getItem`/`removeItem` throwing → silent no-op/null (satisfies `docs/standards/error-fallback-test-coverage.md` via paired failure-path tests).
- `WorkoutLogger.test.tsx` additions: persist-while-typing, restore-after-remount, clear-after-log, ignore-stale-draft-when-editing-an-already-logged-set.

## Acceptance criteria (from #878)

- [x] New `workoutDraftStorage.ts` module: `buildDraftKey`, `readDraft`, `writeDraft`, `clearDraft` — SSR-guarded, fail-open on any storage error, runtime-validated on read (no unsafe cast).
- [x] `WorkingSetRow` reads a draft on mount (when unlogged + not read-only), writes on each keystroke, clears on successful "Log".
- [x] Stray/stale drafts are never read for an already-logged or read-only set.
- [x] Unit tests for the storage module and integration tests in `WorkoutLogger.test.tsx`.
- [x] `npm run typecheck`, `npm run lint`, `npm test -w @lifting-logbook/web` all pass.

Closes #878

## Review findings disposition

Per [/review](https://github.com/merickvaughn/lifting-logbook/pull/879#issuecomment-5154160113) (0 blocking, 2 non-blocking):

- **[documentation]** PR body test-count typo (299 → 295 for the web workspace) — fixed in this PR body edit.
- **[maintainability]** `weightInput` initializer structurally asymmetric vs. `repsInput`/`notesInput` — fixed in `d793daf`.

ADR-warrant: not-warranted (no `claude/`-scoped rule/hook/skill/settings touched). Doc-reconciliation: not-applicable (repo has no Documentation Maintenance table).
