### PR TITLE
Phase 2B: TM-history seeding script (seed-tm-history.ts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,12 @@ next-env.d.ts
 scripts/cloud-sql-proxy
 scripts/cloud-sql-proxy.exe
 
+# Phase 2B seed script backups (apps/api/scripts/seed-tm-history.ts) — default
+# outside the repo (os.tmpdir()), but this is a backstop in case --backup-dir
+# ever points inside the tree. Contains a full dump of one user's training-max
+# history keyed to their Clerk id — never committed.
+tm-history-backup-*.json
+
 # Playwright staging auth state — contains real session tokens, never commit
 apps/web/playwright/.auth/
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,7 +22,6 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-fastify": "^10.0.0",
-    "csv-parse": "^6.1.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.75.0",
     "@opentelemetry/exporter-logs-otlp-http": "^0.217.0",
@@ -61,6 +60,7 @@
     "@opentelemetry/sdk-trace-base": "^2.7.1",
     "@testcontainers/postgresql": "^12.0.1",
     "@types/pg": "^8.11.0",
+    "csv-parse": "^6.1.0",
     "prisma": "^5.22.0",
     "ts-node": "^10.9.0",
     "tsconfig-paths": "^4.2.0"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,7 +10,8 @@
     "test": "jest",
     "test:db": "jest --testPathPatterns=db\\.e2e",
     "db:generate": "prisma generate",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "seed:tm-history": "ts-node scripts/seed-tm-history.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.92.0",
@@ -21,6 +22,7 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-fastify": "^10.0.0",
+    "csv-parse": "^6.1.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.75.0",
     "@opentelemetry/exporter-logs-otlp-http": "^0.217.0",

--- a/apps/api/scripts/seed-tm-history.db.e2e.spec.ts
+++ b/apps/api/scripts/seed-tm-history.db.e2e.spec.ts
@@ -17,20 +17,42 @@ import { PrismaClient } from '@prisma/client';
 import {
   backupExistingHistory,
   ProgramOwnershipError,
+  REQUIRED_COLUMNS,
   runSeed,
   SeedArgs,
   verifyProgramOwnership,
 } from './seed-tm-history';
+import { PrismaTrainingMaxHistoryRepository } from '../src/adapters/prisma/training-max-history.repository';
 
 const OWNER_DATABASE_URL = process.env.LIFTING_TC_OWNER_DATABASE_URL;
 // Skip only when globalSetup did not provision a DB (e.g. Docker unavailable
 // and not running in CI) — matches programs.db.e2e.spec.ts's pattern.
 const describeOrSkip = OWNER_DATABASE_URL ? describe : describe.skip;
 
+// Applied to every hook that actually touches Postgres (beforeEach/afterAll)
+// — matching programs.db.e2e.spec.ts's own placement (its comment there
+// explains #567: these hooks intermittently trip Jest's 5s default under a
+// full-suite Windows `turbo run test`, since apps/api/jest.config.js does
+// not extend the win32-capped base config). Deliberately NOT on beforeAll
+// here, which only constructs a PrismaClient (Prisma connects lazily) and
+// does no DB work of its own.
 const DB_E2E_HOOK_TIMEOUT_MS = 30_000;
 
 const USER_A = 'seed-tm-history-e2e-user-a';
 const USER_B = 'seed-tm-history-e2e-user-b';
+
+/** Fails loudly and narrows the type — the one idiom this file uses for
+ * "an assertion already proved this is non-null, now tell the compiler."
+ * Replaces a mix of `!` and `as` that either "solved" the same problem
+ * differently in different spots, or, in `expect(x).not.toBeNull()`'s
+ * case, doesn't actually narrow at all (Jest's matchers have no type-level
+ * effect) — so on an unexpected null both `!` and `as` produce a confusing
+ * failure the first time they're actually wrong, whereas this throws a
+ * named error immediately. */
+function assertNotNull<T>(value: T | null, what: string): T {
+  if (value === null) throw new Error(`expected ${what} to be non-null`);
+  return value;
+}
 
 async function cleanTestUsers(prisma: PrismaClient): Promise<void> {
   await prisma.trainingMaxHistory.deleteMany({
@@ -41,22 +63,18 @@ async function cleanTestUsers(prisma: PrismaClient): Promise<void> {
   });
 }
 
+const tmpDirs: string[] = [];
 function tmpBackupDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'seed-tm-history-e2e-'));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'seed-tm-history-e2e-'));
+  tmpDirs.push(dir);
+  return dir;
 }
 
 function csvOf(rows: Record<string, string>[]): string {
-  const headers = [
-    'Program',
-    'Lift',
-    'Cycle Date',
-    'TM',
-    'Goal Met',
-    'Is PR',
-    'Will Seed',
-  ];
-  const lines = [headers.join(',')];
-  for (const row of rows) lines.push(headers.map((h) => row[h] ?? '').join(','));
+  const lines = [REQUIRED_COLUMNS.join(',')];
+  for (const row of rows) {
+    lines.push(REQUIRED_COLUMNS.map((h) => row[h] ?? '').join(','));
+  }
   return lines.join('\n');
 }
 
@@ -79,17 +97,23 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
 
   beforeAll(() => {
     prisma = new PrismaClient({ datasources: { db: { url: OWNER_DATABASE_URL } } });
-  }, DB_E2E_HOOK_TIMEOUT_MS);
+  });
 
   beforeEach(async () => {
     await cleanTestUsers(prisma);
     backupDir = tmpBackupDir();
+  }, DB_E2E_HOOK_TIMEOUT_MS);
+
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   afterAll(async () => {
     await cleanTestUsers(prisma);
     await prisma.$disconnect();
-  });
+  }, DB_E2E_HOOK_TIMEOUT_MS);
 
   describe('verifyProgramOwnership', () => {
     it('resolves without throwing when the program belongs to the given user', async () => {
@@ -115,6 +139,23 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
         verifyProgramOwnership(prisma, '00000000-0000-0000-0000-000000000000', USER_A),
       ).rejects.toThrow(/does not exist/);
     });
+
+    it('logs the connected role/database identity for audit purposes', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'Identity Log' },
+      });
+      const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        await verifyProgramOwnership(prisma, program.id, USER_A);
+        expect(
+          logSpy.mock.calls.some((call) =>
+            String(call[0]).startsWith('Connected as '),
+          ),
+        ).toBe(true);
+      } finally {
+        logSpy.mockRestore();
+      }
+    });
   });
 
   describe('backupExistingHistory', () => {
@@ -122,15 +163,12 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
       const program = await prisma.customProgram.create({
         data: { userId: USER_A, name: 'Empty History' },
       });
-      const { PrismaTrainingMaxHistoryRepository } = await import(
-        '../src/adapters/prisma/training-max-history.repository'
-      );
       const repo = new PrismaTrainingMaxHistoryRepository(prisma, USER_A);
       const result = await backupExistingHistory(repo, program.id, backupDir);
       expect(result).toBeNull();
     });
 
-    it('writes existing history to a JSON file and returns its path + count', async () => {
+    it('writes existing history to a JSON file, verifies the write, and returns its path + count', async () => {
       const program = await prisma.customProgram.create({
         data: { userId: USER_A, name: 'Has History' },
       });
@@ -147,14 +185,13 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
           goalMet: true,
         },
       });
-      const { PrismaTrainingMaxHistoryRepository } = await import(
-        '../src/adapters/prisma/training-max-history.repository'
-      );
       const repo = new PrismaTrainingMaxHistoryRepository(prisma, USER_A);
-      const result = await backupExistingHistory(repo, program.id, backupDir);
-      expect(result).not.toBeNull();
-      expect(result?.count).toBe(1);
-      const written = JSON.parse(fs.readFileSync(result!.path, 'utf8'));
+      const result = assertNotNull(
+        await backupExistingHistory(repo, program.id, backupDir),
+        'backupExistingHistory result',
+      );
+      expect(result.count).toBe(1);
+      const written = JSON.parse(fs.readFileSync(result.path, 'utf8'));
       expect(written).toHaveLength(1);
       expect(written[0]).toMatchObject({ lift: 'back-squat', weight: 300 });
     });
@@ -163,12 +200,13 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
   describe('runSeed', () => {
     function baseArgs(program: string, input: string): SeedArgs {
       return {
+        mode: 'seed',
         program,
         userId: USER_A,
         input,
         dryRun: false,
         force: false,
-        rollback: false,
+        backupDir: null,
       };
     }
 
@@ -217,6 +255,39 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
       expect(rows).toHaveLength(2);
       expect(rows.map((r) => r.lift).sort()).toEqual(['back-squat', 'bench-press']);
       expect(rows.every((r) => r.reps === 1 && r.source === 'program')).toBe(true);
+    });
+
+    it('refuses a seed that would write zero rows, rather than silently wiping existing history', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'All Holds' },
+      });
+      await prisma.trainingMaxHistory.create({
+        data: {
+          userId: USER_A,
+          program: program.id,
+          lift: 'back-squat',
+          weight: 250,
+          reps: 1,
+          date: new Date('2025-01-01'),
+          isPR: false,
+          source: 'program',
+          goalMet: false,
+        },
+      });
+      const csvPath = path.join(backupDir, 'export.csv');
+      // Every row is a hold (Will Seed=false) — a plausible wrong-file or
+      // wrong-export-state mistake, not itself invalid CSV.
+      fs.writeFileSync(csvPath, csvOf([willSeedRow({ 'Will Seed': 'false' })]));
+
+      await expect(
+        runSeed(prisma, { ...baseArgs(program.id, csvPath), force: true }, backupDir),
+      ).rejects.toThrow(/zero rows to seed/);
+
+      const rows = await prisma.trainingMaxHistory.findMany({
+        where: { program: program.id },
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.weight).toBe(250); // untouched — refused before any delete
     });
 
     it('refuses without --force when the program already has history, and writes nothing', async () => {
@@ -279,8 +350,8 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
       expect(result.mode).toBe('seeded');
       expect(result.existingCount).toBe(1);
       expect(result.writtenCount).toBe(1);
-      expect(result.backupPath).not.toBeNull();
-      const backedUp = JSON.parse(fs.readFileSync(result.backupPath as string, 'utf8'));
+      const backupPath = assertNotNull(result.backupPath, 'result.backupPath');
+      const backedUp = JSON.parse(fs.readFileSync(backupPath, 'utf8'));
       expect(backedUp).toHaveLength(1);
       expect(backedUp[0]).toMatchObject({ weight: 250 }); // the OLD row, preserved in the backup
 
@@ -312,6 +383,75 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
         where: { program: program.id },
       });
       expect(rows).toHaveLength(0);
+    });
+
+    it('--dry-run validates rows the same way a real run would (throws on a bad row, writes nothing)', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'Dry Run Validates' },
+      });
+      const csvPath = path.join(backupDir, 'export.csv');
+      fs.writeFileSync(csvPath, csvOf([willSeedRow({ TM: 'not-a-number' })]));
+
+      await expect(
+        runSeed(prisma, { ...baseArgs(program.id, csvPath), dryRun: true }, backupDir),
+      ).rejects.toThrow(/invalid TM/);
+
+      const rows = await prisma.trainingMaxHistory.findMany({
+        where: { program: program.id },
+      });
+      expect(rows).toHaveLength(0);
+    });
+
+    it('rolls back the whole write if appendHistoryEntries fails after deleteAllHistory has run', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'Transactional Safety' },
+      });
+      await prisma.trainingMaxHistory.create({
+        data: {
+          userId: USER_A,
+          program: program.id,
+          lift: 'back-squat',
+          weight: 250,
+          reps: 1,
+          date: new Date('2025-01-01'),
+          isPR: false,
+          source: 'program',
+          goalMet: false,
+        },
+      });
+      const csvPath = path.join(backupDir, 'export.csv');
+      // 'source' is DB-CHECK-constrained to 'test'|'program' — appendHistoryEntries
+      // always writes 'program' (see mapRowToEntry), so provoke the failure a
+      // different way: a lift name long enough to violate no column length
+      // constraint is fragile to rely on, so instead simulate the failure
+      // directly against the real repository to prove the transaction
+      // boundary, independent of finding a naturally-failing row shape.
+      fs.writeFileSync(csvPath, csvOf([willSeedRow({ TM: '999' })]));
+
+      const txSpy = jest
+        .spyOn(prisma, '$transaction')
+        .mockImplementationOnce(async () => {
+          throw new Error('simulated append failure');
+        });
+      try {
+        await expect(
+          runSeed(prisma, { ...baseArgs(program.id, csvPath), force: true }, backupDir),
+        ).rejects.toThrow('simulated append failure');
+      } finally {
+        txSpy.mockRestore();
+      }
+
+      // The pre-existing row must still be there — Prisma's real
+      // $transaction would have rolled back the delete along with the
+      // failed append; this test proves runSeed routes both calls through
+      // $transaction at all (a regression back to two independent
+      // statements would still pass every other test in this file, since
+      // they don't inject a failure between the two calls).
+      const rows = await prisma.trainingMaxHistory.findMany({
+        where: { program: program.id },
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.weight).toBe(250);
     });
 
     it('--rollback deletes all history (after backing it up) and appends nothing', async () => {
@@ -348,12 +488,12 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
       const result = await runSeed(
         prisma,
         {
+          mode: 'rollback',
           program: program.id,
           userId: USER_A,
-          input: null,
           dryRun: false,
           force: true,
-          rollback: true,
+          backupDir: null,
         },
         backupDir,
       );
@@ -390,12 +530,12 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
       const result = await runSeed(
         prisma,
         {
+          mode: 'rollback',
           program: program.id,
           userId: USER_A,
-          input: null,
           dryRun: true,
           force: false,
-          rollback: true,
+          backupDir: null,
         },
         backupDir,
       );
@@ -408,6 +548,100 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
         where: { program: program.id },
       });
       expect(rows).toHaveLength(1); // untouched
+    });
+
+    it('--restore replaces current history with a previously-captured backup file', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'Restore Target' },
+      });
+      // Seed once, capturing a backup of the (empty) prior state, so we have
+      // a real backup file shaped exactly like backupExistingHistory writes.
+      const seeded = await prisma.trainingMaxHistory.create({
+        data: {
+          userId: USER_A,
+          program: program.id,
+          lift: 'back-squat',
+          weight: 305,
+          reps: 1,
+          date: new Date('2026-03-01'),
+          isPR: true,
+          source: 'program',
+          goalMet: true,
+        },
+      });
+      const repo = new PrismaTrainingMaxHistoryRepository(prisma, USER_A);
+      const backup = assertNotNull(
+        await backupExistingHistory(repo, program.id, backupDir),
+        'backup of seeded row',
+      );
+      expect(backup.count).toBe(1);
+
+      // Simulate a bad reseed the operator wants to undo.
+      await prisma.trainingMaxHistory.deleteMany({ where: { program: program.id } });
+      await prisma.trainingMaxHistory.create({
+        data: {
+          userId: USER_A,
+          program: program.id,
+          lift: 'deadlift',
+          weight: 1,
+          reps: 1,
+          date: new Date('2026-01-01'),
+          isPR: false,
+          source: 'program',
+          goalMet: false,
+        },
+      });
+
+      const result = await runSeed(
+        prisma,
+        {
+          mode: 'restore',
+          program: program.id,
+          userId: USER_A,
+          restorePath: backup.path,
+          dryRun: false,
+          force: true,
+          backupDir: null,
+        },
+        backupDir,
+      );
+
+      expect(result.mode).toBe('restored');
+      expect(result.writtenCount).toBe(1);
+
+      const rows = await prisma.trainingMaxHistory.findMany({
+        where: { program: program.id },
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.lift).toBe('back-squat');
+      expect(rows[0]?.weight).toBe(305);
+      expect(rows[0]?.id).not.toBe(seeded.id); // restored as a new row, not the literal old id
+    });
+
+    it('flags a cross-user data anomaly (rows under this program but a different userId) rather than silently under-counting', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'Anomaly' },
+      });
+      // A row for this program under a *different* user — not a state the
+      // application itself should ever produce, but exactly the kind of
+      // anomaly only the RLS-bypassing connection this script uses can see.
+      await prisma.trainingMaxHistory.create({
+        data: {
+          userId: USER_B,
+          program: program.id,
+          lift: 'back-squat',
+          weight: 1,
+          reps: 1,
+          date: new Date('2025-01-01'),
+          isPR: false,
+          source: 'program',
+          goalMet: false,
+        },
+      });
+
+      await expect(
+        verifyProgramOwnership(prisma, program.id, USER_A),
+      ).rejects.toThrow(/some rows exist under a different userId/);
     });
   });
 });

--- a/apps/api/scripts/seed-tm-history.db.e2e.spec.ts
+++ b/apps/api/scripts/seed-tm-history.db.e2e.spec.ts
@@ -158,44 +158,12 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
     });
   });
 
-  describe('backupExistingHistory', () => {
-    it('returns null and writes no file when the program has no existing history', async () => {
-      const program = await prisma.customProgram.create({
-        data: { userId: USER_A, name: 'Empty History' },
-      });
-      const repo = new PrismaTrainingMaxHistoryRepository(prisma, USER_A);
-      const result = await backupExistingHistory(repo, program.id, backupDir);
-      expect(result).toBeNull();
-    });
-
-    it('writes existing history to a JSON file, verifies the write, and returns its path + count', async () => {
-      const program = await prisma.customProgram.create({
-        data: { userId: USER_A, name: 'Has History' },
-      });
-      await prisma.trainingMaxHistory.create({
-        data: {
-          userId: USER_A,
-          program: program.id,
-          lift: 'back-squat',
-          weight: 300,
-          reps: 1,
-          date: new Date('2026-01-01'),
-          isPR: true,
-          source: 'program',
-          goalMet: true,
-        },
-      });
-      const repo = new PrismaTrainingMaxHistoryRepository(prisma, USER_A);
-      const result = assertNotNull(
-        await backupExistingHistory(repo, program.id, backupDir),
-        'backupExistingHistory result',
-      );
-      expect(result.count).toBe(1);
-      const written = JSON.parse(fs.readFileSync(result.path, 'utf8'));
-      expect(written).toHaveLength(1);
-      expect(written[0]).toMatchObject({ lift: 'back-squat', weight: 300 });
-    });
-  });
+  // backupExistingHistory is now fs/JSON-only (no Prisma) and is covered at
+  // the function level in seed-tm-history.spec.ts, including the envelope
+  // shape and read-back verification. The real-DB round trip (a Prisma-
+  // fetched TrainingMaxHistoryEntry[] all the way through to a restorable
+  // file) is exercised by the "--restore" test below via runSeed, which is
+  // this suite's reason to exist — no separate describe block needed here.
 
   describe('runSeed', () => {
     function baseArgs(program: string, input: string): SeedArgs {
@@ -206,7 +174,7 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
         input,
         dryRun: false,
         force: false,
-        backupDir: null,
+        backupDir,
       };
     }
 
@@ -218,7 +186,7 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
       fs.writeFileSync(csvPath, csvOf([willSeedRow()]));
 
       await expect(
-        runSeed(prisma, baseArgs(program.id, csvPath), backupDir),
+        runSeed(prisma, baseArgs(program.id, csvPath)),
       ).rejects.toBeInstanceOf(ProgramOwnershipError);
 
       const rows = await prisma.trainingMaxHistory.findMany({
@@ -241,7 +209,7 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
         ]),
       );
 
-      const result = await runSeed(prisma, baseArgs(program.id, csvPath), backupDir);
+      const result = await runSeed(prisma, baseArgs(program.id, csvPath));
 
       expect(result.mode).toBe('seeded');
       expect(result.existingCount).toBe(0);
@@ -280,7 +248,7 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
       fs.writeFileSync(csvPath, csvOf([willSeedRow({ 'Will Seed': 'false' })]));
 
       await expect(
-        runSeed(prisma, { ...baseArgs(program.id, csvPath), force: true }, backupDir),
+        runSeed(prisma, { ...baseArgs(program.id, csvPath), force: true }),
       ).rejects.toThrow(/zero rows to seed/);
 
       const rows = await prisma.trainingMaxHistory.findMany({
@@ -311,7 +279,7 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
       fs.writeFileSync(csvPath, csvOf([willSeedRow({ TM: '999' })]));
 
       await expect(
-        runSeed(prisma, baseArgs(program.id, csvPath), backupDir),
+        runSeed(prisma, baseArgs(program.id, csvPath)),
       ).rejects.toThrow(/already has 1 history row/);
 
       const rows = await prisma.trainingMaxHistory.findMany({
@@ -344,7 +312,6 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
       const result = await runSeed(
         prisma,
         { ...baseArgs(program.id, csvPath), force: true },
-        backupDir,
       );
 
       expect(result.mode).toBe('seeded');
@@ -352,8 +319,8 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
       expect(result.writtenCount).toBe(1);
       const backupPath = assertNotNull(result.backupPath, 'result.backupPath');
       const backedUp = JSON.parse(fs.readFileSync(backupPath, 'utf8'));
-      expect(backedUp).toHaveLength(1);
-      expect(backedUp[0]).toMatchObject({ weight: 250 }); // the OLD row, preserved in the backup
+      expect(backedUp.entries).toHaveLength(1);
+      expect(backedUp.entries[0]).toMatchObject({ weight: 250 }); // the OLD row, preserved in the backup
 
       const rows = await prisma.trainingMaxHistory.findMany({
         where: { program: program.id },
@@ -372,7 +339,6 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
       const result = await runSeed(
         prisma,
         { ...baseArgs(program.id, csvPath), dryRun: true },
-        backupDir,
       );
 
       expect(result.mode).toBe('dry-run');
@@ -393,7 +359,7 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
       fs.writeFileSync(csvPath, csvOf([willSeedRow({ TM: 'not-a-number' })]));
 
       await expect(
-        runSeed(prisma, { ...baseArgs(program.id, csvPath), dryRun: true }, backupDir),
+        runSeed(prisma, { ...baseArgs(program.id, csvPath), dryRun: true }),
       ).rejects.toThrow(/invalid TM/);
 
       const rows = await prisma.trainingMaxHistory.findMany({
@@ -435,7 +401,7 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
         });
       try {
         await expect(
-          runSeed(prisma, { ...baseArgs(program.id, csvPath), force: true }, backupDir),
+          runSeed(prisma, { ...baseArgs(program.id, csvPath), force: true }),
         ).rejects.toThrow('simulated append failure');
       } finally {
         txSpy.mockRestore();
@@ -493,9 +459,8 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
           userId: USER_A,
           dryRun: false,
           force: true,
-          backupDir: null,
+          backupDir,
         },
-        backupDir,
       );
 
       expect(result.mode).toBe('rolled-back');
@@ -535,9 +500,8 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
           userId: USER_A,
           dryRun: true,
           force: false,
-          backupDir: null,
+          backupDir,
         },
-        backupDir,
       );
 
       expect(result.mode).toBe('dry-run');
@@ -570,8 +534,9 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
         },
       });
       const repo = new PrismaTrainingMaxHistoryRepository(prisma, USER_A);
+      const existingForBackup = await repo.getHistory(program.id);
       const backup = assertNotNull(
-        await backupExistingHistory(repo, program.id, backupDir),
+        await backupExistingHistory(existingForBackup, program.id, USER_A, backupDir),
         'backup of seeded row',
       );
       expect(backup.count).toBe(1);
@@ -601,9 +566,8 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
           restorePath: backup.path,
           dryRun: false,
           force: true,
-          backupDir: null,
+          backupDir,
         },
-        backupDir,
       );
 
       expect(result.mode).toBe('restored');
@@ -642,6 +606,154 @@ describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)'
       await expect(
         verifyProgramOwnership(prisma, program.id, USER_A),
       ).rejects.toThrow(/some rows exist under a different userId/);
+    });
+
+    it('refuses a CSV whose Will Seed=true rows span more than one Program value', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'Multi-Program Guard' },
+      });
+      const csvPath = path.join(backupDir, 'export.csv');
+      fs.writeFileSync(
+        csvPath,
+        csvOf([willSeedRow({ Program: 'RPT' }), willSeedRow({ Program: 'nSuns', Lift: 'Bench Press' })]),
+      );
+
+      await expect(
+        runSeed(prisma, baseArgs(program.id, csvPath)),
+      ).rejects.toThrow(/different Program values/);
+
+      const rows = await prisma.trainingMaxHistory.findMany({ where: { program: program.id } });
+      expect(rows).toHaveLength(0);
+    });
+
+    it('the --force-required refusal is mode-aware: --rollback does not get the seed-oriented message', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'Rollback Message' },
+      });
+      await prisma.trainingMaxHistory.create({
+        data: {
+          userId: USER_A,
+          program: program.id,
+          lift: 'back-squat',
+          weight: 300,
+          reps: 1,
+          date: new Date('2026-01-01'),
+          isPR: true,
+          source: 'program',
+          goalMet: true,
+        },
+      });
+
+      // The runbook's documented rollback invocation passes no --force —
+      // this is the exact command it tells operators to run, pinned here so
+      // a future divergence between the script and the runbook fails a test
+      // instead of surfacing mid-procedure. One call, two assertions on the
+      // same captured error, rather than two separate rejecting calls.
+      let caught: Error | undefined;
+      try {
+        await runSeed(prisma, {
+          mode: 'rollback',
+          program: program.id,
+          userId: USER_A,
+          dryRun: false,
+          force: false,
+          backupDir,
+        });
+      } catch (e) {
+        caught = e instanceof Error ? e : undefined;
+      }
+      expect(caught?.message).toMatch(/--rollback will delete 1 existing history row/);
+      expect(caught?.message).not.toMatch(/unexpected at the normal Phase 2B timing/);
+
+      const rows = await prisma.trainingMaxHistory.findMany({ where: { program: program.id } });
+      expect(rows).toHaveLength(1); // refused before any delete
+    });
+
+    it('--restore refuses a backup captured for a different program', async () => {
+      const programA = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'Backup Source' },
+      });
+      const programB = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'Restore Target (Wrong)' },
+      });
+      await prisma.trainingMaxHistory.create({
+        data: {
+          userId: USER_A,
+          program: programA.id,
+          lift: 'back-squat',
+          weight: 300,
+          reps: 1,
+          date: new Date('2026-01-01'),
+          isPR: true,
+          source: 'program',
+          goalMet: true,
+        },
+      });
+      const repo = new PrismaTrainingMaxHistoryRepository(prisma, USER_A);
+      const existingForBackup = await repo.getHistory(programA.id);
+      const backup = assertNotNull(
+        await backupExistingHistory(existingForBackup, programA.id, USER_A, backupDir),
+        'backup of program A',
+      );
+
+      await expect(
+        runSeed(prisma, {
+          mode: 'restore',
+          program: programB.id,
+          userId: USER_A,
+          restorePath: backup.path,
+          dryRun: false,
+          force: true,
+          backupDir,
+        }),
+      ).rejects.toThrow(/was captured for program/);
+
+      const rowsB = await prisma.trainingMaxHistory.findMany({ where: { program: programB.id } });
+      expect(rowsB).toHaveLength(0);
+    });
+
+    it('--restore refuses an empty backup file rather than silently wiping current history', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'Restore Empty Guard' },
+      });
+      await prisma.trainingMaxHistory.create({
+        data: {
+          userId: USER_A,
+          program: program.id,
+          lift: 'back-squat',
+          weight: 300,
+          reps: 1,
+          date: new Date('2026-01-01'),
+          isPR: true,
+          source: 'program',
+          goalMet: true,
+        },
+      });
+      const emptyBackupPath = path.join(backupDir, 'empty-backup.json');
+      fs.writeFileSync(
+        emptyBackupPath,
+        JSON.stringify({
+          program: program.id,
+          userId: USER_A,
+          capturedAt: new Date().toISOString(),
+          entries: [],
+        }),
+      );
+
+      await expect(
+        runSeed(prisma, {
+          mode: 'restore',
+          program: program.id,
+          userId: USER_A,
+          restorePath: emptyBackupPath,
+          dryRun: false,
+          force: true,
+          backupDir,
+        }),
+      ).rejects.toThrow(/zero rows to seed/);
+
+      const rows = await prisma.trainingMaxHistory.findMany({ where: { program: program.id } });
+      expect(rows).toHaveLength(1); // untouched — refused before any delete
     });
   });
 });

--- a/apps/api/scripts/seed-tm-history.db.e2e.spec.ts
+++ b/apps/api/scripts/seed-tm-history.db.e2e.spec.ts
@@ -1,0 +1,413 @@
+// Real-Postgres E2E suite for the Phase 2B seed script (issue #885).
+// Postgres is provisioned by ../jest.global-setup.js (see that file's header
+// comment for the three provisioning paths: CI passthrough, local
+// Testcontainers, or LIFTING_SKIP_DB_E2E=1 opt-out).
+//
+// Unlike programs.db.e2e.spec.ts, this suite has no reason to touch
+// LIFTING_TC_DATABASE_URL (the restricted `lifting_app` role) at all — the
+// seed script always connects as the migrator/owner role specifically to
+// bypass RLS (see docs/phase2b-tm-history-seeding-runbook.md on
+// gas-lifting-logbook), so LIFTING_TC_OWNER_DATABASE_URL is the only
+// connection under test here, exactly mirroring the script's real
+// production connection.
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { PrismaClient } from '@prisma/client';
+import {
+  backupExistingHistory,
+  ProgramOwnershipError,
+  runSeed,
+  SeedArgs,
+  verifyProgramOwnership,
+} from './seed-tm-history';
+
+const OWNER_DATABASE_URL = process.env.LIFTING_TC_OWNER_DATABASE_URL;
+// Skip only when globalSetup did not provision a DB (e.g. Docker unavailable
+// and not running in CI) — matches programs.db.e2e.spec.ts's pattern.
+const describeOrSkip = OWNER_DATABASE_URL ? describe : describe.skip;
+
+const DB_E2E_HOOK_TIMEOUT_MS = 30_000;
+
+const USER_A = 'seed-tm-history-e2e-user-a';
+const USER_B = 'seed-tm-history-e2e-user-b';
+
+async function cleanTestUsers(prisma: PrismaClient): Promise<void> {
+  await prisma.trainingMaxHistory.deleteMany({
+    where: { userId: { in: [USER_A, USER_B] } },
+  });
+  await prisma.customProgram.deleteMany({
+    where: { userId: { in: [USER_A, USER_B] } },
+  });
+}
+
+function tmpBackupDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'seed-tm-history-e2e-'));
+}
+
+function csvOf(rows: Record<string, string>[]): string {
+  const headers = [
+    'Program',
+    'Lift',
+    'Cycle Date',
+    'TM',
+    'Goal Met',
+    'Is PR',
+    'Will Seed',
+  ];
+  const lines = [headers.join(',')];
+  for (const row of rows) lines.push(headers.map((h) => row[h] ?? '').join(','));
+  return lines.join('\n');
+}
+
+function willSeedRow(overrides: Record<string, string> = {}): Record<string, string> {
+  return {
+    Program: 'RPT',
+    Lift: 'Squat',
+    'Cycle Date': '2026-03-01',
+    TM: '305',
+    'Goal Met': 'true',
+    'Is PR': 'true',
+    'Will Seed': 'true',
+    ...overrides,
+  };
+}
+
+describeOrSkip('seed-tm-history (e2e, real Postgres, owner/migrator connection)', () => {
+  let prisma: PrismaClient;
+  let backupDir: string;
+
+  beforeAll(() => {
+    prisma = new PrismaClient({ datasources: { db: { url: OWNER_DATABASE_URL } } });
+  }, DB_E2E_HOOK_TIMEOUT_MS);
+
+  beforeEach(async () => {
+    await cleanTestUsers(prisma);
+    backupDir = tmpBackupDir();
+  });
+
+  afterAll(async () => {
+    await cleanTestUsers(prisma);
+    await prisma.$disconnect();
+  });
+
+  describe('verifyProgramOwnership', () => {
+    it('resolves without throwing when the program belongs to the given user', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'Owned Program' },
+      });
+      await expect(
+        verifyProgramOwnership(prisma, program.id, USER_A),
+      ).resolves.toBeUndefined();
+    });
+
+    it('throws ProgramOwnershipError when the program belongs to a different user', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'Alice Program' },
+      });
+      await expect(
+        verifyProgramOwnership(prisma, program.id, USER_B),
+      ).rejects.toBeInstanceOf(ProgramOwnershipError);
+    });
+
+    it('throws ProgramOwnershipError when the program does not exist', async () => {
+      await expect(
+        verifyProgramOwnership(prisma, '00000000-0000-0000-0000-000000000000', USER_A),
+      ).rejects.toThrow(/does not exist/);
+    });
+  });
+
+  describe('backupExistingHistory', () => {
+    it('returns null and writes no file when the program has no existing history', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'Empty History' },
+      });
+      const { PrismaTrainingMaxHistoryRepository } = await import(
+        '../src/adapters/prisma/training-max-history.repository'
+      );
+      const repo = new PrismaTrainingMaxHistoryRepository(prisma, USER_A);
+      const result = await backupExistingHistory(repo, program.id, backupDir);
+      expect(result).toBeNull();
+    });
+
+    it('writes existing history to a JSON file and returns its path + count', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'Has History' },
+      });
+      await prisma.trainingMaxHistory.create({
+        data: {
+          userId: USER_A,
+          program: program.id,
+          lift: 'back-squat',
+          weight: 300,
+          reps: 1,
+          date: new Date('2026-01-01'),
+          isPR: true,
+          source: 'program',
+          goalMet: true,
+        },
+      });
+      const { PrismaTrainingMaxHistoryRepository } = await import(
+        '../src/adapters/prisma/training-max-history.repository'
+      );
+      const repo = new PrismaTrainingMaxHistoryRepository(prisma, USER_A);
+      const result = await backupExistingHistory(repo, program.id, backupDir);
+      expect(result).not.toBeNull();
+      expect(result?.count).toBe(1);
+      const written = JSON.parse(fs.readFileSync(result!.path, 'utf8'));
+      expect(written).toHaveLength(1);
+      expect(written[0]).toMatchObject({ lift: 'back-squat', weight: 300 });
+    });
+  });
+
+  describe('runSeed', () => {
+    function baseArgs(program: string, input: string): SeedArgs {
+      return {
+        program,
+        userId: USER_A,
+        input,
+        dryRun: false,
+        force: false,
+        rollback: false,
+      };
+    }
+
+    it('refuses to proceed when the program belongs to a different user (defense in depth)', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_B, name: 'Not Yours' },
+      });
+      const csvPath = path.join(backupDir, 'export.csv');
+      fs.writeFileSync(csvPath, csvOf([willSeedRow()]));
+
+      await expect(
+        runSeed(prisma, baseArgs(program.id, csvPath), backupDir),
+      ).rejects.toBeInstanceOf(ProgramOwnershipError);
+
+      const rows = await prisma.trainingMaxHistory.findMany({
+        where: { program: program.id },
+      });
+      expect(rows).toHaveLength(0);
+    });
+
+    it('seeds only Will Seed=true rows, mapped correctly, on a program with no existing history', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'Fresh Seed' },
+      });
+      const csvPath = path.join(backupDir, 'export.csv');
+      fs.writeFileSync(
+        csvPath,
+        csvOf([
+          willSeedRow({ Lift: 'Squat', TM: '300' }),
+          willSeedRow({ Lift: 'Deadlift', TM: '400', 'Will Seed': 'false' }), // hold — must not seed
+          willSeedRow({ Lift: 'Bench Press', TM: '200' }),
+        ]),
+      );
+
+      const result = await runSeed(prisma, baseArgs(program.id, csvPath), backupDir);
+
+      expect(result.mode).toBe('seeded');
+      expect(result.existingCount).toBe(0);
+      expect(result.writtenCount).toBe(2);
+      expect(result.backupPath).toBeNull(); // nothing pre-existing to back up
+
+      const rows = await prisma.trainingMaxHistory.findMany({
+        where: { userId: USER_A, program: program.id },
+        orderBy: { lift: 'asc' },
+      });
+      expect(rows).toHaveLength(2);
+      expect(rows.map((r) => r.lift).sort()).toEqual(['back-squat', 'bench-press']);
+      expect(rows.every((r) => r.reps === 1 && r.source === 'program')).toBe(true);
+    });
+
+    it('refuses without --force when the program already has history, and writes nothing', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'Already Seeded' },
+      });
+      await prisma.trainingMaxHistory.create({
+        data: {
+          userId: USER_A,
+          program: program.id,
+          lift: 'back-squat',
+          weight: 250,
+          reps: 1,
+          date: new Date('2025-01-01'),
+          isPR: false,
+          source: 'program',
+          goalMet: false,
+        },
+      });
+      const csvPath = path.join(backupDir, 'export.csv');
+      fs.writeFileSync(csvPath, csvOf([willSeedRow({ TM: '999' })]));
+
+      await expect(
+        runSeed(prisma, baseArgs(program.id, csvPath), backupDir),
+      ).rejects.toThrow(/already has 1 history row/);
+
+      const rows = await prisma.trainingMaxHistory.findMany({
+        where: { program: program.id },
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.weight).toBe(250); // unchanged — the refusal happened before any write
+    });
+
+    it('with --force, backs up then replaces existing history with the new seed (delete-all-then-append)', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'Reseed' },
+      });
+      await prisma.trainingMaxHistory.create({
+        data: {
+          userId: USER_A,
+          program: program.id,
+          lift: 'back-squat',
+          weight: 250,
+          reps: 1,
+          date: new Date('2025-01-01'),
+          isPR: false,
+          source: 'program',
+          goalMet: false,
+        },
+      });
+      const csvPath = path.join(backupDir, 'export.csv');
+      fs.writeFileSync(csvPath, csvOf([willSeedRow({ TM: '999' })]));
+
+      const result = await runSeed(
+        prisma,
+        { ...baseArgs(program.id, csvPath), force: true },
+        backupDir,
+      );
+
+      expect(result.mode).toBe('seeded');
+      expect(result.existingCount).toBe(1);
+      expect(result.writtenCount).toBe(1);
+      expect(result.backupPath).not.toBeNull();
+      const backedUp = JSON.parse(fs.readFileSync(result.backupPath as string, 'utf8'));
+      expect(backedUp).toHaveLength(1);
+      expect(backedUp[0]).toMatchObject({ weight: 250 }); // the OLD row, preserved in the backup
+
+      const rows = await prisma.trainingMaxHistory.findMany({
+        where: { program: program.id },
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.weight).toBe(999); // the old row is gone, replaced by the new seed
+    });
+
+    it('--dry-run writes nothing and leaves existing history untouched, even when --force is not passed', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'Dry Run Only' },
+      });
+      const csvPath = path.join(backupDir, 'export.csv');
+      fs.writeFileSync(csvPath, csvOf([willSeedRow(), willSeedRow({ Lift: 'Deadlift' })]));
+
+      const result = await runSeed(
+        prisma,
+        { ...baseArgs(program.id, csvPath), dryRun: true },
+        backupDir,
+      );
+
+      expect(result.mode).toBe('dry-run');
+      expect(result.writtenCount).toBe(2);
+      expect(result.backupPath).toBeNull();
+
+      const rows = await prisma.trainingMaxHistory.findMany({
+        where: { program: program.id },
+      });
+      expect(rows).toHaveLength(0);
+    });
+
+    it('--rollback deletes all history (after backing it up) and appends nothing', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'To Roll Back' },
+      });
+      await prisma.trainingMaxHistory.createMany({
+        data: [
+          {
+            userId: USER_A,
+            program: program.id,
+            lift: 'back-squat',
+            weight: 300,
+            reps: 1,
+            date: new Date('2026-01-01'),
+            isPR: true,
+            source: 'program',
+            goalMet: true,
+          },
+          {
+            userId: USER_A,
+            program: program.id,
+            lift: 'deadlift',
+            weight: 400,
+            reps: 1,
+            date: new Date('2026-01-01'),
+            isPR: true,
+            source: 'program',
+            goalMet: true,
+          },
+        ],
+      });
+
+      const result = await runSeed(
+        prisma,
+        {
+          program: program.id,
+          userId: USER_A,
+          input: null,
+          dryRun: false,
+          force: true,
+          rollback: true,
+        },
+        backupDir,
+      );
+
+      expect(result.mode).toBe('rolled-back');
+      expect(result.existingCount).toBe(2);
+      expect(result.writtenCount).toBe(0);
+      expect(result.backupPath).not.toBeNull();
+
+      const rows = await prisma.trainingMaxHistory.findMany({
+        where: { program: program.id },
+      });
+      expect(rows).toHaveLength(0);
+    });
+
+    it('--rollback --dry-run reports what would happen without deleting anything', async () => {
+      const program = await prisma.customProgram.create({
+        data: { userId: USER_A, name: 'Rollback Preview' },
+      });
+      await prisma.trainingMaxHistory.create({
+        data: {
+          userId: USER_A,
+          program: program.id,
+          lift: 'back-squat',
+          weight: 300,
+          reps: 1,
+          date: new Date('2026-01-01'),
+          isPR: true,
+          source: 'program',
+          goalMet: true,
+        },
+      });
+
+      const result = await runSeed(
+        prisma,
+        {
+          program: program.id,
+          userId: USER_A,
+          input: null,
+          dryRun: true,
+          force: false,
+          rollback: true,
+        },
+        backupDir,
+      );
+
+      expect(result.mode).toBe('dry-run');
+      expect(result.existingCount).toBe(1);
+      expect(result.forceRequired).toBe(true);
+
+      const rows = await prisma.trainingMaxHistory.findMany({
+        where: { program: program.id },
+      });
+      expect(rows).toHaveLength(1); // untouched
+    });
+  });
+});

--- a/apps/api/scripts/seed-tm-history.spec.ts
+++ b/apps/api/scripts/seed-tm-history.spec.ts
@@ -1,15 +1,48 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { TrainingMaxHistoryEntry } from '@lifting-logbook/core';
 import {
   ArgParseError,
+  assertNoDuplicateSeedKeys,
+  assertSingleProgram,
+  backupExistingHistory,
   backupFilePath,
   filterWillSeedRows,
   formatResult,
   mapRowToEntry,
   parseArgs,
   parseTMHistoryCsv,
+  readBackupFile,
   REQUIRED_COLUMNS,
   resolveLiftId,
   SeedResult,
 } from './seed-tm-history';
+
+function historyEntry(overrides: Partial<TrainingMaxHistoryEntry> = {}): TrainingMaxHistoryEntry {
+  return {
+    id: 'entry-1',
+    lift: 'back-squat',
+    weight: 300,
+    reps: 1,
+    date: new Date('2026-01-01T00:00:00.000Z'),
+    isPR: true,
+    source: 'program',
+    goalMet: true,
+    ...overrides,
+  };
+}
+
+/** Mirrors seed-tm-history.db.e2e.spec.ts's helper of the same name/shape —
+ * see that file's doc comment for the full rationale ("an assertion already
+ * proved this is non-null, now tell the compiler," without the confusing
+ * failure mode a bare `!` or `as` produces the first time it's actually
+ * wrong). Not shared/imported from there: each spec file's test helpers
+ * stay local and self-contained, matching this repo's existing convention. */
+function assertNotNull<T>(value: T | null, what: string): T {
+  if (value === null) throw new Error(`expected ${what} to be non-null`);
+  return value;
+}
 
 describe('parseArgs', () => {
   it('parses a full normal-seed argument set', () => {
@@ -276,6 +309,27 @@ describe('parseTMHistoryCsv', () => {
       /missing expected column/,
     );
   });
+
+  it('strips a leading UTF-8 BOM from the header rather than treating the first column as missing', () => {
+    // The natural way a human eyeballs this file (per the runbook's Step 3)
+    // is opening it in a spreadsheet tool, which reliably re-saves with a
+    // BOM — csv-parse leaves it attached to the first header cell unless
+    // told to strip it, turning "Program" into "﻿Program".
+    const content = '﻿' + csvOf([validRow()]);
+    const rows = parseTMHistoryCsv(content);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ Program: 'RPT' });
+  });
+
+  it('trims stray whitespace from header names before comparing against REQUIRED_COLUMNS', () => {
+    const headersWithSpace = HEADERS.map((h) => (h === 'Program' ? ' Program ' : h));
+    const content = [
+      headersWithSpace.join(','),
+      headersWithSpace.map((h) => validRow()[h.trim()] ?? '').join(','),
+    ].join('\n');
+    const rows = parseTMHistoryCsv(content);
+    expect(rows[0]).toMatchObject({ Program: 'RPT' });
+  });
 });
 
 describe('filterWillSeedRows', () => {
@@ -302,6 +356,65 @@ describe('filterWillSeedRows', () => {
   it('throws on a blank Will Seed value (never legitimately empty)', () => {
     const rows = parseTMHistoryCsv(csvOf([validRow({ 'Will Seed': '' })]));
     expect(() => filterWillSeedRows(rows)).toThrow(/not a recognized boolean/);
+  });
+});
+
+describe('assertSingleProgram', () => {
+  it('does not throw when every row shares the same Program value', () => {
+    const rows = parseTMHistoryCsv(
+      csvOf([validRow({ Program: 'RPT' }), validRow({ Program: 'RPT', 'Cycle #': '5' })]),
+    );
+    expect(() => assertSingleProgram(rows)).not.toThrow();
+  });
+
+  it('does not throw on an empty row set', () => {
+    expect(() => assertSingleProgram([])).not.toThrow();
+  });
+
+  it('throws when rows span more than one distinct Program value', () => {
+    const rows = parseTMHistoryCsv(
+      csvOf([validRow({ Program: 'RPT' }), validRow({ Program: 'nSuns', 'Cycle #': '5' })]),
+    );
+    expect(() => assertSingleProgram(rows)).toThrow(/2 different Program values/);
+    expect(() => assertSingleProgram(rows)).toThrow(/RPT/);
+    expect(() => assertSingleProgram(rows)).toThrow(/nSuns/);
+  });
+
+  it('ignores blank Program values rather than counting them as a distinct program', () => {
+    const rows = parseTMHistoryCsv(
+      csvOf([validRow({ Program: 'RPT' }), validRow({ Program: '', 'Cycle #': '5' })]),
+    );
+    expect(() => assertSingleProgram(rows)).not.toThrow();
+  });
+});
+
+describe('assertNoDuplicateSeedKeys', () => {
+  it('does not throw when every (lift, date) pair is unique', () => {
+    const entries = [validRow(), validRow({ Lift: 'Bench Press', 'Cycle #': '5' })].map(
+      mapRowToEntry,
+    );
+    expect(() => assertNoDuplicateSeedKeys(entries)).not.toThrow();
+  });
+
+  it('throws when the same resolved lift and cycle date appear twice', () => {
+    const entries = [
+      validRow({ Lift: 'Squat' }),
+      validRow({ Lift: 'Squat', 'Cycle #': '5' }), // same lift + same Cycle Date
+    ].map(mapRowToEntry);
+    expect(() => assertNoDuplicateSeedKeys(entries)).toThrow(/Duplicate seed key/);
+    expect(() => assertNoDuplicateSeedKeys(entries)).toThrow(/back-squat/);
+  });
+
+  it('compares resolved lift ids, not raw CSV lift strings', () => {
+    // Constructed directly (bypassing mapRowToEntry/resolveLiftId) to
+    // deterministically exercise the case two differently-spelled raw CSV
+    // names that both resolve to the same target lift would produce: two
+    // entries sharing one resolved `lift` id. The check must operate on
+    // that resolved id, not on whatever the CSV originally said (which
+    // isn't even available at this point in the pipeline).
+    const a = mapRowToEntry(validRow({ Lift: 'Squat' }));
+    const b = { ...mapRowToEntry(validRow({ Lift: 'Bench Press', 'Cycle #': '5' })), lift: a.lift };
+    expect(() => assertNoDuplicateSeedKeys([a, b])).toThrow(/Duplicate seed key/);
   });
 });
 
@@ -407,6 +520,127 @@ describe('backupFilePath', () => {
     const b = backupFilePath('/tmp', 'p', new Date('2026-03-01T00:00:01.000Z'));
     expect(a).not.toBe(b);
   });
+});
+
+// backupExistingHistory/readBackupFile take already-fetched entries and do
+// only fs/JSON work now (no Prisma) — real Postgres coverage of the whole
+// backup-then-restore round trip against a live DB still lives in
+// seed-tm-history.db.e2e.spec.ts via runSeed; these are the function-level
+// tests for the fs/envelope mechanics themselves. Uses real temp
+// directories (fs.mkdtempSync) rather than mocking fs, per this repo's
+// general "test against the real thing" preference.
+describe('backupExistingHistory / readBackupFile', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'seed-tm-history-unit-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns null and writes no file when there is nothing to back up', async () => {
+    const result = await backupExistingHistory([], 'prog-1', 'user-1', dir);
+    expect(result).toBeNull();
+    expect(fs.readdirSync(dir)).toHaveLength(0);
+  });
+
+  it('writes an envelope (not a bare array) and verifies it by reading it back', async () => {
+    const entries = [historyEntry({ id: 'a' }), historyEntry({ id: 'b', lift: 'deadlift' })];
+    const result = await backupExistingHistory(entries, 'prog-1', 'user-1', dir);
+    expect(result).not.toBeNull();
+    expect(result?.count).toBe(2);
+
+    const nonNullResult = assertNotNull(result, 'backupExistingHistory result');
+    const raw = JSON.parse(fs.readFileSync(nonNullResult.path, 'utf8'));
+    expect(raw.program).toBe('prog-1');
+    expect(raw.userId).toBe('user-1');
+    expect(typeof raw.capturedAt).toBe('string');
+    expect(raw.entries).toHaveLength(2);
+  });
+
+  it('round-trips through readBackupFile back to appendable entries', async () => {
+    const entries = [historyEntry({ id: 'a', weight: 315 })];
+    const backup = assertNotNull(
+      await backupExistingHistory(entries, 'prog-1', 'user-1', dir),
+      'backup',
+    );
+    const restored = readBackupFile(backup.path, 'prog-1', 'user-1');
+    expect(restored).toHaveLength(1);
+    expect(restored[0]).toMatchObject({ lift: 'back-squat', weight: 315 });
+    expect(restored[0]).not.toHaveProperty('id'); // stripped, not carried into the re-append
+    expect(restored[0]?.date).toBeInstanceOf(Date);
+  });
+
+  it('readBackupFile refuses to restore against a different program', async () => {
+    const backup = assertNotNull(
+      await backupExistingHistory([historyEntry()], 'prog-1', 'user-1', dir),
+      'backup',
+    );
+    expect(() => readBackupFile(backup.path, 'prog-2', 'user-1')).toThrow(
+      /captured for program 'prog-1'.*not the requested --program 'prog-2'/s,
+    );
+  });
+
+  it('readBackupFile refuses to restore against a different user', async () => {
+    const backup = assertNotNull(
+      await backupExistingHistory([historyEntry()], 'prog-1', 'user-1', dir),
+      'backup',
+    );
+    expect(() => readBackupFile(backup.path, 'prog-1', 'user-2')).toThrow(
+      /captured for --user-id 'user-1'.*not the requested --user-id 'user-2'/s,
+    );
+  });
+
+  it('readBackupFile rejects a bare-array backup (pre-envelope format)', () => {
+    const file = path.join(dir, 'old-format.json');
+    fs.writeFileSync(file, JSON.stringify([{ id: 'a', lift: 'back-squat' }]));
+    expect(() => readBackupFile(file, 'prog-1', 'user-1')).toThrow(
+      /does not look like a backup file/,
+    );
+  });
+
+  it('readBackupFile rejects invalid JSON with a clear message rather than an unhandled parse error', () => {
+    const file = path.join(dir, 'corrupt.json');
+    fs.writeFileSync(file, '{not valid json');
+    expect(() => readBackupFile(file, 'prog-1', 'user-1')).toThrow(/not valid JSON/);
+  });
+
+  it('readBackupFile rejects an entry with an invalid weight rather than passing it through to the DB', async () => {
+    const backup = assertNotNull(
+      await backupExistingHistory([historyEntry()], 'prog-1', 'user-1', dir),
+      'backup',
+    );
+    const raw = JSON.parse(fs.readFileSync(backup.path, 'utf8'));
+    raw.entries[0].weight = 'not-a-number';
+    fs.writeFileSync(backup.path, JSON.stringify(raw));
+    expect(() => readBackupFile(backup.path, 'prog-1', 'user-1')).toThrow(
+      /invalid weight/,
+    );
+  });
+
+  it('readBackupFile rejects an entry with an invalid date', async () => {
+    const backup = assertNotNull(
+      await backupExistingHistory([historyEntry()], 'prog-1', 'user-1', dir),
+      'backup',
+    );
+    const raw = JSON.parse(fs.readFileSync(backup.path, 'utf8'));
+    raw.entries[0].date = 'not-a-date';
+    fs.writeFileSync(backup.path, JSON.stringify(raw));
+    expect(() => readBackupFile(backup.path, 'prog-1', 'user-1')).toThrow(/invalid date/);
+  });
+
+  // Deliberately not covered here: the symlink-backup-directory refusal
+  // (creating a directory symlink in a unit test is unreliable across
+  // platforms — Windows requires Developer Mode or elevation for
+  // fs.symlinkSync, which cannot be assumed in every environment this
+  // suite runs in) and exact permission-mode assertions (Windows has no
+  // unix mode bits, so a `mode === 0o600`-style assertion would be
+  // meaningless/flaky there even though the underlying fs.writeFileSync
+  // `mode` option is real, functioning hardening on Linux/macOS, where the
+  // exposure this guards against actually applies). Noted in the PR body
+  // as a deliberate coverage deferral rather than an oversight.
 });
 
 describe('formatResult', () => {

--- a/apps/api/scripts/seed-tm-history.spec.ts
+++ b/apps/api/scripts/seed-tm-history.spec.ts
@@ -1,0 +1,316 @@
+import {
+  ArgParseError,
+  backupFilePath,
+  filterWillSeedRows,
+  formatResult,
+  mapRowToEntry,
+  parseArgs,
+  parseTMHistoryCsv,
+  resolveLiftId,
+  SeedResult,
+} from './seed-tm-history';
+
+describe('parseArgs', () => {
+  it('parses a full normal-seed argument set', () => {
+    const args = parseArgs([
+      '--program',
+      'prog-uuid',
+      '--user-id',
+      'user-1',
+      '--input',
+      '/tmp/export.csv',
+    ]);
+    expect(args).toEqual({
+      program: 'prog-uuid',
+      userId: 'user-1',
+      input: '/tmp/export.csv',
+      dryRun: false,
+      force: false,
+      rollback: false,
+    });
+  });
+
+  it('parses --dry-run and --force as flags', () => {
+    const args = parseArgs([
+      '--program',
+      'p',
+      '--user-id',
+      'u',
+      '--input',
+      'f.csv',
+      '--dry-run',
+      '--force',
+    ]);
+    expect(args.dryRun).toBe(true);
+    expect(args.force).toBe(true);
+  });
+
+  it('parses a --rollback argument set with no --input', () => {
+    const args = parseArgs(['--program', 'p', '--user-id', 'u', '--rollback']);
+    expect(args).toEqual({
+      program: 'p',
+      userId: 'u',
+      input: null,
+      dryRun: false,
+      force: false,
+      rollback: true,
+    });
+  });
+
+  it('allows --rollback combined with --dry-run', () => {
+    const args = parseArgs([
+      '--program',
+      'p',
+      '--user-id',
+      'u',
+      '--rollback',
+      '--dry-run',
+    ]);
+    expect(args.rollback).toBe(true);
+    expect(args.dryRun).toBe(true);
+  });
+
+  it('throws when --program is missing', () => {
+    expect(() =>
+      parseArgs(['--user-id', 'u', '--input', 'f.csv']),
+    ).toThrow(ArgParseError);
+  });
+
+  it('throws when --user-id is missing', () => {
+    expect(() => parseArgs(['--program', 'p', '--input', 'f.csv'])).toThrow(
+      ArgParseError,
+    );
+  });
+
+  it('throws when neither --input nor --rollback is given', () => {
+    expect(() => parseArgs(['--program', 'p', '--user-id', 'u'])).toThrow(
+      /--input.*required unless --rollback/,
+    );
+  });
+
+  it('throws when --input is combined with --rollback', () => {
+    expect(() =>
+      parseArgs([
+        '--program',
+        'p',
+        '--user-id',
+        'u',
+        '--rollback',
+        '--input',
+        'f.csv',
+      ]),
+    ).toThrow(/--input is not used with --rollback/);
+  });
+
+  it('throws when a flag expecting a value is given none', () => {
+    expect(() => parseArgs(['--program'])).toThrow('--program requires a value');
+  });
+
+  it('throws when a flag expecting a value is immediately followed by another flag', () => {
+    expect(() =>
+      parseArgs(['--program', '--user-id', 'u']),
+    ).toThrow('--program requires a value');
+  });
+});
+
+describe('resolveLiftId', () => {
+  it('resolves a known human-readable lift name to its canonical id', () => {
+    expect(resolveLiftId('Squat')).toBe('back-squat');
+  });
+
+  it('passes through an unresolved lift name verbatim', () => {
+    expect(resolveLiftId("Farmer's Carry")).toBe("Farmer's Carry");
+  });
+});
+
+const HEADERS = [
+  'Program',
+  'Lift',
+  'Cycle #',
+  'Cycle Date',
+  'TM',
+  'Set 1 Reps',
+  'Spec Reps',
+  'Increment',
+  'Transition',
+  'Goal Met',
+  'Is PR',
+  'Will Seed',
+  'TM Source',
+  'Bodyweight',
+  'Added Weight',
+];
+
+function csvOf(rows: Record<string, string>[]): string {
+  const lines = [HEADERS.join(',')];
+  for (const row of rows) {
+    lines.push(HEADERS.map((h) => row[h] ?? '').join(','));
+  }
+  return lines.join('\n');
+}
+
+function validRow(overrides: Record<string, string> = {}): Record<string, string> {
+  return {
+    Program: 'RPT',
+    Lift: 'Squat',
+    'Cycle #': '4',
+    'Cycle Date': '2026-03-01',
+    TM: '305',
+    'Set 1 Reps': '5',
+    'Spec Reps': '5',
+    Increment: '5',
+    Transition: 'bump',
+    'Goal Met': 'true',
+    'Is PR': 'true',
+    'Will Seed': 'true',
+    'TM Source': 'workout-sheet',
+    Bodyweight: '',
+    'Added Weight': '',
+    ...overrides,
+  };
+}
+
+describe('parseTMHistoryCsv', () => {
+  it('parses a well-formed export into row objects', () => {
+    const rows = parseTMHistoryCsv(csvOf([validRow()]));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ Program: 'RPT', Lift: 'Squat', TM: '305' });
+  });
+
+  it('returns an empty array for a header-only CSV', () => {
+    expect(parseTMHistoryCsv(HEADERS.join(','))).toEqual([]);
+  });
+
+  it('throws an actionable error when expected columns are missing (stale export)', () => {
+    const staleHeaders = HEADERS.filter((h) => h !== 'Will Seed');
+    const content = [staleHeaders.join(','), staleHeaders.map(() => 'x').join(',')].join(
+      '\n',
+    );
+    expect(() => parseTMHistoryCsv(content)).toThrow(/missing expected column/);
+    expect(() => parseTMHistoryCsv(content)).toThrow(/Will Seed/);
+  });
+});
+
+describe('filterWillSeedRows', () => {
+  it('keeps only rows where Will Seed is exactly "true"', () => {
+    const rows = parseTMHistoryCsv(
+      csvOf([
+        validRow({ 'Cycle #': '1', 'Will Seed': 'true' }),
+        validRow({ 'Cycle #': '2', 'Will Seed': 'false' }),
+        validRow({ 'Cycle #': '3', 'Will Seed': 'true' }),
+      ]),
+    );
+    const willSeed = filterWillSeedRows(rows);
+    expect(willSeed.map((r) => r['Cycle #'])).toEqual(['1', '3']);
+  });
+});
+
+describe('mapRowToEntry', () => {
+  it('maps a valid row to the appendHistoryEntries shape', () => {
+    const entry = mapRowToEntry(validRow());
+    expect(entry).toEqual({
+      lift: 'back-squat',
+      weight: 305,
+      reps: 1,
+      date: new Date('2026-03-01'),
+      isPR: true,
+      source: 'program',
+      goalMet: true,
+    });
+  });
+
+  it('always sets reps to 1, regardless of the source row', () => {
+    const entry = mapRowToEntry(validRow());
+    expect(entry.reps).toBe(1);
+  });
+
+  it('always sets source to "program", never derived from TM Source', () => {
+    const entry = mapRowToEntry(validRow({ 'TM Source': 'lift-records' }));
+    expect(entry.source).toBe('program');
+  });
+
+  it('coerces a blank Goal Met to false (the target column is non-null Boolean)', () => {
+    const entry = mapRowToEntry(validRow({ 'Goal Met': '' }));
+    expect(entry.goalMet).toBe(false);
+  });
+
+  it('resolves an unmapped lift name verbatim, matching resolveLiftId', () => {
+    const entry = mapRowToEntry(validRow({ Lift: "Farmer's Carry" }));
+    expect(entry.lift).toBe("Farmer's Carry");
+  });
+
+  it('throws on a non-numeric TM', () => {
+    expect(() => mapRowToEntry(validRow({ TM: 'not-a-number' }))).toThrow(
+      /non-numeric TM/,
+    );
+  });
+
+  it('throws on an invalid Cycle Date', () => {
+    expect(() =>
+      mapRowToEntry(validRow({ 'Cycle Date': 'not-a-date' })),
+    ).toThrow(/invalid Cycle Date/);
+  });
+});
+
+describe('backupFilePath', () => {
+  it('builds a deterministic, collision-resistant path from program + timestamp', () => {
+    const now = new Date('2026-03-01T12:34:56.789Z');
+    const p = backupFilePath('/tmp/backups', 'prog-uuid', now);
+    expect(p).toContain('prog-uuid');
+    expect(p).toContain('tm-history-backup-');
+    expect(p.endsWith('.json')).toBe(true);
+    // No raw colons/dots from the ISO timestamp — must be filesystem-safe on Windows.
+    expect(p).not.toMatch(/\d{2}:\d{2}:\d{2}/);
+  });
+
+  it('produces different paths for different timestamps on the same program', () => {
+    const a = backupFilePath('/tmp', 'p', new Date('2026-03-01T00:00:00.000Z'));
+    const b = backupFilePath('/tmp', 'p', new Date('2026-03-01T00:00:01.000Z'));
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('formatResult', () => {
+  const base: SeedResult = {
+    mode: 'seeded',
+    program: 'prog-uuid',
+    existingCount: 0,
+    forceRequired: false,
+    writtenCount: 12,
+    backupPath: null,
+  };
+
+  it('reports a normal seed', () => {
+    const out = formatResult(base);
+    expect(out).toContain('Seeded');
+    expect(out).toContain('wrote 12 row(s)');
+  });
+
+  it('reports a dry run without claiming anything was written', () => {
+    const out = formatResult({ ...base, mode: 'dry-run' });
+    expect(out).toContain('DRY RUN');
+    expect(out).toContain('nothing was written');
+  });
+
+  it('flags that --force would be required when forceRequired is true, on a dry run', () => {
+    const out = formatResult({
+      ...base,
+      mode: 'dry-run',
+      existingCount: 5,
+      forceRequired: true,
+    });
+    expect(out).toContain('would require --force');
+  });
+
+  it('reports a rollback with zero written', () => {
+    const out = formatResult({ ...base, mode: 'rolled-back', existingCount: 5 });
+    expect(out).toContain('Rolled back');
+    expect(out).toContain('deleted 5 row(s)');
+    expect(out).toContain('wrote 0');
+  });
+
+  it('mentions the backup path when one was written', () => {
+    const out = formatResult({ ...base, backupPath: '/tmp/backup.json' });
+    expect(out).toContain('/tmp/backup.json');
+  });
+});

--- a/apps/api/scripts/seed-tm-history.spec.ts
+++ b/apps/api/scripts/seed-tm-history.spec.ts
@@ -6,6 +6,7 @@ import {
   mapRowToEntry,
   parseArgs,
   parseTMHistoryCsv,
+  REQUIRED_COLUMNS,
   resolveLiftId,
   SeedResult,
 } from './seed-tm-history';
@@ -21,16 +22,17 @@ describe('parseArgs', () => {
       '/tmp/export.csv',
     ]);
     expect(args).toEqual({
+      mode: 'seed',
       program: 'prog-uuid',
       userId: 'user-1',
       input: '/tmp/export.csv',
       dryRun: false,
       force: false,
-      rollback: false,
+      backupDir: null,
     });
   });
 
-  it('parses --dry-run and --force as flags', () => {
+  it('parses --dry-run, --force, and --backup-dir', () => {
     const args = parseArgs([
       '--program',
       'p',
@@ -40,20 +42,48 @@ describe('parseArgs', () => {
       'f.csv',
       '--dry-run',
       '--force',
+      '--backup-dir',
+      '/tmp/backups',
     ]);
     expect(args.dryRun).toBe(true);
     expect(args.force).toBe(true);
+    expect(args.backupDir).toBe('/tmp/backups');
   });
 
-  it('parses a --rollback argument set with no --input', () => {
+  it('accepts --flag=value syntax', () => {
+    const args = parseArgs(['--program=p', '--user-id=u', '--input=f.csv']);
+    expect(args).toMatchObject({ program: 'p', userId: 'u', input: 'f.csv' });
+  });
+
+  it('parses a --rollback argument set with mode "rollback"', () => {
     const args = parseArgs(['--program', 'p', '--user-id', 'u', '--rollback']);
     expect(args).toEqual({
+      mode: 'rollback',
       program: 'p',
       userId: 'u',
-      input: null,
       dryRun: false,
       force: false,
-      rollback: true,
+      backupDir: null,
+    });
+  });
+
+  it('parses a --restore argument set with mode "restore"', () => {
+    const args = parseArgs([
+      '--program',
+      'p',
+      '--user-id',
+      'u',
+      '--restore',
+      '/tmp/backup.json',
+    ]);
+    expect(args).toEqual({
+      mode: 'restore',
+      program: 'p',
+      userId: 'u',
+      restorePath: '/tmp/backup.json',
+      dryRun: false,
+      force: false,
+      backupDir: null,
     });
   });
 
@@ -66,7 +96,7 @@ describe('parseArgs', () => {
       '--rollback',
       '--dry-run',
     ]);
-    expect(args.rollback).toBe(true);
+    expect(args.mode).toBe('rollback');
     expect(args.dryRun).toBe(true);
   });
 
@@ -82,9 +112,9 @@ describe('parseArgs', () => {
     );
   });
 
-  it('throws when neither --input nor --rollback is given', () => {
+  it('throws when none of --input/--rollback/--restore is given', () => {
     expect(() => parseArgs(['--program', 'p', '--user-id', 'u'])).toThrow(
-      /--input.*required unless --rollback/,
+      /exactly one of --input/,
     );
   });
 
@@ -99,7 +129,22 @@ describe('parseArgs', () => {
         '--input',
         'f.csv',
       ]),
-    ).toThrow(/--input is not used with --rollback/);
+    ).toThrow(/mutually exclusive/);
+  });
+
+  it('throws when --input is combined with --restore', () => {
+    expect(() =>
+      parseArgs([
+        '--program',
+        'p',
+        '--user-id',
+        'u',
+        '--input',
+        'f.csv',
+        '--restore',
+        'b.json',
+      ]),
+    ).toThrow(/mutually exclusive/);
   });
 
   it('throws when a flag expecting a value is given none', () => {
@@ -110,6 +155,31 @@ describe('parseArgs', () => {
     expect(() =>
       parseArgs(['--program', '--user-id', 'u']),
     ).toThrow('--program requires a value');
+  });
+
+  it('throws on an unrecognized flag rather than silently ignoring it', () => {
+    // The exact scenario a typo'd --dry-run used to hit: silently parsed as
+    // "flag not set" instead of erroring, turning a preview request into a
+    // real write.
+    expect(() =>
+      parseArgs(['--program', 'p', '--user-id', 'u', '--input', 'f.csv', '--dryrun']),
+    ).toThrow(/Unrecognized flag '--dryrun'/);
+  });
+
+  it('throws on a bare non-flag token', () => {
+    expect(() => parseArgs(['p'])).toThrow(/Unrecognized argument 'p'/);
+  });
+
+  it('throws when a value-flag is passed more than once', () => {
+    expect(() =>
+      parseArgs(['--program', 'a', '--program', 'b', '--user-id', 'u', '--rollback']),
+    ).toThrow(/--program was passed more than once/);
+  });
+
+  it('throws when a boolean flag is given a value via = syntax', () => {
+    expect(() =>
+      parseArgs(['--program', 'p', '--user-id', 'u', '--rollback=true']),
+    ).toThrow(/--rollback does not take a value/);
   });
 });
 
@@ -170,6 +240,14 @@ function validRow(overrides: Record<string, string> = {}): Record<string, string
   };
 }
 
+describe('REQUIRED_COLUMNS', () => {
+  it('is a superset the fixture headers above actually satisfy', () => {
+    for (const col of REQUIRED_COLUMNS) {
+      expect(HEADERS).toContain(col);
+    }
+  });
+});
+
 describe('parseTMHistoryCsv', () => {
   it('parses a well-formed export into row objects', () => {
     const rows = parseTMHistoryCsv(csvOf([validRow()]));
@@ -189,19 +267,41 @@ describe('parseTMHistoryCsv', () => {
     expect(() => parseTMHistoryCsv(content)).toThrow(/missing expected column/);
     expect(() => parseTMHistoryCsv(content)).toThrow(/Will Seed/);
   });
+
+  it('throws when expected columns are missing even on a header-only (zero data row) CSV', () => {
+    // Previously the column check only ran when rows.length > 0, so a
+    // header-only OR fully-empty file skipped validation entirely.
+    const staleHeaders = HEADERS.filter((h) => h !== 'Will Seed');
+    expect(() => parseTMHistoryCsv(staleHeaders.join(','))).toThrow(
+      /missing expected column/,
+    );
+  });
 });
 
 describe('filterWillSeedRows', () => {
-  it('keeps only rows where Will Seed is exactly "true"', () => {
+  it('keeps only rows where Will Seed is exactly "true" (case-insensitive)', () => {
     const rows = parseTMHistoryCsv(
       csvOf([
         validRow({ 'Cycle #': '1', 'Will Seed': 'true' }),
         validRow({ 'Cycle #': '2', 'Will Seed': 'false' }),
-        validRow({ 'Cycle #': '3', 'Will Seed': 'true' }),
+        validRow({ 'Cycle #': '3', 'Will Seed': 'TRUE' }),
       ]),
     );
     const willSeed = filterWillSeedRows(rows);
     expect(willSeed.map((r) => r['Cycle #'])).toEqual(['1', '3']);
+  });
+
+  it('throws on an unrecognized Will Seed value rather than silently treating it as false', () => {
+    // This is the guard against a whole-file format mismatch (e.g. Google
+    // Sheets rendering booleans differently on CSV export) silently
+    // producing an empty seed set, which downstream feeds a full wipe.
+    const rows = parseTMHistoryCsv(csvOf([validRow({ 'Will Seed': 'yes' })]));
+    expect(() => filterWillSeedRows(rows)).toThrow(/not a recognized boolean/);
+  });
+
+  it('throws on a blank Will Seed value (never legitimately empty)', () => {
+    const rows = parseTMHistoryCsv(csvOf([validRow({ 'Will Seed': '' })]));
+    expect(() => filterWillSeedRows(rows)).toThrow(/not a recognized boolean/);
   });
 });
 
@@ -212,11 +312,16 @@ describe('mapRowToEntry', () => {
       lift: 'back-squat',
       weight: 305,
       reps: 1,
-      date: new Date('2026-03-01'),
+      date: new Date(Date.UTC(2026, 2, 1)),
       isPR: true,
       source: 'program',
       goalMet: true,
     });
+  });
+
+  it('accepts uppercase TRUE/FALSE for Is PR (case-insensitive)', () => {
+    expect(mapRowToEntry(validRow({ 'Is PR': 'TRUE' })).isPR).toBe(true);
+    expect(mapRowToEntry(validRow({ 'Is PR': 'FALSE' })).isPR).toBe(false);
   });
 
   it('always sets reps to 1, regardless of the source row', () => {
@@ -239,16 +344,50 @@ describe('mapRowToEntry', () => {
     expect(entry.lift).toBe("Farmer's Carry");
   });
 
+  it('throws on an empty TM', () => {
+    expect(() => mapRowToEntry(validRow({ TM: '' }))).toThrow(/empty TM/);
+  });
+
+  it('throws on a whitespace-only TM', () => {
+    expect(() => mapRowToEntry(validRow({ TM: '   ' }))).toThrow(/empty TM/);
+  });
+
   it('throws on a non-numeric TM', () => {
     expect(() => mapRowToEntry(validRow({ TM: 'not-a-number' }))).toThrow(
-      /non-numeric TM/,
+      /invalid TM/,
     );
+  });
+
+  it('throws on a zero TM (Number("") === 0 must not silently pass as a real value)', () => {
+    expect(() => mapRowToEntry(validRow({ TM: '0' }))).toThrow(/invalid TM/);
+  });
+
+  it('throws on a negative TM', () => {
+    expect(() => mapRowToEntry(validRow({ TM: '-5' }))).toThrow(/invalid TM/);
+  });
+
+  it('throws on a non-finite TM', () => {
+    expect(() => mapRowToEntry(validRow({ TM: 'Infinity' }))).toThrow(/invalid TM/);
   });
 
   it('throws on an invalid Cycle Date', () => {
     expect(() =>
       mapRowToEntry(validRow({ 'Cycle Date': 'not-a-date' })),
-    ).toThrow(/invalid Cycle Date/);
+    ).toThrow(/not in yyyy-MM-dd format/);
+  });
+
+  it('throws on a locale-formatted Cycle Date rather than silently transposing month/day', () => {
+    expect(() =>
+      mapRowToEntry(validRow({ 'Cycle Date': '03/01/2026' })),
+    ).toThrow(/not in yyyy-MM-dd format/);
+  });
+
+  it('parses Cycle Date as UTC midnight, not local midnight', () => {
+    const entry = mapRowToEntry(validRow({ 'Cycle Date': '2026-03-01' }));
+    expect(entry.date.getUTCFullYear()).toBe(2026);
+    expect(entry.date.getUTCMonth()).toBe(2); // 0-indexed: March
+    expect(entry.date.getUTCDate()).toBe(1);
+    expect(entry.date.getUTCHours()).toBe(0);
   });
 });
 
@@ -307,6 +446,13 @@ describe('formatResult', () => {
     expect(out).toContain('Rolled back');
     expect(out).toContain('deleted 5 row(s)');
     expect(out).toContain('wrote 0');
+  });
+
+  it('reports a restore', () => {
+    const out = formatResult({ ...base, mode: 'restored', existingCount: 2, writtenCount: 5 });
+    expect(out).toContain('Restored');
+    expect(out).toContain('deleted 2 row(s)');
+    expect(out).toContain('wrote 5 row(s) from backup');
   });
 
   it('mentions the backup path when one was written', () => {

--- a/apps/api/scripts/seed-tm-history.ts
+++ b/apps/api/scripts/seed-tm-history.ts
@@ -26,19 +26,27 @@
  *   not build workspace packages.
  * - `DATABASE_URL` is exported and points at the migrator/owner role,
  *   through the break-glass connection (runbook "Establish the break-glass
- *   DB connection").
+ *   DB connection"). `runSeed` verifies this via `SELECT current_user` and
+ *   aborts if the connected role can't see the target program (the classic
+ *   failure mode here is running with the *runtime* role's connection
+ *   string by mistake, which RLS then hides everything from).
  *
  * Usage:
  *   npx ts-node scripts/seed-tm-history.ts \
  *     --program <target-program-uuid> --user-id <clerk-user-id> \
- *     --input <path-to-GCP_EXPORT_TMHistory.csv> [--dry-run] [--force]
+ *     --input <path-to-GCP_EXPORT_TMHistory.csv> [--dry-run] [--force] [--backup-dir <path>]
  *
  *   npx ts-node scripts/seed-tm-history.ts \
  *     --program <target-program-uuid> --user-id <clerk-user-id> \
- *     --rollback [--dry-run]
+ *     --rollback [--dry-run] [--force] [--backup-dir <path>]
+ *
+ *   npx ts-node scripts/seed-tm-history.ts \
+ *     --program <target-program-uuid> --user-id <clerk-user-id> \
+ *     --restore <path-to-backup.json> [--dry-run] [--force] [--backup-dir <path>]
  */
 
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { parse } from 'csv-parse/sync';
 import { PrismaClient } from '@prisma/client';
@@ -51,51 +59,121 @@ import { PrismaTrainingMaxHistoryRepository } from '../src/adapters/prisma/train
 // unit-testable without any mocking).
 // ---------------------------------------------------------------------------
 
-export interface SeedArgs {
+interface CommonArgs {
   program: string;
   userId: string;
-  /** Required unless rollback is true; null when rollback is true. */
-  input: string | null;
   dryRun: boolean;
   force: boolean;
-  rollback: boolean;
+  backupDir: string | null;
 }
+
+/**
+ * Discriminated on `mode` so every call site that branches on it (`runSeed`)
+ * gets exhaustiveness checking, and `input`/`restorePath` are only present
+ * on the one mode that actually uses them — no `as string` cast needed at
+ * either use site (the previous, non-discriminated shape needed one at
+ * each), and no way to construct e.g. `{ mode: 'rollback', input: '...' }`.
+ */
+export type SeedArgs =
+  | (CommonArgs & { mode: 'seed'; input: string })
+  | (CommonArgs & { mode: 'rollback' })
+  | (CommonArgs & { mode: 'restore'; restorePath: string });
 
 export class ArgParseError extends Error {}
 
-export function parseArgs(argv: string[]): SeedArgs {
-  const getValue = (flag: string): string | null => {
-    const i = argv.indexOf(flag);
-    if (i === -1) return null;
-    const value = argv[i + 1];
-    if (value === undefined || value.startsWith('--')) {
-      throw new ArgParseError(`${flag} requires a value`);
-    }
-    return value;
-  };
-  const hasFlag = (flag: string): boolean => argv.includes(flag);
+const FLAGS_WITH_VALUE = new Set([
+  '--program',
+  '--user-id',
+  '--input',
+  '--restore',
+  '--backup-dir',
+]);
+const BOOLEAN_FLAGS = new Set(['--dry-run', '--force', '--rollback']);
 
-  const program = getValue('--program');
-  const userId = getValue('--user-id');
-  const input = getValue('--input');
-  const dryRun = hasFlag('--dry-run');
-  const force = hasFlag('--force');
-  const rollback = hasFlag('--rollback');
+/**
+ * Strict parser: rejects any token that isn't a recognized `--flag` (or the
+ * value immediately following one), rejects a flag passed more than once,
+ * and accepts both `--flag value` and `--flag=value` forms. A typo like
+ * `--dryrun` or `--dry_run` previously parsed silently as "flag not set" —
+ * for `--dry-run` specifically, that meant a mistyped preview request
+ * silently became a real destructive write. See the runbook's "Re-run
+ * semantics" section for why that distinction matters here more than in a
+ * typical CLI.
+ */
+export function parseArgs(argv: string[]): SeedArgs {
+  const values: Partial<Record<string, string>> = {};
+  const flags: Partial<Record<string, boolean>> = {};
+
+  let i = 0;
+  while (i < argv.length) {
+    const tok = argv[i] as string;
+    if (!tok.startsWith('--')) {
+      throw new ArgParseError(`Unrecognized argument '${tok}' (expected a --flag)`);
+    }
+    const eqIdx = tok.indexOf('=');
+    const flag = eqIdx === -1 ? tok : tok.slice(0, eqIdx);
+
+    if (FLAGS_WITH_VALUE.has(flag)) {
+      let value: string;
+      if (eqIdx !== -1) {
+        value = tok.slice(eqIdx + 1);
+        i += 1;
+      } else {
+        const next = argv[i + 1];
+        if (next === undefined || next.startsWith('--')) {
+          throw new ArgParseError(`${flag} requires a value`);
+        }
+        value = next;
+        i += 2;
+      }
+      if (values[flag] !== undefined) {
+        throw new ArgParseError(`${flag} was passed more than once`);
+      }
+      values[flag] = value;
+    } else if (BOOLEAN_FLAGS.has(flag)) {
+      if (eqIdx !== -1) {
+        throw new ArgParseError(`${flag} does not take a value`);
+      }
+      flags[flag] = true;
+      i += 1;
+    } else {
+      throw new ArgParseError(`Unrecognized flag '${flag}'`);
+    }
+  }
+
+  const program = values['--program'];
+  const userId = values['--user-id'];
+  const input = values['--input'];
+  const restorePath = values['--restore'];
+  const backupDir = values['--backup-dir'] ?? null;
+  const dryRun = flags['--dry-run'] ?? false;
+  const force = flags['--force'] ?? false;
+  const rollback = flags['--rollback'] ?? false;
 
   if (!program) throw new ArgParseError('--program <uuid> is required');
   if (!userId) throw new ArgParseError('--user-id <clerk-user-id> is required');
-  if (!rollback && !input) {
+
+  const modeCount = [input !== undefined, rollback, restorePath !== undefined].filter(
+    Boolean,
+  ).length;
+  if (modeCount === 0) {
     throw new ArgParseError(
-      '--input <path-to-csv> is required unless --rollback is passed',
+      'exactly one of --input <path>, --rollback, or --restore <path> is required',
     );
   }
-  if (rollback && input) {
+  if (modeCount > 1) {
     throw new ArgParseError(
-      '--input is not used with --rollback — rollback only deletes, it never re-seeds from a CSV',
+      '--input, --rollback, and --restore are mutually exclusive — pass exactly one',
     );
   }
 
-  return { program, userId, input, dryRun, force, rollback };
+  if (rollback) {
+    return { mode: 'rollback', program, userId, dryRun, force, backupDir };
+  }
+  if (restorePath !== undefined) {
+    return { mode: 'restore', program, userId, restorePath, dryRun, force, backupDir };
+  }
+  return { mode: 'seed', program, userId, input: input as string, dryRun, force, backupDir };
 }
 
 // ---------------------------------------------------------------------------
@@ -129,7 +207,7 @@ export function resolveLiftId(lift: string): string {
 
 export type TMHistoryCsvRow = Record<string, string>;
 
-const REQUIRED_COLUMNS = [
+export const REQUIRED_COLUMNS = [
   'Program',
   'Lift',
   'Cycle Date',
@@ -140,28 +218,67 @@ const REQUIRED_COLUMNS = [
 ];
 
 /**
- * Parses the downloaded `GCP_EXPORT_TMHistory.csv`. Throws with an
- * actionable message (not a generic csv-parse error) if the expected
- * columns aren't present — the most likely cause is a stale or
- * hand-truncated export.
+ * Parses the downloaded `GCP_EXPORT_TMHistory.csv`. Validates the header
+ * independently of row count — a header-only or entirely empty file used
+ * to skip this check silently (it only ran when `rows.length > 0`) and
+ * flow straight into an empty-seed run; see `filterWillSeedRows`'s doc
+ * comment for why an empty seed is now refused outright rather than
+ * silently treated as a valid "nothing to do" outcome.
  */
 export function parseTMHistoryCsv(content: string): TMHistoryCsvRow[] {
+  let header: string[] = [];
   const rows = parse(content, {
-    columns: true,
+    columns: (rawHeader: string[]) => {
+      header = rawHeader;
+      return rawHeader;
+    },
     skip_empty_lines: true,
   }) as TMHistoryCsvRow[];
 
-  if (rows.length > 0) {
-    const first = rows[0] as TMHistoryCsvRow;
-    const missing = REQUIRED_COLUMNS.filter((c) => !(c in first));
-    if (missing.length > 0) {
-      throw new Error(
-        `GCP_EXPORT_TMHistory.csv is missing expected column(s): ${missing.join(', ')} — ` +
-          `re-export from the Sheet (Logbook Tools → Export TM History (preview))`,
-      );
-    }
+  const missing = REQUIRED_COLUMNS.filter((c) => !header.includes(c));
+  if (missing.length > 0) {
+    throw new Error(
+      `GCP_EXPORT_TMHistory.csv is missing expected column(s): ${missing.join(', ')} — ` +
+        `re-export from the Sheet (Logbook Tools → Export TM History (preview))`,
+    );
   }
   return rows;
+}
+
+/**
+ * Parses a `"true"`/`"false"` cell, case-insensitively and with surrounding
+ * whitespace trimmed, and throws on anything else. Google Sheets renders a
+ * boolean-*looking* cell to CSV export in its own canonical case, which is
+ * not guaranteed to match the lowercase `String(booleanValue)` gas-lifting-
+ * logbook's export code writes — case-insensitive matching is cheap
+ * insurance against that either way. Throwing (rather than defaulting to
+ * `false`) on an unrecognized value matters specifically for `Will Seed`:
+ * a silent false there previously meant a whole-file format mismatch could
+ * make every row look like a hold, producing an empty seed set that then
+ * fed a full, successful-looking wipe of the program's history (see
+ * `filterWillSeedRows`).
+ */
+function parseStrictBooleanCell(raw: string | undefined, field: string): boolean {
+  const normalized = (raw ?? '').trim().toLowerCase();
+  if (normalized === 'true') return true;
+  if (normalized === 'false') return false;
+  throw new Error(
+    `${field} value ${JSON.stringify(raw ?? '')} is not a recognized boolean (expected "true" or "false", case-insensitive)`,
+  );
+}
+
+/**
+ * Same as {@link parseStrictBooleanCell}, except an empty cell is legitimate
+ * and coerces to `false` — used only for `Goal Met`, which `buildTMHistory`
+ * on the gas-lifting-logbook side genuinely emits as null/blank when set-1
+ * reps or spec reps weren't available for that cycle. `Will Seed` and
+ * `Is PR` are never legitimately blank (both non-nullable in the source
+ * model), so they use the strict parser instead.
+ */
+function parseNullableBooleanCell(raw: string | undefined, field: string): boolean {
+  const normalized = (raw ?? '').trim().toLowerCase();
+  if (normalized === '') return false;
+  return parseStrictBooleanCell(raw, field);
 }
 
 /**
@@ -170,58 +287,84 @@ export function parseTMHistoryCsv(content: string): TMHistoryCsvRow[] {
  * `transition !== "hold"`) — this script trusts that column directly and
  * never re-derives the classification itself, matching the contract the
  * runbook and gas-lifting-logbook's validator both document.
+ *
+ * Uses the strict boolean parser (throws on anything but exactly
+ * `true`/`false`, case-insensitive) rather than a loose `=== 'true'`
+ * comparison: a loose comparison would silently treat *every* row as a
+ * hold if the whole file used a different case or format, producing an
+ * empty seed set — and `runSeed` refuses to proceed on an empty seed set
+ * specifically because that shape (zero rows to write) is what a
+ * plain-append-vs-delete-all-then-append design turns into a full,
+ * successful-looking wipe.
  */
 export function filterWillSeedRows(rows: TMHistoryCsvRow[]): TMHistoryCsvRow[] {
-  return rows.filter((r) => r['Will Seed'] === 'true');
+  return rows.filter((r) => parseStrictBooleanCell(r['Will Seed'], 'Will Seed'));
 }
 
-function parseBooleanCell(raw: string | undefined): boolean {
-  return raw === 'true';
+const ISO_DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Parses a `Cycle Date` cell. Requires the exact `yyyy-MM-dd` shape
+ * `TMHistoryRow.cycleDate` is documented to always be (ISO, date-only) and
+ * builds the `Date` explicitly via `Date.UTC` — `new Date(str)`'s built-in
+ * parser is too permissive two different ways: (1) it accepts locale-
+ * formatted strings like `03/01/2026` without complaint, silently
+ * transposing month/day versus what gas-lifting-logbook actually derived,
+ * and (2) even for a correctly-ISO string, JS parses a date-only ISO string
+ * as **UTC** midnight but would parse an equivalent slash-formatted string
+ * as **local** midnight — a real day could shift depending on which shape
+ * showed up, for any reader west of UTC. These dates are the ordering key
+ * for the seeded history, so a silent day-shift is a real correctness bug,
+ * not a cosmetic one.
+ */
+function parseCycleDate(raw: string | undefined, field = 'Cycle Date'): Date {
+  const value = (raw ?? '').trim();
+  const match = ISO_DATE_ONLY.exec(value);
+  if (!match) {
+    throw new Error(
+      `${field} value ${JSON.stringify(raw ?? '')} is not in yyyy-MM-dd format`,
+    );
+  }
+  const [year, month, day] = value.split('-').map(Number) as [number, number, number];
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (isNaN(date.getTime())) {
+    throw new Error(`${field} value ${JSON.stringify(raw ?? '')} is not a valid date`);
+  }
+  return date;
 }
 
 /**
  * Maps one CSV row to an `appendHistoryEntries` entry. Field mapping
- * matches the runbook's table ("Step 4 — Field mapping") exactly:
- * - `reps` is always `1` — matches `CycleGenerationService.buildHistoryEntries`'s
- *   convention: a training-max value, not a logged set.
- * - `source` is always `'program'` — RPT has no test-week concept; the
- *   target's DB CHECK constraint on `training_max_history.source` only
- *   accepts `'test'` or `'program'` regardless.
- * - `Is PR` is taken as-is; a blank cell is never legitimate here (`isPR` is
- *   non-nullable in the source model, and gas-lifting-logbook's own
- *   pre-flight validator blocks an empty `Is PR` cell before this script
- *   would ever see one) — `parseBooleanCell` intentionally has no special
- *   handling for that case, so a row that slipped through unvalidated maps
- *   an empty/garbage `Is PR` to `false` rather than throwing, matching this
- *   function's general lenient-parse posture (validation is the pre-flight
- *   validator's job, not this mapper's).
- * - `Goal Met` coerces a blank cell to `false` — the target's `goalMet`
- *   column is a non-null `Boolean` with `@default(false)`, and a blank cell
- *   here is a real, expected state (unlike `Is PR`): `buildTMHistory`
- *   genuinely emits `goalMet: null` whenever set-1 reps or spec reps weren't
- *   available for that cycle. `parseBooleanCell`'s `raw === 'true'` check
- *   already coerces both `''` and `'false'` to `false` identically, which is
- *   exactly the coercion the runbook documents — no extra branching needed.
+ * matches the runbook's table ("Step 4 — Field mapping") exactly — see
+ * that table for the `reps`/`source`/`Goal Met` rationale, unchanged here.
+ *
+ * `TM` is validated as non-empty and a positive finite number: `Number('')`
+ * and `Number('   ')` are `0`, not `NaN`, so a blank cell previously passed
+ * an `isNaN`-only guard and seeded `weight: 0` into a non-null column. This
+ * is the last check before a direct DB write on an RLS-bypassing
+ * connection — gas-lifting-logbook's own pre-flight validator runs against
+ * the Sheet tab, not this downloaded CSV, so it does not cover this input.
  */
 export function mapRowToEntry(
   row: TMHistoryCsvRow,
 ): Omit<TrainingMaxHistoryEntry, 'id'> {
-  const weight = Number(row['TM']);
-  const date = new Date(row['Cycle Date'] as string);
-  if (isNaN(weight)) {
-    throw new Error(`Row has a non-numeric TM: ${JSON.stringify(row)}`);
+  const tmRaw = (row['TM'] ?? '').trim();
+  if (!tmRaw) {
+    throw new Error('Row has an empty TM');
   }
-  if (isNaN(date.getTime())) {
-    throw new Error(`Row has an invalid Cycle Date: ${JSON.stringify(row)}`);
+  const weight = Number(tmRaw);
+  if (!Number.isFinite(weight) || weight <= 0) {
+    throw new Error(`Row has an invalid TM: ${JSON.stringify(row['TM'])}`);
   }
+  const date = parseCycleDate(row['Cycle Date']);
   return {
     lift: resolveLiftId((row['Lift'] ?? '').trim()),
     weight,
     reps: 1,
     date,
-    isPR: parseBooleanCell(row['Is PR']),
+    isPR: parseStrictBooleanCell(row['Is PR'], 'Is PR'),
     source: 'program',
-    goalMet: parseBooleanCell(row['Goal Met']),
+    goalMet: parseNullableBooleanCell(row['Goal Met'], 'Goal Met'),
   };
 }
 
@@ -237,14 +380,35 @@ export function mapRowToEntry(
 
 export class ProgramOwnershipError extends Error {}
 
+/**
+ * Confirms `DATABASE_URL` is actually the migrator/owner role before
+ * interpreting `findUnique`'s result — a `null` result is ambiguous between
+ * "no such program" and "RLS is hiding it because this connection is the
+ * restricted runtime role, not the migrator one." Given the script's whole
+ * premise is a *manually established* break-glass connection, that mix-up
+ * is a realistic operator error, and the two cases warrant different next
+ * steps (fix `--program` vs. fix the connection). Echoes the resolved
+ * role/database so the run is auditable from its own output.
+ */
 export async function verifyProgramOwnership(
   prisma: PrismaClient,
   program: string,
   userId: string,
 ): Promise<void> {
+  const [identity] = await prisma.$queryRaw<
+    Array<{ current_user: string; current_database: string }>
+  >`SELECT current_user, current_database()`;
+  console.log(
+    `Connected as ${identity?.current_user ?? '(unknown)'} on database ${identity?.current_database ?? '(unknown)'}.`,
+  );
+
   const row = await prisma.customProgram.findUnique({ where: { id: program } });
   if (!row) {
-    throw new ProgramOwnershipError(`Program '${program}' does not exist`);
+    throw new ProgramOwnershipError(
+      `Program '${program}' does not exist — or exists but is invisible on this connection. ` +
+        `If you're certain the UUID is correct, confirm DATABASE_URL is the migrator/owner role, ` +
+        `not the restricted runtime role (RLS silently hides rows from the latter).`,
+    );
   }
   if (row.userId !== userId) {
     throw new ProgramOwnershipError(
@@ -254,18 +418,58 @@ export async function verifyProgramOwnership(
         `so it is the only tenant-isolation control this script has.`,
     );
   }
+
+  // Defense in depth beyond the program-level check above: the delete and
+  // append below are scoped by (program, userId) through the repository,
+  // not by program alone. If training_max_history somehow held rows for
+  // this program under a *different* userId than the one that owns
+  // customProgram (a data-integrity anomaly, not a normal state), those
+  // rows would be invisible to the user-scoped count/backup/delete below —
+  // undercounting existingCount (so --force never fires) while the append
+  // still adds a new, overlapping series. This connection is the only one
+  // in the system that can see such rows at all, so it's the only place
+  // this check is possible — and it's cheap.
+  const programScopedCount = await prisma.trainingMaxHistory.count({
+    where: { program },
+  });
+  const userScopedCount = await prisma.trainingMaxHistory.count({
+    where: { program, userId },
+  });
+  if (programScopedCount !== userScopedCount) {
+    throw new ProgramOwnershipError(
+      `Program '${program}' has ${programScopedCount} history row(s) total but only ` +
+        `${userScopedCount} belong to --user-id='${userId}' — some rows exist under a ` +
+        `different userId for this same program, which this script cannot safely resolve. ` +
+        `Investigate directly before proceeding.`,
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
 // Backup (ADR-079 back-up-before-mutate — see the runbook's "Re-run
-// semantics" section for why this always runs before any delete).
+// semantics" section for why this always runs before any delete) and
+// restore (the other half of that convention: an idempotent path back to
+// the captured state, not just a generic reset).
 // ---------------------------------------------------------------------------
+
+const DEFAULT_BACKUP_DIR = path.join(os.tmpdir(), 'lifting-logbook-tm-history-backups');
 
 export function backupFilePath(outDir: string, program: string, now: Date): string {
   const stamp = now.toISOString().replace(/[:.]/g, '-');
   return path.join(outDir, `tm-history-backup-${program}-${stamp}.json`);
 }
 
+/**
+ * Writes existing history to a local JSON file, verifies the write by
+ * reading it back and comparing row counts (a corrupt or truncated write —
+ * disk full mid-write, process killed — would otherwise go unnoticed right
+ * up until the moment it's needed for recovery), and returns its path.
+ * Defaults outside the repo working tree (`os.tmpdir()`-based) rather than
+ * `process.cwd()` — the previous default landed the backup, a full dump of
+ * one user's training-max history keyed to their Clerk id, as an untracked
+ * file inside `apps/api/`, one `git add .` away from being committed.
+ * Override with `--backup-dir` when a specific location is wanted.
+ */
 export async function backupExistingHistory(
   repo: ITrainingMaxHistoryRepository,
   program: string,
@@ -276,15 +480,38 @@ export async function backupExistingHistory(
   if (existing.length === 0) return null;
   const filePath = backupFilePath(outDir, program, now);
   fs.mkdirSync(outDir, { recursive: true });
-  fs.writeFileSync(filePath, JSON.stringify(existing, null, 2));
+  const serialized = JSON.stringify(existing, null, 2);
+  fs.writeFileSync(filePath, serialized);
+
+  const readBack = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  if (!Array.isArray(readBack) || readBack.length !== existing.length) {
+    throw new Error(
+      `Backup verification failed for ${filePath}: wrote ${existing.length} row(s) but ` +
+        `read back ${Array.isArray(readBack) ? readBack.length : 'non-array data'}. ` +
+        `Refusing to proceed with any delete until this is resolved.`,
+    );
+  }
   return { path: filePath, count: existing.length };
+}
+
+/** Reads a backup file written by {@link backupExistingHistory} and strips `id` for re-append. */
+function readBackupFile(restorePath: string): Omit<TrainingMaxHistoryEntry, 'id'>[] {
+  const raw = fs.readFileSync(restorePath, 'utf8');
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${restorePath} does not contain a JSON array — not a valid backup file`);
+  }
+  return (parsed as TrainingMaxHistoryEntry[]).map(({ id: _id, ...rest }) => ({
+    ...rest,
+    date: new Date(rest.date),
+  }));
 }
 
 // ---------------------------------------------------------------------------
 // Orchestration
 // ---------------------------------------------------------------------------
 
-export type SeedMode = 'dry-run' | 'seeded' | 'rolled-back';
+export type SeedMode = 'dry-run' | 'seeded' | 'rolled-back' | 'restored';
 
 export interface SeedResult {
   mode: SeedMode;
@@ -297,40 +524,69 @@ export interface SeedResult {
 }
 
 /**
- * Runs the seed (or rollback). Re-run semantics match the runbook exactly:
- * normal mode is delete-all-then-append (never plain append —
+ * Runs the seed, rollback, or restore. Re-run semantics match the runbook
+ * exactly: normal mode is delete-all-then-append (never plain append —
  * `training_max_history` has no unique constraint), gated by `--force`
  * whenever pre-existing history is found (unexpected at the normal Phase 2B
- * timing — see the runbook). `--dry-run` never touches the database beyond
- * the read-only `getHistory` call already needed to report `existingCount`
- * — it never enforces the `--force` gate itself, so a dry run always
- * succeeds and reports whether `--force` would be needed, rather than
- * failing before the operator has a chance to see that.
+ * timing — see the runbook). `--dry-run` never enforces the `--force` gate
+ * itself — it always succeeds and reports whether `--force` would be
+ * needed, and now also runs the *same* row mapping/validation the real run
+ * would (previously it stopped at a row count, so a CSV that would fail
+ * `mapRowToEntry` passed dry-run cleanly and only failed on the real,
+ * already-destructive run).
+ *
+ * The delete and append (or the rollback delete, or the restore's
+ * delete-then-append) run inside one `prisma.$transaction` — previously two
+ * independent statements, so a failure between them (a dropped break-glass
+ * connection, a constraint violation) left the program's history fully
+ * deleted with no automatic recovery. The `as PrismaClient` cast below on
+ * the transaction client mirrors this codebase's own established pattern
+ * for constructing a repository over a transaction client — see
+ * `prisma-repository-factory.ts`'s `client()`, which does the identical
+ * cast for the same structural reason (a transaction client is call-
+ * compatible for repository purposes but not identical to the full
+ * `PrismaClient` type).
  */
 export async function runSeed(
   prisma: PrismaClient,
   args: SeedArgs,
-  backupDir: string = process.cwd(),
+  backupDirOverride?: string,
 ): Promise<SeedResult> {
   await verifyProgramOwnership(prisma, args.program, args.userId);
+  const backupDir = backupDirOverride ?? args.backupDir ?? DEFAULT_BACKUP_DIR;
   const repo = new PrismaTrainingMaxHistoryRepository(prisma, args.userId);
 
   const existing = await repo.getHistory(args.program);
   const existingCount = existing.length;
   const forceRequired = existingCount > 0;
 
+  // Pre-compute what a real run would write, for both the dry-run report
+  // and (below) the actual write — validated identically either way, so a
+  // dry run is a genuine full rehearsal of everything except the two
+  // mutating calls.
+  let entries: Omit<TrainingMaxHistoryEntry, 'id'>[] = [];
+  if (args.mode === 'seed') {
+    entries = filterWillSeedRows(
+      parseTMHistoryCsv(fs.readFileSync(args.input, 'utf8')),
+    ).map(mapRowToEntry);
+    if (entries.length === 0) {
+      throw new Error(
+        'The export produced zero rows to seed (Will Seed=true). A zero-row seed is never ' +
+          'a legitimate outcome for this script — check --input is the correct, current export, ' +
+          'and that the source Sheet actually has data to derive from.',
+      );
+    }
+  } else if (args.mode === 'restore') {
+    entries = readBackupFile(args.restorePath);
+  }
+
   if (args.dryRun) {
-    const writtenCount = args.rollback
-      ? 0
-      : filterWillSeedRows(
-          parseTMHistoryCsv(fs.readFileSync(args.input as string, 'utf8')),
-        ).length;
     return {
       mode: 'dry-run',
       program: args.program,
       existingCount,
       forceRequired,
-      writtenCount,
+      writtenCount: args.mode === 'rollback' ? 0 : entries.length,
       backupPath: null,
     };
   }
@@ -349,33 +605,37 @@ export async function runSeed(
   if (existingCount > 0) {
     const backup = await backupExistingHistory(repo, args.program, backupDir);
     backupPath = backup?.path ?? null;
+    if (backupPath) {
+      // Disclosed immediately, not only in the final success summary — this
+      // is the sole recovery artifact if the transaction below still fails
+      // for a reason a DB transaction can't protect against (e.g. the
+      // process being killed), so it must be visible on the failure path
+      // too, not just on success.
+      console.log(`Backed up ${backup?.count} existing row(s) to ${backupPath}`);
+    }
   }
 
-  if (args.rollback) {
-    await repo.deleteAllHistory(args.program);
-    return {
-      mode: 'rolled-back',
-      program: args.program,
-      existingCount,
-      forceRequired,
-      writtenCount: 0,
-      backupPath,
-    };
-  }
-
-  const entries = filterWillSeedRows(
-    parseTMHistoryCsv(fs.readFileSync(args.input as string, 'utf8')),
-  ).map(mapRowToEntry);
-
-  await repo.deleteAllHistory(args.program);
-  await repo.appendHistoryEntries(args.program, entries);
+  const writtenCount = await prisma.$transaction(async (tx) => {
+    // See this function's doc comment for why this cast mirrors an
+    // existing, accepted pattern in this codebase rather than being a
+    // one-off suppression.
+    const txRepo = new PrismaTrainingMaxHistoryRepository(
+      tx as PrismaClient,
+      args.userId,
+    );
+    await txRepo.deleteAllHistory(args.program);
+    if (args.mode !== 'rollback') {
+      await txRepo.appendHistoryEntries(args.program, entries);
+    }
+    return args.mode === 'rollback' ? 0 : entries.length;
+  });
 
   return {
-    mode: 'seeded',
+    mode: args.mode === 'rollback' ? 'rolled-back' : args.mode === 'restore' ? 'restored' : 'seeded',
     program: args.program,
     existingCount,
     forceRequired,
-    writtenCount: entries.length,
+    writtenCount,
     backupPath,
   };
 }
@@ -400,6 +660,10 @@ export function formatResult(result: SeedResult): string {
     lines.push(
       `Rolled back — deleted ${result.existingCount} row(s), wrote 0 (no re-seed).`,
     );
+  } else if (result.mode === 'restored') {
+    lines.push(
+      `Restored — deleted ${result.existingCount} row(s), wrote ${result.writtenCount} row(s) from backup.`,
+    );
   } else {
     lines.push(
       `Seeded — deleted ${result.existingCount} row(s), wrote ${result.writtenCount} row(s).`,
@@ -410,6 +674,19 @@ export function formatResult(result: SeedResult): string {
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
+  console.log(
+    `Mode: ${args.mode === 'seed' ? (args.dryRun ? 'DRY RUN (no writes)' : 'REAL WRITE') : args.mode.toUpperCase()}` +
+      (args.dryRun && args.mode !== 'seed' ? ' (DRY RUN — no writes)' : ''),
+  );
+  if (args.mode === 'seed') {
+    // Fail fast on a bad --input before any DB round trip.
+    if (!fs.existsSync(args.input)) {
+      throw new Error(
+        `--input path does not exist: ${path.resolve(args.input)}. Re-export from the ` +
+          `Sheet (Logbook Tools → Export TM History (preview)) and download it as CSV.`,
+      );
+    }
+  }
   const prisma = new PrismaClient();
   try {
     const result = await runSeed(prisma, args);
@@ -421,7 +698,11 @@ async function main(): Promise<void> {
 
 if (require.main === module) {
   main().catch((e) => {
-    console.error(e instanceof Error ? e.message : e);
-    process.exit(1);
+    // process.exitCode (not process.exit()) lets pending stdio writes flush
+    // before the process actually exits — process.exit() can truncate the
+    // final error line when stderr is a pipe (e.g. `... | tee seed.log`,
+    // exactly what an auditable break-glass run would use).
+    console.error(e instanceof Error ? (e.stack ?? e.message) : e);
+    process.exitCode = 1;
   });
 }

--- a/apps/api/scripts/seed-tm-history.ts
+++ b/apps/api/scripts/seed-tm-history.ts
@@ -1,0 +1,427 @@
+/**
+ * Phase 2B one-time seeding script — writes gas-lifting-logbook's derived,
+ * human-approved `GCP_EXPORT_TMHistory.csv` into `training_max_history` via
+ * `ITrainingMaxHistoryRepository`, run as the migrator/owner role (bypasses
+ * RLS) through the break-glass connection established per
+ * gas-lifting-logbook's `docs/phase2b-tm-history-seeding-runbook.md`.
+ *
+ * Tracked in issue #885 (companion to gas-lifting-logbook#23/#4). Read that
+ * runbook before running this for real — it's the full human-executed
+ * procedure (export, validate, review, connect, verify ownership, tear
+ * down), of which this script implements only the "Dry run, then the real
+ * seed" and "Rollback / redo" steps. This file exists to implement that
+ * documented contract exactly, not to redefine it — if the two ever
+ * disagree, treat it as a bug in one of them, not an ambiguity to resolve
+ * ad hoc.
+ *
+ * Prerequisites this script assumes (see the runbook for the human steps):
+ * - `packages/core` and `packages/types` have both been built
+ *   (`npm run build -w @lifting-logbook/core -w @lifting-logbook/types`, or
+ *   the root `npm run build`) — their compiled `dist/` output is what this
+ *   script's `@lifting-logbook/core` import (and `apps/api`'s own compile)
+ *   resolves to under plain `ts-node` (unlike Jest, which maps straight to
+ *   `src/` — see `apps/api/jest.config.js`'s moduleNameMapper comment for
+ *   why: workspace packages resolve to `dist` outside Jest). A fresh clone
+ *   or worktree needs this step once; `npm install`'s own postinstall does
+ *   not build workspace packages.
+ * - `DATABASE_URL` is exported and points at the migrator/owner role,
+ *   through the break-glass connection (runbook "Establish the break-glass
+ *   DB connection").
+ *
+ * Usage:
+ *   npx ts-node scripts/seed-tm-history.ts \
+ *     --program <target-program-uuid> --user-id <clerk-user-id> \
+ *     --input <path-to-GCP_EXPORT_TMHistory.csv> [--dry-run] [--force]
+ *
+ *   npx ts-node scripts/seed-tm-history.ts \
+ *     --program <target-program-uuid> --user-id <clerk-user-id> \
+ *     --rollback [--dry-run]
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { parse } from 'csv-parse/sync';
+import { PrismaClient } from '@prisma/client';
+import { DEFAULT_SLOT_MAP, TrainingMaxHistoryEntry } from '@lifting-logbook/core';
+import { ITrainingMaxHistoryRepository } from '../src/ports/ITrainingMaxHistoryRepository';
+import { PrismaTrainingMaxHistoryRepository } from '../src/adapters/prisma/training-max-history.repository';
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing (pure — no fs/DB access, so this is directly
+// unit-testable without any mocking).
+// ---------------------------------------------------------------------------
+
+export interface SeedArgs {
+  program: string;
+  userId: string;
+  /** Required unless rollback is true; null when rollback is true. */
+  input: string | null;
+  dryRun: boolean;
+  force: boolean;
+  rollback: boolean;
+}
+
+export class ArgParseError extends Error {}
+
+export function parseArgs(argv: string[]): SeedArgs {
+  const getValue = (flag: string): string | null => {
+    const i = argv.indexOf(flag);
+    if (i === -1) return null;
+    const value = argv[i + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new ArgParseError(`${flag} requires a value`);
+    }
+    return value;
+  };
+  const hasFlag = (flag: string): boolean => argv.includes(flag);
+
+  const program = getValue('--program');
+  const userId = getValue('--user-id');
+  const input = getValue('--input');
+  const dryRun = hasFlag('--dry-run');
+  const force = hasFlag('--force');
+  const rollback = hasFlag('--rollback');
+
+  if (!program) throw new ArgParseError('--program <uuid> is required');
+  if (!userId) throw new ArgParseError('--user-id <clerk-user-id> is required');
+  if (!rollback && !input) {
+    throw new ArgParseError(
+      '--input <path-to-csv> is required unless --rollback is passed',
+    );
+  }
+  if (rollback && input) {
+    throw new ArgParseError(
+      '--input is not used with --rollback — rollback only deletes, it never re-seeds from a CSV',
+    );
+  }
+
+  return { program, userId, input, dryRun, force, rollback };
+}
+
+// ---------------------------------------------------------------------------
+// Lift resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves a GAS-side lift name to the target's canonical lift id string,
+ * passing an unresolved name through verbatim. Deliberately **not** the
+ * catalog's own `resolveLift` (`packages/core/src/catalog/resolve.ts`) —
+ * that function has different semantics for a different purpose: it throws
+ * on an unmapped slot name (right for validating a program spec against a
+ * known catalog) and returns a full `Lift` catalog object, not an id
+ * string. This script instead matches the passthrough behavior the import
+ * path already uses for training-maxes (`slotMap[lift] ?? lift`) — an
+ * unresolved historical lift name should still seed with whatever string
+ * gas-lifting-logbook derived it as, not abort the whole run. Named
+ * `resolveLiftId` (not `resolveLift`) specifically so it's never confused
+ * with the catalog function at a glance. Unlike gas-lifting-logbook's own
+ * validator, which mirrors a hand-copied, drift-documented snapshot of this
+ * map (`gcpTargetImportRules.ts`), this script imports the real
+ * `DEFAULT_SLOT_MAP` directly — no mirror, no drift risk.
+ */
+export function resolveLiftId(lift: string): string {
+  return DEFAULT_SLOT_MAP[lift] ?? lift;
+}
+
+// ---------------------------------------------------------------------------
+// CSV parsing + row mapping (pure — unit-testable without fs/DB access).
+// ---------------------------------------------------------------------------
+
+export type TMHistoryCsvRow = Record<string, string>;
+
+const REQUIRED_COLUMNS = [
+  'Program',
+  'Lift',
+  'Cycle Date',
+  'TM',
+  'Goal Met',
+  'Is PR',
+  'Will Seed',
+];
+
+/**
+ * Parses the downloaded `GCP_EXPORT_TMHistory.csv`. Throws with an
+ * actionable message (not a generic csv-parse error) if the expected
+ * columns aren't present — the most likely cause is a stale or
+ * hand-truncated export.
+ */
+export function parseTMHistoryCsv(content: string): TMHistoryCsvRow[] {
+  const rows = parse(content, {
+    columns: true,
+    skip_empty_lines: true,
+  }) as TMHistoryCsvRow[];
+
+  if (rows.length > 0) {
+    const first = rows[0] as TMHistoryCsvRow;
+    const missing = REQUIRED_COLUMNS.filter((c) => !(c in first));
+    if (missing.length > 0) {
+      throw new Error(
+        `GCP_EXPORT_TMHistory.csv is missing expected column(s): ${missing.join(', ')} — ` +
+          `re-export from the Sheet (Logbook Tools → Export TM History (preview))`,
+      );
+    }
+  }
+  return rows;
+}
+
+/**
+ * Rows the write path actually acts on. `Will Seed` is gas-lifting-logbook's
+ * single source of truth for this (`TMHistoryRow.willSeed`,
+ * `transition !== "hold"`) — this script trusts that column directly and
+ * never re-derives the classification itself, matching the contract the
+ * runbook and gas-lifting-logbook's validator both document.
+ */
+export function filterWillSeedRows(rows: TMHistoryCsvRow[]): TMHistoryCsvRow[] {
+  return rows.filter((r) => r['Will Seed'] === 'true');
+}
+
+function parseBooleanCell(raw: string | undefined): boolean {
+  return raw === 'true';
+}
+
+/**
+ * Maps one CSV row to an `appendHistoryEntries` entry. Field mapping
+ * matches the runbook's table ("Step 4 — Field mapping") exactly:
+ * - `reps` is always `1` — matches `CycleGenerationService.buildHistoryEntries`'s
+ *   convention: a training-max value, not a logged set.
+ * - `source` is always `'program'` — RPT has no test-week concept; the
+ *   target's DB CHECK constraint on `training_max_history.source` only
+ *   accepts `'test'` or `'program'` regardless.
+ * - `Is PR` is taken as-is; a blank cell is never legitimate here (`isPR` is
+ *   non-nullable in the source model, and gas-lifting-logbook's own
+ *   pre-flight validator blocks an empty `Is PR` cell before this script
+ *   would ever see one) — `parseBooleanCell` intentionally has no special
+ *   handling for that case, so a row that slipped through unvalidated maps
+ *   an empty/garbage `Is PR` to `false` rather than throwing, matching this
+ *   function's general lenient-parse posture (validation is the pre-flight
+ *   validator's job, not this mapper's).
+ * - `Goal Met` coerces a blank cell to `false` — the target's `goalMet`
+ *   column is a non-null `Boolean` with `@default(false)`, and a blank cell
+ *   here is a real, expected state (unlike `Is PR`): `buildTMHistory`
+ *   genuinely emits `goalMet: null` whenever set-1 reps or spec reps weren't
+ *   available for that cycle. `parseBooleanCell`'s `raw === 'true'` check
+ *   already coerces both `''` and `'false'` to `false` identically, which is
+ *   exactly the coercion the runbook documents — no extra branching needed.
+ */
+export function mapRowToEntry(
+  row: TMHistoryCsvRow,
+): Omit<TrainingMaxHistoryEntry, 'id'> {
+  const weight = Number(row['TM']);
+  const date = new Date(row['Cycle Date'] as string);
+  if (isNaN(weight)) {
+    throw new Error(`Row has a non-numeric TM: ${JSON.stringify(row)}`);
+  }
+  if (isNaN(date.getTime())) {
+    throw new Error(`Row has an invalid Cycle Date: ${JSON.stringify(row)}`);
+  }
+  return {
+    lift: resolveLiftId((row['Lift'] ?? '').trim()),
+    weight,
+    reps: 1,
+    date,
+    isPR: parseBooleanCell(row['Is PR']),
+    source: 'program',
+    goalMet: parseBooleanCell(row['Goal Met']),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Program-ownership verification — security requirement added during
+// gas-lifting-logbook PR #24's /review (see issue #885's review-comment
+// addendum and the runbook's "Verify program ownership" step). Because this
+// script connects as the migrator/owner role specifically to bypass RLS,
+// `--program` is the *only* tenant-isolation control left on both the seed
+// write and --rollback's delete — there is no database-level check behind
+// it the way RLS normally provides. This function is that check.
+// ---------------------------------------------------------------------------
+
+export class ProgramOwnershipError extends Error {}
+
+export async function verifyProgramOwnership(
+  prisma: PrismaClient,
+  program: string,
+  userId: string,
+): Promise<void> {
+  const row = await prisma.customProgram.findUnique({ where: { id: program } });
+  if (!row) {
+    throw new ProgramOwnershipError(`Program '${program}' does not exist`);
+  }
+  if (row.userId !== userId) {
+    throw new ProgramOwnershipError(
+      `Program '${program}' belongs to a different user than --user-id='${userId}' — ` +
+        `refusing to write or delete. Double-check --program before retrying; this ` +
+        `check exists because the migrator/owner role bypasses Row-Level Security, ` +
+        `so it is the only tenant-isolation control this script has.`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Backup (ADR-079 back-up-before-mutate — see the runbook's "Re-run
+// semantics" section for why this always runs before any delete).
+// ---------------------------------------------------------------------------
+
+export function backupFilePath(outDir: string, program: string, now: Date): string {
+  const stamp = now.toISOString().replace(/[:.]/g, '-');
+  return path.join(outDir, `tm-history-backup-${program}-${stamp}.json`);
+}
+
+export async function backupExistingHistory(
+  repo: ITrainingMaxHistoryRepository,
+  program: string,
+  outDir: string,
+  now: Date = new Date(),
+): Promise<{ path: string; count: number } | null> {
+  const existing = await repo.getHistory(program);
+  if (existing.length === 0) return null;
+  const filePath = backupFilePath(outDir, program, now);
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(existing, null, 2));
+  return { path: filePath, count: existing.length };
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+export type SeedMode = 'dry-run' | 'seeded' | 'rolled-back';
+
+export interface SeedResult {
+  mode: SeedMode;
+  program: string;
+  existingCount: number;
+  /** Whether --force would be (or was) required given existingCount. */
+  forceRequired: boolean;
+  writtenCount: number;
+  backupPath: string | null;
+}
+
+/**
+ * Runs the seed (or rollback). Re-run semantics match the runbook exactly:
+ * normal mode is delete-all-then-append (never plain append —
+ * `training_max_history` has no unique constraint), gated by `--force`
+ * whenever pre-existing history is found (unexpected at the normal Phase 2B
+ * timing — see the runbook). `--dry-run` never touches the database beyond
+ * the read-only `getHistory` call already needed to report `existingCount`
+ * — it never enforces the `--force` gate itself, so a dry run always
+ * succeeds and reports whether `--force` would be needed, rather than
+ * failing before the operator has a chance to see that.
+ */
+export async function runSeed(
+  prisma: PrismaClient,
+  args: SeedArgs,
+  backupDir: string = process.cwd(),
+): Promise<SeedResult> {
+  await verifyProgramOwnership(prisma, args.program, args.userId);
+  const repo = new PrismaTrainingMaxHistoryRepository(prisma, args.userId);
+
+  const existing = await repo.getHistory(args.program);
+  const existingCount = existing.length;
+  const forceRequired = existingCount > 0;
+
+  if (args.dryRun) {
+    const writtenCount = args.rollback
+      ? 0
+      : filterWillSeedRows(
+          parseTMHistoryCsv(fs.readFileSync(args.input as string, 'utf8')),
+        ).length;
+    return {
+      mode: 'dry-run',
+      program: args.program,
+      existingCount,
+      forceRequired,
+      writtenCount,
+      backupPath: null,
+    };
+  }
+
+  if (forceRequired && !args.force) {
+    throw new Error(
+      `Program '${args.program}' already has ${existingCount} history row(s). ` +
+        `This is unexpected at the normal Phase 2B timing — double-check --program ` +
+        `is the intended program before proceeding. Pass --force to confirm and ` +
+        `continue (this will delete those ${existingCount} row(s); a backup is ` +
+        `written first either way).`,
+    );
+  }
+
+  let backupPath: string | null = null;
+  if (existingCount > 0) {
+    const backup = await backupExistingHistory(repo, args.program, backupDir);
+    backupPath = backup?.path ?? null;
+  }
+
+  if (args.rollback) {
+    await repo.deleteAllHistory(args.program);
+    return {
+      mode: 'rolled-back',
+      program: args.program,
+      existingCount,
+      forceRequired,
+      writtenCount: 0,
+      backupPath,
+    };
+  }
+
+  const entries = filterWillSeedRows(
+    parseTMHistoryCsv(fs.readFileSync(args.input as string, 'utf8')),
+  ).map(mapRowToEntry);
+
+  await repo.deleteAllHistory(args.program);
+  await repo.appendHistoryEntries(args.program, entries);
+
+  return {
+    mode: 'seeded',
+    program: args.program,
+    existingCount,
+    forceRequired,
+    writtenCount: entries.length,
+    backupPath,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLI entrypoint
+// ---------------------------------------------------------------------------
+
+export function formatResult(result: SeedResult): string {
+  const lines = [`Program: ${result.program}`];
+  lines.push(
+    `Pre-existing history rows: ${result.existingCount}` +
+      (result.backupPath ? ` (backed up to ${result.backupPath})` : ''),
+  );
+  if (result.mode === 'dry-run') {
+    lines.push(
+      `DRY RUN — nothing was written. Would delete ${result.existingCount} row(s)` +
+        (result.forceRequired ? ' (would require --force)' : '') +
+        ` and write ${result.writtenCount} row(s).`,
+    );
+  } else if (result.mode === 'rolled-back') {
+    lines.push(
+      `Rolled back — deleted ${result.existingCount} row(s), wrote 0 (no re-seed).`,
+    );
+  } else {
+    lines.push(
+      `Seeded — deleted ${result.existingCount} row(s), wrote ${result.writtenCount} row(s).`,
+    );
+  }
+  return lines.join('\n');
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const prisma = new PrismaClient();
+  try {
+    const result = await runSeed(prisma, args);
+    console.log(formatResult(result));
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+if (require.main === module) {
+  main().catch((e) => {
+    console.error(e instanceof Error ? e.message : e);
+    process.exit(1);
+  });
+}

--- a/apps/api/scripts/seed-tm-history.ts
+++ b/apps/api/scripts/seed-tm-history.ts
@@ -885,6 +885,13 @@ export async function runSeed(prisma: PrismaClient, args: SeedArgs): Promise<See
       // process being killed), so it must be visible on the failure path
       // too, not just on success.
       console.log(`Backed up ${backup?.count} existing row(s) to ${backupPath}`);
+      if (backupDir === DEFAULT_BACKUP_DIR) {
+        console.log(
+          `(Default backup location — os.tmpdir() is purged on a schedule or at reboot on ` +
+            `most platforms. Copy this file somewhere durable, or re-run with --backup-dir ` +
+            `next time, if you need it to outlive this session.)`,
+        );
+      }
     }
   }
 

--- a/apps/api/scripts/seed-tm-history.ts
+++ b/apps/api/scripts/seed-tm-history.ts
@@ -22,7 +22,7 @@
  *   resolves to under plain `ts-node` (unlike Jest, which maps straight to
  *   `src/` — see `apps/api/jest.config.js`'s moduleNameMapper comment for
  *   why: workspace packages resolve to `dist` outside Jest). A fresh clone
- *   or worktree needs this step once; `npm install`'s own postinstall does
+ *   or worktree needs this step once; `npm install`'s postinstall does
  *   not build workspace packages.
  * - `DATABASE_URL` is exported and points at the migrator/owner role,
  *   through the break-glass connection (runbook "Establish the break-glass
@@ -43,6 +43,12 @@
  *   npx ts-node scripts/seed-tm-history.ts \
  *     --program <target-program-uuid> --user-id <clerk-user-id> \
  *     --restore <path-to-backup.json> [--dry-run] [--force] [--backup-dir <path>]
+ *
+ *   npx ts-node scripts/seed-tm-history.ts --help
+ *
+ * Backups are written as a JSON envelope (`{ program, userId, capturedAt,
+ * entries }`, not a bare array) so `--restore` can refuse to restore across
+ * programs or users — see `readBackupFile`'s doc comment.
  */
 
 import * as fs from 'fs';
@@ -51,8 +57,15 @@ import * as path from 'path';
 import { parse } from 'csv-parse/sync';
 import { PrismaClient } from '@prisma/client';
 import { DEFAULT_SLOT_MAP, TrainingMaxHistoryEntry } from '@lifting-logbook/core';
-import { ITrainingMaxHistoryRepository } from '../src/ports/ITrainingMaxHistoryRepository';
 import { PrismaTrainingMaxHistoryRepository } from '../src/adapters/prisma/training-max-history.repository';
+import { runInteractive, IMPORT_BATCH_TX_OPTIONS } from '../src/adapters/prisma/prisma-tx.util';
+
+const USAGE = `Usage:
+  npx ts-node scripts/seed-tm-history.ts --program <uuid> --user-id <id> --input <path> [--dry-run] [--force] [--backup-dir <path>]
+  npx ts-node scripts/seed-tm-history.ts --program <uuid> --user-id <id> --rollback [--dry-run] [--force] [--backup-dir <path>]
+  npx ts-node scripts/seed-tm-history.ts --program <uuid> --user-id <id> --restore <path> [--dry-run] [--force] [--backup-dir <path>]
+
+See docs/phase2b-tm-history-seeding-runbook.md (gas-lifting-logbook repo) for the full human-executed procedure this script is one step of.`;
 
 // ---------------------------------------------------------------------------
 // CLI argument parsing (pure — no fs/DB access, so this is directly
@@ -71,8 +84,7 @@ interface CommonArgs {
  * Discriminated on `mode` so every call site that branches on it (`runSeed`)
  * gets exhaustiveness checking, and `input`/`restorePath` are only present
  * on the one mode that actually uses them — no `as string` cast needed at
- * either use site (the previous, non-discriminated shape needed one at
- * each), and no way to construct e.g. `{ mode: 'rollback', input: '...' }`.
+ * either use site.
  */
 export type SeedArgs =
   | (CommonArgs & { mode: 'seed'; input: string })
@@ -98,7 +110,8 @@ const BOOLEAN_FLAGS = new Set(['--dry-run', '--force', '--rollback']);
  * for `--dry-run` specifically, that meant a mistyped preview request
  * silently became a real destructive write. See the runbook's "Re-run
  * semantics" section for why that distinction matters here more than in a
- * typical CLI.
+ * typical CLI. `--help`/`-h` are handled in `main()` before this is ever
+ * called, so they are not part of this parser's flag vocabulary.
  */
 export function parseArgs(argv: string[]): SeedArgs {
   const values: Partial<Record<string, string>> = {};
@@ -173,7 +186,13 @@ export function parseArgs(argv: string[]): SeedArgs {
   if (restorePath !== undefined) {
     return { mode: 'restore', program, userId, restorePath, dryRun, force, backupDir };
   }
-  return { mode: 'seed', program, userId, input: input as string, dryRun, force, backupDir };
+  if (input !== undefined) {
+    return { mode: 'seed', program, userId, input, dryRun, force, backupDir };
+  }
+  // Unreachable: modeCount === 1 above guarantees exactly one of
+  // rollback/restorePath/input is set, and the first two branches handle
+  // the other two. Present only so TypeScript sees every path return.
+  throw new ArgParseError('unreachable: no seed mode matched');
 }
 
 // ---------------------------------------------------------------------------
@@ -224,13 +243,22 @@ export const REQUIRED_COLUMNS = [
  * flow straight into an empty-seed run; see `filterWillSeedRows`'s doc
  * comment for why an empty seed is now refused outright rather than
  * silently treated as a valid "nothing to do" outcome.
+ *
+ * `bom: true` strips a leading UTF-8 byte-order mark, and header names are
+ * trimmed before the `REQUIRED_COLUMNS` comparison (and before they become
+ * the row object's own keys) — a human is expected to open this file in a
+ * spreadsheet tool to eyeball it before running the script (the runbook's
+ * Step 3), and a BOM or stray trailing space surviving that round trip
+ * would otherwise fail with "missing expected column(s)" even though the
+ * column is right there, visibly, when the operator re-opens the file.
  */
 export function parseTMHistoryCsv(content: string): TMHistoryCsvRow[] {
   let header: string[] = [];
   const rows = parse(content, {
+    bom: true,
     columns: (rawHeader: string[]) => {
-      header = rawHeader;
-      return rawHeader;
+      header = rawHeader.map((h) => h.trim());
+      return header;
     },
     skip_empty_lines: true,
   }) as TMHistoryCsvRow[];
@@ -301,6 +329,65 @@ export function filterWillSeedRows(rows: TMHistoryCsvRow[]): TMHistoryCsvRow[] {
   return rows.filter((r) => parseStrictBooleanCell(r['Will Seed'], 'Will Seed'));
 }
 
+/**
+ * Cross-row invariant mirroring gas-lifting-logbook's own pre-flight
+ * validator (`docs/phase2b-tm-history-seeding-runbook.md` Step 2's
+ * "blocking" multi-program check). That validator runs against the live
+ * Sheet tab, not this downloaded CSV, so nothing guarantees the two are
+ * the same vintage — the same reasoning `mapRowToEntry`'s doc comment
+ * gives for re-validating `TM`, applied here to a cross-row invariant
+ * instead of a per-cell one. `program` scoping for the actual write is
+ * always the `--program` CLI argument, never this column (see the
+ * runbook's Field mapping table) — this check exists only to catch a CSV
+ * that mixes rows from more than one program, which `--program` alone
+ * can't detect, before they're silently written under the wrong program's
+ * UUID.
+ */
+export function assertSingleProgram(rows: TMHistoryCsvRow[]): void {
+  const programs = new Set(
+    rows.map((r) => (r['Program'] ?? '').trim()).filter((p) => p !== ''),
+  );
+  if (programs.size > 1) {
+    throw new Error(
+      `Will Seed rows span ${programs.size} different Program values ` +
+        `(${[...programs].sort().join(', ')}) — this CSV appears to mix more than one ` +
+        `program. Re-export from a workbook holding only the program you're seeding, ` +
+        `or fix the source data (see the runbook's Step 2).`,
+    );
+  }
+}
+
+/**
+ * The other half of gas-lifting-logbook's Step 2 blocking checks, re-applied
+ * here for the same reason as {@link assertSingleProgram}: a `(program,
+ * lift, cycle date)` collision the Sheet-side validator already rejects,
+ * re-checked against this CSV because `training_max_history` has no unique
+ * constraint to catch it at the database level. Checked on the *resolved*
+ * lift id (post-`resolveLiftId`), not the raw CSV `Lift` string, because
+ * that's what would actually collide as two rows for the same cycle in the
+ * database — two differently-spelled raw names that resolve to the same
+ * target lift are exactly the case a raw-string comparison would miss.
+ */
+export function assertNoDuplicateSeedKeys(
+  entries: Omit<TrainingMaxHistoryEntry, 'id'>[],
+): void {
+  const seenAt = new Map<string, number>();
+  entries.forEach((entry, index) => {
+    const dateKey = entry.date.toISOString().slice(0, 10);
+    const key = `${entry.lift}::${dateKey}`;
+    const firstIndex = seenAt.get(key);
+    if (firstIndex !== undefined) {
+      throw new Error(
+        `Duplicate seed key: lift '${entry.lift}' on ${dateKey} appears more than once ` +
+          `among Will Seed=true rows (rows ${firstIndex + 1} and ${index + 1}). ` +
+          `training_max_history has no unique constraint, so this would silently write ` +
+          `two rows for the same cycle — fix the source data (see the runbook's Step 2).`,
+      );
+    }
+    seenAt.set(key, index);
+  });
+}
+
 const ISO_DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
 
 /**
@@ -344,6 +431,11 @@ function parseCycleDate(raw: string | undefined, field = 'Cycle Date'): Date {
  * is the last check before a direct DB write on an RLS-bypassing
  * connection — gas-lifting-logbook's own pre-flight validator runs against
  * the Sheet tab, not this downloaded CSV, so it does not cover this input.
+ *
+ * Deliberately does not include row context (index, lift, date) in its own
+ * error messages — it stays a pure function with a stable, directly
+ * unit-testable contract. The seed-time call site in `runSeed` wraps each
+ * call and adds that context to the thrown message instead.
  */
 export function mapRowToEntry(
   row: TMHistoryCsvRow,
@@ -459,52 +551,183 @@ export function backupFilePath(outDir: string, program: string, now: Date): stri
   return path.join(outDir, `tm-history-backup-${program}-${stamp}.json`);
 }
 
+interface BackupEnvelope {
+  program: string;
+  userId: string;
+  capturedAt: string;
+  entries: TrainingMaxHistoryEntry[];
+}
+
 /**
- * Writes existing history to a local JSON file, verifies the write by
- * reading it back and comparing row counts (a corrupt or truncated write —
- * disk full mid-write, process killed — would otherwise go unnoticed right
- * up until the moment it's needed for recovery), and returns its path.
+ * Writes already-fetched history to a local JSON *envelope* (not a bare
+ * array — `program`/`userId`/`capturedAt` travel with the data so
+ * `readBackupFile` can refuse to restore it against the wrong program or
+ * user), verifies the write by reading it back and comparing row counts,
+ * fsyncs before returning, and returns its path. Takes `existing` as an
+ * already-fetched array rather than a repository + re-fetching internally:
+ * `runSeed` fetches history exactly once now, and passes the same array to
+ * both the reported `existingCount` and this backup, so the audit line and
+ * the recovery artifact are provably the same snapshot (previously two
+ * independent `getHistory` calls, which also made this function trivially
+ * DB-free and unit-testable rather than Testcontainers-only).
+ *
+ * Creates `outDir` (and refuses to proceed if it turns out to already be a
+ * symlink) and writes the file with restrictive permissions (`0o700`
+ * directory, `0o600` file) — the file is a complete dump of one user's
+ * training-max history keyed to their Clerk id (see the `.gitignore`
+ * comment for this pattern), and the default location is `os.tmpdir()`,
+ * which on a shared multi-user Linux host (a bastion, jump host, or CI
+ * runner — plausible venues for break-glass production DB access) is
+ * world-readable by default. `mode` is a no-op on Windows (NTFS has no
+ * unix permission bits) but a real hardening on Linux/macOS, which is
+ * where the exposure actually applies.
+ *
  * Defaults outside the repo working tree (`os.tmpdir()`-based) rather than
- * `process.cwd()` — the previous default landed the backup, a full dump of
- * one user's training-max history keyed to their Clerk id, as an untracked
+ * `process.cwd()` — the previous default landed the backup as an untracked
  * file inside `apps/api/`, one `git add .` away from being committed.
- * Override with `--backup-dir` when a specific location is wanted.
+ * Override with `--backup-dir` when a specific (and more durable —
+ * `os.tmpdir()` is purged on a schedule or at reboot on most platforms)
+ * location is wanted.
  */
 export async function backupExistingHistory(
-  repo: ITrainingMaxHistoryRepository,
+  existing: TrainingMaxHistoryEntry[],
   program: string,
+  userId: string,
   outDir: string,
   now: Date = new Date(),
 ): Promise<{ path: string; count: number } | null> {
-  const existing = await repo.getHistory(program);
   if (existing.length === 0) return null;
-  const filePath = backupFilePath(outDir, program, now);
-  fs.mkdirSync(outDir, { recursive: true });
-  const serialized = JSON.stringify(existing, null, 2);
-  fs.writeFileSync(filePath, serialized);
 
-  const readBack = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  if (!Array.isArray(readBack) || readBack.length !== existing.length) {
+  fs.mkdirSync(outDir, { recursive: true, mode: 0o700 });
+  if (fs.lstatSync(outDir).isSymbolicLink()) {
+    throw new Error(
+      `Backup directory '${outDir}' is a symlink — refusing to write a sensitive backup ` +
+        `(one user's full training-max history) through it. Remove it or pass a different --backup-dir.`,
+    );
+  }
+
+  const filePath = backupFilePath(outDir, program, now);
+  const envelope: BackupEnvelope = {
+    program,
+    userId,
+    capturedAt: now.toISOString(),
+    entries: existing,
+  };
+  fs.writeFileSync(filePath, JSON.stringify(envelope, null, 2), { mode: 0o600 });
+
+  // A same-process read-back proves the bytes are readable, but not that
+  // they're durable (both writer and reader can be served from the page
+  // cache) — fsync before the verification read closes that gap for the
+  // sole recovery artifact this function exists to produce.
+  const fd = fs.openSync(filePath, 'r+');
+  try {
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+
+  const readBack = JSON.parse(fs.readFileSync(filePath, 'utf8')) as Partial<BackupEnvelope>;
+  if (!Array.isArray(readBack.entries) || readBack.entries.length !== existing.length) {
     throw new Error(
       `Backup verification failed for ${filePath}: wrote ${existing.length} row(s) but ` +
-        `read back ${Array.isArray(readBack) ? readBack.length : 'non-array data'}. ` +
+        `read back ${Array.isArray(readBack.entries) ? readBack.entries.length : 'non-array data'}. ` +
         `Refusing to proceed with any delete until this is resolved.`,
     );
   }
   return { path: filePath, count: existing.length };
 }
 
-/** Reads a backup file written by {@link backupExistingHistory} and strips `id` for re-append. */
-function readBackupFile(restorePath: string): Omit<TrainingMaxHistoryEntry, 'id'>[] {
-  const raw = fs.readFileSync(restorePath, 'utf8');
-  const parsed = JSON.parse(raw);
-  if (!Array.isArray(parsed)) {
-    throw new Error(`${restorePath} does not contain a JSON array — not a valid backup file`);
+function validateBackupEntry(entry: unknown, index: number): Omit<TrainingMaxHistoryEntry, 'id'> {
+  if (!entry || typeof entry !== 'object') {
+    throw new Error(`Backup entries[${index}] is not an object`);
   }
-  return (parsed as TrainingMaxHistoryEntry[]).map(({ id: _id, ...rest }) => ({
-    ...rest,
-    date: new Date(rest.date),
-  }));
+  const e = entry as Record<string, unknown>;
+  const lift = e['lift'];
+  if (typeof lift !== 'string' || lift.trim() === '') {
+    throw new Error(`Backup entries[${index}] has an invalid lift`);
+  }
+  const weight = e['weight'];
+  if (typeof weight !== 'number' || !Number.isFinite(weight) || weight <= 0) {
+    throw new Error(`Backup entries[${index}] (lift '${lift}') has an invalid weight`);
+  }
+  const reps = e['reps'];
+  if (typeof reps !== 'number' || !Number.isFinite(reps) || reps <= 0) {
+    throw new Error(`Backup entries[${index}] (lift '${lift}') has an invalid reps`);
+  }
+  const date = new Date(e['date'] as string);
+  if (isNaN(date.getTime())) {
+    throw new Error(`Backup entries[${index}] (lift '${lift}') has an invalid date`);
+  }
+  const isPR = e['isPR'];
+  if (typeof isPR !== 'boolean') {
+    throw new Error(`Backup entries[${index}] (lift '${lift}') has an invalid isPR`);
+  }
+  const source = e['source'];
+  if (source !== 'test' && source !== 'program') {
+    throw new Error(`Backup entries[${index}] (lift '${lift}') has an invalid source`);
+  }
+  const goalMet = e['goalMet'];
+  if (typeof goalMet !== 'boolean') {
+    throw new Error(`Backup entries[${index}] (lift '${lift}') has an invalid goalMet`);
+  }
+  return { lift, weight, reps, date, isPR, source, goalMet };
+}
+
+/**
+ * Reads a backup file written by {@link backupExistingHistory} — the
+ * envelope shape, not a bare array — and refuses to proceed unless its
+ * recorded `program`/`userId` match the current CLI arguments. Without
+ * this, `backupFilePath` embeds the program id in the *filename*, but
+ * nothing checked that on the way back in: restoring program A's backup
+ * into program B would previously succeed silently whenever both belong
+ * to the same `--user-id` (the ownership check only proves the caller owns
+ * the *target*), overwriting B's history with A's on the one command an
+ * operator reaches for precisely because something already went wrong.
+ * Every entry is also individually validated ({@link validateBackupEntry})
+ * before being handed to the transaction — the seed (CSV) path validates
+ * every cell already; a hand-edited or partially-corrupt backup file
+ * previously reached the DB with only Prisma's own type errors behind it.
+ */
+export function readBackupFile(
+  restorePath: string,
+  program: string,
+  userId: string,
+): Omit<TrainingMaxHistoryEntry, 'id'>[] {
+  const raw = fs.readFileSync(restorePath, 'utf8');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(
+      `${restorePath} is not valid JSON (${e instanceof Error ? e.message : String(e)})`,
+    );
+  }
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    !Array.isArray((parsed as { entries?: unknown }).entries)
+  ) {
+    throw new Error(
+      `${restorePath} does not look like a backup file written by this script — expected an ` +
+        `object with "program", "userId", and an "entries" array. If this file predates ` +
+        `program/user provenance checking (a bare JSON array), it cannot be safely ` +
+        `auto-verified — restore it manually, or contact whoever captured it.`,
+    );
+  }
+  const envelope = parsed as BackupEnvelope;
+  if (envelope.program !== program) {
+    throw new Error(
+      `${restorePath} was captured for program '${envelope.program}', not the requested ` +
+        `--program '${program}' — refusing to restore across programs.`,
+    );
+  }
+  if (envelope.userId !== userId) {
+    throw new Error(
+      `${restorePath} was captured for --user-id '${envelope.userId}', not the requested ` +
+        `--user-id '${userId}' — refusing to restore across users.`,
+    );
+  }
+  return envelope.entries.map((entry, i) => validateBackupEntry(entry, i));
 }
 
 // ---------------------------------------------------------------------------
@@ -523,37 +746,64 @@ export interface SeedResult {
   backupPath: string | null;
 }
 
+function forceRequiredMessage(
+  mode: SeedArgs['mode'],
+  program: string,
+  existingCount: number,
+): string {
+  if (mode === 'seed') {
+    return (
+      `Program '${program}' already has ${existingCount} history row(s). ` +
+      `This is unexpected at the normal Phase 2B timing — double-check --program ` +
+      `is the intended program before proceeding. Pass --force to confirm and ` +
+      `continue (this will delete those ${existingCount} row(s); a backup is ` +
+      `written first either way).`
+    );
+  }
+  const verb = mode === 'rollback' ? '--rollback' : '--restore';
+  const consequence =
+    mode === 'rollback' ? 'exiting without re-seeding' : 're-appending the backup contents';
+  return (
+    `${verb} will delete ${existingCount} existing history row(s) for program '${program}' ` +
+    `before ${consequence}. Pass --force to confirm (a backup of the current state is ` +
+    `written first either way).`
+  );
+}
+
 /**
  * Runs the seed, rollback, or restore. Re-run semantics match the runbook
  * exactly: normal mode is delete-all-then-append (never plain append —
  * `training_max_history` has no unique constraint), gated by `--force`
  * whenever pre-existing history is found (unexpected at the normal Phase 2B
- * timing — see the runbook). `--dry-run` never enforces the `--force` gate
- * itself — it always succeeds and reports whether `--force` would be
- * needed, and now also runs the *same* row mapping/validation the real run
- * would (previously it stopped at a row count, so a CSV that would fail
- * `mapRowToEntry` passed dry-run cleanly and only failed on the real,
- * already-destructive run).
+ * timing for `seed`; the expected, normal case for `rollback`/`restore` —
+ * see {@link forceRequiredMessage}). `--dry-run` never enforces the
+ * `--force` gate itself — it always succeeds and reports whether `--force`
+ * would be needed, and also runs the *same* row mapping/validation the
+ * real run would, plus a writability probe of the backup directory when
+ * there's existing history to back up (the one filesystem dependency the
+ * real run's recovery story rests on, and the one thing a rehearsal would
+ * otherwise never exercise).
  *
  * The delete and append (or the rollback delete, or the restore's
- * delete-then-append) run inside one `prisma.$transaction` — previously two
- * independent statements, so a failure between them (a dropped break-glass
- * connection, a constraint violation) left the program's history fully
- * deleted with no automatic recovery. The `as PrismaClient` cast below on
- * the transaction client mirrors this codebase's own established pattern
- * for constructing a repository over a transaction client — see
- * `prisma-repository-factory.ts`'s `client()`, which does the identical
- * cast for the same structural reason (a transaction client is call-
- * compatible for repository purposes but not identical to the full
- * `PrismaClient` type).
+ * delete-then-append) run inside one `runInteractive` call (from
+ * `prisma-tx.util.ts`) with `IMPORT_BATCH_TX_OPTIONS` — previously two
+ * independent statements with no transaction at all, so a failure between
+ * them left the program's history fully deleted with no automatic
+ * recovery; then a bare `prisma.$transaction()` with Prisma's 5s default
+ * timeout, which this codebase already found too tight for a large batch
+ * write over a normal connection (`IMPORT_TX_TIMEOUT_MS`, #532) — and this
+ * script's break-glass connection (a manually-proxied Cloud SQL connection
+ * from an operator's machine) has strictly higher latency than that
+ * already-too-tight path. `runInteractive` is also this codebase's
+ * sanctioned wrapper for exactly this call shape (see
+ * `tools/eslint-rules/no-direct-prisma-transaction.js`); the `tx as
+ * PrismaClient` cast inside its callback narrows `PrismaExecutor` (`tx`'s
+ * declared type) to the concrete type `PrismaTrainingMaxHistoryRepository`
+ * requires — the same pattern `PrismaExecutor`'s own doc comment describes.
  */
-export async function runSeed(
-  prisma: PrismaClient,
-  args: SeedArgs,
-  backupDirOverride?: string,
-): Promise<SeedResult> {
+export async function runSeed(prisma: PrismaClient, args: SeedArgs): Promise<SeedResult> {
   await verifyProgramOwnership(prisma, args.program, args.userId);
-  const backupDir = backupDirOverride ?? args.backupDir ?? DEFAULT_BACKUP_DIR;
+  const backupDir = args.backupDir ?? DEFAULT_BACKUP_DIR;
   const repo = new PrismaTrainingMaxHistoryRepository(prisma, args.userId);
 
   const existing = await repo.getHistory(args.program);
@@ -566,21 +816,50 @@ export async function runSeed(
   // mutating calls.
   let entries: Omit<TrainingMaxHistoryEntry, 'id'>[] = [];
   if (args.mode === 'seed') {
-    entries = filterWillSeedRows(
+    const willSeedRows = filterWillSeedRows(
       parseTMHistoryCsv(fs.readFileSync(args.input, 'utf8')),
-    ).map(mapRowToEntry);
-    if (entries.length === 0) {
-      throw new Error(
-        'The export produced zero rows to seed (Will Seed=true). A zero-row seed is never ' +
-          'a legitimate outcome for this script — check --input is the correct, current export, ' +
-          'and that the source Sheet actually has data to derive from.',
-      );
-    }
+    );
+    assertSingleProgram(willSeedRows);
+    entries = willSeedRows.map((row, i) => {
+      try {
+        return mapRowToEntry(row);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        throw new Error(
+          `Row ${i + 1} of Will Seed=true rows (Lift='${row['Lift'] ?? ''}', ` +
+            `Cycle Date='${row['Cycle Date'] ?? ''}'): ${msg}`,
+        );
+      }
+    });
+    assertNoDuplicateSeedKeys(entries);
   } else if (args.mode === 'restore') {
-    entries = readBackupFile(args.restorePath);
+    entries = readBackupFile(args.restorePath, args.program, args.userId);
+  }
+
+  if (args.mode !== 'rollback' && entries.length === 0) {
+    throw new Error(
+      `The ${args.mode === 'seed' ? 'export' : 'backup file'} produced zero rows to seed ` +
+        `(Will Seed=true). A zero-row seed is never a legitimate outcome for this script — ` +
+        (args.mode === 'seed'
+          ? 'check --input is the correct, current export, and that the source Sheet ' +
+            'actually has data to derive from.'
+          : 'check --restore points at the correct, non-empty backup file.'),
+    );
   }
 
   if (args.dryRun) {
+    if (existingCount > 0) {
+      try {
+        fs.mkdirSync(backupDir, { recursive: true, mode: 0o700 });
+        fs.accessSync(backupDir, fs.constants.W_OK);
+      } catch (e) {
+        throw new Error(
+          `--dry-run: backup directory '${backupDir}' is not writable ` +
+            `(${e instanceof Error ? e.message : String(e)}) — the real run would fail here, ` +
+            `after already validating your input. Fix --backup-dir or its permissions first.`,
+        );
+      }
+    }
     return {
       mode: 'dry-run',
       program: args.program,
@@ -592,18 +871,12 @@ export async function runSeed(
   }
 
   if (forceRequired && !args.force) {
-    throw new Error(
-      `Program '${args.program}' already has ${existingCount} history row(s). ` +
-        `This is unexpected at the normal Phase 2B timing — double-check --program ` +
-        `is the intended program before proceeding. Pass --force to confirm and ` +
-        `continue (this will delete those ${existingCount} row(s); a backup is ` +
-        `written first either way).`,
-    );
+    throw new Error(forceRequiredMessage(args.mode, args.program, existingCount));
   }
 
   let backupPath: string | null = null;
   if (existingCount > 0) {
-    const backup = await backupExistingHistory(repo, args.program, backupDir);
+    const backup = await backupExistingHistory(existing, args.program, args.userId, backupDir);
     backupPath = backup?.path ?? null;
     if (backupPath) {
       // Disclosed immediately, not only in the final success summary — this
@@ -615,20 +888,21 @@ export async function runSeed(
     }
   }
 
-  const writtenCount = await prisma.$transaction(async (tx) => {
-    // See this function's doc comment for why this cast mirrors an
-    // existing, accepted pattern in this codebase rather than being a
-    // one-off suppression.
-    const txRepo = new PrismaTrainingMaxHistoryRepository(
-      tx as PrismaClient,
-      args.userId,
-    );
-    await txRepo.deleteAllHistory(args.program);
-    if (args.mode !== 'rollback') {
-      await txRepo.appendHistoryEntries(args.program, entries);
-    }
-    return args.mode === 'rollback' ? 0 : entries.length;
-  });
+  const writtenCount = await runInteractive(
+    prisma,
+    async (tx) => {
+      const txRepo = new PrismaTrainingMaxHistoryRepository(
+        tx as PrismaClient,
+        args.userId,
+      );
+      await txRepo.deleteAllHistory(args.program);
+      if (args.mode !== 'rollback') {
+        await txRepo.appendHistoryEntries(args.program, entries);
+      }
+      return args.mode === 'rollback' ? 0 : entries.length;
+    },
+    IMPORT_BATCH_TX_OPTIONS,
+  );
 
   return {
     mode: args.mode === 'rollback' ? 'rolled-back' : args.mode === 'restore' ? 'restored' : 'seeded',
@@ -673,19 +947,26 @@ export function formatResult(result: SeedResult): string {
 }
 
 async function main(): Promise<void> {
-  const args = parseArgs(process.argv.slice(2));
+  const argv = process.argv.slice(2);
+  if (argv.includes('--help') || argv.includes('-h')) {
+    console.log(USAGE);
+    return;
+  }
+
+  const args = parseArgs(argv);
   console.log(
     `Mode: ${args.mode === 'seed' ? (args.dryRun ? 'DRY RUN (no writes)' : 'REAL WRITE') : args.mode.toUpperCase()}` +
       (args.dryRun && args.mode !== 'seed' ? ' (DRY RUN — no writes)' : ''),
   );
-  if (args.mode === 'seed') {
-    // Fail fast on a bad --input before any DB round trip.
-    if (!fs.existsSync(args.input)) {
-      throw new Error(
-        `--input path does not exist: ${path.resolve(args.input)}. Re-export from the ` +
-          `Sheet (Logbook Tools → Export TM History (preview)) and download it as CSV.`,
-      );
-    }
+  // Fail fast on a bad operator-supplied path before any DB round trip.
+  if (args.mode === 'seed' && !fs.existsSync(args.input)) {
+    throw new Error(
+      `--input path does not exist: ${path.resolve(args.input)}. Re-export from the ` +
+        `Sheet (Logbook Tools → Export TM History (preview)) and download it as CSV.`,
+    );
+  }
+  if (args.mode === 'restore' && !fs.existsSync(args.restorePath)) {
+    throw new Error(`--restore path does not exist: ${path.resolve(args.restorePath)}.`);
   }
   const prisma = new PrismaClient();
   try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "@prisma/instrumentation": "^5.22.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
-        "csv-parse": "^6.1.0",
         "fastify": "^4.0.0",
         "nestjs-cls": "^4.5.0",
         "nestjs-pino": "^4.6.1",
@@ -73,6 +72,7 @@
         "@opentelemetry/sdk-trace-base": "^2.7.1",
         "@testcontainers/postgresql": "^12.0.1",
         "@types/pg": "^8.11.0",
+        "csv-parse": "^6.1.0",
         "prisma": "^5.22.0",
         "ts-node": "^10.9.0",
         "tsconfig-paths": "^4.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@prisma/instrumentation": "^5.22.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
+        "csv-parse": "^6.1.0",
         "fastify": "^4.0.0",
         "nestjs-cls": "^4.5.0",
         "nestjs-pino": "^4.6.1",


### PR DESCRIPTION
## Summary

Closes #885 — the write path for gas-lifting-logbook's Phase 2B (historical training-max-progression seeding), companion to [gas-lifting-logbook#23](https://github.com/brownm09/gas-lifting-logbook/issues/23) / [#4](https://github.com/brownm09/gas-lifting-logbook/issues/4) (the GAS → GCP data transition). The export/validation side is already merged in [gas-lifting-logbook#24](https://github.com/brownm09/gas-lifting-logbook/pull/24); [`docs/phase2b-tm-history-seeding-runbook.md`](https://github.com/brownm09/gas-lifting-logbook/blob/main/docs/phase2b-tm-history-seeding-runbook.md) there is the full human-executed procedure this script is one step of.

## What's in this PR

**`apps/api/scripts/seed-tm-history.ts`** — a one-time script that reads gas-lifting-logbook's derived, human-approved `GCP_EXPORT_TMHistory.csv` and writes it into `training_max_history` via `ITrainingMaxHistoryRepository.appendHistoryEntries`/`deleteAllHistory`, run as the migrator/owner role (bypasses RLS) through the break-glass connection the runbook establishes. CLI: `--program`, `--user-id`, `--input`, `--dry-run`, `--force`, `--rollback`, `--restore <path>`, `--help` — the contract the runbook documents (`--restore` and `--help` added during review — see disposition below).

Pure functions (arg parsing, CSV parsing, row→entry mapping, backup-path derivation, cross-row invariant checks) are separated from I/O orchestration (ownership check, backup, seed/rollback/restore), so the former are directly unit-testable and the latter is tested against real Postgres.

**Program-ownership verification** (`verifyProgramOwnership`) — a security requirement surfaced during gas-lifting-logbook PR #24's `/review`: since this script connects as the RLS-bypassing migrator/owner role, `--program` is the *only* tenant-isolation control left on both the seed write and `--rollback`'s delete. Runs before any write/delete; throws on a program belonging to a different user, not existing at all, or a cross-user data anomaly this connection is uniquely positioned to detect.

**Cross-row invariant checks** (`assertSingleProgram`, `assertNoDuplicateSeedKeys`) — re-apply gas-lifting-logbook's own pre-flight validator checks (multi-program mixing, duplicate seed keys) against the CSV this script actually reads, since that validator runs against the live Sheet tab, not this downloaded file (added during review — see disposition below).

**Re-run semantics** match the runbook's "Re-run semantics" section exactly: delete-all-then-append (never plain append — `training_max_history` has no unique constraint), gated by `--force` whenever pre-existing history is found. `--dry-run` never enforces the `--force` gate itself — it always succeeds, runs the same validation a real run would, and reports whether `--force` *would* be needed, so an operator learns that before deciding, rather than the dry run itself failing.

**Backup before mutate, and restore** (ADR-079 pattern, per the runbook) — `backupExistingHistory` writes existing history to a local, provenance-checked JSON envelope before any delete (seeding over existing history, rolling back, or restoring), fsynced and permission-restricted; `--restore <path>` is the other half — refuses to restore across a different `--program`/`--user-id` than the one that captured the backup.

**Field mapping** matches the runbook's table exactly: `reps` always `1` (`CycleGenerationService`'s convention — a TM value, not a logged set); `source` always `'program'` (RPT has no test-week concept; the DB CHECK constraint on `training_max_history.source` only accepts `'test'|'program'` regardless); a blank `Goal Met` coerces to `false` (`buildTMHistory` genuinely emits `null` there for some will-seed rows; the target column is a non-null `Boolean`). Lift resolution uses the real `DEFAULT_SLOT_MAP` directly — no drift-prone hand-copied mirror, unlike gas-lifting-logbook's own pre-flight validator, which necessarily has one since it can't import this repo's code.

Named the resolver `resolveLiftId`, deliberately distinct from the catalog's own `resolveLift` (`packages/core/src/catalog/resolve.ts`) — that function throws on an unmapped slot name and returns a full `Lift` catalog object; this script needs passthrough-on-unmapped semantics and a plain id string (matching the training-max import path's existing behavior), so reusing it directly would have been wrong, not just redundant.

Only `Will Seed = true` rows are ever written — the script trusts that column directly and never re-derives gas-lifting-logbook's transition classification itself.

**`apps/api/package.json`** — `csv-parse` as an explicit `devDependencies` entry (already present transitively via `packages/core`; made explicit rather than relying on workspace hoisting — a script-only tool, not a prod API dependency) and a `seed:tm-history` npm script. `package-lock.json` regenerated per the lockfile policy.

## Testing

```
Test Suites: 42 passed, 42 total (2 new: seed-tm-history.spec.ts, seed-tm-history.db.e2e.spec.ts)
Tests:       599 passed, 0 skipped, 0 failed (88 new in the two script test files)
```

- `apps/api/scripts/seed-tm-history.spec.ts` — unit tests for every pure function: `parseArgs`, `resolveLiftId`, `parseTMHistoryCsv` (including BOM/header-trim), `filterWillSeedRows`, `assertSingleProgram`, `assertNoDuplicateSeedKeys`, `mapRowToEntry`, `backupFilePath`, `backupExistingHistory`/`readBackupFile` (envelope format, provenance checks, per-entry validation — moved here from e2e once the function became DB-free during review), `formatResult`. All pure/fs-only — no DB or repository mocking needed (per ADR-013).
- `apps/api/scripts/seed-tm-history.db.e2e.spec.ts` — tests against real Postgres via Testcontainers (per ADR-013: never mock the Prisma adapter itself), connected as the owner/migrator role exactly as the script does in production. Covers `verifyProgramOwnership` (owned / wrong-user / nonexistent / cross-user anomaly), and `runSeed`'s full matrix: fresh seed with holds correctly excluded, multi-program CSV refusal, refuse-without-`--force` on unexpected existing history, the now-mode-aware `--force` message (pinned against the runbook's exact documented `--rollback` invocation), `--force` reseed-over-existing (backup captures the *old* data, DB ends with the *new* data), `--dry-run` (DB untouched, validates like a real run, probes backup-dir writability), transaction-rollback-on-simulated-failure, `--rollback`, `--rollback --dry-run`, `--restore` (round-trip, cross-program refusal, empty-backup refusal).
- `npm run build` (`nest build`, the real typecheck gate for `apps/api`) clean, after building `packages/core` and `packages/types` first. `npx eslint` clean on all three script files (`npm run lint` only covers `src/`, matching the existing precedent for `apps/api/scripts/check-globalsetup-failure-paths.js` — the coverage gap itself is filed, see disposition below).
- No suppressions or test-integrity violations introduced (checked via the standard greps, and via `/review`'s dedicated gate — see disposition). Lockfile verified in sync (`npm install --package-lock-only --ignore-scripts` + `git diff --exit-code package-lock.json` exits clean).

## Review findings disposition

Full review: [PR comment](https://github.com/merickvaughn/lifting-logbook/pull/886#issuecomment-5230231644) (`blocking=7 non_blocking=12`). All 19 findings resolved — 17 fixed in-PR (commits `f2e5da8`, `456064a`, `695af47`), 2 filed as genuinely out-of-scope follow-ups. Summary (full detail in the review comment):

| Finding | Disposition |
|---|---|
| Multi-program CSV not re-validated | Fixed `456064a` |
| Duplicate seed key not re-validated | Fixed `456064a` |
| `--restore` missing zero-entries guard | Fixed `456064a` |
| Backup provenance / restore entry validation | Fixed `456064a` |
| Backup dir/file permissions, symlink guard | Fixed `456064a` |
| `--force` message not mode-aware; runbook `--rollback` broken | Fixed `456064a` + [gas-lifting-logbook#31](https://github.com/brownm09/gas-lifting-logbook/pull/31) |
| `csv-parse` lockfile section drift | Fixed `456064a` |
| No transaction timeout budget | Fixed `456064a` |
| Bypasses `no-direct-prisma-transaction` rule (path scope) | Fixed `456064a` (uses `runInteractive`) |
| `apps/api/scripts/` no typecheck/lint coverage | Filed [#887](https://github.com/merickvaughn/lifting-logbook/issues/887) |
| CSV BOM / header trim | Fixed `456064a` |
| No row context in errors; fails on first bad row | Partially fixed `456064a` (row context; full aggregation deferred, noted) |
| Backup fsync + tmpdir purge warning | Fixed `456064a`, `695af47` |
| `--dry-run` skips backup-dir writability probe | Fixed `456064a` |
| Triple-fetch of existing history | Fixed `456064a` |
| `backupDirOverride` test backdoor | Fixed `456064a` |
| `--restore` path not existence-checked | Fixed `456064a` |
| No `--help`/`-h` | Fixed `456064a` |
| Surviving `as string` cast in `parseArgs` | Fixed `456064a` |

Plus a cross-repo question with no code fix here: whether Google Sheets renders a boolean-looking CSV cell lowercase or uppercase (this script defends both ways regardless) — filed [gas-lifting-logbook#29](https://github.com/brownm09/gas-lifting-logbook/issues/29), needs live Sheets access this session doesn't have.

## Follow-up

- The actual production seed run is a human-executed procedure per gas-lifting-logbook's runbook — this PR does not (and cannot) run it.
- The runbook's `packages/core`/`packages/types` build-prerequisite addendum merged: [gas-lifting-logbook#28](https://github.com/brownm09/gas-lifting-logbook/pull/28).
- The runbook's rollback-`--force`/`--restore`-documentation fix is open: [gas-lifting-logbook#31](https://github.com/brownm09/gas-lifting-logbook/pull/31).
- gas-lifting-logbook#23 stays open until this PR merges (both halves of Phase 2B will then be complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
